### PR TITLE
fix(interface): don't shrink thumbs when filename is truncated

### DIFF
--- a/packages/interface/src/components/file/FileList.tsx
+++ b/packages/interface/src/components/file/FileList.tsx
@@ -226,7 +226,7 @@ const RenderCell: React.FC<{ colKey?: ColumnKey; dirId?: number; file?: FilePath
     case 'name':
       return (
         <div className="flex flex-row items-center overflow-hidden">
-          <div className="w-6 h-6 mr-3">
+          <div className="flex items-center justify-center shrink-0 w-6 h-6 mr-3">
             <FileThumb
               hasThumbnailOverride={hasNewThumbnail}
               file={row}

--- a/packages/interface/src/components/file/FileThumb.tsx
+++ b/packages/interface/src/components/file/FileThumb.tsx
@@ -22,7 +22,7 @@ export default function FileThumb(props: {
   if (client?.data_path && (props.file.has_local_thumbnail || props.hasThumbnailOverride)) {
     return (
       <img
-        className="mt-0.5 pointer-events-none z-90"
+        className="pointer-events-none z-90"
         src={appPropsContext?.convertFileSrc(
           `${client.data_path}/thumbnails/${props.locationId}/${props.file.temp_cas_id}.webp`
         )}


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/36709480/165861223-6d86bf55-b269-4457-86aa-62418b50cf8a.png)

After:
![image](https://user-images.githubusercontent.com/36709480/165861258-928eb38d-a088-45d2-890b-726a08b62a66.png)

This PR also centers thumbnails on both axes.