### PR TITLE
Support Docker

### DIFF
--- a/.github/scripts/setup-system.sh
+++ b/.github/scripts/setup-system.sh
@@ -15,24 +15,29 @@ if [ $? -eq 1 ]; then
 fi
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        if (( $EUID != 0 )); then
+                echo "Please run as root"
+                exit
+        fi
+
         if which apt-get &> /dev/null; then
                 echo "Detected 'apt' based distro!"
                 DEBIAN_TAURI_DEPS="libwebkit2gtk-4.0-dev build-essential curl wget libssl-dev libgtk-3-dev libappindicator3-dev librsvg2-dev" # Tauri dependencies
                 DEBIAN_FFMPEG_DEPS="libavcodec-dev libavdevice-dev libavfilter-dev libavformat-dev libavresample-dev libavutil-dev libswscale-dev libswresample-dev ffmpeg" # FFMPEG dependencies
                 DEBIAN_BINDGEN_DEPS="pkg-config clang" # Bindgen dependencies - it's used by a dependency of Spacedrive
 
-                sudo apt-get -y update
-                sudo apt-get -y install $DEBIAN_TAURI_DEPS $DEBIAN_FFMPEG_DEPS $DEBIAN_BINDGEN_DEPS
+                apt-get -y update
+                apt-get -y install $DEBIAN_TAURI_DEPS $DEBIAN_FFMPEG_DEPS $DEBIAN_BINDGEN_DEPS
         elif which pacman &> /dev/null; then
                 echo "Detected 'pacman' based distro!"
-                 sudo pacman -S --needed webkit2gtk base-devel curl wget openssl appmenu-gtk-module gtk3 libappindicator-gtk3 librsvg libvips
+                 pacman -S --needed webkit2gtk base-devel curl wget openssl appmenu-gtk-module gtk3 libappindicator-gtk3 librsvg libvips
 
                 ARCH_TAURI_DEPS="libwebkit2gtk-4.0-dev build-essential curl wget libssl-dev libgtk-3-dev libappindicator3-dev librsvg2-dev" # Tauri dependencies
                 ARCH_FFMPEG_DEPS="" # FFMPEG dependencies # TODO
                 ARCH_BINDGEN_DEPS="clang" # Bindgen dependencies - it's used by a dependency of Spacedrive
 
-                sudo pacman -Syu
-                sudo pacman -S --needed $ARCH_TAURI_DEPS $ARCH_FFMPEG_DEPS $ARCH_BINDGEN_DEPS
+                pacman -Syu
+                pacman -S --needed $ARCH_TAURI_DEPS $ARCH_FFMPEG_DEPS $ARCH_BINDGEN_DEPS
 
                 # TODO: Remove warning
                 echo "The FFMPEG dependencies are not yet included in this script for your Linux Distro. Please install them manually."
@@ -44,9 +49,9 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
                 FEDORA_FFMPEG_DEPS="" # FFMPEG dependencies # TODO
                 FEDORA_BINDGEN_DEPS="clang" # Bindgen dependencies - it's used by a dependency of Spacedrive
 
-                sudo dnf check-update
-                sudo dnf install $FEDORA_TAURI_DEPS $FEDORA_FFMPEG_DEPS $FEDORA_BINDGEN_DEPS
-                sudo dnf group install "C Development Tools and Libraries"
+                dnf check-update
+                dnf install $FEDORA_TAURI_DEPS $FEDORA_FFMPEG_DEPS $FEDORA_BINDGEN_DEPS
+                dnf group install "C Development Tools and Libraries"
 
                 # TODO: Remove warning
                 echo "The FFMPEG dependencies are not yet included in this script for your Linux Distro. Please install them manually."

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ cli/turbo.exe
 .DS_Store
 cache
 .env
+.pnpm-store
 vendor/
 dist
 data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM node:lts-slim
+
+WORKDIR /app
+
+# Update default packages
+RUN apt-get update
+
+# Get Ubuntu packages
+RUN apt-get install -y \
+  build-essential \
+  curl \
+  vim
+
+# Install pnpm
+RUN curl -fsSL https://get.pnpm.io/install.sh | PNPM_VERSION=7.0.0-rc.9 sh -
+# Install Rust
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+
+# Set the PATH to include the pnpm and rust executables
+ENV PATH="/root/.cargo/bin:/root/.local/share/pnpm:${PATH}"
+ENV PNPM_HOME="/root/.local/share/pnpm"
+
+COPY .github/scripts/setup-system.sh .github/scripts/setup-system.sh
+
+# Setup the system
+RUN ["/bin/bash", ".github/scripts/setup-system.sh"]
+
+COPY . .
+
+RUN pnpm i -w react react-dom
+RUN pnpm i
+RUN pnpm prep


### PR DESCRIPTION
Reasons of this PR:
---

- Enhance the developer experience, by building a single reusable Docker image containing the system dependencies so that developers can focus on developing features instead of wasting time debugging the right version of system dependencies
- Make it easier for new contributors to get up and running just by having very few dependencies: **Docker**
- Make it easier for new contributors to start developing a package. For example, in order to start developing the **landing** package, follow these steps:

```bash
# Build the docker image
docker build -t spacedrive .

# Run a new container
docker run -v `pwd`/apps/landing:/app/apps/landing -it spacedrive /bin/bash

# Run the dev command:
pnpm landing dev --host 0.0.0.0
```

- Once the docker image is published (on [dockerhub](https://hub.docker.com/) or alternative), it will be very easy for everyone to try [spacedrive](https://www.spacedrive.app/) on their own machines.
