### PR TITLE
Add credit for GitHub contributors

### DIFF
--- a/docs/product/credits.md
+++ b/docs/product/credits.md
@@ -1,12 +1,17 @@
 ## Spacedrive
+
 _&copy; Copyright 2022-Present Jamie Pine_
 
 ### Business contact
+
 hello@jamiepine.com
 
-
 ### Developers
+
 Jamie Pine, Brendonovich, Oscar Beaumont
 
 ### Contributors
-Haden Fletcher
+
+Haden Fletcher, and other contributors listed [here][contributors]
+
+[contributors]: https://github.com/spacedriveapp/spacedrive/graphs/contributors

--- a/docs/product/credits.md
+++ b/docs/product/credits.md
@@ -12,6 +12,9 @@ Jamie Pine, Brendonovich, Oscar Beaumont
 
 ### Contributors
 
-Haden Fletcher, and other contributors listed [here][contributors]
-
-[contributors]: https://github.com/spacedriveapp/spacedrive/graphs/contributors
+<a href="https://github.com/spacedriveapp/spacedrive/graphs/contributors">
+  <img
+    src="https://contrib.rocks/image?repo=spacedriveapp/spacedrive&columns=8&max=40"
+    alt="Avatars of the top contributors the the Spacedrive repository. Follow link for names and data."
+  />
+</a>


### PR DESCRIPTION
Added a link in `credits.md` to the GitHub contributors page found at: https://github.com/spacedriveapp/spacedrive/graphs/contributors
