### PR TITLE
Add Arch Linux commands to setup script

### DIFF
--- a/.github/scripts/setup-system.sh
+++ b/.github/scripts/setup-system.sh
@@ -25,19 +25,12 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
                 sudo apt-get -y install $DEBIAN_TAURI_DEPS $DEBIAN_FFMPEG_DEPS $DEBIAN_BINDGEN_DEPS
         elif which pacman &> /dev/null; then
                 echo "Detected 'pacman' based distro!"
-                 sudo pacman -S --needed webkit2gtk base-devel curl wget openssl appmenu-gtk-module gtk3 libappindicator-gtk3 librsvg libvips
-
-                ARCH_TAURI_DEPS="libwebkit2gtk-4.0-dev build-essential curl wget libssl-dev libgtk-3-dev libappindicator3-dev librsvg2-dev" # Tauri dependencies
-                ARCH_FFMPEG_DEPS="" # FFMPEG dependencies # TODO
+                ARCH_TAURI_DEPS="webkit2gtk base-devel curl wget openssl appmenu-gtk-module gtk3 libappindicator-gtk3 librsvg libvips" # Tauri deps https://tauri.studio/guides/getting-started/setup/linux#1-system-dependencies
+                ARCH_FFMPEG_DEPS="ffmpeg" # FFMPEG dependencies
                 ARCH_BINDGEN_DEPS="clang" # Bindgen dependencies - it's used by a dependency of Spacedrive
 
                 sudo pacman -Syu
                 sudo pacman -S --needed $ARCH_TAURI_DEPS $ARCH_FFMPEG_DEPS $ARCH_BINDGEN_DEPS
-
-                # TODO: Remove warning
-                echo "The FFMPEG dependencies are not yet included in this script for your Linux Distro. Please install them manually."
-                echo "It would also be greatly appreciated if you could ping @oscartbeaumont in the Discord or GitHub so that you can help me work these out and update the script for everyone."
-                exit 1
         elif which dnf &> /dev/null; then
                 echo "Detected 'dnf' based distro!"
                 FEDORA_TAURI_DEPS="webkit2gtk3-devel.x86_64 openssl-devel curl wget libappindicator-gtk3 librsvg2-devel" # Tauri dependencies


### PR DESCRIPTION
I have added the necessary `pacman` commands to the setup script for installing dependencies on Arch Linux. The build works and has been tested with:
```sh
pnpm i
pnpm prep
pnpm desktop dev
# and
pnpm web dev
pnpm landing dev
```

Addresses the Arch Linux part of #77 
