### PR TITLE
Simple update to Tauri guide url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ To get an overview of the project, read the [README](README.md). Here are some r
 - [Set up Git](https://docs.github.com/en/get-started/quickstart/set-up-git)
 - [GitHub flow](https://docs.github.com/en/get-started/quickstart/github-flow)
 - [Collaborating with pull requests](https://docs.github.com/en/github/collaborating-with-pull-requests)
-- [Your First Tauri App](https://tauri.studio/docs/getting-started/beginning-tutorial)
+- [Your First Tauri App](https://tauri.studio/guides/getting-started/beginning-tutorial)
 - [pnpm CLI](https://pnpm.io/pnpm-cli)
 
 ## Getting started


### PR DESCRIPTION
<!-- Put any information about this PR up here -->

The Tauri "getting started" url is out of date.
Updates to: https://tauri.studio/guides/getting-started/beginning-tutorial

closes #136 
