### PR TITLE
Reorder steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,9 +38,9 @@ This project uses [Cargo](https://doc.rust-lang.org/cargo/getting-started/instal
 > Note: MacOS M1 users should choose the customize option in the rustup init script and enter `x86_64-apple-darwin` as the default host triple instead of the default `aarch64-apple-darwin`
 
 - `$ git clone https://github.com/spacedriveapp/spacedrive`
+- `$ cd spacedrive`
 - For Linux or MacOS users run: `chmod +x ./.github/scripts/setup-system.sh && ./.github/scripts/setup-system.sh`
   - This will install FFMPEG and any other required dependencies for Spacedrive to build.
-- `$ cd spacedrive`
 - `$ pnpm i`
 - `$ pnpm prep` - Runs all necessary codegen & builds required dependencies.
 


### PR DESCRIPTION
The steps:
- `$ cd spacedrive`
and
- For Linux or MacOS users run: `chmod +x ./.github/scripts/setup-system.sh && ./.github/scripts/setup-system.sh`
were backwards.

<!-- Put any information about this PR up here -->



<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->
Closes #(issue)
