### PR TITLE
Add a type-check script

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "node": ">=14.0.0"
   },
   "dependencies": {
-    "zustand": "^3.7.2",
-    "typescript": "4.6.4"
+    "zustand": "^3.7.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "core": "pnpm --filter @sd/core -- ",
     "docs": "pnpm --filter @sd/docs -- ",
     "client": "pnpm --filter @sd/client -- ",
-    "server": "pnpm --filter @sd/server -- "
+    "server": "pnpm --filter @sd/server -- ",
+    "typecheck": "pnpm -r exec tsc"
   },
   "devDependencies": {
     "prettier": "^2.6.2",
@@ -35,6 +36,7 @@
     "node": ">=14.0.0"
   },
   "dependencies": {
-    "zustand": "^3.7.2"
+    "zustand": "^3.7.2",
+    "typescript": "4.6.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,10 +6,8 @@ importers:
     specifiers:
       prettier: ^2.6.2
       turbo: ^1.2.4
-      typescript: 4.6.4
       zustand: ^3.7.2
     dependencies:
-      typescript: 4.6.4
       zustand: 3.7.2
     devDependencies:
       prettier: 2.6.2
@@ -8429,12 +8427,6 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true
-
-  /typescript/4.6.4:
-    resolution: {integrity: sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
-    dev: false
 
   /ua-parser-js/0.7.31:
     resolution: {integrity: sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,10 @@ importers:
     specifiers:
       prettier: ^2.6.2
       turbo: ^1.2.4
+      typescript: 4.6.4
       zustand: ^3.7.2
     dependencies:
+      typescript: 4.6.4
       zustand: 3.7.2
     devDependencies:
       prettier: 2.6.2
@@ -619,12 +621,16 @@ packages:
     resolution: {integrity: sha512-oG0ej7efjEXxb4UgE+klVx+3j4MVo+A2vCzm7OUN4CLo6WhQ+vSOD2yJ8m7B+DghObxtLxt3EfgMWpq+AsWehQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+    dependencies:
+      '@babel/types': 7.17.0
     dev: true
 
   /@babel/parser/7.17.9:
     resolution: {integrity: sha512-vqUSBLP8dQHFPdPi9bc5GK9vRkYHJ49fsZdtoJ8EQ8ibpwk5rPKfvNIwChB0KVXcIjcepEBBd2VHC5r9Gy8ueg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+    dependencies:
+      '@babel/types': 7.17.0
 
   /@babel/plugin-syntax-jsx/7.16.7:
     resolution: {integrity: sha512-Esxmk7YjA8QysKeT3VhTXvF6y77f/a91SIs4pWb4H2eWGQkCKFgQaG6hdoEVZtGsrAcb2K5BW66XsOErD4WU3Q==}
@@ -4584,6 +4590,8 @@ packages:
     resolution: {integrity: sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==}
     engines: {node: '>=4'}
     dependencies:
+      '@types/keyv': 3.1.4
+      '@types/responselike': 1.0.0
       decompress-response: 3.3.0
       duplexer3: 0.1.4
       get-stream: 3.0.0
@@ -4605,6 +4613,8 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       '@sindresorhus/is': 0.7.0
+      '@types/keyv': 3.1.4
+      '@types/responselike': 1.0.0
       cacheable-request: 2.1.4
       decompress-response: 3.3.0
       duplexer3: 0.1.4
@@ -4629,6 +4639,8 @@ packages:
     dependencies:
       '@sindresorhus/is': 0.14.0
       '@szmarczak/http-timer': 1.1.2
+      '@types/keyv': 3.1.4
+      '@types/responselike': 1.0.0
       cacheable-request: 6.1.0
       decompress-response: 3.3.0
       duplexer3: 0.1.4
@@ -8417,6 +8429,12 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true
+
+  /typescript/4.6.4:
+    resolution: {integrity: sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: false
 
   /ua-parser-js/0.7.31:
     resolution: {integrity: sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==}


### PR DESCRIPTION
Add a script to check if TS code is valid using the same method CI uses. Running `pnpm typecheck` in the root executes this check.