### PR TITLE
Return `null` if using mobile.

### DIFF
--- a/apps/landing/src/components/AppEmbed.tsx
+++ b/apps/landing/src/components/AppEmbed.tsx
@@ -35,7 +35,7 @@ export default function AppEmbed() {
     }, 1000);
   }, []);
 
-  return (
+  return !isMobile && (
     <div className="w-screen">
       <div className="relative z-30 h-[200px] p-2 sm:p-0 sm:h-[328px] lg:h-[628px] mt-8 sm:mt-16 overflow-hidden ">
         {showApp && (

--- a/apps/landing/src/components/AppEmbed.tsx
+++ b/apps/landing/src/components/AppEmbed.tsx
@@ -35,7 +35,7 @@ export default function AppEmbed() {
     }, 1000);
   }, []);
 
-  return !isMobile && (
+  return isMobile ? null : (
     <div className="w-screen">
       <div className="relative z-30 h-[200px] p-2 sm:p-0 sm:h-[328px] lg:h-[628px] mt-8 sm:mt-16 overflow-hidden ">
         {showApp && (


### PR DESCRIPTION
<!-- Put any information about this PR up here -->
Not entirely sure if this is what the issue meant, let me know, but now the `AppEmbed` component returns null if `isMobile`.


<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->
Closes #128
