### PR TITLE
Remvoe rust-analyzer cosmetic options

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,8 +21,5 @@
     "editor.defaultFormatter": "matklad.rust-analyzer"
   },
   "rust-analyzer.procMacro.enable": true,
-  "rust-analyzer.inlayHints.enable": false,
-  "rust-analyzer.diagnostics.experimental.enable": false,
-  "rust-analyzer.inlayHints.parameterHints.enable": false,
-  "rust-analyzer.inlayHints.typeHints.enable": false
+  "rust-analyzer.diagnostics.experimental.enable": false
 }


### PR DESCRIPTION
<!-- Put any information about this PR up here -->

Instead of configuring cosmetic options in the workspace (which syncs for all developers), developers should configure these options in their VS Code user settings.

<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->
