### PR TITLE
Fix weird grammar.

### DIFF
--- a/apps/landing/src/pages/index.tsx
+++ b/apps/landing/src/pages/index.tsx
@@ -98,9 +98,9 @@ function Page() {
 				</Button>
 			</div>
 			<p className="px-6 mt-3 text-sm text-center opacity-75 text-gray-450">
-				Coming soon on macOS, Windows and Linux.
+				Coming soon to macOS, Windows, Linux,
 				<br />
-				Shortly after to iOS & Android.
+				And shortly after to iOS & Android.
 			</p>
 
 			<AppEmbed />


### PR DESCRIPTION
Fixed some weird grammar on the landing page.

From: 

> Coming soon on macOS, Windows and Linux. 
Shortly after to iOS & Android.

To

> Coming soon to macOS, Windows, Linux 
And shortly after to iOS & Android