### PR TITLE
Fix for CSS animation lag 

### DIFF
--- a/apps/landing/src/style.scss
+++ b/apps/landing/src/style.scss
@@ -89,6 +89,7 @@ html {
 	animation-fill-mode: forwards;
 	animation-iteration-count: 1;
 	animation-direction: forwards;
+	will-change: scroll-position;
 	&.bloom-one {
 		background: conic-gradient(from 90deg at 50% 50%, #255bef, #aa1cca);
 		animation-delay: 300ms;


### PR DESCRIPTION
Added a fix to speed up the css animation for users without hardware acceleration by adding will-change to .bloom

will-change hints to browsers that the element is expected to change. This will slightly increase memory usage as the browser prepares for the action before it takes place.


Closes Issue #217
