### PR TITLE
fix: disappearing icons

### DIFF
--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,6 +1,6 @@
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
-import svg from 'vite-plugin-svgr';
+import svgr from 'vite-plugin-svgr';
 
 import { name, version } from './package.json';
 
@@ -14,7 +14,11 @@ export default defineConfig({
 		react({
 			jsxRuntime: 'classic'
 		}),
-		svg({ svgrOptions: { icon: true } })
+		svgr({
+			svgrOptions: {
+				icon: true
+			}
+		})
 	],
 	root: 'src',
 	publicDir: '../../packages/interface/src/assets',

--- a/apps/landing/src/pages/roadmap.tsx
+++ b/apps/landing/src/pages/roadmap.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import { ReactComponent as Content } from '~/docs/product/roadmap.md';
 
-import folderSvg from '../../../../packages/interface/src/assets/svg/folder.svg';
+import { Folder } from '../../../../packages/interface/src/components/icons/Folder';
 import Markdown from '../components/Markdown';
 
 function Page() {
@@ -13,7 +13,7 @@ function Page() {
 				<meta name="description" content="What can Spacedrive do?" />
 			</Helmet>
 			<div className="w-24 mb-10">
-				<img src={folderSvg} alt="Folder icon" />
+				<Folder />
 			</div>
 			<Content />
 		</Markdown>

--- a/apps/landing/src/pages/roadmap.tsx
+++ b/apps/landing/src/pages/roadmap.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import { ReactComponent as Content } from '~/docs/product/roadmap.md';
 
-import { ReactComponent as Folder } from '../../../../packages/interface/src/assets/svg/folder.svg';
+import folderSvg from '../../../../packages/interface/src/assets/svg/folder.svg';
 import Markdown from '../components/Markdown';
 
 function Page() {
@@ -13,7 +13,7 @@ function Page() {
 				<meta name="description" content="What can Spacedrive do?" />
 			</Helmet>
 			<div className="w-24 mb-10">
-				<Folder className="" />
+				<img src={folderSvg} alt="Folder icon" />
 			</div>
 			<Content />
 		</Markdown>

--- a/packages/interface/src/components/file/FileThumb.tsx
+++ b/packages/interface/src/components/file/FileThumb.tsx
@@ -5,7 +5,7 @@ import React, { useContext } from 'react';
 
 import { AppPropsContext } from '../../App';
 import icons from '../../assets/icons';
-import { ReactComponent as Folder } from '../../assets/svg/folder.svg';
+import folderSvg from '../../assets/svg/folder.svg';
 
 export default function FileThumb(props: {
 	file: FilePath;
@@ -17,7 +17,7 @@ export default function FileThumb(props: {
 	const { data: client } = useBridgeQuery('NodeGetState');
 
 	if (props.file.is_dir) {
-		return <Folder className="max-w-[170px]" />;
+		return <img src={folderSvg} className="max-w-[20px]" alt="Folder icon" />;
 	}
 
 	if (client?.data_path && (props.file.file?.has_thumbnail || props.hasThumbnailOverride)) {

--- a/packages/interface/src/components/file/FileThumb.tsx
+++ b/packages/interface/src/components/file/FileThumb.tsx
@@ -5,7 +5,7 @@ import React, { useContext } from 'react';
 
 import { AppPropsContext } from '../../App';
 import icons from '../../assets/icons';
-import folderSvg from '../../assets/svg/folder.svg';
+import { Folder } from '../icons/Folder';
 
 export default function FileThumb(props: {
 	file: FilePath;
@@ -17,7 +17,7 @@ export default function FileThumb(props: {
 	const { data: client } = useBridgeQuery('NodeGetState');
 
 	if (props.file.is_dir) {
-		return <img src={folderSvg} className="max-w-[20px]" alt="Folder icon" />;
+		return <Folder className="max-w-[20px]" />;
 	}
 
 	if (client?.data_path && (props.file.file?.has_thumbnail || props.hasThumbnailOverride)) {

--- a/packages/interface/src/components/file/Sidebar.tsx
+++ b/packages/interface/src/components/file/Sidebar.tsx
@@ -8,7 +8,6 @@ import React, { useContext } from 'react';
 import { NavLink, NavLinkProps } from 'react-router-dom';
 
 import { AppPropsContext } from '../../App';
-import { ReactComponent as FolderWhite } from '../../assets/svg/folder-white.svg';
 import folderWhiteSvg from '../../assets/svg/folder-white.svg';
 import folderSvg from '../../assets/svg/folder.svg';
 import { useNodeStore } from '../device/Stores';

--- a/packages/interface/src/components/file/Sidebar.tsx
+++ b/packages/interface/src/components/file/Sidebar.tsx
@@ -9,7 +9,8 @@ import { NavLink, NavLinkProps } from 'react-router-dom';
 
 import { AppPropsContext } from '../../App';
 import { ReactComponent as FolderWhite } from '../../assets/svg/folder-white.svg';
-import { ReactComponent as Folder } from '../../assets/svg/folder.svg';
+import folderWhiteSvg from '../../assets/svg/folder-white.svg';
+import folderSvg from '../../assets/svg/folder.svg';
 import { useNodeStore } from '../device/Stores';
 import RunningJobsWidget from '../jobs/RunningJobsWidget';
 import { MacTrafficLights } from '../os/TrafficLights';
@@ -172,8 +173,16 @@ export const Sidebar: React.FC<SidebarProps> = (props) => {
 										)}
 									>
 										<div className="w-[18px] mr-2 -mt-0.5">
-											<FolderWhite className={clsx(!isActive && 'hidden')} />
-											<Folder className={clsx(isActive && 'hidden')} />
+											<img
+												src={folderWhiteSvg}
+												className={clsx(!isActive && 'hidden')}
+												alt="Folder icon"
+											/>
+											<img
+												src={folderSvg}
+												className={clsx(isActive && 'hidden')}
+												alt="Folder icon"
+											/>
 										</div>
 										{location.name}
 										<div className="flex-grow" />

--- a/packages/interface/src/components/file/Sidebar.tsx
+++ b/packages/interface/src/components/file/Sidebar.tsx
@@ -8,9 +8,8 @@ import React, { useContext } from 'react';
 import { NavLink, NavLinkProps } from 'react-router-dom';
 
 import { AppPropsContext } from '../../App';
-import folderWhiteSvg from '../../assets/svg/folder-white.svg';
-import folderSvg from '../../assets/svg/folder.svg';
 import { useNodeStore } from '../device/Stores';
+import { Folder } from '../icons/Folder';
 import RunningJobsWidget from '../jobs/RunningJobsWidget';
 import { MacTrafficLights } from '../os/TrafficLights';
 import { DefaultProps } from '../primitive/types';
@@ -172,16 +171,8 @@ export const Sidebar: React.FC<SidebarProps> = (props) => {
 										)}
 									>
 										<div className="w-[18px] mr-2 -mt-0.5">
-											<img
-												src={folderWhiteSvg}
-												className={clsx(!isActive && 'hidden')}
-												alt="Folder icon"
-											/>
-											<img
-												src={folderSvg}
-												className={clsx(isActive && 'hidden')}
-												alt="Folder icon"
-											/>
+											<Folder className={clsx(!isActive && 'hidden')} white />
+											<Folder className={clsx(isActive && 'hidden')} />
 										</div>
 										{location.name}
 										<div className="flex-grow" />

--- a/packages/interface/src/components/icons/Folder.tsx
+++ b/packages/interface/src/components/icons/Folder.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import folderWhiteSvg from '../../assets/svg/folder-white.svg';
+import folderSvg from '../../assets/svg/folder.svg';
+
+interface FolderProps {
+	/**
+	 * Append additional classes to the underlying SVG
+	 */
+	className?: string;
+
+	/**
+	 * Render a white folder icon
+	 */
+	white?: boolean;
+}
+
+export function Folder(props: FolderProps) {
+	return (
+		<img
+			className={props.className}
+			src={props.white ? folderWhiteSvg : folderSvg}
+			alt="Folder icon"
+		/>
+	);
+}


### PR DESCRIPTION
**Problem**
The folder icon uses a gradient which requires an ID so that the path element can use it as a reference when using `fill`. However, we use these SVGs in a lot of places, meaning we have duplicate instances of the same gradient definition. This causes problems in browsers where icons might not render properly from time to time. 

**Solution**
To solve this, I first attempted playing around with the [Shadow DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM) to keep using SVGs directly as React components, but with the benefit of residing inside a fully encapsulated environment where styles and IDs don't leak outside. However, I wasn't very successful with this so I ended up sourcing the SVGs as images to avoid the id collisions.

The icons seem to behave the same, so I don't have any immediate concerns with this solution. Feel free to let me know if anyone has any objections.

_[SVGO](https://react-svgr.com/docs/options/#svgo) should automatically prefix ids to help avoid collisions like these, but that didn't seem to do work, so I moved away from trying to transform the SVG through svgr to create unique IDs per instance. However, this solution is still open if we want to keep using svgs over image elements, but would require a bit more hacking._ 

<img width="201" alt="Image showcasing folder icons with gradients" src="https://user-images.githubusercontent.com/16625915/171682616-f7dc1a4c-8a90-4f29-a8c0-0ff16b5aa24b.png">
