### PR TITLE
Add debug menu items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6763,6 +6763,7 @@ name = "spacedrive"
 version = "0.1.0"
 dependencies = [
  "cocoa",
+ "objc",
  "sdcore",
  "swift-rs",
  "tauri",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -6,9 +6,9 @@
 	"private": true,
 	"scripts": {
 		"vite": "vite",
-		"dev": "concurrently \"pnpm tauri dev\" \"vite\"",
+		"dev": "tauri dev",
 		"tauri": "tauri",
-		"build": "vite build"
+		"build": "tauri build"
 	},
 	"dependencies": {
 		"@sd/client": "workspace:*",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ window-shadows = "0.1.2"
 # macOS system libs
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.24.0"
+objc = "0.2.7"
 
 [features]
 default = [ "custom-protocol" ]

--- a/apps/desktop/src-tauri/src/menu.rs
+++ b/apps/desktop/src-tauri/src/menu.rs
@@ -17,61 +17,51 @@ fn custom_menu_bar() -> Menu {
 	//   "File",
 	//   Menu::new().add_item(quit).add_item(close).add_item(jeff),
 	// );
-	let spacedrive = Submenu::new(
-		"Spacedrive",
-		Menu::new()
-			.add_native_item(MenuItem::About(
-				"Spacedrive".to_string(),
-				AboutMetadata::new(),
-			)) // TODO: fill out about metadata
-			.add_native_item(MenuItem::Separator)
-			.add_native_item(MenuItem::Services)
-			.add_native_item(MenuItem::Separator)
-			.add_native_item(MenuItem::Hide)
-			.add_native_item(MenuItem::HideOthers)
-			.add_native_item(MenuItem::ShowAll)
-			.add_native_item(MenuItem::Separator)
-			.add_native_item(MenuItem::Quit),
-	);
+	let app_menu = Menu::new()
+		.add_native_item(MenuItem::About(
+			"Spacedrive".to_string(),
+			AboutMetadata::new(),
+		)) // TODO: fill out about metadata
+		.add_native_item(MenuItem::Separator)
+		.add_native_item(MenuItem::Services)
+		.add_native_item(MenuItem::Separator)
+		.add_native_item(MenuItem::Hide)
+		.add_native_item(MenuItem::HideOthers)
+		.add_native_item(MenuItem::ShowAll)
+		.add_native_item(MenuItem::Separator)
+		.add_native_item(MenuItem::Quit);
 
-	let file = Submenu::new(
-		"File",
-		Menu::new()
-			.add_item(
-				CustomMenuItem::new("new_window".to_string(), "New Window")
-					.accelerator("CmdOrCtrl+N")
-					.disabled(),
-			)
-			.add_item(
-				CustomMenuItem::new("close".to_string(), "Close Window").accelerator("CmdOrCtrl+W"),
-			),
-	);
-	let edit = Submenu::new(
-		"Edit",
-		Menu::new()
-			.add_native_item(MenuItem::Copy)
-			.add_native_item(MenuItem::Paste),
-	);
-	let view = Submenu::new(
-		"View",
-		Menu::new()
-			.add_item(
-				CustomMenuItem::new("command_pallete".to_string(), "Command Pallete")
-					.accelerator("CmdOrCtrl+P"),
-			)
-			.add_item(CustomMenuItem::new("layout".to_string(), "Layout").disabled()),
-	);
+	let file_menu = Menu::new()
+		.add_item(
+			CustomMenuItem::new("new_window".to_string(), "New Window")
+				.accelerator("CmdOrCtrl+N")
+				.disabled(),
+		)
+		.add_item(
+			CustomMenuItem::new("close".to_string(), "Close Window").accelerator("CmdOrCtrl+W"),
+		);
+	let edit_menu = Menu::new()
+		.add_native_item(MenuItem::Copy)
+		.add_native_item(MenuItem::Paste);
+	let view_menu = Menu::new()
+		.add_item(
+			CustomMenuItem::new("command_pallete".to_string(), "Command Pallete")
+				.accelerator("CmdOrCtrl+P"),
+		)
+		.add_item(CustomMenuItem::new("layout".to_string(), "Layout").disabled());
+	let window_menu = Menu::new().add_native_item(MenuItem::EnterFullScreen);
+
 	let window = Submenu::new(
 		"Window",
 		Menu::new().add_native_item(MenuItem::EnterFullScreen),
 	);
 
 	let menu = Menu::new()
-		.add_submenu(spacedrive)
-		.add_submenu(file)
-		.add_submenu(edit)
-		.add_submenu(view)
-		.add_submenu(window);
+		.add_submenu(Submenu::new("Spacedrive", app_menu))
+		.add_submenu(Submenu::new("File", file_menu))
+		.add_submenu(Submenu::new("Edit", edit_menu))
+		.add_submenu(Submenu::new("View", view_menu))
+		.add_submenu(Submenu::new("Window", window_menu));
 
 	menu
 }

--- a/apps/desktop/src-tauri/src/menu.rs
+++ b/apps/desktop/src-tauri/src/menu.rs
@@ -10,13 +10,6 @@ pub(crate) fn get_menu() -> Menu {
 }
 
 fn custom_menu_bar() -> Menu {
-	// let quit = CustomMenuItem::new("quit".to_string(), "Quit");
-	// let close = CustomMenuItem::new("close".to_string(), "Close");
-	// let jeff = CustomMenuItem::new("jeff".to_string(), "Jeff");
-	// let submenu = Submenu::new(
-	//   "File",
-	//   Menu::new().add_item(quit).add_item(close).add_item(jeff),
-	// );
 	let app_menu = Menu::new()
 		.add_native_item(MenuItem::About(
 			"Spacedrive".to_string(),

--- a/apps/desktop/src-tauri/src/menu.rs
+++ b/apps/desktop/src-tauri/src/menu.rs
@@ -4,7 +4,6 @@ use tauri::{AboutMetadata, CustomMenuItem, Menu, MenuItem, Submenu, WindowMenuEv
 
 pub(crate) fn get_menu() -> Menu {
 	match consts::OS {
-		"linux" => Menu::new(),
 		"macos" => custom_menu_bar(),
 		_ => Menu::new(),
 	}

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -6,8 +6,8 @@
 	"build": {
 		"distDir": "../dist",
 		"devPath": "http://localhost:8001",
-		"beforeDevCommand": "",
-		"beforeBuildCommand": ""
+		"beforeDevCommand": "pnpm exec vite --clearScreen=false",
+		"beforeBuildCommand": "pnpm exec vite build"
 	},
 	"tauri": {
 		"macOSPrivateApi": true,


### PR DESCRIPTION
<!-- Put any information about this PR up here -->

- Refactored menu definitions so each submenu's set of items is a variable of its own, and the submenus are created separately. This allows for easier modification of the menus (such as the conditional adding of development menu items)
- Add debug menu items (under View menu)
  - Reload. Only implemented for macOS because there's no reload function provided by Tauri and we have to use the native webview object... doesn't seem worth it to figure out native implementation for other platforms than macOS due to our dev team almost exclusively developing on one platform
  - Toggle Developer Tools
- Remove 'jeff' commented-out menu item examples. I assume these were there for API reference previously.
- Removed the linux menu, as what we were doing for that platform before is identical to the generic fallback
- Use tauri pre-dev & pre-build commands (opens vite server/runs vite build in tauri's native flow). Seemingly also fixed our shadow-on-first-render issue on macOS. Need to verify to be sure

<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->

Closes ENG-133
