### PR TITLE
Hotfix: only use bright pink color for embeds

### DIFF
--- a/apps/landing/index.html
+++ b/apps/landing/index.html
@@ -13,7 +13,7 @@
 			name="og:image"
 			content="https://raw.githubusercontent.com/spacedriveapp/.github/main/profile/spacedrive_icon.png"
 		/>
-		<meta name="theme-color" content="#E751ED" />
+		<meta name="theme-color" content="#E751ED" media="not screen" />
 		<meta
 			name="keywords"
 			content="files,file manager,spacedrive,file explorer,vdfs,distributed filesystem,cas,content addressable storage,virtual filesystem,photos app, video organizer,video encoder,tags,tag based filesystem"


### PR DESCRIPTION
<!-- Put any information about this PR up here -->

This theme color showed on Safari (overscroll zone and compact tab-bar background) and was incredibly jarring

No related issue as this is a hotfix patch