### PR TITLE
Made the open positions header appear in view

### DIFF
--- a/apps/landing/src/pages/careers.page.tsx
+++ b/apps/landing/src/pages/careers.page.tsx
@@ -98,7 +98,7 @@ const perks = [
 ];
 
 function Page() {
-	const openPositionsRef = React.useRef<HTMLDivElement>(null);
+	const openPositionsRef = React.useRef<HTMLHRElement>(null);
 	const scrollToPositions = () => openPositionsRef.current?.scrollIntoView({ behavior: 'smooth' });
 
 	return (
@@ -161,9 +161,8 @@ function Page() {
 							</div>
 						))}
 					</div>
-					<hr className="w-full my-24 border-gray-200 opacity-10 border-1" />
+					<hr className="w-full my-24 border-gray-200 opacity-10 border-1" ref={openPositionsRef} />
 					<h1
-						ref={openPositionsRef}
 						className="px-2 mb-0 text-4xl font-black leading-tight text-center text-white"
 					>
 						Open Positions


### PR DESCRIPTION
<!-- Put any information about this PR up here -->
Made the "Open Positions" header appear in view when clicking the "See Open Positions" button.

Before (ew, bad, wtf!!!):
![Before](https://user-images.githubusercontent.com/30363562/174418604-a5795406-2cbf-45bc-9c96-2fa40640fc11.png)
After (yay! woo! amazin): 
![After](https://user-images.githubusercontent.com/30363562/174418610-b9eb6849-8fa8-4580-bb6a-6bf24ba17ebb.png)

This kinda just bugged me when I clicked the button soooooooooo understandable if rejected :^)