### PR TITLE
fix `@rpath/libswiftCore.dylib` error + etc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1364,6 +1364,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "embed-resource"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc24ff8d764818e9ab17963b0593c535f077a513f565e75e4352d758bc4d8c0"
+dependencies = [
+ "cc",
+ "rustc_version 0.4.0",
+ "toml",
+ "vswhom",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4570,12 +4583,13 @@ dependencies = [
 
 [[package]]
 name = "rfd"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f756b55bff8f256a1a8c24dbabb1430ac8110628e418a02e4a1c5ff67179f56"
+checksum = "f121348fd3b9035ed11be1f028e8944263c30641f8c5deacf57a4320782fb402"
 dependencies = [
  "block",
  "dispatch",
+ "embed-resource",
  "glib-sys",
  "gobject-sys",
  "gtk-sys",
@@ -5367,7 +5381,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 [[package]]
 name = "swift-rs"
 version = "0.3.0"
-source = "git+https://github.com/Brendonovich/swift-rs.git?branch=autorelease#fe5a1c2f668e6bade43d6f56e2530f110055cee9"
+source = "git+https://github.com/Brendonovich/swift-rs.git?branch=autorelease#b16ba936ca2330bb27c6b9b7a84ad0d583ef0caa"
 dependencies = [
  "base64 0.13.0",
  "serde",
@@ -5378,7 +5392,7 @@ dependencies = [
 [[package]]
 name = "swift-rs-macros"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/swift-rs.git?branch=autorelease#fe5a1c2f668e6bade43d6f56e2530f110055cee9"
+source = "git+https://github.com/Brendonovich/swift-rs.git?branch=autorelease#b16ba936ca2330bb27c6b9b7a84ad0d583ef0caa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5445,9 +5459,9 @@ checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
 name = "tao"
-version = "0.10.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2497feadd60f2a5a7f124572d7a44b2aba589a0ad2a65d3aaf2d073c327c3b8"
+checksum = "3bfe4c782f0543f667ee3b732d026b2f1c64af39cd52e726dec1ea1f2d8f6b80"
 dependencies = [
  "bitflags",
  "cairo-rs",
@@ -5465,6 +5479,7 @@ dependencies = [
  "glib",
  "glib-sys",
  "gtk",
+ "image",
  "instant",
  "jni 0.19.0",
  "lazy_static",
@@ -5477,11 +5492,13 @@ dependencies = [
  "once_cell",
  "parking_lot 0.11.2",
  "paste",
+ "png 0.17.5",
  "raw-window-handle",
  "scopeguard",
  "serde",
  "tao-core-video-sys",
  "unicode-segmentation",
+ "uuid 0.8.2",
  "windows 0.37.0",
  "windows-implement",
  "x11-dl",
@@ -5518,9 +5535,9 @@ dependencies = [
 
 [[package]]
 name = "tauri"
-version = "1.0.0-rc.15"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb533e95e09fd191ef8e0a0ee6b61701b5f32175e48f82854a71a8f8367bdb41"
+checksum = "8e1ebb60bb8f246d5351ff9b7728fdfa7a6eba72baa722ab6021d553981caba1"
 dependencies = [
  "anyhow",
  "attohttpc",
@@ -5571,9 +5588,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "1.0.0-rc.13"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f9a1c87ad53f584f970b06c9243b39d1c2aeca6116dd04c641f406133053b0"
+checksum = "e7b26eb3523e962b90012fedbfb744ca153d9be85e7981e00737e106d5323941"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -5586,9 +5603,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "1.0.0-rc.9"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceb3b7cb66f1a6ca30f601cccfa01820477881c27412909a3e6f80b6a2f73815"
+checksum = "9468c5189188c820ef605dfe4937c768cb2918e9460c8093dc4ee2cbd717b262"
 dependencies = [
  "base64 0.13.0",
  "brotli",
@@ -5609,9 +5626,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "1.0.0-rc.9"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07883238ade4c96be38a6a0025f15cbb5e0539fe99ba92d444af9cdbc656b613"
+checksum = "40e3ffddd7a274fc7baaa260888c971a0d95d2ef403aa16600c878b8b1c00ffe"
 dependencies = [
  "heck 0.4.0",
  "proc-macro2",
@@ -5623,9 +5640,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bad3a8ce06d4e71a52efef175446c8eb7e9109b6f988782fdc6a234526f226a"
+checksum = "fb7dc4db360bb40584187b6cb7834da736ce4ef2ab0914e2be98014444fa9920"
 dependencies = [
  "gtk",
  "http",
@@ -5642,9 +5659,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2cbc41ea88305f3e5dc133cc5c717c6913a15f121f99e7a238a0135dac083e"
+checksum = "c876fb3a6e7c6fe2ac466b2a6ecd83658528844b4df0914558a9bc1501b31cf3"
 dependencies = [
  "cocoa",
  "gtk",
@@ -5661,9 +5678,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "1.0.0-rc.9"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09e7ec7933a833f3b64e932a9d32d94705687aa5caa3cacf43222876a6d7e24"
+checksum = "727145cb55b8897fa9f2bcea4fad31dc39394703d037c9669b40f2d1c0c2d7f3"
 dependencies = [
  "brotli",
  "ctor",
@@ -6322,6 +6339,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
+name = "vswhom"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be979b7f07507105799e854203b470ff7c78a1639e330a58f183b5fea574608b"
+dependencies = [
+ "libc",
+ "vswhom-sys",
+]
+
+[[package]]
+name = "vswhom-sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22025f6d8eb903ebf920ea6933b70b1e495be37e2cb4099e62c80454aaf57c39"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6833,9 +6870,9 @@ dependencies = [
 
 [[package]]
 name = "wry"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e84a6f7f0ef90004a244a6dd4125b5fb78074b48c4369ab52b3cac68a863e"
+checksum = "26b1ba327c7dd4292f46bf8e6ba8e6ec2db4443b2973c9d304a359d95e0aa856"
 dependencies = [
  "block",
  "cocoa",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -15,12 +15,12 @@
 		"@sd/core": "workspace:*",
 		"@sd/interface": "workspace:*",
 		"@sd/ui": "workspace:*",
-		"@tauri-apps/api": "1.0.0-rc.6",
+		"@tauri-apps/api": "1.0.0",
 		"react": "^18.1.0",
 		"react-dom": "^18.1.0"
 	},
 	"devDependencies": {
-		"@tauri-apps/cli": "1.0.0-rc.13",
+		"@tauri-apps/cli": "1.0.0",
 		"@tauri-apps/tauricon": "github:tauri-apps/tauricon",
 		"@types/babel-core": "^6.25.7",
 		"@types/byte-size": "^8.1.0",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2021"
 build = "build.rs"
 
 [build-dependencies]
-tauri-build = { version = "1.0.0-rc.5", features = [] }
+tauri-build = { version = "1.0.0", features = [] }
 
 [dependencies]
 # Project dependencies
-tauri = { version = "1.0.0-rc.6", features = ["api-all", "macos-private-api"] }
+tauri = { version = "1.0.0", features = ["api-all", "macos-private-api"] }
 sdcore = { path = "../../../core" }
 # tauri-plugin-shadows = { git = "https://github.com/tauri-apps/tauri-plugin-shadows", features = ["tauri-impl"] }
 

--- a/apps/desktop/src-tauri/build.rs
+++ b/apps/desktop/src-tauri/build.rs
@@ -3,7 +3,7 @@ fn main() {
 	{
 		use swift_rs::build::{link_swift, link_swift_package};
 
-		link_swift();
+		link_swift("10.15"); // macOS Catalina. Earliest version that is officially supported by Apple.
 		link_swift_package("sd-desktop-macos", "./native/macos/");
 	}
 

--- a/apps/desktop/src-tauri/native/macos/Package.resolved
+++ b/apps/desktop/src-tauri/native/macos/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/brendonovich/swift-rs.git",
         "state": {
           "branch": "autorelease",
-          "revision": "fe5a1c2f668e6bade43d6f56e2530f110055cee9",
+          "revision": "b16ba936ca2330bb27c6b9b7a84ad0d583ef0caa",
           "version": null
         }
       }

--- a/apps/desktop/src-tauri/native/macos/Package.swift
+++ b/apps/desktop/src-tauri/native/macos/Package.swift
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
 	name: "sd-desktop-macos",
 	platforms: [
-		.macOS(.v11)
-	],
+        .macOS(.v10_15), // macOS Catalina. Earliest version that is officially supported by Apple.
+    ],
 	products: [
 		// Products define the executables and libraries a package produces, and make them visible to other packages.
 		.library(

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -14,7 +14,7 @@
 		"bundle": {
 			"active": true,
 			"targets": "all",
-			"identifier": "app.spacedrive.desktop",
+			"identifier": "com.spacedrive.desktop",
 			"icon": [
 				"icons/32x32.png",
 				"icons/128x128.png",
@@ -32,7 +32,7 @@
 			},
 			"macOS": {
 				"frameworks": [],
-				"minimumSystemVersion": "",
+				"minimumSystemVersion": "10.15",
 				"exceptionDomain": "",
 				"signingIdentity": null,
 				"entitlements": null
@@ -50,6 +50,9 @@
 			"all": true,
 			"protocol": {
 				"assetScope": ["*"]
+			},
+			"os": {
+				"all": true
 			},
 			"dialog": {
 				"all": true,

--- a/apps/desktop/src-tauri/tauri.linux.conf.json
+++ b/apps/desktop/src-tauri/tauri.linux.conf.json
@@ -10,10 +10,11 @@
 		"beforeBuildCommand": "pnpm exec vite build"
 	},
 	"tauri": {
+		"macOSPrivateApi": true,
 		"bundle": {
 			"active": true,
 			"targets": "all",
-			"identifier": "co.spacedrive.desktop",
+			"identifier": "com.spacedrive.desktop",
 			"icon": ["icons/icon.icns"],
 			"resources": [],
 			"externalBin": [],
@@ -25,7 +26,7 @@
 			},
 			"macOS": {
 				"frameworks": [],
-				"minimumSystemVersion": "",
+				"minimumSystemVersion": "10.14",
 				"exceptionDomain": "",
 				"signingIdentity": null,
 				"entitlements": null
@@ -41,6 +42,9 @@
 		},
 		"allowlist": {
 			"all": true,
+			"protocol": {
+				"assetScope": ["*"]
+			},
 			"os": {
 				"all": true
 			},
@@ -53,15 +57,17 @@
 		"windows": [
 			{
 				"title": "Spacedrive",
-				"width": 1250,
-				"height": 625,
+				"width": 1200,
+				"height": 725,
+				"minWidth": 700,
+				"minHeight": 500,
 				"resizable": true,
 				"fullscreen": false,
 				"alwaysOnTop": false,
-				"focus": true,
+				"focus": false,
 				"fileDropEnabled": false,
 				"decorations": true,
-				"transparent": false,
+				"transparent": true,
 				"center": true
 			}
 		],

--- a/apps/landing/src/vite-env.d.ts
+++ b/apps/landing/src/vite-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="vite/client" />
-/// <reference types="vite-plugin-pages/client-react" />
 
 interface ImportMetaEnv {
 	readonly VITE_SDWEB_BASE_URL: string;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
 	"devDependencies": {
 		"@trivago/prettier-plugin-sort-imports": "^3.2.0",
 		"prettier": "^2.6.2",
-		"turbo": "^1.2.14"
+		"turbo": "^1.2.14",
+		"typescript": "^4.7.4"
 	},
 	"overrides": {
 		"vite-plugin-svgr": "https://github.com/spacedriveapp/vite-plugin-svgr#cb4195b69849429cdb18d1f12381676bf9196a84"

--- a/packages/interface/src/hooks/useCoreEvents.tsx
+++ b/packages/interface/src/hooks/useCoreEvents.tsx
@@ -3,7 +3,7 @@ import { CoreEvent } from '@sd/core';
 import { useContext, useEffect } from 'react';
 import { useQueryClient } from 'react-query';
 
-import { AppPropsContext } from '../App';
+import { AppPropsContext } from '../AppPropsContext';
 import { useExplorerState } from './useExplorerState';
 
 export function useCoreEvents() {

--- a/packages/macos/Package.resolved
+++ b/packages/macos/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Brendonovich/swift-rs",
         "state": {
           "branch": null,
-          "revision": "7e856764418a5ea2b452146e8c6c65937f32e2e3",
-          "version": "0.2.3"
+          "revision": "e47a9e8186f6e25be6fae40d3cc3c272abea63a2",
+          "version": "0.3.0"
         }
       }
     ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,12 @@ importers:
       '@trivago/prettier-plugin-sort-imports': ^3.2.0
       prettier: ^2.6.2
       turbo: ^1.2.14
+      typescript: ^4.7.4
     devDependencies:
       '@trivago/prettier-plugin-sort-imports': 3.2.0_prettier@2.7.0
       prettier: 2.7.0
       turbo: 1.2.16
+      typescript: 4.7.4
 
   apps/desktop:
     specifiers:
@@ -18,8 +20,8 @@ importers:
       '@sd/core': workspace:*
       '@sd/interface': workspace:*
       '@sd/ui': workspace:*
-      '@tauri-apps/api': 1.0.0-rc.6
-      '@tauri-apps/cli': 1.0.0-rc.13
+      '@tauri-apps/api': 1.0.0
+      '@tauri-apps/cli': 1.0.0
       '@tauri-apps/tauricon': github:tauri-apps/tauricon
       '@types/babel-core': ^6.25.7
       '@types/byte-size': ^8.1.0
@@ -43,11 +45,11 @@ importers:
       '@sd/core': link:../../core
       '@sd/interface': link:../../packages/interface
       '@sd/ui': link:../../packages/ui
-      '@tauri-apps/api': 1.0.0-rc.6
+      '@tauri-apps/api': 1.0.0
       react: 18.1.0
       react-dom: 18.1.0_react@18.1.0
     devDependencies:
-      '@tauri-apps/cli': 1.0.0-rc.13
+      '@tauri-apps/cli': 1.0.0
       '@tauri-apps/tauricon': github.com/tauri-apps/tauricon/f104e2af7a19e1cdf9ee8212d2d3f6456d3aa00f
       '@types/babel-core': 6.25.7
       '@types/byte-size': 8.1.0
@@ -3755,7 +3757,7 @@ packages:
       css-loader: 3.6.0_webpack@4.46.0
       file-loader: 6.2.0_webpack@4.46.0
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 4.1.6
+      fork-ts-checker-webpack-plugin: 4.1.6_d54fnnm3nr3ir3gri66dmbwtfi
       glob: 7.2.3
       glob-promise: 3.4.0_glob@7.2.3
       global: 4.4.0
@@ -4859,15 +4861,15 @@ packages:
       lodash.merge: 4.6.2
     dev: false
 
-  /@tauri-apps/api/1.0.0-rc.6:
-    resolution: {integrity: sha512-/PbVs3/dUzid0/1XbML8tAkRSOmp+6Gv9ql02HGt3aIjNTvaL2902qEbiTX6xK++3oUoKJJ88t+V6IiNd1JUkw==}
-    engines: {node: '>= 12.13.0', npm: '>= 6.6.0', yarn: '>= 1.19.1'}
+  /@tauri-apps/api/1.0.0:
+    resolution: {integrity: sha512-sPnq8/WQumCnyHERTeqKQiryRoM8X4ImMT7K+BJ3zT7bmp/n5162fZS/ZqYIFxKHgQqzwWqT7C96Sb0/CL7WsA==}
+    engines: {node: '>= 12.22.0', npm: '>= 6.6.0', yarn: '>= 1.19.1'}
     dependencies:
-      type-fest: 2.12.2
+      type-fest: 2.13.1
     dev: false
 
-  /@tauri-apps/cli-darwin-arm64/1.0.0-rc.13:
-    resolution: {integrity: sha512-/EqOz7ASHOU98H58Ibbkg12pLG/P5oyQz8OlueaMYryajkJdmi+bHTkJ05DfbS0owAaHkRJ6f+NmoW/AnyqUbg==}
+  /@tauri-apps/cli-darwin-arm64/1.0.0:
+    resolution: {integrity: sha512-0ryomgLjdpylXypMPVXLU3PZCde3Sw5nwN4coUhBcHPBLFRb8QPet+nweVK/HiZ3mxg8WeIazvpx2s8hS0l2GQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -4875,8 +4877,8 @@ packages:
     dev: true
     optional: true
 
-  /@tauri-apps/cli-darwin-x64/1.0.0-rc.13:
-    resolution: {integrity: sha512-bvZ0MBKFD1kc4gdVPXgwUA6tHNKj0EmlQK0Xolk6PYP9vZZeNTP1vejevW0bh2IqxC8DuqUArbG9USXwu+LFbQ==}
+  /@tauri-apps/cli-darwin-x64/1.0.0:
+    resolution: {integrity: sha512-oejvYUT4dEfzBi+FWMj+CMz4cZ6C2gEFHrUtKVLdTXr8Flj5UTwdB1YPGQjiOqk73LOI7cB/vXxb9DZT+Lrxgg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -4884,8 +4886,8 @@ packages:
     dev: true
     optional: true
 
-  /@tauri-apps/cli-linux-arm-gnueabihf/1.0.0-rc.13:
-    resolution: {integrity: sha512-yODvfUkNvtYYdDTOJSDXMx9fpoEB66I2PTrYx1UKonKTEaLrQDcpw2exD/S9LPQzCYgyTuJ/kHRhG1uLdO/UUQ==}
+  /@tauri-apps/cli-linux-arm-gnueabihf/1.0.0:
+    resolution: {integrity: sha512-yAu78v8TeXNx/ETS5F2G2Uw/HX+LQvZkX94zNiqFsAj7snfWI/IqSUM52OBrdh/D0EC9NCdjUJ7Vuo32uxf7tg==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
@@ -4893,8 +4895,8 @@ packages:
     dev: true
     optional: true
 
-  /@tauri-apps/cli-linux-arm64-gnu/1.0.0-rc.13:
-    resolution: {integrity: sha512-kVDJHERD8CmTeMcd2VTnD/nVCHdnNAK8a6ur3l0KTR1iF8A1AtN/sPahMQjK4f7Ar00UDjIzTw74liqakOeiZg==}
+  /@tauri-apps/cli-linux-arm64-gnu/1.0.0:
+    resolution: {integrity: sha512-YFUN/S58AN317njAynzcQ+EHhRsCDXqmp5g9Oiqmcdg1vU7fPWZivVLc1WHz+0037C7JnsX5PtKpNYewP/+Oqw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -4902,8 +4904,8 @@ packages:
     dev: true
     optional: true
 
-  /@tauri-apps/cli-linux-arm64-musl/1.0.0-rc.13:
-    resolution: {integrity: sha512-PFHz+0xKCGMqqn2TmbOSPvTRS61xJQV7srwTZjs5sHBvK536mdBnF/6V6BPEvTn5LzfRnxMu2A5X5GFkYnrZ7w==}
+  /@tauri-apps/cli-linux-arm64-musl/1.0.0:
+    resolution: {integrity: sha512-al+TxMGoNVikEvRQfMyYE/mdjUcUNMo5brkCIAb+fL4rWQlAhAnYVzmg/rM8N4nhdXm1MOaYAagQmxr8898dNA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -4911,8 +4913,8 @@ packages:
     dev: true
     optional: true
 
-  /@tauri-apps/cli-linux-x64-gnu/1.0.0-rc.13:
-    resolution: {integrity: sha512-EWhTOUNHaaMM7mxp/ue+Osnzn6/o9/7qVle3MSnNI9pGQzumc/dOtBs+sWS/NPXdVEiWKET2mFMK120KJlYcQQ==}
+  /@tauri-apps/cli-linux-x64-gnu/1.0.0:
+    resolution: {integrity: sha512-KQmYlYyGpn6/2kSl9QivWG6EIepm6PJd57e6IKmYwAyNhLr2XfGl1CLuocUQQgO+jprjT70HXp+MXD0tcB0+Sw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -4920,8 +4922,8 @@ packages:
     dev: true
     optional: true
 
-  /@tauri-apps/cli-linux-x64-musl/1.0.0-rc.13:
-    resolution: {integrity: sha512-i8lsKw5iAGTAhqSQHeUCISLjhRXNrloHPoFCaSZtU0/GAPGbW/qST7u593h7cKWxRooeMwzo74ij4GhgmddClQ==}
+  /@tauri-apps/cli-linux-x64-musl/1.0.0:
+    resolution: {integrity: sha512-Qpaq5lZz569Aea6jfrRchgfEJaOrfLpCRBATcF8CJFFwVKmfCUcoV+MxbCIW30Zqw5Y06njC/ffa3261AV/ZIQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -4929,8 +4931,8 @@ packages:
     dev: true
     optional: true
 
-  /@tauri-apps/cli-win32-ia32-msvc/1.0.0-rc.13:
-    resolution: {integrity: sha512-rJxSqWIQXeeT2oLzSiQyqZPgDKSGH5sK7MUr8cOCBitqy3T0COlOMX4O7hhqF3cJ/5s0aX+MuNZBzF/D0QUcxA==}
+  /@tauri-apps/cli-win32-ia32-msvc/1.0.0:
+    resolution: {integrity: sha512-e2DzFqEMI+s+gv14UupdI91gPxTbUJTbbfQlTHdQlOsTk4HEZTsh+ibAYBcCLAaMRW38NEsFlAUe1lQA0iRu/w==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
@@ -4938,8 +4940,8 @@ packages:
     dev: true
     optional: true
 
-  /@tauri-apps/cli-win32-x64-msvc/1.0.0-rc.13:
-    resolution: {integrity: sha512-ifOTrJVQoBAQUYX+EVnE4XJ/FCMHs4FQ8qxGNszqkSxrU24mmT7La6tzj77352q80KnxRa05xjjLL6GGhmzXRg==}
+  /@tauri-apps/cli-win32-x64-msvc/1.0.0:
+    resolution: {integrity: sha512-lWSs90pJeQX+L31IqIzmRhwLayEeyTh7mga0AxX8G868hvdLtcXCQA/rKoFtGdVLuHAx4+M+CBF5SMYb76xGYA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -4947,20 +4949,20 @@ packages:
     dev: true
     optional: true
 
-  /@tauri-apps/cli/1.0.0-rc.13:
-    resolution: {integrity: sha512-q7i45Mi1SMv5XllNoX09QS4Q/fYVFwD6piVYmqMSrKY/T5RwedQhytiVH60TxC2xk6o0akVHa7BdYiyJvXNR8A==}
+  /@tauri-apps/cli/1.0.0:
+    resolution: {integrity: sha512-4eHnk3p0xnCXd9Zel3kLvdiiSURnN98GMFvWUAdirm5AjyOjcx8TIET/jqRYmYKE5yd+LMQqYMUfHRwA6JJUkg==}
     engines: {node: '>= 10'}
     hasBin: true
     optionalDependencies:
-      '@tauri-apps/cli-darwin-arm64': 1.0.0-rc.13
-      '@tauri-apps/cli-darwin-x64': 1.0.0-rc.13
-      '@tauri-apps/cli-linux-arm-gnueabihf': 1.0.0-rc.13
-      '@tauri-apps/cli-linux-arm64-gnu': 1.0.0-rc.13
-      '@tauri-apps/cli-linux-arm64-musl': 1.0.0-rc.13
-      '@tauri-apps/cli-linux-x64-gnu': 1.0.0-rc.13
-      '@tauri-apps/cli-linux-x64-musl': 1.0.0-rc.13
-      '@tauri-apps/cli-win32-ia32-msvc': 1.0.0-rc.13
-      '@tauri-apps/cli-win32-x64-msvc': 1.0.0-rc.13
+      '@tauri-apps/cli-darwin-arm64': 1.0.0
+      '@tauri-apps/cli-darwin-x64': 1.0.0
+      '@tauri-apps/cli-linux-arm-gnueabihf': 1.0.0
+      '@tauri-apps/cli-linux-arm64-gnu': 1.0.0
+      '@tauri-apps/cli-linux-arm64-musl': 1.0.0
+      '@tauri-apps/cli-linux-x64-gnu': 1.0.0
+      '@tauri-apps/cli-linux-x64-musl': 1.0.0
+      '@tauri-apps/cli-win32-ia32-msvc': 1.0.0
+      '@tauri-apps/cli-win32-x64-msvc': 1.0.0
     dev: true
 
   /@testing-library/dom/8.13.0:
@@ -5261,7 +5263,6 @@ packages:
 
   /@types/node/17.0.36:
     resolution: {integrity: sha512-V3orv+ggDsWVHP99K3JlwtH20R7J4IhI1Kksgc+64q5VxgfRkQG8Ws3MFm/FZOKDYGy9feGFlZ70/HpCNe9QaA==}
-    dev: true
 
   /@types/normalize-package-data/2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -5296,7 +5297,6 @@ packages:
 
   /@types/prop-types/15.7.5:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
-    dev: true
 
   /@types/qs/6.9.7:
     resolution: {integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==}
@@ -5357,7 +5357,6 @@ packages:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
       csstype: 3.1.0
-    dev: true
 
   /@types/responselike/1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
@@ -5367,7 +5366,6 @@ packages:
 
   /@types/scheduler/0.16.2:
     resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
-    dev: true
 
   /@types/serve-static/1.13.10:
     resolution: {integrity: sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==}
@@ -6798,7 +6796,7 @@ packages:
     dev: true
 
   /buffer-equal/0.0.1:
-    resolution: {integrity: sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs=}
+    resolution: {integrity: sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA==}
     engines: {node: '>=0.4.0'}
     dev: true
 
@@ -9396,9 +9394,19 @@ packages:
       signal-exit: 3.0.7
     dev: true
 
-  /fork-ts-checker-webpack-plugin/4.1.6:
+  /fork-ts-checker-webpack-plugin/4.1.6_d54fnnm3nr3ir3gri66dmbwtfi:
     resolution: {integrity: sha512-DUxuQaKoqfNne8iikd14SAkh5uw4+8vNifp6gmA73yYNS6ywLIWSLD/n/mBzHQRpW3J7rbATEakmiA8JvkTyZw==}
     engines: {node: '>=6.11.5', yarn: '>=1.0.0'}
+    peerDependencies:
+      eslint: '>= 6'
+      typescript: '>= 2.7'
+      vue-template-compiler: '*'
+      webpack: '>= 4'
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+      vue-template-compiler:
+        optional: true
     dependencies:
       '@babel/code-frame': 7.16.7
       chalk: 2.4.2
@@ -9406,6 +9414,8 @@ packages:
       minimatch: 3.1.2
       semver: 5.7.1
       tapable: 1.1.3
+      typescript: 4.7.2
+      webpack: 4.46.0
       worker-rpc: 0.1.1
     dev: true
 
@@ -9725,7 +9735,7 @@ packages:
     dev: true
 
   /github-from-package/0.0.0:
-    resolution: {integrity: sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=}
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
     dev: true
 
   /github-slugger/1.4.0:
@@ -13741,7 +13751,6 @@ packages:
       loose-envify: 1.4.0
       react: 18.1.0
       scheduler: 0.22.0
-    dev: false
 
   /react-draggable/4.4.5_ef5jwxihqo6n7gxfmzogljlgcm:
     resolution: {integrity: sha512-OMHzJdyJbYTZo4uQE393fHcqqPYsEtkjfMgvCHr6rejT+Ezn4OZbNyGH50vv+SunC1RMvwOTSWkEODQLzw1M9g==}
@@ -14112,7 +14121,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
-    dev: false
 
   /read-cache/1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
@@ -14661,7 +14669,6 @@ packages:
     resolution: {integrity: sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==}
     dependencies:
       loose-envify: 1.4.0
-    dev: false
 
   /schema-utils/1.0.0:
     resolution: {integrity: sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==}
@@ -16440,8 +16447,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /type-fest/2.12.2:
-    resolution: {integrity: sha512-qt6ylCGpLjZ7AaODxbpyBZSs9fCI9SkL3Z9q2oxMBQhs/uyY+VD8jHA8ULCGmWQJlBgqvO3EJeAngOHD8zQCrQ==}
+  /type-fest/2.13.1:
+    resolution: {integrity: sha512-hXYyrPFwETT2swFLHeoKtJrvSF/ftG/sA15/8nGaLuaDGfVAaq8DYFpu4yOyV4tzp082WqnTEoMsm3flKMI2FQ==}
     engines: {node: '>=12.20'}
     dev: false
 
@@ -16474,6 +16481,12 @@ packages:
     resolution: {integrity: sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==}
     engines: {node: '>=4.2.0'}
     hasBin: true
+
+  /typescript/4.7.4:
+    resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: true
 
   /ua-parser-js/0.7.31:
     resolution: {integrity: sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==}
@@ -17008,7 +17021,7 @@ packages:
       vite: ^2.6.0
     dependencies:
       '@svgr/core': 6.2.1
-      vite: 2.9.9_sass@1.52.1
+      vite: 2.9.9
     transitivePeerDependencies:
       - supports-color
     dev: true


### PR DESCRIPTION
Changes:
 - Fix main not compiling on macOS due to `swift-rs` issues.
   -  The app would crash with an error containing `dyld[17517]: Library not loaded: @rpath/libswiftCore.dylib`.
 - Update Tauri to v1
 - Ensure consistency between `tauri.config.json` and `tauri.linux.config.json`
 - Make CI typechecks pass

Please ensure @jamiepine has reviewed this PR before merging as I changed the app bundle identifier to `com.spacedrive.desktop` as it was both `co.spacedrive.desktop` and `app.spacedrive.desktop` in the existing configuration.