### PR TITLE
Install dependencies to avoid clippy errors in CI

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -15,6 +15,9 @@ jobs:
       
       - run: rustup component add clippy
       
+      - name: Install Dependencies
+      - run: sudo apt update && sudo apt install libdbus-1-dev pkg-config
+      
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
To avoid this error => https://github.com/spacedriveapp/spacedrive/runs/6951523959?check_suite_focus=true

<!-- Put any information about this PR up here -->

<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->

Closes #(issue)
