### PR TITLE
Better Inspector Scroll

### DIFF
--- a/packages/interface/src/AppLayout.tsx
+++ b/packages/interface/src/AppLayout.tsx
@@ -25,10 +25,8 @@ export function AppLayout() {
 			)}
 		>
 			<Sidebar />
-			<div className="flex flex-col w-full min-h-full">
-				<div className="relative flex w-full min-h-full bg-white dark:bg-gray-650">
-					<Outlet />
-				</div>
+			<div className="relative flex w-full h-screen max-h-screen bg-white dark:bg-gray-650">
+				<Outlet />
 			</div>
 		</div>
 	);

--- a/packages/interface/src/components/file/FileList.tsx
+++ b/packages/interface/src/components/file/FileList.tsx
@@ -121,7 +121,7 @@ export const FileList: React.FC<{ location_id: number; path: string; limit: numb
 			<div
 				ref={tableContainer}
 				style={{ marginTop: -44 }}
-				className="w-full pl-2 bg-white cursor-default table-container dark:bg-gray-650"
+				className="w-full pl-2 bg-white cursor-default dark:bg-gray-650"
 			>
 				<LocationContext.Provider
 					value={{ location_id: props.location_id, data_path: client?.data_path as string }}

--- a/packages/interface/src/components/file/Inspector.tsx
+++ b/packages/interface/src/components/file/Inspector.tsx
@@ -57,6 +57,7 @@ export const Inspector = (props: {
 
 	return (
 		<Transition
+			as={React.Fragment}
 			show={true}
 			enter="transition-translate ease-in-out duration-200"
 			enterFrom="translate-x-64"
@@ -65,9 +66,9 @@ export const Inspector = (props: {
 			leaveFrom="translate-x-0"
 			leaveTo="translate-x-64"
 		>
-			<div className="top-0 right-0 m-2 border border-gray-100 w-60 dark:border-gray-850 custom-scroll page-scroll">
+			<div className="flex p-2 pr-1 mr-1 pb-[51px] w-72 flex-wrap overflow-x-hidden custom-scroll inspector-scroll">
 				{!!file_path && (
-					<div className="flex flex-col overflow-x-hidden bg-white rounded-lg select-text dark:bg-gray-600 bg-opacity-70">
+					<div className="flex flex-col pb-2 overflow-hidden bg-white rounded-lg select-text dark:bg-gray-600 bg-opacity-70">
 						<div className="flex items-center justify-center w-full h-64 overflow-hidden rounded-t-lg bg-gray-50 dark:bg-gray-900">
 							<FileThumb
 								hasThumbnailOverride={false}

--- a/packages/interface/src/components/layout/TopBar.tsx
+++ b/packages/interface/src/components/layout/TopBar.tsx
@@ -71,7 +71,7 @@ export const TopBar: React.FC<TopBarProps> = (props) => {
 		<>
 			<div
 				data-tauri-drag-region
-				className="flex h-[2.95rem] -mt-0.5 max-w z-10 pl-3 rounded-tr-2xl flex-shrink-0 items-center border-b  dark:bg-gray-600 border-gray-100 dark:border-gray-800 !bg-opacity-60 backdrop-blur"
+				className="flex h-[2.95rem] -mt-0.5 max-w z-10 pl-3 flex-shrink-0 items-center border-b  dark:bg-gray-600 border-gray-100 dark:border-gray-800 !bg-opacity-60 backdrop-blur"
 			>
 				<div className="flex">
 					<TopBarButton icon={ChevronLeftIcon} onClick={() => navigate(-1)} />

--- a/packages/interface/src/screens/Explorer.tsx
+++ b/packages/interface/src/screens/Explorer.tsx
@@ -29,9 +29,9 @@ export const ExplorerScreen: React.FC<{}> = () => {
 	);
 
 	return (
-		<div className="flex flex-col w-full h-full">
+		<div className="relative flex flex-col w-full">
 			<TopBar />
-			<div className="relative flex flex-row w-full ">
+			<div className="relative flex flex-row w-full max-h-full">
 				<FileList location_id={location_id} path={path} limit={limit} />
 				{currentDir?.contents && (
 					<Inspector

--- a/packages/interface/src/style.scss
+++ b/packages/interface/src/style.scss
@@ -59,6 +59,24 @@ body {
 		@apply rounded-[6px] bg-gray-300  dark:bg-gray-550;
 	}
 }
+.inspector-scroll {
+	// overflow: overlay;
+	&::-webkit-scrollbar {
+		height: 6px;
+		width: 5px;
+	}
+	&::-webkit-scrollbar-track {
+		@apply bg-transparent my-[8px];
+	}
+	&::-webkit-scrollbar-thumb {
+		@apply rounded-[6px] opacity-0 bg-gray-300 dark:bg-gray-950;
+	}
+	&:hover {
+		&::-webkit-scrollbar-thumb {
+			@apply opacity-100;
+		}
+	}
+}
 
 @keyframes fadeIn {
 	from {


### PR DESCRIPTION
Previously inspector had incorrect height and was not scrollable. Now the inspector has a custom scroll bar that only shows when hovering the inspector. It is also small and dark, not to distract.

The inspector is also the correct height for the available space, this required changing the parent divs, so hopefully this hasn't broken anything elsewhere, though the app looks fine.