### PR TITLE
Edit Sidebar.tsx // Fix Issue #191

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 .next
+.idea
 dist
 *.tsbuildinfo
 package-lock.json

--- a/packages/interface/src/components/file/Sidebar.tsx
+++ b/packages/interface/src/components/file/Sidebar.tsx
@@ -108,7 +108,7 @@ export const Sidebar: React.FC<SidebarProps> = (props) => {
 				buttonProps={{
 					justifyLeft: true,
 					className: clsx(
-						`flex w-full text-left max-w-full mb-1 mt-1 -mr-0.5 shadow-xs rounded 
+						`flex w-full text-left max-w-full mb-1 mt-1 -mr-0.5 shadow-xs rounded outline-none
           !bg-gray-50 
           border-gray-150 
           hover:!bg-gray-1000 


### PR DESCRIPTION
Add .idea to the .gitignore for Webstorm users.
Fixed the outline around the Library changer on initial Render of this App.

![LibraryChangerOutlineFix](https://user-images.githubusercontent.com/34302688/175789467-7e674c9a-e603-402c-956b-e666a9451ae6.png)


Closes #191 

<!-- Put any information about this PR up here -->

<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->
