### PR TITLE
Client tries to reconnect when sockets close

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,35 +1,47 @@
 import { BaseTransport } from '@sd/client';
-import { ClientCommand, ClientQuery, CoreEvent } from '@sd/core';
+import { ClientCommand, ClientQuery } from '@sd/core';
 import SpacedriveInterface from '@sd/interface';
 import React, { useEffect } from 'react';
 
-const timeouts = [1, 2, 5, 10];
-
-const startWebsocket = (timeoutIndex = 0) => {
-	const ws = new WebSocket(import.meta.env.VITE_SDSERVER_BASE_URL || 'ws://localhost:8080/ws');
-
-	ws.addEventListener('close', (event) => {
-		setTimeout(
-			() => startWebsocket(timeoutIndex++),
-			timeouts[timeoutIndex] ?? timeouts[timeouts.length - 1]
-		);
-	});
-
-	return ws;
-};
-
-const websocket = startWebsocket();
+const timeouts = [1000, 2000, 5000, 10000]; // In milliseconds
 
 const randomId = () => Math.random().toString(36).slice(2);
 
 // bind state to core via Tauri
 class Transport extends BaseTransport {
+	websocket: WebSocket;
 	requestMap = new Map<string, (data: any) => void>();
 
 	constructor() {
 		super();
+		this.websocket = new WebSocket(
+			import.meta.env.VITE_SDSERVER_BASE_URL || 'ws://localhost:8080/ws'
+		);
+		this.attachEventListeners();
+	}
 
-		websocket.addEventListener('message', (event) => {
+	async reconnect(timeoutIndex = 0) {
+		let timeout =
+			(timeouts[timeoutIndex] ?? timeouts[timeouts.length - 1]) +
+			(Math.floor(Math.random() * 5000 /* 5 Seconds */) + 1);
+
+		setTimeout(() => {
+			let ws = new WebSocket(import.meta.env.VITE_SDSERVER_BASE_URL || 'ws://localhost:8080/ws');
+			new Promise(function (resolve, reject) {
+				ws.addEventListener('open', () => resolve(null));
+				ws.addEventListener('close', reject);
+			})
+				.then(() => {
+					this.websocket = ws;
+					this.attachEventListeners();
+					console.log('Reconnected!');
+				})
+				.catch((err) => this.reconnect(timeoutIndex++));
+		}, timeout);
+	}
+
+	attachEventListeners() {
+		this.websocket.addEventListener('message', (event) => {
 			if (!event.data) return;
 
 			const { id, payload } = JSON.parse(event.data);
@@ -44,7 +56,13 @@ class Transport extends BaseTransport {
 				}
 			}
 		});
+
+		this.websocket.addEventListener('close', () => {
+			console.log('GONE');
+			this.reconnect();
+		});
 	}
+
 	async query(query: ClientQuery) {
 		const id = randomId();
 		let resolve: (data: any) => void;
@@ -56,7 +74,7 @@ class Transport extends BaseTransport {
 		// @ts-ignore
 		this.requestMap.set(id, resolve);
 
-		websocket.send(JSON.stringify({ id, payload: { type: 'query', data: query } }));
+		this.websocket.send(JSON.stringify({ id, payload: { type: 'query', data: query } }));
 
 		return await promise;
 	}
@@ -71,11 +89,13 @@ class Transport extends BaseTransport {
 		// @ts-ignore
 		this.requestMap.set(id, resolve);
 
-		websocket.send(JSON.stringify({ id, payload: { type: 'command', data: command } }));
+		this.websocket.send(JSON.stringify({ id, payload: { type: 'command', data: command } }));
 
 		return await promise;
 	}
 }
+
+const transport = new Transport();
 
 function App() {
 	useEffect(() => {
@@ -87,7 +107,7 @@ function App() {
 			{/* <header className="App-header"></header> */}
 			<SpacedriveInterface
 				demoMode
-				transport={new Transport()}
+				transport={transport}
 				platform={'browser'}
 				convertFileSrc={function (url: string): string {
 					return url;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,7 +3,22 @@ import { ClientCommand, ClientQuery, CoreEvent } from '@sd/core';
 import SpacedriveInterface from '@sd/interface';
 import React, { useEffect } from 'react';
 
-const websocket = new WebSocket(import.meta.env.VITE_SDSERVER_BASE_URL || 'ws://localhost:8080/ws');
+const timeouts = [1, 2, 5, 10];
+
+const startWebsocket = (timeoutIndex = 0) => {
+	const ws = new WebSocket(import.meta.env.VITE_SDSERVER_BASE_URL || 'ws://localhost:8080/ws');
+
+	ws.addEventListener('close', (event) => {
+		setTimeout(
+			() => startWebsocket(timeoutIndex++),
+			timeouts[timeoutIndex] ?? timeouts[timeouts.length - 1]
+		);
+	});
+
+	return ws;
+};
+
+const websocket = startWebsocket();
 
 const randomId = () => Math.random().toString(36).slice(2);
 


### PR DESCRIPTION
It tries to reconnect after:
1. 1 second
2. 2 seconds
3. 5 seconds
4. 10 seconds (keeps trying this forever)

Each attempted reconnect puts an error in the console, this can be suppressed by adding a `error` event listener to `startWebsocket`.

I didn't suppress it because I think this really should have some way of telling the user that its reconnecting, ideally a toast notification, but for the time being, an error is probably okay. 

Toast notifications wouldn't be too hard to add, the [react-hot-toast](https://react-hot-toast.com/) package is pretty nice, but they aren't too hard to add manually so I didn't want to do that without getting opinions of more people. 

<!-- Put any information about this PR up here -->

<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->

Closes #292 
