### PR TITLE
Don't show Tags on the sidebar if no tags exist.

### DIFF
--- a/packages/interface/src/components/file/Sidebar.tsx
+++ b/packages/interface/src/components/file/Sidebar.tsx
@@ -238,20 +238,24 @@ export const Sidebar: React.FC<SidebarProps> = (props) => {
 					</button>
 				)}
 			</div>
-			<div>
-				<Heading>Tags</Heading>
-				<div className="mb-2">
-					{tags?.slice(0, 6).map((tag, index) => (
-						<SidebarLink key={index} to={`tag/${tag.id}`} className="">
-							<div
-								className="w-[12px] h-[12px] rounded-full"
-								style={{ backgroundColor: tag.color || '#efefef' }}
-							/>
-							<span className="ml-2 text-sm">{tag.name}</span>
-						</SidebarLink>
-					))}
+			{tags?.length ? (
+				<div>
+					<Heading>Tags</Heading>
+					<div className="mb-2">
+						{tags?.slice(0, 6).map((tag, index) => (
+							<SidebarLink key={index} to={`tag/${tag.id}`} className="">
+								<div
+									className="w-[12px] h-[12px] rounded-full"
+									style={{ backgroundColor: tag.color || '#efefef' }}
+								/>
+								<span className="ml-2 text-sm">{tag.name}</span>
+							</SidebarLink>
+						))}
+					</div>
 				</div>
-			</div>
+			) : (
+				<></>
+			)}
 			<div className="flex-grow" />
 			<RunningJobsWidget />
 			{/* <div className="flex w-full">


### PR DESCRIPTION
Closes ENG-208. Currently, if there are no tags in the sidebar then there is just the word "Tags" on the side. This PR makes it so "Tags" is only shown if there is at least one tag.