### PR TITLE
Setup system script

### DIFF
--- a/.github/scripts/setup-system.sh
+++ b/.github/scripts/setup-system.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 echo "Setting up your system for Spacedrive development!"
 
 which cargo &> /dev/null
@@ -29,7 +27,7 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
                 else
                         DEBIAN_FFMPEG_DEPS="libavcodec-dev libavdevice-dev libavfilter-dev libavformat-dev libavresample-dev libavutil-dev libswscale-dev libswresample-dev ffmpeg" # FFMPEG dependencies
                 fi
-                DEBIAN_TAURI_DEPS="libwebkit2gtk-4.0-dev build-essential curl wget libssl-dev libgtk-3-dev libappindicator3-dev librsvg2-dev" # Tauri dependencies
+                DEBIAN_TAURI_DEPS="libwebkit2gtk-4.0-dev build-essential curl wget libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev" # Tauri dependencies
                 DEBIAN_BINDGEN_DEPS="pkg-config clang" # Bindgen dependencies - it's used by a dependency of Spacedrive
                 
                 sudo apt-get -y update


### PR DESCRIPTION
Adds trap to notify users of script failure during otherwise silent exit from set -e and facilitate debugging by providing line number of error.

Updates conditionals to work as originally intended with set -e on.

Updates Tauri dependencies for Debian.  That may also need to be set conditionally depending on whether Pop also uses libayantana-appindicator3-dev.  

Includes mobile stuff from other PR still in progress.

<!-- Put any information about this PR up here -->

<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->

Closes #(issue)
