### PR TITLE
fix: Disable CMD window in Windows

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1,3 +1,8 @@
+#![cfg_attr(
+    all(not(debug_assertions), target_os = "windows"),
+    windows_subsystem = "windows"
+)]
+
 use std::path::PathBuf;
 
 use sdcore::Node;


### PR DESCRIPTION
At the moment, when opening the app it will launch a CMD window (Only in windows)  (Screenshot from user in Spacedrive Discord):

![image](https://user-images.githubusercontent.com/38158676/188483826-cc79dd39-0a83-479a-8d42-9fb6f02488c0.png)

You can see the changes on this PR are used in all the Tauri examples (e.j https://github.com/tauri-apps/tauri/blob/bf5a9ab9e6c1ac51fe78afa84919e8b2c83d4bb8/examples/helloworld/main.rs#L5)

With these changes it will now only show the app's window.

