### PR TITLE
Only show a period at the end of a filename if it has an extension

### DIFF
--- a/packages/interface/src/components/explorer/FileItem.tsx
+++ b/packages/interface/src/components/explorer/FileItem.tsx
@@ -65,7 +65,7 @@ export default function FileItem(props: Props) {
 					)}
 				>
 					{props.data?.name}
-					{props.data?.extension && <>.{props.data.extension}</>}
+					{props.data?.extension && `.${props.data.extension}`}
 				</span>
 			</div>
 		</div>

--- a/packages/interface/src/components/explorer/FileItem.tsx
+++ b/packages/interface/src/components/explorer/FileItem.tsx
@@ -64,7 +64,8 @@ export default function FileItem(props: Props) {
 						}
 					)}
 				>
-					{props.data?.name}.{props.data?.extension}
+					{props.data?.name}
+					{props.data?.extension && <>.{props.data.extension}</>}
 				</span>
 			</div>
 		</div>

--- a/packages/interface/src/components/explorer/Inspector.tsx
+++ b/packages/interface/src/components/explorer/Inspector.tsx
@@ -37,7 +37,8 @@ export const Inspector = (props: Props) => {
 					</div>
 					<div className="flex flex-col w-full pt-0.5 pb-4 overflow-hidden bg-white rounded-lg shadow select-text dark:shadow-gray-700 dark:bg-gray-550 dark:bg-opacity-40">
 						<h3 className="pt-3 pl-3 text-base font-bold">
-							{props.data?.name}.{props.data?.extension}
+							{props.data?.name}
+							{props.data?.extension && <>.{props.data.extension}</>}
 						</h3>
 						{objectData && (
 							<div className="flex flex-row m-3 space-x-2">

--- a/packages/interface/src/components/explorer/Inspector.tsx
+++ b/packages/interface/src/components/explorer/Inspector.tsx
@@ -38,7 +38,7 @@ export const Inspector = (props: Props) => {
 					<div className="flex flex-col w-full pt-0.5 pb-4 overflow-hidden bg-white rounded-lg shadow select-text dark:shadow-gray-700 dark:bg-gray-550 dark:bg-opacity-40">
 						<h3 className="pt-3 pl-3 text-base font-bold">
 							{props.data?.name}
-							{props.data?.extension && <>.{props.data.extension}</>}
+							{props.data?.extension && `.${props.data.extension}`}
 						</h3>
 						{objectData && (
 							<div className="flex flex-row m-3 space-x-2">


### PR DESCRIPTION
Removes the extra period at the end of a file or folder if it doesn't have an extension.

**before:**
![image](https://user-images.githubusercontent.com/88915203/188759560-61b73f24-98d0-4328-bc4c-4340ae476f7e.png)

**after:**
![image](https://user-images.githubusercontent.com/88915203/188759585-b681cd4d-8ea9-4953-8e60-a89c0a482a0d.png)

Closes #379 
