### PR TITLE
expand prisma client cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./core/src/prisma.rs
-          key: prisma-${{ runner.os }}-${{ hashFiles('./core/prisma/*', "./Cargo.toml") }}
+          key: prisma-${{ runner.os }}-${{ hashFiles('./core/prisma/*', './Cargo.toml') }}
 
       - name: Generate Prisma client
         working-directory: core

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./core/src/prisma.rs
-          key: prisma-${{ runner.os }}-${{ hashFiles('./core/prisma/Cargo.toml', './core/prisma/schema.prisma', './core/prisma/src/main.rs') }}
+          key: prisma-${{ runner.os }}-${{ hashFiles('./core/prisma/*', "./Cargo.toml") }}
 
       - name: Generate Prisma client
         working-directory: core


### PR DESCRIPTION
Changes Prisma client caching to derive its key from anything in `core/prisma`, and the root `Cargo.toml` to account for workspace-wide patches.