### PR TITLE
fix incorrect faq URLs

### DIFF
--- a/apps/landing/src/components/Footer.tsx
+++ b/apps/landing/src/components/Footer.tsx
@@ -56,7 +56,7 @@ export function Footer() {
 					<h3 className="mb-1 text-xs font-bold uppercase ">About</h3>
 
 					<FooterLink link="/team">Team</FooterLink>
-					<FooterLink link="/faq">FAQ</FooterLink>
+					<FooterLink link="/docs/product/resources/faq">FAQ</FooterLink>
 					<FooterLink link="/careers">Careers</FooterLink>
 					<FooterLink link="/changelog">Changelog</FooterLink>
 					<FooterLink link="/blog">Blog</FooterLink>

--- a/apps/landing/src/pages/team.page.tsx
+++ b/apps/landing/src/pages/team.page.tsx
@@ -226,7 +226,7 @@ function Page() {
 						lives, at unlimited scale.
 					</p>
 					<a
-						href="/faq"
+						href="/docs/product/resources/faq"
 						className="flex flex-row items-center text-gray-400 duration-150 animation-delay-3 fade-in-heading hover:text-white text-underline underline-offset-4"
 					>
 						<ArrowRight className="mr-2" />


### PR DESCRIPTION
This PR fixes the 404 from hitting "Read more" in the [teams page](https://www.spacedrive.com/team), and the FAQ button in the footer. I'm unsure whether or not `/faq` should be linked to `/docs/product/resources/faq`, but this at least fixes it for now.

There aren't any relevant issues as it's likely just classed as a typo (one can be made though if required).