### PR TITLE
Fixed horizontal scrolling overflow

### DIFF
--- a/apps/landing/src/pages/index.page.tsx
+++ b/apps/landing/src/pages/index.page.tsx
@@ -82,7 +82,7 @@ function Page() {
 	}, []);
 
 	return (
-		<div className="flex flex-col items-center w-full px-4">
+		<div className="flex flex-col items-center w-full px-4 overflow-hidden">
 			<Helmet>
 				<title>Spacedrive — A file manager from the future.</title>
 				<meta


### PR DESCRIPTION
Fixed the horizontal scrolling issue present on IOS and Mac by adding overflow-hidden to landing page.

I do not have an Iphone to test that this does not cause any unintended issues so some further testing should be done before accepting this. 

Closes #(issue): [ENG-253] Spacedrive landing page has horizontal scroll on ios and mac #402
