### PR TITLE
Mobile CI

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -1,0 +1,1 @@
+!/core/src/prisma.rs

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - mobile-ci # TEMP
     paths-ignore:
       - '**/.md'
   workflow_dispatch:

--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -1,10 +1,11 @@
-name: CI
+name: Desktop CI
 
 on:
   pull_request:
   push:
     branches:
       - main
+      - mobile-ci # TEMP
     paths-ignore:
       - '**/.md'
   workflow_dispatch:
@@ -21,7 +22,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.2.2
+        uses: pnpm/action-setup@v2.2.4
         with:
           version: 7.x.x
 
@@ -36,69 +37,6 @@ jobs:
 
       - name: Perform typechecks
         run: pnpm typecheck
-
-  rustfmt:
-    name: rustfmt
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          components: rustfmt
-
-      - name: Cache Rust dependencies
-        uses: ./.github/actions/cache-rust-deps
-
-      - name: Generate Prisma client
-        uses: ./.github/actions/generate-prisma-client
-
-      - name: Run rustfmt
-        run: cargo fmt --all -- --check
-
-  clippy_check:
-    name: Clippy
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-          components: clippy
-
-      - name: Cache Rust dependencies
-        uses: ./.github/actions/cache-rust-deps
-
-      - name: Install Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 17
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2.0.1
-        with:
-          version: 7
-          run_install: false
-
-      - name: Run 'setup-system.sh' script
-        run: ./.github/scripts/setup-system.sh
-
-      - name: Generate Prisma client
-        uses: ./.github/actions/generate-prisma-client
-
-      - name: Run Clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --release
 
   build-and-publish:
     name: Build and Publish (${{ matrix.platform }})
@@ -131,7 +69,7 @@ jobs:
         uses: ./.github/actions/cache-rust-deps
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.2.2
+        uses: pnpm/action-setup@v2.2.4
         with:
           version: 7.x.x
 

--- a/.github/workflows/mobile-ci.yaml
+++ b/.github/workflows/mobile-ci.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - mobile-ci # TEMP
     paths-ignore:
       - '**/.md'
   workflow_dispatch:

--- a/.github/workflows/mobile-ci.yaml
+++ b/.github/workflows/mobile-ci.yaml
@@ -128,18 +128,13 @@ jobs:
         working-directory: ./apps/mobile
         run: pnpm i --frozen-lockfile
       
-      # - name: Generate Prisma client
-      #   uses: ./.github/actions/generate-prisma-client
-
-      # - name: Generate Prisma client
-      #   uses: ./.github/actions/generate-prisma-client
-
-      # Something is broke. This should be cached but that no worky.
-      # - name: Generate Prisma client
-      #   working-directory: core
-      #   # if: steps.cache-prisma.outputs.cache-hit != 'true'
-      #   shell: bash
-      #   run: cargo run -p prisma-cli --release -- generate
+      # TODO: Debug
+      - name: Why Prisma????
+        run: ls ./core/src
+      - name: Cargo fetch
+        run: cargo fetch
+      - name: Check core
+        run: cargo check -p sd-core --release
       
       - name: Build Android
         working-directory: ./apps/mobile

--- a/.github/workflows/mobile-ci.yaml
+++ b/.github/workflows/mobile-ci.yaml
@@ -14,39 +14,39 @@ env:
   SPACEDRIVE_CUSTOM_APT_FLAGS: --no-install-recommends
 
 jobs:
-  # lint:
-  #   name: Typecheck & Lint
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v3
+  lint:
+    name: Typecheck & Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-  #     - name: Install pnpm
-  #       uses: pnpm/action-setup@v2.2.4
-  #       with:
-  #         version: 7.x.x
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2.2.4
+        with:
+          version: 7.x.x
 
-  #     - name: Install Node.js
-  #       uses: actions/setup-node@v3
-  #       with:
-  #         node-version: 17
-  #         cache: 'pnpm'
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 17
+          cache: 'pnpm'
 
-  #     - name: Install workspace pnpm dependencies
-  #       run: pnpm i --frozen-lockfile
+      - name: Install workspace pnpm dependencies
+        run: pnpm i --frozen-lockfile
       
-  #     - name: Install mobile pnpm dependencies
-  #       working-directory: ./apps/mobile
-  #       run: pnpm i --frozen-lockfile
+      - name: Install mobile pnpm dependencies
+        working-directory: ./apps/mobile
+        run: pnpm i --frozen-lockfile
 
-  #     - name: Perform typechecks
-  #       working-directory: ./apps/mobile
-  #       run: pnpm lint
+      - name: Perform typechecks
+        working-directory: ./apps/mobile
+        run: pnpm lint
   
   build:
     name: Build
     runs-on: ubuntu-latest
-    # needs: lint
+    needs: lint
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -89,17 +89,9 @@ jobs:
       
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
-      
-      # - name: Install pnpm dependencies
-      #   run: pnpm i --frozen-lockfile
 
       - name: Run 'setup-system.sh' script
-        # if: matrix.platform == 'ubuntu-latest' || matrix.platform == 'macos-latest'
-        run: ./.github/scripts/setup-system.sh mobile # TODO: Mobile flag
-
-      # - name: Run 'setup-system.ps1' script
-      #   if: matrix.platform == 'windows-latest'
-      #   run: ./.github/scripts/setup-system.ps1 -ci
+        run: ./.github/scripts/setup-system.sh mobile
 
       - name: Generate Prisma client
         uses: ./.github/actions/generate-prisma-client
@@ -109,13 +101,6 @@ jobs:
           sudo mkdir -p /usr/local/lib/android/sdk/ndk
           sudo chmod -R 777 /usr/local/lib/android/sdk/ndk
           sudo chown -R $USER:$USER /usr/local/lib/android/sdk/ndk
-      
-      # - name: NDK Cache
-      #   id: ndk-cache
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: /usr/local/lib/android/sdk/ndk
-      #     key: ndk-cache-21.4.7075529-v2
 
       - name: plz work?
         run: export CARGO_TARGET_DIR="$(pwd)/../../target"
@@ -130,14 +115,6 @@ jobs:
       - name: Install mobile pnpm dependencies
         working-directory: ./apps/mobile
         run: pnpm i --frozen-lockfile
-      
-      # TODO: Debug
-      # - name: Why Prisma????
-      #   run: ls ./core/src
-      # - name: Cargo fetch
-      #   run: cargo fetch
-      # - name: Check core
-      #   run: cargo check -p sd-core --release
       
       - name: Build Android
         working-directory: ./apps/mobile

--- a/.github/workflows/mobile-ci.yaml
+++ b/.github/workflows/mobile-ci.yaml
@@ -1,0 +1,148 @@
+name: Mobile CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - mobile-ci # TEMP
+    paths-ignore:
+      - '**/.md'
+  workflow_dispatch:
+
+env:
+  SPACEDRIVE_CUSTOM_APT_FLAGS: --no-install-recommends
+
+jobs:
+  # lint:
+  #   name: Typecheck & Lint
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v3
+
+  #     - name: Install pnpm
+  #       uses: pnpm/action-setup@v2.2.4
+  #       with:
+  #         version: 7.x.x
+
+  #     - name: Install Node.js
+  #       uses: actions/setup-node@v3
+  #       with:
+  #         node-version: 17
+  #         cache: 'pnpm'
+
+  #     - name: Install workspace pnpm dependencies
+  #       run: pnpm i --frozen-lockfile
+      
+  #     - name: Install mobile pnpm dependencies
+  #       working-directory: ./apps/mobile
+  #       run: pnpm i --frozen-lockfile
+
+  #     - name: Perform typechecks
+  #       working-directory: ./apps/mobile
+  #       run: pnpm lint
+  
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    # needs: lint
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Rust stable
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+          components: rustfmt, rust-src
+
+      - name: Cache Rust dependencies
+        uses: ./.github/actions/cache-rust-deps
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2.2.4
+        with:
+          version: 7.x.x
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 17
+          cache: 'pnpm'
+      
+      - name: Setup Expo and EAS
+        uses: expo/expo-github-action@v7
+        with:
+          expo-version: 6.x
+          eas-version: latest
+          packager: pnpm
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 18
+      
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+      
+      # - name: Install pnpm dependencies
+      #   run: pnpm i --frozen-lockfile
+
+      - name: Run 'setup-system.sh' script
+        # if: matrix.platform == 'ubuntu-latest' || matrix.platform == 'macos-latest'
+        run: ./.github/scripts/setup-system.sh mobile # TODO: Mobile flag
+
+      # - name: Run 'setup-system.ps1' script
+      #   if: matrix.platform == 'windows-latest'
+      #   run: ./.github/scripts/setup-system.ps1 -ci
+
+      - name: Generate Prisma client
+        uses: ./.github/actions/generate-prisma-client
+
+      - name: Prepare NDK dir for caching ( workaround for https://github.com/actions/virtual-environments/issues/1337 )
+        run: |
+          sudo mkdir -p /usr/local/lib/android/sdk/ndk
+          sudo chmod -R 777 /usr/local/lib/android/sdk/ndk
+          sudo chown -R $USER:$USER /usr/local/lib/android/sdk/ndk
+      
+      # - name: NDK Cache
+      #   id: ndk-cache
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: /usr/local/lib/android/sdk/ndk
+      #     key: ndk-cache-21.4.7075529-v2
+      
+      - name: Install NDK
+        if: steps.ndk-cache.outputs.cache-hit != 'true'
+        run: echo "y" | sudo /usr/local/lib/android/sdk/tools/bin/sdkmanager --install "ndk;21.4.7075529"
+
+      - name: Install workspace pnpm dependencies
+        run: pnpm i --frozen-lockfile
+      
+      - name: Install mobile pnpm dependencies
+        working-directory: ./apps/mobile
+        run: pnpm i --frozen-lockfile
+      
+      # - name: Generate Prisma client
+      #   uses: ./.github/actions/generate-prisma-client
+
+      # - name: Generate Prisma client
+      #   uses: ./.github/actions/generate-prisma-client
+
+      # Something is broke. This should be cached but that no worky.
+      # - name: Generate Prisma client
+      #   working-directory: core
+      #   # if: steps.cache-prisma.outputs.cache-hit != 'true'
+      #   shell: bash
+      #   run: cargo run -p prisma-cli --release -- generate
+      
+      - name: Build Android
+        working-directory: ./apps/mobile
+        run: eas build --platform android --local --non-interactive
+      
+      # TODO: Build for IOS once Apple Developer account is setup

--- a/.github/workflows/mobile-ci.yaml
+++ b/.github/workflows/mobile-ci.yaml
@@ -116,6 +116,9 @@ jobs:
       #   with:
       #     path: /usr/local/lib/android/sdk/ndk
       #     key: ndk-cache-21.4.7075529-v2
+
+      - name: plz work?
+        run: export CARGO_TARGET_DIR="$(pwd)/../../target"
       
       - name: Install NDK
         if: steps.ndk-cache.outputs.cache-hit != 'true'
@@ -129,12 +132,12 @@ jobs:
         run: pnpm i --frozen-lockfile
       
       # TODO: Debug
-      - name: Why Prisma????
-        run: ls ./core/src
-      - name: Cargo fetch
-        run: cargo fetch
-      - name: Check core
-        run: cargo check -p sd-core --release
+      # - name: Why Prisma????
+      #   run: ls ./core/src
+      # - name: Cargo fetch
+      #   run: cargo fetch
+      # - name: Check core
+      #   run: cargo check -p sd-core --release
       
       - name: Build Android
         working-directory: ./apps/mobile

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,68 @@
+name: Rust CI
+
+on:
+  pull_request:
+    paths:
+      - '**.rs'
+  push:
+    branches:
+      - main
+      - mobile-ci # TEMP
+    paths:
+      - '**.rs'
+  workflow_dispatch:
+
+jobs:
+  rustfmt:
+    name: Rust Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt
+      
+      - name: Cache Rust dependencies
+        uses: ./.github/actions/cache-rust-deps
+
+      - name: Run 'setup-system.sh' script
+        run: ./.github/scripts/setup-system.sh
+
+      - name: Generate Prisma client
+        uses: ./.github/actions/generate-prisma-client
+
+      - name: Run rustfmt
+        run: cargo fmt --all -- --check
+  
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+          components: clippy
+
+      - name: Cache Rust dependencies
+        uses: ./.github/actions/cache-rust-deps
+
+      - name: Run 'setup-system.sh' script
+        run: ./.github/scripts/setup-system.sh
+
+      - name: Generate Prisma client
+        uses: ./.github/actions/generate-prisma-client
+
+      - name: Run Clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features --release

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - mobile-ci # TEMP
     paths:
       - '**.rs'
   workflow_dispatch:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,9 @@ on:
       - '**.rs'
   workflow_dispatch:
 
+env:
+  SPACEDRIVE_CUSTOM_APT_FLAGS: --no-install-recommends
+
 jobs:
   rustfmt:
     name: Rust Format


### PR DESCRIPTION
Add a CI process for running a Typescript typecheck + ESLint and then an `eas build` in CI.

This PR currently only does Android builds because we need to have an Apple Developer account to build IOS. This can be easily added at a later date.