### PR TITLE
Startup error handling + refactor @sd/client + fix Sentry config

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -18,8 +18,7 @@
 		"@rspc/react": "^0.0.0-main-7c0a67c1",
 		"@sd/config": "workspace:*",
 		"@tanstack/react-query": "^4.12.0",
-		"valtio": "^1.7.4",
-		"valtio-persist": "^1.0.2"
+		"valtio": "^1.7.4"
 	},
 	"devDependencies": {
 		"@types/react": "^18.0.21",

--- a/packages/client/src/stores/themeStore.ts
+++ b/packages/client/src/stores/themeStore.ts
@@ -1,26 +1,12 @@
-import { proxy, useSnapshot } from 'valtio';
-import proxyWithPersist, { PersistStrategy, ProxyPersistStorageEngine } from 'valtio-persist';
+import { useSnapshot } from 'valtio';
 
-const storage: ProxyPersistStorageEngine = {
-	getItem: (name) => window.localStorage.getItem(name),
-	setItem: (name, value) => window.localStorage.setItem(name, value),
-	removeItem: (name) => window.localStorage.removeItem(name),
-	getAllKeys: () => Object.keys(window.localStorage)
-};
+import { valtioPersist } from './util';
 
-const appThemeStore = proxyWithPersist({
-	// must be unique, files/paths will be created with this prefix
-	name: 'appTheme',
-	version: 0,
-	initialState: {
-		themeName: 'vanilla',
-		themeMode: 'light' as 'light' | 'dark',
-		syncThemeWithSystem: false,
-		hueValue: null as number | null
-	},
-	persistStrategies: PersistStrategy.SingleFile,
-	migrations: {},
-	getStorage: () => storage
+const appThemeStore = valtioPersist('appTheme', {
+	themeName: 'vanilla',
+	themeMode: 'light' as 'light' | 'dark',
+	syncThemeWithSystem: false,
+	hueValue: null as number | null
 });
 
 export function useThemeStore() {

--- a/packages/client/src/stores/util.ts
+++ b/packages/client/src/stores/util.ts
@@ -1,5 +1,4 @@
 import { proxy, subscribe } from 'valtio';
-import { ProxyPersistStorageEngine } from 'valtio-persist';
 
 export function resetStore<T extends Record<string, any>, E extends Record<string, any>>(
 	store: T,
@@ -10,13 +9,6 @@ export function resetStore<T extends Record<string, any>, E extends Record<strin
 		store[key] = defaults[key];
 	}
 }
-
-export const storageEngine: ProxyPersistStorageEngine = {
-	getItem: (name) => window.localStorage.getItem(name),
-	setItem: (name, value) => window.localStorage.setItem(name, value),
-	removeItem: (name) => window.localStorage.removeItem(name),
-	getAllKeys: () => Object.keys(window.localStorage)
-};
 
 // The `valtio-persist` library is not working so this is a small alternative for us to use.
 export function valtioPersist<T extends object>(localStorageKey: string, initialObject?: T): T {

--- a/packages/interface/src/App.tsx
+++ b/packages/interface/src/App.tsx
@@ -1,6 +1,10 @@
 import '@fontsource/inter/variable.css';
 import { LibraryContextProvider, queryClient, useDebugState } from '@sd/client';
-import { init } from '@sentry/browser';
+import {
+	Dedupe as DedupeIntegration,
+	HttpContext as HttpContextIntegration,
+	init
+} from '@sentry/browser';
 import { QueryClientProvider, defaultContext } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import dayjs from 'dayjs';
@@ -19,7 +23,10 @@ dayjs.extend(relativeTime);
 dayjs.extend(duration);
 
 init({
-	dsn: 'https://2fb2450aabb9401b92f379b111402dbc@o1261130.ingest.sentry.io/4504053670412288'
+	dsn: 'https://2fb2450aabb9401b92f379b111402dbc@o1261130.ingest.sentry.io/4504053670412288',
+	environment: import.meta.env.MODE,
+	defaultIntegrations: false,
+	integrations: [new HttpContextIntegration(), new DedupeIntegration()]
 });
 
 export default function SpacedriveInterface() {

--- a/packages/interface/src/ErrorFallback.tsx
+++ b/packages/interface/src/ErrorFallback.tsx
@@ -8,7 +8,6 @@ export function ErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
 	const version = 'unknown'; // TODO: Embed the version into the frontend via ENV var when compiled so we can use it here.
 
 	const onClick = () => {
-		console.log('TODO', error);
 		captureException(error);
 		// platform.openLink(
 		// 	`https://github.com/spacedriveapp/spacedrive/issues/new?assignees=&labels=kind%2Fbug%2Cstatus%2Fneeds-triage&template=bug_report.yml&logs=${encodeURIComponent(


### PR DESCRIPTION
Changes:
 - [x] Fix Sentry sending all errors -> Errors should only send if you press the report button -> Moved onto #443 
 - [x] Mark Sentry errors as development or production correctly -> Moved onto #443 
 - [x] Refactor `@sd/client` to allow for sharing more code between desktop and mobile -> Moved onto #443 
 - [ ] Handle Rust errors on startup -> Show a UI instead of just silently dieing
 - [ ] DMG Background
