### PR TITLE
[ENG-262] Key Manager Integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5202,6 +5202,7 @@ dependencies = [
  "dashmap",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
+ "rspc",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5199,6 +5199,7 @@ dependencies = [
  "aes-gcm",
  "argon2",
  "chacha20poly1305",
+ "dashmap",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5204,6 +5204,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rspc",
  "serde",
+ "serde-big-array",
  "serde_json",
  "specta 0.0.4",
  "thiserror",
@@ -5358,6 +5359,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3323f09a748af288c3dc2474ea6803ee81f118321775bffa3ac8f7e65c5e90e7"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5205,6 +5205,7 @@ dependencies = [
  "rspc",
  "serde",
  "serde_json",
+ "specta 0.0.4",
  "thiserror",
  "uuid 1.2.1",
  "zeroize",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -54,7 +54,7 @@ image = "0.24.4"
 webp = "0.2.2"
 ffmpeg-next = { version = "5.1.1", optional = true, features = [] }
 sd-ffmpeg = { path = "../crates/ffmpeg", optional = true }
-sd-crypto = { path = "../crates/crypto" }
+sd-crypto = { path = "../crates/crypto", features = ["rspc"] }
 sd-file-ext = { path = "../crates/file-ext"}
 fs_extra = "1.2.0"
 tracing = "0.1.36"

--- a/core/prisma/migrations/20221102114916_key_update/migration.sql
+++ b/core/prisma/migrations/20221102114916_key_update/migration.sql
@@ -1,0 +1,24 @@
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_key" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "uuid" TEXT NOT NULL,
+    "name" TEXT,
+    "default" BOOLEAN NOT NULL DEFAULT false,
+    "date_created" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    "algorithm" BLOB NOT NULL,
+    "hashing_algorithm" BLOB NOT NULL,
+    "salt" BLOB NOT NULL,
+    "content_salt" BLOB NOT NULL,
+    "master_key" BLOB NOT NULL,
+    "master_key_nonce" BLOB NOT NULL,
+    "key_nonce" BLOB NOT NULL,
+    "key" BLOB NOT NULL,
+    "automount" BOOLEAN NOT NULL DEFAULT false
+);
+INSERT INTO "new_key" ("algorithm", "content_salt", "date_created", "default", "hashing_algorithm", "id", "key", "key_nonce", "master_key", "master_key_nonce", "name", "salt", "uuid") SELECT "algorithm", "content_salt", "date_created", "default", "hashing_algorithm", "id", "key", "key_nonce", "master_key", "master_key_nonce", "name", "salt", "uuid" FROM "key";
+DROP TABLE "key";
+ALTER TABLE "new_key" RENAME TO "key";
+CREATE UNIQUE INDEX "key_uuid_key" ON "key"("uuid");
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/core/prisma/schema.prisma
+++ b/core/prisma/schema.prisma
@@ -196,7 +196,7 @@ model Key {
   // is this key the default for encryption?
   // was not tagged as unique as i'm not too sure if PCR will handle it
   // can always be tagged as unique, the keys API will need updating to use `find_unique()`
-  default      Boolean
+  default      Boolean @default(false)
   // nullable if concealed for security
   date_created DateTime? @default(now())
   // encryption algorithm used to encrypt the key
@@ -216,7 +216,7 @@ model Key {
   // the *encrypted* key
   key Bytes
 
-  automount Boolean
+  automount Boolean @default(false)
 
   objects    Object[]
   file_paths FilePath[]

--- a/core/prisma/schema.prisma
+++ b/core/prisma/schema.prisma
@@ -194,6 +194,8 @@ model Key {
   // the name that the user sets
   name         String?
   // is this key the default for encryption?
+  // was not tagged as unique as i'm not too sure if PCR will handle it
+  // can always be tagged as unique, the keys API will need updating to use `find_unique()`
   default      Boolean
   // nullable if concealed for security
   date_created DateTime? @default(now())

--- a/core/prisma/schema.prisma
+++ b/core/prisma/schema.prisma
@@ -192,7 +192,7 @@ model Key {
   // uuid to identify the key
   uuid         String    @unique
   // the name that the user sets
-  name         String
+  name         String?
   // is this key the default for encryption?
   default      Boolean
   // nullable if concealed for security

--- a/core/prisma/schema.prisma
+++ b/core/prisma/schema.prisma
@@ -192,7 +192,7 @@ model Key {
   // uuid to identify the key
   uuid         String    @unique
   // the name that the user sets
-  name         String?
+  name         String
   // is this key the default for encryption?
   default      Boolean
   // nullable if concealed for security

--- a/core/prisma/schema.prisma
+++ b/core/prisma/schema.prisma
@@ -214,6 +214,8 @@ model Key {
   // the *encrypted* key
   key Bytes
 
+  automount Boolean
+
   objects    Object[]
   file_paths FilePath[]
 

--- a/core/src/api/keys.rs
+++ b/core/src/api/keys.rs
@@ -153,8 +153,12 @@ pub(crate) fn mount() -> RouterBuilder {
 					.await?)
 			})
 		})
-		.library_query("add", |t| {
+		.library_mutation("add", |t| {
 			t(|_, args: KeyAddArgs, library| async move {
+				// TODO(jake): remove this once we are able to get the master password from the UI
+				// use the designated route for setting it
+				library.key_manager.lock().await.set_master_password(Protected::new(b"password".to_vec())).unwrap();
+
 				let algorithm = match &args.algorithm as &str {
 					"XChaCha20Poly1305" => Algorithm::XChaCha20Poly1305,
 					"Aes256Gcm" => Algorithm::Aes256Gcm,

--- a/core/src/api/keys.rs
+++ b/core/src/api/keys.rs
@@ -1,0 +1,10 @@
+use super::{utils::LibraryRequest, RouterBuilder};
+
+pub(crate) fn mount() -> RouterBuilder {
+	RouterBuilder::new()
+		.library_query("list", |t| {
+			t(
+				|_, _: (), library| async move { Ok(library.key_manager.lock().await.dump_keystore()) },
+			)
+		})
+}

--- a/core/src/api/keys.rs
+++ b/core/src/api/keys.rs
@@ -193,20 +193,6 @@ pub(crate) fn mount() -> RouterBuilder {
 		// this also mounts the key
 		.library_mutation("add", |t| {
 			t(|_, args: KeyAddArgs, library| async move {
-				// let algorithm = match &args.algorithm as &str {
-				// 	"XChaCha20Poly1305" => Algorithm::XChaCha20Poly1305,
-				// 	"Aes256Gcm" => Algorithm::Aes256Gcm,
-				// 	_ => unreachable!(),
-				// };
-
-				// // we need to get parameters from somewhere, possibly tie them to the hashing algorithm the user selects
-				// // we're just mapping bcrypt to argon2id temporarily as i'm unsure whether or not we're actually adding bcrypt
-				// let hashing_algorithm = match &args.hashing_algorithm as &str {
-				// 	"Argon2id" => HashingAlgorithm::Argon2id(Params::Standard),
-				// 	"Bcrypt" => HashingAlgorithm::Argon2id(Params::Standard),
-				// 	_ => unreachable!(),
-				// };
-
 				// register the key with the keymanager
 				let uuid = library.key_manager.add_to_keystore(
 					Protected::new(args.key.as_bytes().to_vec()),

--- a/core/src/api/keys.rs
+++ b/core/src/api/keys.rs
@@ -163,6 +163,12 @@ pub(crate) fn mount() -> RouterBuilder {
 					.await?)
 			})
 		})
+		.library_mutation("unmountAll", |t| {
+			t(|_, _: (), library| async move {
+				library.key_manager.lock().await.empty_keymount();
+				Ok(())
+			})
+		})
 		.library_mutation("add", |t| {
 			t(|_, args: KeyAddArgs, library| async move {
 				// TODO(jake): remove this once we are able to get the master password from the UI

--- a/core/src/api/keys.rs
+++ b/core/src/api/keys.rs
@@ -8,7 +8,7 @@ use sd_crypto::{
 use serde::Deserialize;
 use specta::Type;
 
-use crate::prisma::key;
+use crate::{prisma::key, invalidate_query};
 
 use super::{utils::LibraryRequest, RouterBuilder};
 
@@ -160,6 +160,7 @@ pub(crate) fn mount() -> RouterBuilder {
 		.library_mutation("unmountAll", |t| {
 			t(|_, _: (), library| async move {
 				library.key_manager.empty_keymount();
+				invalidate_query!(library, "keys.list");
 				Ok(())
 			})
 		})
@@ -201,7 +202,7 @@ pub(crate) fn mount() -> RouterBuilder {
 					.access_keystore(uuid)
 					.unwrap();
 
-				library
+			library
 					.db
 					.key()
 					.create(

--- a/core/src/api/keys.rs
+++ b/core/src/api/keys.rs
@@ -1,10 +1,6 @@
 use std::str::FromStr;
 
-use sd_crypto::{
-	crypto::stream::Algorithm,
-	keys::hashing::HashingAlgorithm,
-	Protected,
-};
+use sd_crypto::{crypto::stream::Algorithm, keys::hashing::HashingAlgorithm, Protected};
 use serde::Deserialize;
 use specta::Type;
 
@@ -28,7 +24,7 @@ pub struct KeyNameUpdateArgs {
 pub(crate) fn mount() -> RouterBuilder {
 	RouterBuilder::new()
 		.library_query("list", |t| {
-			t(|_, _: (), library| async move { Ok(library.key_manager.dump_keystore()) },)
+			t(|_, _: (), library| async move { Ok(library.key_manager.dump_keystore()) })
 		})
 		// this is so we can show the key as mounted in the UI
 		.library_query("listMounted", |t| {

--- a/core/src/api/keys.rs
+++ b/core/src/api/keys.rs
@@ -35,12 +35,12 @@ pub(crate) fn mount() -> RouterBuilder {
 		// this is so we can show the key as mounted in the UI
 		.library_query("listMounted", |t| {
 			t(|_, _: (), library| async move {
-				Ok(library.key_manager.lock().await.get_mounted_uuids())
+				Ok(library.key_manager.get_mounted_uuids())
 			})
 		})
 		.library_query("mount", |t| {
 			t(|_, key_uuid: uuid::Uuid, library| async move {
-				library.key_manager.lock().await.mount(key_uuid).unwrap();
+				library.key_manager.mount(key_uuid).unwrap();
 				// we also need to dispatch jobs that automatically decrypt preview media and metadata here
 
 				Ok(())
@@ -63,7 +63,7 @@ pub(crate) fn mount() -> RouterBuilder {
 		})
 		.library_query("unmount", |t| {
 			t(|_, key_uuid: uuid::Uuid, library| async move {
-				library.key_manager.lock().await.unmount(key_uuid).unwrap();
+				library.key_manager.unmount(key_uuid).unwrap();
 				// we also need to delete all in-memory decrypted data associated with this key
 
 				Ok(())
@@ -78,8 +78,6 @@ pub(crate) fn mount() -> RouterBuilder {
 
 				library
 					.key_manager
-					.lock()
-					.await
 					.set_master_password(Protected::new(password.as_bytes().to_vec()))
 					.unwrap();
 
@@ -93,8 +91,6 @@ pub(crate) fn mount() -> RouterBuilder {
 				for key in automount {
 					library
 						.key_manager
-						.lock()
-						.await
 						.mount(uuid::Uuid::from_str(&key.uuid).unwrap())
 						.unwrap();
 				}
@@ -106,8 +102,6 @@ pub(crate) fn mount() -> RouterBuilder {
 			t(|_, key_uuid: uuid::Uuid, library| async move {
 				library
 					.key_manager
-					.lock()
-					.await
 					.set_default(key_uuid)
 					.unwrap();
 
@@ -165,7 +159,7 @@ pub(crate) fn mount() -> RouterBuilder {
 		})
 		.library_mutation("unmountAll", |t| {
 			t(|_, _: (), library| async move {
-				library.key_manager.lock().await.empty_keymount();
+				library.key_manager.empty_keymount();
 				Ok(())
 			})
 		})
@@ -175,8 +169,6 @@ pub(crate) fn mount() -> RouterBuilder {
 				// use the designated route for setting it
 				library
 					.key_manager
-					.lock()
-					.await
 					.set_master_password(Protected::new(b"password".to_vec()))
 					.unwrap();
 
@@ -197,8 +189,6 @@ pub(crate) fn mount() -> RouterBuilder {
 				// register the key with the keymanager
 				let uuid = library
 					.key_manager
-					.lock()
-					.await
 					.add_to_keystore(
 						Protected::new(args.key.as_bytes().to_vec()),
 						algorithm,
@@ -208,8 +198,6 @@ pub(crate) fn mount() -> RouterBuilder {
 
 				let stored_key = library
 					.key_manager
-					.lock()
-					.await
 					.access_keystore(uuid)
 					.unwrap();
 
@@ -234,7 +222,7 @@ pub(crate) fn mount() -> RouterBuilder {
 					.await?;
 
 				// mount the key
-				library.key_manager.lock().await.mount(uuid).unwrap();
+				library.key_manager.mount(uuid).unwrap();
 
 				Ok(())
 			})

--- a/core/src/api/keys.rs
+++ b/core/src/api/keys.rs
@@ -81,6 +81,7 @@ pub(crate) fn mount() -> RouterBuilder {
 				// we also need to delete all in-memory decrypted data associated with this key
 				invalidate_query!(library, "keys.list");
 				invalidate_query!(library, "keys.listMounted");
+				invalidate_query!(library, "keys.getDefault");
 				Ok(())
 			})
 		})

--- a/core/src/api/keys.rs
+++ b/core/src/api/keys.rs
@@ -4,7 +4,20 @@ pub(crate) fn mount() -> RouterBuilder {
 	RouterBuilder::new()
 		.library_query("list", |t| {
 			t(
-				|_, _: (), library| async move { Ok(library.key_manager.lock().await.dump_keystore()) },
+				|_, _: (), library| async move { Ok(library.db.key().find_many(vec![]).exec().await?) },
 			)
+		})
+		.library_query("listMounted", |t| {
+			t(
+				|_, _: (), library| async move { Ok(library.key_manager.lock().await.get_mounted_uuids()) },
+			)
+		})
+		.library_query("mount", |t| {
+			t(|_, key_uuid: uuid::Uuid, library| async move {
+				library.key_manager.lock().await.mount(key_uuid).unwrap();
+				// we also need to dispatch jobs that automatically decrypt preview media and metadata here
+
+				Ok(())
+			})
 		})
 }

--- a/core/src/api/keys.rs
+++ b/core/src/api/keys.rs
@@ -28,9 +28,7 @@ pub struct KeyNameUpdateArgs {
 pub(crate) fn mount() -> RouterBuilder {
 	RouterBuilder::new()
 		.library_query("list", |t| {
-			t(
-				|_, _: (), library| async move { Ok(library.db.key().find_many(vec![]).exec().await?) },
-			)
+			t(|_, _: (), library| async move { Ok(library.key_manager.dump_keystore()) },)
 		})
 		// this is so we can show the key as mounted in the UI
 		.library_query("listMounted", |t| {

--- a/core/src/api/keys.rs
+++ b/core/src/api/keys.rs
@@ -167,7 +167,7 @@ pub(crate) fn mount() -> RouterBuilder {
 					.key()
 					.find_first(vec![key::default::equals(true)])
 					.exec()
-					.await?)
+					.await?.unwrap().uuid)
 			})
 		})
 		.library_mutation("unmountAll", |t| {

--- a/core/src/api/keys.rs
+++ b/core/src/api/keys.rs
@@ -93,7 +93,7 @@ pub(crate) fn mount() -> RouterBuilder {
 
 				library
 					.key_manager
-					.set_master_password(Protected::new(password.as_bytes().to_vec()))?;
+					.set_master_password(Protected::new(password.as_bytes().to_vec()));
 
 				let automount = library
 					.db

--- a/core/src/api/keys.rs
+++ b/core/src/api/keys.rs
@@ -1,4 +1,8 @@
-use sd_crypto::{Protected, crypto::stream::Algorithm, keys::hashing::{HashingAlgorithm, Params}};
+use sd_crypto::{
+	crypto::stream::Algorithm,
+	keys::hashing::{HashingAlgorithm, Params},
+	Protected,
+};
 use serde::Deserialize;
 use specta::Type;
 
@@ -22,9 +26,9 @@ pub(crate) fn mount() -> RouterBuilder {
 		})
 		// this is so we can show the key as mounted in the UI
 		.library_query("listMounted", |t| {
-			t(
-				|_, _: (), library| async move { Ok(library.key_manager.lock().await.get_mounted_uuids()) },
-			)
+			t(|_, _: (), library| async move {
+				Ok(library.key_manager.lock().await.get_mounted_uuids())
+			})
 		})
 		.library_query("mount", |t| {
 			t(|_, key_uuid: uuid::Uuid, library| async move {
@@ -47,24 +51,61 @@ pub(crate) fn mount() -> RouterBuilder {
 				// need to add master password checks to make sure it's correct
 				// this can either unwrap&fail, or we can return the error. either way, the user will have to correct this
 				// by entering the correct password
-				library.key_manager.lock().await.set_master_password(Protected::new(password.as_bytes().to_vec())).unwrap();
+				library
+					.key_manager
+					.lock()
+					.await
+					.set_master_password(Protected::new(password.as_bytes().to_vec()))
+					.unwrap();
 
 				Ok(())
 			})
 		})
 		.library_query("setDefault", |t| {
 			t(|_, key_uuid: uuid::Uuid, library| async move {
-				library.key_manager.lock().await.set_default(key_uuid).unwrap();
+				library
+					.key_manager
+					.lock()
+					.await
+					.set_default(key_uuid)
+					.unwrap();
 
 				// if an old default is set, unset it as the default
-				let old_default = library.db.key().find_first(vec![key::default::equals(true)]).exec().await?;
+				let old_default = library
+					.db
+					.key()
+					.find_first(vec![key::default::equals(true)])
+					.exec()
+					.await?;
 				if let Some(key) = old_default {
-					library.db.key().update(key::uuid::equals(key.uuid), vec![key::SetParam::SetDefault(false)]).exec().await?;
+					library
+						.db
+						.key()
+						.update(
+							key::uuid::equals(key.uuid),
+							vec![key::SetParam::SetDefault(false)],
+						)
+						.exec()
+						.await?;
 				}
 
 				// we allow this to error as the new default **SHOULD** exist
-				let new_default = library.db.key().find_unique(key::uuid::equals(key_uuid.to_string())).exec().await?.unwrap();
-				library.db.key().update(key::uuid::equals(new_default.uuid), vec![key::SetParam::SetDefault(true)]).exec().await?;
+				let new_default = library
+					.db
+					.key()
+					.find_unique(key::uuid::equals(key_uuid.to_string()))
+					.exec()
+					.await?
+					.unwrap();
+				library
+					.db
+					.key()
+					.update(
+						key::uuid::equals(new_default.uuid),
+						vec![key::SetParam::SetDefault(true)],
+					)
+					.exec()
+					.await?;
 
 				Ok(())
 			})
@@ -72,8 +113,13 @@ pub(crate) fn mount() -> RouterBuilder {
 		.library_query("getDefault", |t| {
 			t(|_, _: (), library| async move {
 				// `find_first` should be okay here as only one default key should ever be set
-				// this is also stored in the keymanager but it's probably easier to get it from the DB				
-				Ok(library.db.key().find_first(vec![key::default::equals(true)]).exec().await?)
+				// this is also stored in the keymanager but it's probably easier to get it from the DB
+				Ok(library
+					.db
+					.key()
+					.find_first(vec![key::default::equals(true)])
+					.exec()
+					.await?)
 			})
 		})
 		.library_query("add", |t| {
@@ -81,7 +127,7 @@ pub(crate) fn mount() -> RouterBuilder {
 				let algorithm = match &args.algorithm as &str {
 					"XChaCha20Poly1305" => Algorithm::XChaCha20Poly1305,
 					"Aes256Gcm" => Algorithm::Aes256Gcm,
-					_ => unreachable!()
+					_ => unreachable!(),
 				};
 
 				// we need to get parameters from somewhere, possibly a global config setting - they're just set to standard for now
@@ -89,16 +135,50 @@ pub(crate) fn mount() -> RouterBuilder {
 				let hashing_algorithm = match &args.hashing_algorithm as &str {
 					"Argon2id" => HashingAlgorithm::Argon2id(Params::Standard),
 					"Bcrypt" => HashingAlgorithm::Argon2id(Params::Standard),
-					_ => unreachable!()
+					_ => unreachable!(),
 				};
 
 				// register the key with the keymanager
-				let uuid = library.key_manager.lock().await.add_to_keystore(Protected::new(args.key.as_bytes().to_vec()), algorithm, hashing_algorithm).unwrap();
+				let uuid = library
+					.key_manager
+					.lock()
+					.await
+					.add_to_keystore(
+						Protected::new(args.key.as_bytes().to_vec()),
+						algorithm,
+						hashing_algorithm,
+					)
+					.unwrap();
+
+				let stored_key = library
+					.key_manager
+					.lock()
+					.await
+					.access_keystore(uuid)
+					.unwrap();
+
+				library
+					.db
+					.key()
+					.create(
+						uuid.to_string(),
+						"Key".to_string(),
+						false,
+						algorithm.serialize().to_vec(),
+						hashing_algorithm.serialize().to_vec(),
+						stored_key.salt.to_vec(),
+						stored_key.content_salt.to_vec(),
+						stored_key.master_key.to_vec(),
+						stored_key.master_key_nonce.to_vec(),
+						stored_key.key_nonce.to_vec(),
+						stored_key.key.to_vec(),
+						vec![],
+					)
+					.exec()
+					.await?;
 
 				// mount the key
 				library.key_manager.lock().await.mount(uuid).unwrap();
-
-				// need to add the key to prisma too
 
 				Ok(())
 			})

--- a/core/src/api/keys.rs
+++ b/core/src/api/keys.rs
@@ -151,16 +151,15 @@ pub(crate) fn mount() -> RouterBuilder {
 				// if the new default key is stored in the library, update it as the default
 				if let Some(default) = new_default {
 					library
-					.db
-					.key()
-					.update(
-						key::uuid::equals(default.uuid),
-						vec![key::SetParam::SetDefault(true)],
-					)
-					.exec()
-					.await?;
+						.db
+						.key()
+						.update(
+							key::uuid::equals(default.uuid),
+							vec![key::SetParam::SetDefault(true)],
+						)
+						.exec()
+						.await?;
 				}
-
 
 				invalidate_query!(library, "keys.getDefault");
 				Ok(())

--- a/core/src/api/keys.rs
+++ b/core/src/api/keys.rs
@@ -83,10 +83,20 @@ pub(crate) fn mount() -> RouterBuilder {
 					.set_master_password(Protected::new(password.as_bytes().to_vec()))
 					.unwrap();
 
-				let automount = library.db.key().find_many(vec![key::automount::equals(true)]).exec().await?;
+				let automount = library
+					.db
+					.key()
+					.find_many(vec![key::automount::equals(true)])
+					.exec()
+					.await?;
 
 				for key in automount {
-					library.key_manager.lock().await.mount(uuid::Uuid::from_str(&key.uuid).unwrap()).unwrap();
+					library
+						.key_manager
+						.lock()
+						.await
+						.mount(uuid::Uuid::from_str(&key.uuid).unwrap())
+						.unwrap();
 				}
 
 				Ok(())
@@ -157,7 +167,12 @@ pub(crate) fn mount() -> RouterBuilder {
 			t(|_, args: KeyAddArgs, library| async move {
 				// TODO(jake): remove this once we are able to get the master password from the UI
 				// use the designated route for setting it
-				library.key_manager.lock().await.set_master_password(Protected::new(b"password".to_vec())).unwrap();
+				library
+					.key_manager
+					.lock()
+					.await
+					.set_master_password(Protected::new(b"password".to_vec()))
+					.unwrap();
 
 				let algorithm = match &args.algorithm as &str {
 					"XChaCha20Poly1305" => Algorithm::XChaCha20Poly1305,

--- a/core/src/api/mod.rs
+++ b/core/src/api/mod.rs
@@ -35,8 +35,8 @@ pub struct Ctx {
 }
 
 mod files;
-mod keys;
 mod jobs;
+mod keys;
 mod libraries;
 mod locations;
 mod normi;

--- a/core/src/api/mod.rs
+++ b/core/src/api/mod.rs
@@ -35,6 +35,7 @@ pub struct Ctx {
 }
 
 mod files;
+mod keys;
 mod jobs;
 mod libraries;
 mod locations;
@@ -85,6 +86,7 @@ pub(crate) fn mount() -> Arc<Router> {
 		.merge("library.", libraries::mount())
 		.merge("volumes.", volumes::mount())
 		.merge("tags.", tags::mount())
+		.merge("keys.", tags::mount())
 		.merge("locations.", locations::mount())
 		.merge("files.", files::mount())
 		.merge("jobs.", jobs::mount())

--- a/core/src/api/mod.rs
+++ b/core/src/api/mod.rs
@@ -86,7 +86,7 @@ pub(crate) fn mount() -> Arc<Router> {
 		.merge("library.", libraries::mount())
 		.merge("volumes.", volumes::mount())
 		.merge("tags.", tags::mount())
-		.merge("keys.", tags::mount())
+		.merge("keys.", keys::mount())
 		.merge("locations.", locations::mount())
 		.merge("files.", files::mount())
 		.merge("jobs.", jobs::mount())

--- a/core/src/library/library_ctx.rs
+++ b/core/src/library/library_ctx.rs
@@ -1,7 +1,6 @@
 use crate::job::DynJob;
 use sd_crypto::keys::keymanager::KeyManager;
 use std::sync::Arc;
-use tokio::sync::Mutex;
 use tracing::warn;
 use uuid::Uuid;
 
@@ -19,7 +18,7 @@ pub struct LibraryContext {
 	/// db holds the database client for the current library.
 	pub db: Arc<PrismaClient>,
 	/// key manager that provides encryption keys to functions that require them
-	pub key_manager: Arc<Mutex<KeyManager>>,
+	pub key_manager: Arc<KeyManager>,
 	/// node_local_id holds the local ID of the node which is running the library.
 	pub node_local_id: i32,
 	/// node_context holds the node context for the node which this library is running on.

--- a/core/src/library/library_manager.rs
+++ b/core/src/library/library_manager.rs
@@ -59,7 +59,7 @@ pub enum LibraryManagerError {
 	#[error("Failed to run seeder: {0}")]
 	Seeder(#[from] SeederError),
 	#[error("failed to initialise the key manager")]
-	KeyManager(#[from] sd_crypto::Error)
+	KeyManager(#[from] sd_crypto::Error),
 }
 
 impl From<LibraryManagerError> for rspc::Error {
@@ -119,12 +119,10 @@ pub async fn create_keymanager(client: &PrismaClient) -> Result<KeyManager, Libr
 	}
 
 	////!!!! THIS IS FOR TESTING ONLY, REMOVE IT ONCE WE HAVE THE UI IN PLACE
-	key_manager
-		.set_master_password(Protected::new(b"password".to_vec()))?;
-	
+	key_manager.set_master_password(Protected::new(b"password".to_vec()))?;
+
 	Ok(key_manager)
 }
-
 
 impl LibraryManager {
 	pub(crate) async fn new(

--- a/core/src/library/library_manager.rs
+++ b/core/src/library/library_manager.rs
@@ -15,7 +15,8 @@ use sd_crypto::{
 		hashing::HashingAlgorithm,
 		keymanager::{KeyManager, StoredKey},
 	},
-	primitives::to_array, Protected,
+	primitives::to_array,
+	Protected,
 };
 use std::{
 	env, fs, io,
@@ -84,7 +85,9 @@ pub async fn create_keymanager(client: &PrismaClient) -> Result<KeyManager, Seed
 	}
 
 	////!!!! THIS IS FOR TESTING ONLY, REMOVE IT ONCE WE HAVE THE UI IN PLACE
-	key_manager.set_master_password(Protected::new(b"password".to_vec())).unwrap();
+	key_manager
+		.set_master_password(Protected::new(b"password".to_vec()))
+		.unwrap();
 
 	Ok(key_manager)
 }

--- a/core/src/library/library_manager.rs
+++ b/core/src/library/library_manager.rs
@@ -120,7 +120,7 @@ pub async fn create_keymanager(client: &PrismaClient) -> Result<KeyManager, Libr
 
 	////!!!! THIS IS FOR TESTING ONLY, REMOVE IT ONCE WE HAVE THE UI IN PLACE
 	key_manager
-		.set_master_password(Protected::new(b"password".to_vec()));
+		.set_master_password(Protected::new(b"password".to_vec()))?;
 	
 	Ok(key_manager)
 }

--- a/core/src/library/library_manager.rs
+++ b/core/src/library/library_manager.rs
@@ -40,58 +40,6 @@ pub struct LibraryManager {
 	node_context: NodeContext,
 }
 
-pub async fn create_keymanager(client: &PrismaClient) -> Result<KeyManager, SeederError> {
-	// retrieve all stored keys from the DB
-	let key_manager = KeyManager::new(vec![], None);
-
-	let db_stored_keys = client.key().find_many(vec![]).exec().await?;
-
-	let mut default = Uuid::default();
-
-	// collect and serialize the stored keys
-	let stored_keys: Vec<StoredKey> = db_stored_keys
-		.iter()
-		.map(|d| {
-			let d = d.clone();
-			let uuid = uuid::Uuid::from_str(&d.uuid).unwrap();
-
-			if d.default {
-				default = uuid;
-			}
-
-			StoredKey {
-				uuid,
-				salt: to_array(d.salt).unwrap(),
-				algorithm: Algorithm::deserialize(to_array(d.algorithm).unwrap()).unwrap(),
-				content_salt: to_array(d.content_salt).unwrap(),
-				master_key: to_array(d.master_key).unwrap(),
-				master_key_nonce: d.master_key_nonce,
-				key_nonce: d.key_nonce,
-				key: d.key,
-				hashing_algorithm: HashingAlgorithm::deserialize(
-					to_array(d.hashing_algorithm).unwrap(),
-				)
-				.unwrap(),
-			}
-		})
-		.collect();
-
-	// insert all keys from the DB into the keymanager's keystore
-	key_manager.populate_keystore(stored_keys).unwrap();
-
-	// if any key had an associated default tag
-	if !default.is_nil() {
-		key_manager.set_default(default).unwrap();
-	}
-
-	////!!!! THIS IS FOR TESTING ONLY, REMOVE IT ONCE WE HAVE THE UI IN PLACE
-	key_manager
-		.set_master_password(Protected::new(b"password".to_vec()))
-		.unwrap();
-
-	Ok(key_manager)
-}
-
 #[derive(Error, Debug)]
 pub enum LibraryManagerError {
 	#[error("error saving or loading the config from the filesystem")]
@@ -110,6 +58,8 @@ pub enum LibraryManagerError {
 	InvalidDatabasePath(PathBuf),
 	#[error("Failed to run seeder: {0}")]
 	Seeder(#[from] SeederError),
+	#[error("failed to initialise the key manager")]
+	KeyManager(#[from] sd_crypto::Error)
 }
 
 impl From<LibraryManagerError> for rspc::Error {
@@ -121,6 +71,60 @@ impl From<LibraryManagerError> for rspc::Error {
 		)
 	}
 }
+
+pub async fn create_keymanager(client: &PrismaClient) -> Result<KeyManager, LibraryManagerError> {
+	// retrieve all stored keys from the DB
+	let key_manager = KeyManager::new(vec![], None);
+
+	let db_stored_keys = client.key().find_many(vec![]).exec().await?;
+
+	let mut default = Uuid::default();
+
+	// collect and serialize the stored keys
+	// shouldn't call unwrap so much here
+	let stored_keys: Vec<StoredKey> = db_stored_keys
+		.iter()
+		.map(|key| {
+			let key = key.clone();
+
+			let uuid = uuid::Uuid::from_str(&key.uuid).unwrap();
+
+			if key.default {
+				default = uuid;
+			}
+
+			StoredKey {
+				uuid,
+				salt: to_array(key.salt).unwrap(),
+				algorithm: Algorithm::deserialize(to_array(key.algorithm).unwrap()).unwrap(),
+				content_salt: to_array(key.content_salt).unwrap(),
+				master_key: to_array(key.master_key).unwrap(),
+				master_key_nonce: key.master_key_nonce,
+				key_nonce: key.key_nonce,
+				key: key.key,
+				hashing_algorithm: HashingAlgorithm::deserialize(
+					to_array(key.hashing_algorithm).unwrap(),
+				)
+				.unwrap(),
+			}
+		})
+		.collect();
+
+	// insert all keys from the DB into the keymanager's keystore
+	key_manager.populate_keystore(stored_keys)?;
+
+	// if any key had an associated default tag
+	if !default.is_nil() {
+		key_manager.set_default(default)?;
+	}
+
+	////!!!! THIS IS FOR TESTING ONLY, REMOVE IT ONCE WE HAVE THE UI IN PLACE
+	key_manager
+		.set_master_password(Protected::new(b"password".to_vec()));
+	
+	Ok(key_manager)
+}
+
 
 impl LibraryManager {
 	pub(crate) async fn new(

--- a/core/src/library/library_manager.rs
+++ b/core/src/library/library_manager.rs
@@ -15,7 +15,7 @@ use sd_crypto::{
 		hashing::HashingAlgorithm,
 		keymanager::{KeyManager, StoredKey},
 	},
-	primitives::to_array,
+	primitives::to_array, Protected,
 };
 use std::{
 	env, fs, io,
@@ -82,6 +82,9 @@ pub async fn create_keymanager(client: &PrismaClient) -> Result<KeyManager, Seed
 	if !default.is_nil() {
 		key_manager.set_default(default).unwrap();
 	}
+
+	////!!!! THIS IS FOR TESTING ONLY, REMOVE IT ONCE WE HAVE THE UI IN PLACE
+	key_manager.set_master_password(Protected::new(b"password".to_vec())).unwrap();
 
 	Ok(key_manager)
 }

--- a/core/src/library/library_manager.rs
+++ b/core/src/library/library_manager.rs
@@ -24,7 +24,7 @@ use std::{
 	sync::Arc,
 };
 use thiserror::Error;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::RwLock;
 use uuid::Uuid;
 
 use super::{LibraryConfig, LibraryConfigWrapped, LibraryContext};
@@ -41,7 +41,7 @@ pub struct LibraryManager {
 
 pub async fn create_keymanager(client: &PrismaClient) -> Result<KeyManager, SeederError> {
 	// retrieve all stored keys from the DB
-	let mut key_manager = KeyManager::new(vec![], None);
+	let key_manager = KeyManager::new(vec![], None);
 
 	let db_stored_keys = client.key().find_many(vec![]).exec().await?;
 
@@ -318,7 +318,7 @@ impl LibraryManager {
 		// Run seeders
 		indexer_rules_seeder(&db).await?;
 
-		let key_manager = Arc::new(Mutex::new(create_keymanager(&db).await?));
+		let key_manager = Arc::new(create_keymanager(&db).await?);
 
 		Ok(LibraryContext {
 			id,

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -32,3 +32,4 @@ serde_json = "1.0"
 
 uuid = { version = "1.1.2", features = ["v4", "serde"] }
 
+dashmap = "5.4.0"

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -33,3 +33,8 @@ serde_json = "1.0"
 uuid = { version = "1.1.2", features = ["v4", "serde"] }
 
 dashmap = "5.4.0"
+
+rspc = { workspace = true, optional = true }
+
+[features]
+rpsc = ["rspc"]

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -29,6 +29,7 @@ thiserror = "1.0.37"
 # metadata de/serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde-big-array = "0.4.1"
 
 uuid = { version = "1.1.2", features = ["v4", "serde"] }
 

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -35,6 +35,7 @@ uuid = { version = "1.1.2", features = ["v4", "serde"] }
 dashmap = "5.4.0"
 
 rspc = { workspace = true, optional = true }
+specta = { workspace = true }
 
 [features]
 rpsc = ["rspc"]

--- a/crates/crypto/src/crypto/stream.rs
+++ b/crates/crypto/src/crypto/stream.rs
@@ -7,7 +7,7 @@ use aead::{
 };
 use aes_gcm::Aes256Gcm;
 use chacha20poly1305::XChaCha20Poly1305;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use specta::Type;
 use zeroize::Zeroize;
 

--- a/crates/crypto/src/crypto/stream.rs
+++ b/crates/crypto/src/crypto/stream.rs
@@ -7,12 +7,14 @@ use aead::{
 };
 use aes_gcm::Aes256Gcm;
 use chacha20poly1305::XChaCha20Poly1305;
+use serde::{Serialize, Deserialize};
+use specta::Type;
 use zeroize::Zeroize;
 
 use crate::{primitives::BLOCK_SIZE, Error, Protected, Result};
 
 /// These are all possible algorithms that can be used for encryption and decryption
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Eq, PartialEq, Type, Serialize, Deserialize)]
 #[allow(clippy::use_self)]
 pub enum Algorithm {
 	XChaCha20Poly1305,

--- a/crates/crypto/src/crypto/stream.rs
+++ b/crates/crypto/src/crypto/stream.rs
@@ -9,7 +9,7 @@ use aes_gcm::Aes256Gcm;
 use chacha20poly1305::XChaCha20Poly1305;
 use zeroize::Zeroize;
 
-use crate::{Error, Result, primitives::BLOCK_SIZE, Protected};
+use crate::{primitives::BLOCK_SIZE, Error, Protected, Result};
 
 /// These are all possible algorithms that can be used for encryption and decryption
 #[derive(Clone, Copy, Eq, PartialEq)]
@@ -45,11 +45,7 @@ impl StreamEncryption {
 	///
 	/// The master key, a suitable nonce, and a specific algorithm should be provided.
 	#[allow(clippy::needless_pass_by_value)]
-	pub fn new(
-		key: Protected<[u8; 32]>,
-		nonce: &[u8],
-		algorithm: Algorithm,
-	) -> Result<Self> {
+	pub fn new(key: Protected<[u8; 32]>, nonce: &[u8], algorithm: Algorithm) -> Result<Self> {
 		if nonce.len() != algorithm.nonce_len() {
 			return Err(Error::NonceLengthMismatch);
 		}
@@ -103,12 +99,7 @@ impl StreamEncryption {
 	/// It requires a reader, a writer, and any AAD to go with it.
 	///
 	/// The AAD will be authenticated with each block of data.
-	pub fn encrypt_streams<R, W>(
-		mut self,
-		mut reader: R,
-		mut writer: W,
-		aad: &[u8],
-	) -> Result<()>
+	pub fn encrypt_streams<R, W>(mut self, mut reader: R, mut writer: W, aad: &[u8]) -> Result<()>
 	where
 		R: Read + Seek,
 		W: Write + Seek,
@@ -199,11 +190,7 @@ impl StreamDecryption {
 	///
 	/// The master key, nonce and algorithm that were used for encryption should be provided.
 	#[allow(clippy::needless_pass_by_value)]
-	pub fn new(
-		key: Protected<[u8; 32]>,
-		nonce: &[u8],
-		algorithm: Algorithm,
-	) -> Result<Self> {
+	pub fn new(key: Protected<[u8; 32]>, nonce: &[u8], algorithm: Algorithm) -> Result<Self> {
 		if nonce.len() != algorithm.nonce_len() {
 			return Err(Error::NonceLengthMismatch);
 		}
@@ -257,12 +244,7 @@ impl StreamDecryption {
 	/// It requires a reader, a writer, and any AAD that was used.
 	///
 	/// The AAD will be authenticated with each block of data - if the AAD doesn't match what was used during encryption, an error will be returned.
-	pub fn decrypt_streams<R, W>(
-		mut self,
-		mut reader: R,
-		mut writer: W,
-		aad: &[u8],
-	) -> Result<()>
+	pub fn decrypt_streams<R, W>(mut self, mut reader: R, mut writer: W, aad: &[u8]) -> Result<()>
 	where
 		R: Read + Seek,
 		W: Write + Seek,

--- a/crates/crypto/src/crypto/stream.rs
+++ b/crates/crypto/src/crypto/stream.rs
@@ -9,7 +9,7 @@ use aes_gcm::Aes256Gcm;
 use chacha20poly1305::XChaCha20Poly1305;
 use zeroize::Zeroize;
 
-use crate::{error::Error, primitives::BLOCK_SIZE, Protected};
+use crate::{Error, primitives::BLOCK_SIZE, Protected};
 
 /// These are all possible algorithms that can be used for encryption and decryption
 #[derive(Clone, Copy, Eq, PartialEq)]

--- a/crates/crypto/src/crypto/stream.rs
+++ b/crates/crypto/src/crypto/stream.rs
@@ -9,7 +9,7 @@ use aes_gcm::Aes256Gcm;
 use chacha20poly1305::XChaCha20Poly1305;
 use zeroize::Zeroize;
 
-use crate::{Error, primitives::BLOCK_SIZE, Protected};
+use crate::{Error, Result, primitives::BLOCK_SIZE, Protected};
 
 /// These are all possible algorithms that can be used for encryption and decryption
 #[derive(Clone, Copy, Eq, PartialEq)]
@@ -49,7 +49,7 @@ impl StreamEncryption {
 		key: Protected<[u8; 32]>,
 		nonce: &[u8],
 		algorithm: Algorithm,
-	) -> Result<Self, Error> {
+	) -> Result<Self> {
 		if nonce.len() != algorithm.nonce_len() {
 			return Err(Error::NonceLengthMismatch);
 		}
@@ -108,7 +108,7 @@ impl StreamEncryption {
 		mut reader: R,
 		mut writer: W,
 		aad: &[u8],
-	) -> Result<(), Error>
+	) -> Result<()>
 	where
 		R: Read + Seek,
 		W: Write + Seek,
@@ -181,7 +181,7 @@ impl StreamEncryption {
 		algorithm: Algorithm,
 		bytes: &[u8],
 		aad: &[u8],
-	) -> Result<Vec<u8>, Error> {
+	) -> Result<Vec<u8>> {
 		let mut reader = Cursor::new(bytes);
 		let mut writer = Cursor::new(Vec::<u8>::new());
 
@@ -203,7 +203,7 @@ impl StreamDecryption {
 		key: Protected<[u8; 32]>,
 		nonce: &[u8],
 		algorithm: Algorithm,
-	) -> Result<Self, Error> {
+	) -> Result<Self> {
 		if nonce.len() != algorithm.nonce_len() {
 			return Err(Error::NonceLengthMismatch);
 		}
@@ -262,7 +262,7 @@ impl StreamDecryption {
 		mut reader: R,
 		mut writer: W,
 		aad: &[u8],
-	) -> Result<(), Error>
+	) -> Result<()>
 	where
 		R: Read + Seek,
 		W: Write + Seek,
@@ -332,7 +332,7 @@ impl StreamDecryption {
 		algorithm: Algorithm,
 		bytes: &[u8],
 		aad: &[u8],
-	) -> Result<Protected<Vec<u8>>, Error> {
+	) -> Result<Protected<Vec<u8>>> {
 		let mut reader = Cursor::new(bytes);
 		let mut writer = Cursor::new(Vec::<u8>::new());
 

--- a/crates/crypto/src/error.rs
+++ b/crates/crypto/src/error.rs
@@ -1,13 +1,13 @@
 //! This module contains all possible errors that this crate can return.
+
 use thiserror::Error;
 
 #[cfg(feature = "rspc")]
 impl From<Error> for rspc::Error {
 	fn from(err: Error) -> Self {
-		rspc::Error::with_cause(
+		rspc::Error::new(
 			rspc::ErrorCode::InternalServerError,
-			"Internal cryptographic error occured".into(),
-			err,
+			err.to_string(),
 		)
 	}
 }
@@ -57,4 +57,12 @@ pub enum Error {
 	NoMasterPassword,
 	#[error("mismatch between supplied keys and the keystore")]
 	KeystoreMismatch,
+	#[error("mutex lock error")]
+	MutexLock,
+}
+
+impl <T> From<std::sync::PoisonError<T>> for Error {
+	fn from(_: std::sync::PoisonError<T>) -> Self {
+		Self::MutexLock
+	}
 }

--- a/crates/crypto/src/error.rs
+++ b/crates/crypto/src/error.rs
@@ -1,6 +1,17 @@
 //! This module contains all possible errors that this crate can return.
 use thiserror::Error;
 
+#[cfg(feature = "rspc")]
+impl From<Error> for rspc::Error {
+	fn from(err: Error) -> Self {
+		rspc::Error::with_cause(
+			rspc::ErrorCode::InternalServerError,
+			"Internal cryptographic error occured".into(),
+			err,
+		)
+	}
+}
+
 /// This enum defines all possible errors that this crate can give
 #[derive(Error, Debug)]
 pub enum Error {
@@ -44,4 +55,6 @@ pub enum Error {
 	NoMasterPassword,
 	#[error("mismatch between supplied keys and the keystore")]
 	KeystoreMismatch,
+	#[error("error getting lock on the key manager's internal mutex")]
+	MutexLock,
 }

--- a/crates/crypto/src/error.rs
+++ b/crates/crypto/src/error.rs
@@ -12,6 +12,8 @@ impl From<Error> for rspc::Error {
 	}
 }
 
+pub type Result<T> = std::result::Result<T, Error>;
+
 /// This enum defines all possible errors that this crate can give
 #[derive(Error, Debug)]
 pub enum Error {

--- a/crates/crypto/src/error.rs
+++ b/crates/crypto/src/error.rs
@@ -5,10 +5,7 @@ use thiserror::Error;
 #[cfg(feature = "rspc")]
 impl From<Error> for rspc::Error {
 	fn from(err: Error) -> Self {
-		rspc::Error::new(
-			rspc::ErrorCode::InternalServerError,
-			err.to_string(),
-		)
+		Self::new(rspc::ErrorCode::InternalServerError, err.to_string())
 	}
 }
 
@@ -61,7 +58,7 @@ pub enum Error {
 	MutexLock,
 }
 
-impl <T> From<std::sync::PoisonError<T>> for Error {
+impl<T> From<std::sync::PoisonError<T>> for Error {
 	fn from(_: std::sync::PoisonError<T>) -> Self {
 		Self::MutexLock
 	}

--- a/crates/crypto/src/error.rs
+++ b/crates/crypto/src/error.rs
@@ -57,6 +57,4 @@ pub enum Error {
 	NoMasterPassword,
 	#[error("mismatch between supplied keys and the keystore")]
 	KeystoreMismatch,
-	#[error("error getting lock on the key manager's internal mutex")]
-	MutexLock,
 }

--- a/crates/crypto/src/header/file.rs
+++ b/crates/crypto/src/header/file.rs
@@ -33,10 +33,8 @@ use std::io::{Cursor, Read, Seek, SeekFrom, Write};
 
 use crate::{
 	crypto::stream::Algorithm,
-	Error,
-	Result,
 	primitives::{generate_nonce, MASTER_KEY_LEN},
-	Protected,
+	Error, Protected, Result,
 };
 
 use super::{keyslot::Keyslot, metadata::Metadata, preview_media::PreviewMedia};

--- a/crates/crypto/src/header/file.rs
+++ b/crates/crypto/src/header/file.rs
@@ -33,7 +33,7 @@ use std::io::{Cursor, Read, Seek, SeekFrom, Write};
 
 use crate::{
 	crypto::stream::Algorithm,
-	error::Error,
+	Error,
 	primitives::{generate_nonce, MASTER_KEY_LEN},
 	Protected,
 };

--- a/crates/crypto/src/header/file.rs
+++ b/crates/crypto/src/header/file.rs
@@ -34,6 +34,7 @@ use std::io::{Cursor, Read, Seek, SeekFrom, Write};
 use crate::{
 	crypto::stream::Algorithm,
 	Error,
+	Result,
 	primitives::{generate_nonce, MASTER_KEY_LEN},
 	Protected,
 };
@@ -104,7 +105,7 @@ impl FileHeader {
 	pub fn decrypt_master_key(
 		&self,
 		password: Protected<Vec<u8>>,
-	) -> Result<Protected<[u8; MASTER_KEY_LEN]>, Error> {
+	) -> Result<Protected<[u8; MASTER_KEY_LEN]>> {
 		let mut master_key = [0u8; MASTER_KEY_LEN];
 
 		if self.keyslots.is_empty() {
@@ -125,7 +126,7 @@ impl FileHeader {
 	}
 
 	/// This is a helper function to serialize and write a header to a file.
-	pub fn write<W>(&self, writer: &mut W) -> Result<(), Error>
+	pub fn write<W>(&self, writer: &mut W) -> Result<()>
 	where
 		W: Write + Seek,
 	{
@@ -142,7 +143,7 @@ impl FileHeader {
 	pub fn decrypt_master_key_from_prehashed(
 		&self,
 		hashed_keys: Vec<Protected<[u8; 32]>>,
-	) -> Result<Protected<[u8; MASTER_KEY_LEN]>, Error> {
+	) -> Result<Protected<[u8; MASTER_KEY_LEN]>> {
 		let mut master_key = [0u8; MASTER_KEY_LEN];
 
 		if self.keyslots.is_empty() {
@@ -189,7 +190,7 @@ impl FileHeader {
 	/// This will include keyslots, metadata and preview media (if provided)
 	///
 	/// An error will be returned if there are no keyslots/more than two keyslots attached.
-	pub fn serialize(&self) -> Result<Vec<u8>, Error> {
+	pub fn serialize(&self) -> Result<Vec<u8>> {
 		match self.version {
 			FileHeaderVersion::V1 => {
 				if self.keyslots.len() > 2 {
@@ -231,7 +232,7 @@ impl FileHeader {
 	/// On error, the cursor will not be rewound.
 	///
 	/// It returns both the header, and the AAD that should be used for decryption.
-	pub fn deserialize<R>(reader: &mut R) -> Result<(Self, Vec<u8>), Error>
+	pub fn deserialize<R>(reader: &mut R) -> Result<(Self, Vec<u8>)>
 	where
 		R: Read + Seek,
 	{

--- a/crates/crypto/src/header/keyslot.rs
+++ b/crates/crypto/src/header/keyslot.rs
@@ -25,11 +25,9 @@ use std::io::{Read, Seek};
 
 use crate::{
 	crypto::stream::{Algorithm, StreamDecryption, StreamEncryption},
-	Error,
-	Result,
 	keys::hashing::HashingAlgorithm,
 	primitives::{generate_nonce, to_array, ENCRYPTED_MASTER_KEY_LEN, MASTER_KEY_LEN, SALT_LEN},
-	Protected,
+	Error, Protected, Result,
 };
 
 /// A keyslot - 96 bytes (as of V1), and contains all the information for future-proofing while keeping the size reasonable
@@ -94,10 +92,7 @@ impl Keyslot {
 	/// This attempts to decrypt the master key for a single keyslot
 	///
 	/// An error will be returned on failure.
-	pub fn decrypt_master_key(
-		&self,
-		password: &Protected<Vec<u8>>,
-	) -> Result<Protected<Vec<u8>>> {
+	pub fn decrypt_master_key(&self, password: &Protected<Vec<u8>>) -> Result<Protected<Vec<u8>>> {
 		let key = self
 			.hashing_algorithm
 			.hash(password.clone(), self.salt)

--- a/crates/crypto/src/header/keyslot.rs
+++ b/crates/crypto/src/header/keyslot.rs
@@ -25,7 +25,7 @@ use std::io::{Read, Seek};
 
 use crate::{
 	crypto::stream::{Algorithm, StreamDecryption, StreamEncryption},
-	error::Error,
+	Error,
 	keys::hashing::HashingAlgorithm,
 	primitives::{generate_nonce, to_array, ENCRYPTED_MASTER_KEY_LEN, MASTER_KEY_LEN, SALT_LEN},
 	Protected,

--- a/crates/crypto/src/header/keyslot.rs
+++ b/crates/crypto/src/header/keyslot.rs
@@ -26,6 +26,7 @@ use std::io::{Read, Seek};
 use crate::{
 	crypto::stream::{Algorithm, StreamDecryption, StreamEncryption},
 	Error,
+	Result,
 	keys::hashing::HashingAlgorithm,
 	primitives::{generate_nonce, to_array, ENCRYPTED_MASTER_KEY_LEN, MASTER_KEY_LEN, SALT_LEN},
 	Protected,
@@ -65,7 +66,7 @@ impl Keyslot {
 		salt: [u8; SALT_LEN],
 		password: Protected<Vec<u8>>,
 		master_key: &Protected<[u8; MASTER_KEY_LEN]>,
-	) -> Result<Self, Error> {
+	) -> Result<Self> {
 		let nonce = generate_nonce(algorithm);
 
 		let hashed_password = hashing_algorithm.hash(password, salt)?;
@@ -96,7 +97,7 @@ impl Keyslot {
 	pub fn decrypt_master_key(
 		&self,
 		password: &Protected<Vec<u8>>,
-	) -> Result<Protected<Vec<u8>>, Error> {
+	) -> Result<Protected<Vec<u8>>> {
 		let key = self
 			.hashing_algorithm
 			.hash(password.clone(), self.salt)
@@ -115,7 +116,7 @@ impl Keyslot {
 	pub fn decrypt_master_key_from_prehashed(
 		&self,
 		key: Protected<[u8; 32]>,
-	) -> Result<Protected<Vec<u8>>, Error> {
+	) -> Result<Protected<Vec<u8>>> {
 		StreamDecryption::decrypt_bytes(key, &self.nonce, self.algorithm, &self.master_key, &[])
 	}
 
@@ -142,7 +143,7 @@ impl Keyslot {
 	/// It will leave the cursor at the end of the keyslot on success
 	///
 	/// The cursor will not be rewound on error.
-	pub fn deserialize<R>(reader: &mut R) -> Result<Self, Error>
+	pub fn deserialize<R>(reader: &mut R) -> Result<Self>
 	where
 		R: Read + Seek,
 	{

--- a/crates/crypto/src/header/metadata.rs
+++ b/crates/crypto/src/header/metadata.rs
@@ -31,10 +31,8 @@ use std::io::{Read, Seek};
 
 use crate::{
 	crypto::stream::{Algorithm, StreamDecryption, StreamEncryption},
-	Error,
-	Result,
 	primitives::{generate_nonce, MASTER_KEY_LEN},
-	Protected,
+	Error, Protected, Result,
 };
 
 use super::file::FileHeader;

--- a/crates/crypto/src/header/metadata.rs
+++ b/crates/crypto/src/header/metadata.rs
@@ -32,6 +32,7 @@ use std::io::{Read, Seek};
 use crate::{
 	crypto::stream::{Algorithm, StreamDecryption, StreamEncryption},
 	Error,
+	Result,
 	primitives::{generate_nonce, MASTER_KEY_LEN},
 	Protected,
 };
@@ -70,7 +71,7 @@ impl FileHeader {
 		algorithm: Algorithm,
 		master_key: &Protected<[u8; MASTER_KEY_LEN]>,
 		metadata: &T,
-	) -> Result<(), Error>
+	) -> Result<()>
 	where
 		T: ?Sized + serde::Serialize,
 	{
@@ -104,7 +105,7 @@ impl FileHeader {
 	pub fn decrypt_metadata_from_prehashed<T>(
 		&self,
 		hashed_keys: Vec<Protected<[u8; 32]>>,
-	) -> Result<T, Error>
+	) -> Result<T>
 	where
 		T: serde::de::DeserializeOwned,
 	{
@@ -131,7 +132,7 @@ impl FileHeader {
 	/// All it requires is a password. Hashing is handled for you.
 	///
 	/// A deserialized data type will be returned from this function
-	pub fn decrypt_metadata<T>(&self, password: Protected<Vec<u8>>) -> Result<T, Error>
+	pub fn decrypt_metadata<T>(&self, password: Protected<Vec<u8>>) -> Result<T>
 	where
 		T: serde::de::DeserializeOwned,
 	{
@@ -186,7 +187,7 @@ impl Metadata {
 	/// The cursor will be left at the end of the metadata item on success
 	///
 	/// The cursor will not be rewound on error.
-	pub fn deserialize<R>(reader: &mut R) -> Result<Self, Error>
+	pub fn deserialize<R>(reader: &mut R) -> Result<Self>
 	where
 		R: Read + Seek,
 	{

--- a/crates/crypto/src/header/metadata.rs
+++ b/crates/crypto/src/header/metadata.rs
@@ -31,7 +31,7 @@ use std::io::{Read, Seek};
 
 use crate::{
 	crypto::stream::{Algorithm, StreamDecryption, StreamEncryption},
-	error::Error,
+	Error,
 	primitives::{generate_nonce, MASTER_KEY_LEN},
 	Protected,
 };

--- a/crates/crypto/src/header/preview_media.rs
+++ b/crates/crypto/src/header/preview_media.rs
@@ -24,10 +24,8 @@ use std::io::{Read, Seek};
 
 use crate::{
 	crypto::stream::{Algorithm, StreamDecryption, StreamEncryption},
-	Error,
-	Result,
 	primitives::{generate_nonce, MASTER_KEY_LEN},
-	Protected,
+	Error, Protected, Result,
 };
 
 use super::file::FileHeader;

--- a/crates/crypto/src/header/preview_media.rs
+++ b/crates/crypto/src/header/preview_media.rs
@@ -24,7 +24,7 @@ use std::io::{Read, Seek};
 
 use crate::{
 	crypto::stream::{Algorithm, StreamDecryption, StreamEncryption},
-	error::Error,
+	Error,
 	primitives::{generate_nonce, MASTER_KEY_LEN},
 	Protected,
 };

--- a/crates/crypto/src/header/preview_media.rs
+++ b/crates/crypto/src/header/preview_media.rs
@@ -25,6 +25,7 @@ use std::io::{Read, Seek};
 use crate::{
 	crypto::stream::{Algorithm, StreamDecryption, StreamEncryption},
 	Error,
+	Result,
 	primitives::{generate_nonce, MASTER_KEY_LEN},
 	Protected,
 };
@@ -63,7 +64,7 @@ impl FileHeader {
 		algorithm: Algorithm,
 		master_key: &Protected<[u8; MASTER_KEY_LEN]>,
 		media: &[u8],
-	) -> Result<(), Error> {
+	) -> Result<()> {
 		let media_nonce = generate_nonce(algorithm);
 
 		let encrypted_media = StreamEncryption::encrypt_bytes(
@@ -94,7 +95,7 @@ impl FileHeader {
 	pub fn decrypt_preview_media_from_prehashed(
 		&self,
 		hashed_keys: Vec<Protected<[u8; 32]>>,
-	) -> Result<Protected<Vec<u8>>, Error> {
+	) -> Result<Protected<Vec<u8>>> {
 		let master_key = self.decrypt_master_key_from_prehashed(hashed_keys)?;
 
 		// could be an expensive clone (a few MiB at most)
@@ -121,7 +122,7 @@ impl FileHeader {
 	pub fn decrypt_preview_media(
 		&self,
 		password: Protected<Vec<u8>>,
-	) -> Result<Protected<Vec<u8>>, Error> {
+	) -> Result<Protected<Vec<u8>>> {
 		let master_key = self.decrypt_master_key(password)?;
 
 		// could be an expensive clone (a few MiB at most)
@@ -173,7 +174,7 @@ impl PreviewMedia {
 	/// The cursor will be left at the end of the preview media item on success
 	///
 	/// The cursor will not be rewound on error.
-	pub fn deserialize<R>(reader: &mut R) -> Result<Self, Error>
+	pub fn deserialize<R>(reader: &mut R) -> Result<Self>
 	where
 		R: Read + Seek,
 	{

--- a/crates/crypto/src/header/serialization.rs
+++ b/crates/crypto/src/header/serialization.rs
@@ -3,7 +3,7 @@
 //! It contains `byte -> enum` and `enum -> byte` conversions for everything that could be written to a header (except headers, keyslots, and other header items)
 use crate::{
 	crypto::stream::Algorithm,
-	error::Error,
+	Error,
 	keys::hashing::{HashingAlgorithm, Params},
 };
 

--- a/crates/crypto/src/header/serialization.rs
+++ b/crates/crypto/src/header/serialization.rs
@@ -4,6 +4,7 @@
 use crate::{
 	crypto::stream::Algorithm,
 	Error,
+	Result,
 	keys::hashing::{HashingAlgorithm, Params},
 };
 
@@ -20,7 +21,7 @@ impl FileHeaderVersion {
 		}
 	}
 
-	pub const fn deserialize(bytes: [u8; 2]) -> Result<Self, Error> {
+	pub const fn deserialize(bytes: [u8; 2]) -> Result<Self> {
 		match bytes {
 			[0x0A, 0x01] => Ok(Self::V1),
 			_ => Err(Error::FileHeader),
@@ -36,7 +37,7 @@ impl KeyslotVersion {
 		}
 	}
 
-	pub const fn deserialize(bytes: [u8; 2]) -> Result<Self, Error> {
+	pub const fn deserialize(bytes: [u8; 2]) -> Result<Self> {
 		match bytes {
 			[0x0D, 0x01] => Ok(Self::V1),
 			_ => Err(Error::FileHeader),
@@ -52,7 +53,7 @@ impl PreviewMediaVersion {
 		}
 	}
 
-	pub const fn deserialize(bytes: [u8; 2]) -> Result<Self, Error> {
+	pub const fn deserialize(bytes: [u8; 2]) -> Result<Self> {
 		match bytes {
 			[0x0E, 0x01] => Ok(Self::V1),
 			_ => Err(Error::FileHeader),
@@ -68,7 +69,7 @@ impl MetadataVersion {
 		}
 	}
 
-	pub const fn deserialize(bytes: [u8; 2]) -> Result<Self, Error> {
+	pub const fn deserialize(bytes: [u8; 2]) -> Result<Self> {
 		match bytes {
 			[0x1F, 0x01] => Ok(Self::V1),
 			_ => Err(Error::FileHeader),
@@ -88,7 +89,7 @@ impl HashingAlgorithm {
 		}
 	}
 
-	pub const fn deserialize(bytes: [u8; 2]) -> Result<Self, Error> {
+	pub const fn deserialize(bytes: [u8; 2]) -> Result<Self> {
 		match bytes {
 			[0x0F, 0x01] => Ok(Self::Argon2id(Params::Standard)),
 			[0x0F, 0x02] => Ok(Self::Argon2id(Params::Hardened)),
@@ -107,7 +108,7 @@ impl Algorithm {
 		}
 	}
 
-	pub const fn deserialize(bytes: [u8; 2]) -> Result<Self, Error> {
+	pub const fn deserialize(bytes: [u8; 2]) -> Result<Self> {
 		match bytes {
 			[0x0B, 0x01] => Ok(Self::XChaCha20Poly1305),
 			[0x0B, 0x02] => Ok(Self::Aes256Gcm),

--- a/crates/crypto/src/header/serialization.rs
+++ b/crates/crypto/src/header/serialization.rs
@@ -3,9 +3,8 @@
 //! It contains `byte -> enum` and `enum -> byte` conversions for everything that could be written to a header (except headers, keyslots, and other header items)
 use crate::{
 	crypto::stream::Algorithm,
-	Error,
-	Result,
 	keys::hashing::{HashingAlgorithm, Params},
+	Error, Result,
 };
 
 use super::{

--- a/crates/crypto/src/keys/hashing.rs
+++ b/crates/crypto/src/keys/hashing.rs
@@ -11,7 +11,7 @@
 //! let hashed_password = hashing_algorithm.hash(password, salt).unwrap();
 //! ```
 use crate::Protected;
-use crate::{Error, Result, primitives::SALT_LEN};
+use crate::{primitives::SALT_LEN, Error, Result};
 use argon2::Argon2;
 
 /// These parameters define the password-hashing level.

--- a/crates/crypto/src/keys/hashing.rs
+++ b/crates/crypto/src/keys/hashing.rs
@@ -11,7 +11,7 @@
 //! let hashed_password = hashing_algorithm.hash(password, salt).unwrap();
 //! ```
 use crate::Protected;
-use crate::{Error, primitives::SALT_LEN};
+use crate::{Error, Result, primitives::SALT_LEN};
 use argon2::Argon2;
 
 /// These parameters define the password-hashing level.
@@ -39,7 +39,7 @@ impl HashingAlgorithm {
 		&self,
 		password: Protected<Vec<u8>>,
 		salt: [u8; SALT_LEN],
-	) -> Result<Protected<[u8; 32]>, Error> {
+	) -> Result<Protected<[u8; 32]>> {
 		match self {
 			Self::Argon2id(params) => password_hash_argon2id(password, salt, *params),
 		}
@@ -82,7 +82,7 @@ pub fn password_hash_argon2id(
 	password: Protected<Vec<u8>>,
 	salt: [u8; SALT_LEN],
 	params: Params,
-) -> Result<Protected<[u8; 32]>, Error> {
+) -> Result<Protected<[u8; 32]>> {
 	let mut key = [0u8; 32];
 
 	let argon2 = Argon2::new(

--- a/crates/crypto/src/keys/hashing.rs
+++ b/crates/crypto/src/keys/hashing.rs
@@ -11,7 +11,7 @@
 //! let hashed_password = hashing_algorithm.hash(password, salt).unwrap();
 //! ```
 use crate::Protected;
-use crate::{error::Error, primitives::SALT_LEN};
+use crate::{Error, primitives::SALT_LEN};
 use argon2::Argon2;
 
 /// These parameters define the password-hashing level.

--- a/crates/crypto/src/keys/hashing.rs
+++ b/crates/crypto/src/keys/hashing.rs
@@ -13,11 +13,13 @@
 use crate::Protected;
 use crate::{primitives::SALT_LEN, Error, Result};
 use argon2::Argon2;
+use serde::{Serialize, Deserialize};
+use specta::Type;
 
 /// These parameters define the password-hashing level.
 ///
 /// The harder the parameter, the longer the password will take to hash.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Type, Serialize, Deserialize)]
 #[allow(clippy::use_self)]
 pub enum Params {
 	Standard,
@@ -26,7 +28,7 @@ pub enum Params {
 }
 
 /// This defines all available password hashing algorithms.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Type, Serialize, Deserialize)]
 pub enum HashingAlgorithm {
 	Argon2id(Params),
 }

--- a/crates/crypto/src/keys/hashing.rs
+++ b/crates/crypto/src/keys/hashing.rs
@@ -13,7 +13,7 @@
 use crate::Protected;
 use crate::{primitives::SALT_LEN, Error, Result};
 use argon2::Argon2;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use specta::Type;
 
 /// These parameters define the password-hashing level.

--- a/crates/crypto/src/keys/hashing.rs
+++ b/crates/crypto/src/keys/hashing.rs
@@ -31,15 +31,6 @@ pub enum HashingAlgorithm {
 	Argon2id(Params),
 }
 
-/// This is so we can iterate over all hashing algorithms and parameters.
-///
-/// The main usage is for pre-hashing a key during mounting.
-pub const HASHING_ALGORITHM_LIST: [HashingAlgorithm; 3] = [
-	HashingAlgorithm::Argon2id(Params::Standard),
-	HashingAlgorithm::Argon2id(Params::Hardened),
-	HashingAlgorithm::Argon2id(Params::Paranoid),
-];
-
 impl HashingAlgorithm {
 	/// This function should be used to hash passwords
 	///

--- a/crates/crypto/src/keys/keymanager.rs
+++ b/crates/crypto/src/keys/keymanager.rs
@@ -170,7 +170,6 @@ impl KeyManager {
 		Ok(())
 	}
 
-	#[must_use]
 	pub fn has_master_password(&self) -> Result<bool> {
 		Ok(self
 			.master_password

--- a/crates/crypto/src/keys/keymanager.rs
+++ b/crates/crypto/src/keys/keymanager.rs
@@ -164,7 +164,7 @@ impl KeyManager {
 	}
 
 	pub fn get_mounted_uuids(&self) -> Vec<Uuid> {
-		self.keymount.iter().map(|key| key.0.clone() ).collect()
+		self.keymount.iter().map(|key| key.0.clone()).collect()
 	}
 
 	/// This function does not return a value by design.

--- a/crates/crypto/src/keys/keymanager.rs
+++ b/crates/crypto/src/keys/keymanager.rs
@@ -110,26 +110,25 @@ impl KeyManager {
 
 		Ok(())
 	}
+
+	/// This function removes a key from the keystore, the keymount and it's unset as the default.
 	pub fn remove_key(&self, uuid: Uuid) -> Result<()> {
 		if self.keystore.contains_key(&uuid) {
+			// if key is default, clear it
+			let mut default = self.default.lock()?;
+			if *default == Some(uuid) {
+				*default = None;
+			}
+			drop(default);
+
 			// unmount if mounted
 			if self.keymount.contains_key(&uuid) {
-				self.unmount(uuid)?;
+				// use remove as unmount calls the checks that we just did
+				self.keymount.remove(&uuid);
 			}
 
 			// remove from keystore
 			self.keystore.remove(&uuid);
-
-			// // unset as default (if it is the default)
-			// if let Some(default) = *self.default.lock()? {
-			// 	if default == uuid {
-			// 		*self.default.lock()? = None;
-			// 	}
-			// }
-
-			if self.get_default()? == uuid {
-				self.clear_default()?;
-			}
 		}
 
 		Ok(())

--- a/crates/crypto/src/keys/keymanager.rs
+++ b/crates/crypto/src/keys/keymanager.rs
@@ -146,6 +146,11 @@ impl KeyManager {
 		Ok(())
 	}
 
+	/// This function is for removing a previously-added master password
+	pub fn clear_master_password(&mut self) {
+		self.master_password = None;
+	}
+
 	#[must_use]
 	pub const fn has_master_password(&self) -> bool {
 		self.master_password.is_some()

--- a/crates/crypto/src/keys/keymanager.rs
+++ b/crates/crypto/src/keys/keymanager.rs
@@ -159,12 +159,14 @@ impl KeyManager {
 	/// This function returns a Vec of `StoredKey`s, so you can write them somewhere/update the database with them/etc
 	///
 	/// The database and keystore should be in sync at ALL times
+	#[must_use]
 	pub fn dump_keystore(&self) -> Vec<StoredKey> {
 		self.keystore.iter().map(|key| key.1.clone()).collect()
 	}
 
+	#[must_use]
 	pub fn get_mounted_uuids(&self) -> Vec<Uuid> {
-		self.keymount.iter().map(|key| key.0.clone()).collect()
+		self.keymount.iter().map(|key| *key.0).collect()
 	}
 
 	/// This function does not return a value by design.

--- a/crates/crypto/src/keys/keymanager.rs
+++ b/crates/crypto/src/keys/keymanager.rs
@@ -158,10 +158,7 @@ impl KeyManager {
 		}
 	}
 
-	pub fn set_master_password(
-		&self,
-		master_password: Protected<Vec<u8>>,
-	) -> Result<(), Error> {
+	pub fn set_master_password(&self, master_password: Protected<Vec<u8>>) -> Result<(), Error> {
 		// this returns a result, so we can potentially implement password checking functionality
 		*self.master_password.lock().unwrap() = Some(master_password);
 		Ok(())

--- a/crates/crypto/src/keys/keymanager.rs
+++ b/crates/crypto/src/keys/keymanager.rs
@@ -38,7 +38,6 @@
 use std::sync::Mutex;
 
 use crate::crypto::stream::{StreamDecryption, StreamEncryption};
-use crate::{Error, Result};
 use crate::primitives::{
 	generate_master_key, generate_nonce, generate_salt, to_array, MASTER_KEY_LEN,
 };
@@ -47,6 +46,7 @@ use crate::{
 	primitives::{ENCRYPTED_MASTER_KEY_LEN, SALT_LEN},
 	Protected,
 };
+use crate::{Error, Result};
 
 use dashmap::DashMap;
 use uuid::Uuid;
@@ -172,7 +172,11 @@ impl KeyManager {
 
 	#[must_use]
 	pub fn has_master_password(&self) -> Result<bool> {
-		Ok(self.master_password.lock().map_err(|_| Error::MutexLock)?.is_some())
+		Ok(self
+			.master_password
+			.lock()
+			.map_err(|_| Error::MutexLock)?
+			.is_some())
 	}
 
 	/// This function is used for emptying the entire keystore.

--- a/crates/crypto/src/keys/keymanager.rs
+++ b/crates/crypto/src/keys/keymanager.rs
@@ -88,11 +88,10 @@ pub struct MountedKey {
 	pub hashed_key: Protected<[u8; 32]>, // this is hashed with the content salt, for instant access
 }
 
-
 /// This is the key manager itself.
-/// 
+///
 /// It contains the keystore, the keymount, the master password and the default key.
-/// 
+///
 /// Use the associated functions to interact with it.
 pub struct KeyManager {
 	master_password: Mutex<Option<Protected<Vec<u8>>>>, // the user's. we take ownership here to prevent other functions attempting to manage/pass it to us

--- a/crates/crypto/src/keys/keymanager.rs
+++ b/crates/crypto/src/keys/keymanager.rs
@@ -121,9 +121,9 @@ impl KeyManager {
 			self.keystore.remove(&uuid);
 
 			// unset as default (if it is the default)
-			if let Some(default) = *self.default.lock().map_err(|_| Error::MutexLock)? {
+			if let Some(default) = *self.default.lock().unwrap() {
 				if default == uuid {
-					*self.default.lock().map_err(|_| Error::MutexLock)? = None;
+					*self.default.lock().unwrap() = None;
 				}
 			}
 		}
@@ -134,7 +134,7 @@ impl KeyManager {
 	/// This allows you to set the default key
 	pub fn set_default(&self, uuid: Uuid) -> Result<()> {
 		if self.keystore.contains_key(&uuid) {
-			*self.default.lock().map_err(|_| Error::MutexLock)? = Some(uuid);
+			*self.default.lock().unwrap() = Some(uuid);
 			Ok(())
 		} else {
 			Err(Error::KeyNotFound)
@@ -143,7 +143,7 @@ impl KeyManager {
 
 	/// This allows you to get the default key's ID
 	pub fn get_default(&self) -> Result<Uuid> {
-		if let Some(default) = *self.default.lock().map_err(|_| Error::MutexLock)? {
+		if let Some(default) = *self.default.lock().unwrap() {
 			Ok(default)
 		} else {
 			Err(Error::NoDefaultKeySet)
@@ -152,30 +152,24 @@ impl KeyManager {
 
 	/// This should ONLY be used internally.
 	fn get_master_password(&self) -> Result<Protected<Vec<u8>>> {
-		match &*self.master_password.lock().map_err(|_| Error::MutexLock)? {
+		match &*self.master_password.lock().unwrap() {
 			Some(k) => Ok(k.clone()),
 			None => Err(Error::NoMasterPassword),
 		}
 	}
 
-	pub fn set_master_password(&self, master_password: Protected<Vec<u8>>) -> Result<()> {
+	pub fn set_master_password(&self, master_password: Protected<Vec<u8>>) {
 		// this returns a result, so we can potentially implement password checking functionality
-		*self.master_password.lock().map_err(|_| Error::MutexLock)? = Some(master_password);
-		Ok(())
+		*self.master_password.lock().unwrap() = Some(master_password);
 	}
 
 	/// This function is for removing a previously-added master password
-	pub fn clear_master_password(&self) -> Result<()> {
-		*self.master_password.lock().map_err(|_| Error::MutexLock)? = None;
-		Ok(())
+	pub fn clear_master_password(&self) {
+		*self.master_password.lock().unwrap() = None;
 	}
 
-	pub fn has_master_password(&self) -> Result<bool> {
-		Ok(self
-			.master_password
-			.lock()
-			.map_err(|_| Error::MutexLock)?
-			.is_some())
+	pub fn has_master_password(&self) -> bool {
+		self.master_password.lock().unwrap().is_some()
 	}
 
 	/// This function is used for emptying the entire keystore.

--- a/crates/crypto/src/keys/keymanager.rs
+++ b/crates/crypto/src/keys/keymanager.rs
@@ -110,6 +110,26 @@ impl KeyManager {
 
 		Ok(())
 	}
+	pub fn remove_key(&self, uuid: Uuid) -> Result<(), Error> {
+		if self.keystore.contains_key(&uuid) {
+			// unmount if mounted
+			if self.keymount.contains_key(&uuid) {
+				self.unmount(uuid).unwrap();
+			}
+
+			// remove from keystore
+			self.keystore.remove(&uuid);
+
+			// unset as default (if it is the default)
+			if let Some(default) = *self.default.lock().unwrap() {
+				if default == uuid {
+					*self.default.lock().unwrap() = None;
+				}
+			}
+		}
+
+		Ok(())
+	}
 
 	/// This allows you to set the default key
 	pub fn set_default(&self, uuid: Uuid) -> Result<(), Error> {

--- a/crates/crypto/src/keys/keymanager.rs
+++ b/crates/crypto/src/keys/keymanager.rs
@@ -159,14 +159,12 @@ impl KeyManager {
 	/// This function returns a Vec of `StoredKey`s, so you can write them somewhere/update the database with them/etc
 	///
 	/// The database and keystore should be in sync at ALL times
-	pub fn dump_keystore(&self) -> Result<Vec<StoredKey>, Error> {
-		let mut keys = Vec::<StoredKey>::new();
+	pub fn dump_keystore(&self) -> Vec<StoredKey> {
+		self.keystore.iter().map(|key| key.1.clone()).collect()
+	}
 
-		for key in self.keystore.values() {
-			keys.push(key.clone());
-		}
-
-		Ok(keys)
+	pub fn get_mounted_uuids(&self) -> Vec<Uuid> {
+		self.keymount.iter().map(|key| key.0.clone() ).collect()
 	}
 
 	/// This function does not return a value by design.

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -27,3 +27,5 @@ pub use protected::Protected;
 
 // Re-export zeroize so it can be used elsewhere
 pub use zeroize::Zeroize;
+
+pub use self::error::{Error, Result};

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -10,6 +10,7 @@
 #![allow(clippy::missing_errors_doc)]
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::similar_names)]
+#![allow(clippy::option_if_let_else)]
 
 pub mod crypto;
 pub mod error;

--- a/crates/crypto/src/primitives.rs
+++ b/crates/crypto/src/primitives.rs
@@ -5,7 +5,7 @@
 use rand::{RngCore, SeedableRng};
 use zeroize::Zeroize;
 
-use crate::{crypto::stream::Algorithm, error::Error, Protected};
+use crate::{crypto::stream::Algorithm, Error, Protected};
 
 /// This is the default salt size, and the recommended size for argon2id.
 pub const SALT_LEN: usize = 16;

--- a/crates/crypto/src/primitives.rs
+++ b/crates/crypto/src/primitives.rs
@@ -5,7 +5,7 @@
 use rand::{RngCore, SeedableRng};
 use zeroize::Zeroize;
 
-use crate::{crypto::stream::Algorithm, Error, Result, Protected};
+use crate::{crypto::stream::Algorithm, Error, Protected, Result};
 
 /// This is the default salt size, and the recommended size for argon2id.
 pub const SALT_LEN: usize = 16;

--- a/crates/crypto/src/primitives.rs
+++ b/crates/crypto/src/primitives.rs
@@ -5,7 +5,7 @@
 use rand::{RngCore, SeedableRng};
 use zeroize::Zeroize;
 
-use crate::{crypto::stream::Algorithm, Error, Protected};
+use crate::{crypto::stream::Algorithm, Error, Result, Protected};
 
 /// This is the default salt size, and the recommended size for argon2id.
 pub const SALT_LEN: usize = 16;
@@ -62,7 +62,7 @@ pub fn generate_master_key() -> Protected<[u8; MASTER_KEY_LEN]> {
 /// As the master key is encrypted at this point, it does not need to be `Protected<>`
 ///
 /// This function still `zeroize`s any data it can
-pub fn to_array<const I: usize>(bytes: Vec<u8>) -> Result<[u8; I], Error> {
+pub fn to_array<const I: usize>(bytes: Vec<u8>) -> Result<[u8; I]> {
 	bytes.try_into().map_err(|mut b: Vec<u8>| {
 		b.zeroize();
 		Error::VecArrSizeMismatch

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -8,7 +8,6 @@ export type Procedures = {
         { key: "jobs.getHistory", input: LibraryArgs<null>, result: Array<JobReport> } | 
         { key: "jobs.getRunning", input: LibraryArgs<null>, result: Array<JobReport> } | 
         { key: "jobs.isRunning", input: LibraryArgs<null>, result: boolean } | 
-        { key: "keys.add", input: LibraryArgs<KeyAddArgs>, result: null } | 
         { key: "keys.getDefault", input: LibraryArgs<null>, result: Key | null } | 
         { key: "keys.list", input: LibraryArgs<null>, result: Array<Key> } | 
         { key: "keys.listMounted", input: LibraryArgs<null>, result: Array<string> } | 
@@ -42,6 +41,7 @@ export type Procedures = {
         { key: "jobs.generateThumbsForLocation", input: LibraryArgs<GenerateThumbsForLocationArgs>, result: null } | 
         { key: "jobs.identifyUniqueFiles", input: LibraryArgs<IdentifyUniqueFilesArgs>, result: null } | 
         { key: "jobs.objectValidator", input: LibraryArgs<ObjectValidatorArgs>, result: null } | 
+        { key: "keys.add", input: LibraryArgs<KeyAddArgs>, result: null } | 
         { key: "library.create", input: string, result: LibraryConfigWrapped } | 
         { key: "library.delete", input: string, result: null } | 
         { key: "library.edit", input: EditLibraryArgs, result: null } | 

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -89,7 +89,7 @@ export interface JobReport { id: string, name: string, data: Array<number> | nul
 
 export type JobStatus = "Queued" | "Running" | "Completed" | "Canceled" | "Failed" | "Paused"
 
-export interface Key { id: number, uuid: string, name: string, default: boolean, date_created: string | null, algorithm: Array<number>, hashing_algorithm: Array<number>, salt: Array<number>, content_salt: Array<number>, master_key: Array<number>, master_key_nonce: Array<number>, key_nonce: Array<number>, key: Array<number> }
+export interface Key { id: number, uuid: string, name: string | null, default: boolean, date_created: string | null, algorithm: Array<number>, hashing_algorithm: Array<number>, salt: Array<number>, content_salt: Array<number>, master_key: Array<number>, master_key_nonce: Array<number>, key_nonce: Array<number>, key: Array<number>, automount: boolean }
 
 export interface KeyAddArgs { algorithm: string, hashing_algorithm: string, key: string }
 

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -16,6 +16,7 @@ export type Procedures = {
         { key: "keys.setDefault", input: LibraryArgs<string>, result: null } | 
         { key: "keys.setMasterPassword", input: LibraryArgs<string>, result: null } | 
         { key: "keys.unmount", input: LibraryArgs<string>, result: null } | 
+        { key: "keys.updateKeyName", input: LibraryArgs<KeyNameUpdateArgs>, result: null } | 
         { key: "library.getStatistics", input: LibraryArgs<null>, result: Statistics } | 
         { key: "library.list", input: never, result: Array<LibraryConfigWrapped> } | 
         { key: "locations.getById", input: LibraryArgs<number>, result: Location | null } | 
@@ -91,6 +92,8 @@ export type JobStatus = "Queued" | "Running" | "Completed" | "Canceled" | "Faile
 export interface Key { id: number, uuid: string, name: string, default: boolean, date_created: string | null, algorithm: Array<number>, hashing_algorithm: Array<number>, salt: Array<number>, content_salt: Array<number>, master_key: Array<number>, master_key_nonce: Array<number>, key_nonce: Array<number>, key: Array<number> }
 
 export interface KeyAddArgs { algorithm: string, hashing_algorithm: string, key: string }
+
+export interface KeyNameUpdateArgs { uuid: string, name: string }
 
 export interface LibraryArgs<T> { library_id: string, arg: T }
 

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -9,7 +9,7 @@ export type Procedures = {
         { key: "jobs.getRunning", input: LibraryArgs<null>, result: Array<JobReport> } | 
         { key: "jobs.isRunning", input: LibraryArgs<null>, result: boolean } | 
         { key: "keys.getDefault", input: LibraryArgs<null>, result: string | null } | 
-        { key: "keys.list", input: LibraryArgs<null>, result: Array<Key> } | 
+        { key: "keys.list", input: LibraryArgs<null>, result: Array<StoredKey> } | 
         { key: "keys.listMounted", input: LibraryArgs<null>, result: Array<string> } | 
         { key: "library.getStatistics", input: LibraryArgs<null>, result: Statistics } | 
         { key: "library.list", input: never, result: Array<LibraryConfigWrapped> } | 
@@ -95,8 +95,6 @@ export interface JobReport { id: string, name: string, data: Array<number> | nul
 
 export type JobStatus = "Queued" | "Running" | "Completed" | "Canceled" | "Failed" | "Paused"
 
-export interface Key { id: number, uuid: string, name: string | null, default: boolean, date_created: string | null, algorithm: Array<number>, hashing_algorithm: Array<number>, salt: Array<number>, content_salt: Array<number>, master_key: Array<number>, master_key_nonce: Array<number>, key_nonce: Array<number>, key: Array<number>, automount: boolean }
-
 export interface KeyAddArgs { algorithm: Algorithm, hashing_algorithm: HashingAlgorithm, key: string }
 
 export interface KeyNameUpdateArgs { uuid: string, name: string }
@@ -142,6 +140,8 @@ export interface SetFavoriteArgs { id: number, favorite: boolean }
 export interface SetNoteArgs { id: number, note: string | null }
 
 export interface Statistics { id: number, date_captured: string, total_object_count: number, library_db_size: string, total_bytes_used: string, total_bytes_capacity: string, total_unique_bytes: string, total_bytes_free: string, preview_media_bytes: string }
+
+export interface StoredKey { uuid: string, algorithm: Algorithm, hashing_algorithm: HashingAlgorithm, salt: Array<number>, content_salt: Array<number>, master_key: Array<number>, master_key_nonce: Array<number>, key_nonce: Array<number>, key: Array<number> }
 
 export interface Tag { id: number, pub_id: Array<number>, name: string | null, color: string | null, total_objects: number | null, redundancy_goal: number | null, date_created: string, date_modified: string }
 

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -8,14 +8,9 @@ export type Procedures = {
         { key: "jobs.getHistory", input: LibraryArgs<null>, result: Array<JobReport> } | 
         { key: "jobs.getRunning", input: LibraryArgs<null>, result: Array<JobReport> } | 
         { key: "jobs.isRunning", input: LibraryArgs<null>, result: boolean } | 
-        { key: "keys.getDefault", input: LibraryArgs<null>, result: Key | null } | 
+        { key: "keys.getDefault", input: LibraryArgs<null>, result: string } | 
         { key: "keys.list", input: LibraryArgs<null>, result: Array<Key> } | 
         { key: "keys.listMounted", input: LibraryArgs<null>, result: Array<string> } | 
-        { key: "keys.mount", input: LibraryArgs<string>, result: null } | 
-        { key: "keys.setDefault", input: LibraryArgs<string>, result: null } | 
-        { key: "keys.setMasterPassword", input: LibraryArgs<string>, result: null } | 
-        { key: "keys.unmount", input: LibraryArgs<string>, result: null } | 
-        { key: "keys.updateKeyName", input: LibraryArgs<KeyNameUpdateArgs>, result: null } | 
         { key: "library.getStatistics", input: LibraryArgs<null>, result: Statistics } | 
         { key: "library.list", input: never, result: Array<LibraryConfigWrapped> } | 
         { key: "locations.getById", input: LibraryArgs<number>, result: Location | null } | 
@@ -42,7 +37,13 @@ export type Procedures = {
         { key: "jobs.identifyUniqueFiles", input: LibraryArgs<IdentifyUniqueFilesArgs>, result: null } | 
         { key: "jobs.objectValidator", input: LibraryArgs<ObjectValidatorArgs>, result: null } | 
         { key: "keys.add", input: LibraryArgs<KeyAddArgs>, result: null } | 
+        { key: "keys.deleteFromLibrary", input: LibraryArgs<string>, result: null } | 
+        { key: "keys.mount", input: LibraryArgs<string>, result: null } | 
+        { key: "keys.setDefault", input: LibraryArgs<string>, result: null } | 
+        { key: "keys.setMasterPassword", input: LibraryArgs<string>, result: null } | 
+        { key: "keys.unmount", input: LibraryArgs<string>, result: null } | 
         { key: "keys.unmountAll", input: LibraryArgs<null>, result: null } | 
+        { key: "keys.updateKeyName", input: LibraryArgs<KeyNameUpdateArgs>, result: null } | 
         { key: "library.create", input: string, result: LibraryConfigWrapped } | 
         { key: "library.delete", input: string, result: null } | 
         { key: "library.edit", input: EditLibraryArgs, result: null } | 

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -63,6 +63,8 @@ export type Procedures = {
         { key: "jobs.newThumbnail", input: LibraryArgs<null>, result: string }
 };
 
+export type Algorithm = "XChaCha20Poly1305" | "Aes256Gcm"
+
 export interface BuildInfo { version: string, commit: string }
 
 export interface ConfigMetadata { version: string | null }
@@ -79,6 +81,8 @@ export interface FilePath { id: number, is_dir: boolean, location_id: number, ma
 
 export interface GenerateThumbsForLocationArgs { id: number, path: string }
 
+export type HashingAlgorithm = { Argon2id: Params }
+
 export interface IdentifyUniqueFilesArgs { id: number, path: string }
 
 export interface IndexerRule { id: number, kind: number, name: string, parameters: Array<number>, date_created: string, date_modified: string }
@@ -93,7 +97,7 @@ export type JobStatus = "Queued" | "Running" | "Completed" | "Canceled" | "Faile
 
 export interface Key { id: number, uuid: string, name: string | null, default: boolean, date_created: string | null, algorithm: Array<number>, hashing_algorithm: Array<number>, salt: Array<number>, content_salt: Array<number>, master_key: Array<number>, master_key_nonce: Array<number>, key_nonce: Array<number>, key: Array<number>, automount: boolean }
 
-export interface KeyAddArgs { algorithm: string, hashing_algorithm: string, key: string }
+export interface KeyAddArgs { algorithm: Algorithm, hashing_algorithm: HashingAlgorithm, key: string }
 
 export interface KeyNameUpdateArgs { uuid: string, name: string }
 
@@ -128,6 +132,8 @@ export interface NormalizedVec<T> { $type: string, edges: Array<T> }
 export interface Object { id: number, cas_id: string, integrity_checksum: string | null, name: string | null, extension: string | null, kind: number, size_in_bytes: string, key_id: number | null, hidden: boolean, favorite: boolean, important: boolean, has_thumbnail: boolean, has_thumbstrip: boolean, has_video_preview: boolean, ipfs_id: string | null, note: string | null, date_created: string, date_modified: string, date_indexed: string }
 
 export interface ObjectValidatorArgs { id: number, path: string }
+
+export type Params = "Standard" | "Hardened" | "Paranoid"
 
 export type RuleKind = "AcceptFilesByGlob" | "RejectFilesByGlob" | "AcceptIfChildrenDirectoriesArePresent" | "RejectIfChildrenDirectoriesArePresent"
 

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -9,10 +9,12 @@ export type Procedures = {
         { key: "jobs.getRunning", input: LibraryArgs<null>, result: Array<JobReport> } | 
         { key: "jobs.isRunning", input: LibraryArgs<null>, result: boolean } | 
         { key: "keys.add", input: LibraryArgs<KeyAddArgs>, result: null } | 
+        { key: "keys.getDefault", input: LibraryArgs<null>, result: Key | null } | 
         { key: "keys.list", input: LibraryArgs<null>, result: Array<Key> } | 
         { key: "keys.listMounted", input: LibraryArgs<null>, result: Array<string> } | 
         { key: "keys.mount", input: LibraryArgs<string>, result: null } | 
         { key: "keys.setDefault", input: LibraryArgs<string>, result: null } | 
+        { key: "keys.setMasterPassword", input: LibraryArgs<string>, result: null } | 
         { key: "keys.unmount", input: LibraryArgs<string>, result: null } | 
         { key: "library.getStatistics", input: LibraryArgs<null>, result: Statistics } | 
         { key: "library.list", input: never, result: Array<LibraryConfigWrapped> } | 

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -8,7 +8,7 @@ export type Procedures = {
         { key: "jobs.getHistory", input: LibraryArgs<null>, result: Array<JobReport> } | 
         { key: "jobs.getRunning", input: LibraryArgs<null>, result: Array<JobReport> } | 
         { key: "jobs.isRunning", input: LibraryArgs<null>, result: boolean } | 
-        { key: "keys.getDefault", input: LibraryArgs<null>, result: string } | 
+        { key: "keys.getDefault", input: LibraryArgs<null>, result: string | null } | 
         { key: "keys.list", input: LibraryArgs<null>, result: Array<Key> } | 
         { key: "keys.listMounted", input: LibraryArgs<null>, result: Array<string> } | 
         { key: "library.getStatistics", input: LibraryArgs<null>, result: Statistics } | 

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -42,6 +42,7 @@ export type Procedures = {
         { key: "jobs.identifyUniqueFiles", input: LibraryArgs<IdentifyUniqueFilesArgs>, result: null } | 
         { key: "jobs.objectValidator", input: LibraryArgs<ObjectValidatorArgs>, result: null } | 
         { key: "keys.add", input: LibraryArgs<KeyAddArgs>, result: null } | 
+        { key: "keys.unmountAll", input: LibraryArgs<null>, result: null } | 
         { key: "library.create", input: string, result: LibraryConfigWrapped } | 
         { key: "library.delete", input: string, result: null } | 
         { key: "library.edit", input: EditLibraryArgs, result: null } | 

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -8,6 +8,12 @@ export type Procedures = {
         { key: "jobs.getHistory", input: LibraryArgs<null>, result: Array<JobReport> } | 
         { key: "jobs.getRunning", input: LibraryArgs<null>, result: Array<JobReport> } | 
         { key: "jobs.isRunning", input: LibraryArgs<null>, result: boolean } | 
+        { key: "keys.add", input: LibraryArgs<KeyAddArgs>, result: null } | 
+        { key: "keys.list", input: LibraryArgs<null>, result: Array<Key> } | 
+        { key: "keys.listMounted", input: LibraryArgs<null>, result: Array<string> } | 
+        { key: "keys.mount", input: LibraryArgs<string>, result: null } | 
+        { key: "keys.setDefault", input: LibraryArgs<string>, result: null } | 
+        { key: "keys.unmount", input: LibraryArgs<string>, result: null } | 
         { key: "library.getStatistics", input: LibraryArgs<null>, result: Statistics } | 
         { key: "library.list", input: never, result: Array<LibraryConfigWrapped> } | 
         { key: "locations.getById", input: LibraryArgs<number>, result: Location | null } | 
@@ -79,6 +85,10 @@ export interface InvalidateOperationEvent { key: string, arg: any }
 export interface JobReport { id: string, name: string, data: Array<number> | null, metadata: any | null, date_created: string, date_modified: string, status: JobStatus, task_count: number, completed_task_count: number, message: string, seconds_elapsed: number }
 
 export type JobStatus = "Queued" | "Running" | "Completed" | "Canceled" | "Failed" | "Paused"
+
+export interface Key { id: number, uuid: string, name: string, default: boolean, date_created: string | null, algorithm: Array<number>, hashing_algorithm: Array<number>, salt: Array<number>, content_salt: Array<number>, master_key: Array<number>, master_key_nonce: Array<number>, key_nonce: Array<number>, key: Array<number> }
+
+export interface KeyAddArgs { algorithm: string, hashing_algorithm: string, key: string }
 
 export interface LibraryArgs<T> { library_id: string, arg: T }
 

--- a/packages/interface/src/components/key/Key.tsx
+++ b/packages/interface/src/components/key/Key.tsx
@@ -43,55 +43,54 @@ export const KeyDropdown = ({
 	const [open, setOpen] = useState(false);
 
 	const transitions = useTransition(open, {
-		from: {
-			opacity: 0,
-			transform: `scale(0.9)`,
-			transformOrigin: transformOrigin || 'top'
-		},
-		enter: { opacity: 1, transform: 'scale(1)' },
-		leave: { opacity: -0.5, transform: 'scale(0.95)' },
-		config: { mass: 0.4, tension: 200, friction: 10 }
+	  from: {
+		opacity: 0,
+		transform: `scale(0.9)`,
+		transformOrigin: transformOrigin || "top",
+	  },
+	  enter: { opacity: 1, transform: "scale(1)" },
+	  leave: { opacity: -0.5, transform: "scale(0.95)" },
+	  config: { mass: 0.4, tension: 200, friction: 10 },
 	});
-
+	
 	return (
-		<DropdownMenu.Root open={open} onOpenChange={setOpen}>
-		<DropdownMenu.Trigger>
-			{trigger}
-		</DropdownMenu.Trigger>
+	  <DropdownMenu.Root open={open} onOpenChange={setOpen}>
+		<DropdownMenu.Trigger>{trigger}</DropdownMenu.Trigger>
 		{transitions(
-				(styles, show) =>
-					show && (
-		<DropdownMenu.Portal forceMount>
-			<DropdownMenu.Content forceMount asChild>
-				<animated.div
+		  (styles, show) =>
+			show && (
+			  <DropdownMenu.Portal forceMount>
+				<DropdownMenu.Content forceMount asChild>
+				  <animated.div
 					// most of this is copied over from the `OverlayPanel`
 					className={clsx(
-						'flex flex-col',
-						'pl-4 pr-4 pt-2 pb-2 z-50 m-2 space-y-1',
-						'select-none cursor-default rounded-lg',
-						'text-left text-sm text-ink',
-						'bg-app-overlay/80 backdrop-blur',
-						// 'border border-app-overlay',
-						'shadow-2xl shadow-black/60 ',
-						className
+					  "flex flex-col",
+					  "pl-4 pr-4 pt-2 pb-2 z-50 m-2 space-y-1",
+					  "select-none cursor-default rounded-lg",
+					  "text-left text-sm text-ink",
+					  "bg-app-overlay/80 backdrop-blur",
+					  // 'border border-app-overlay',
+					  "shadow-2xl shadow-black/60 ",
+					  className
 					)}
 					style={styles}
-				>
-				{children}
-				</animated.div>
-			</DropdownMenu.Content>
-		</DropdownMenu.Portal>
-		))}
-		</DropdownMenu.Root>
-	);
+				  >
+					{children}
+				  </animated.div>
+				</DropdownMenu.Content>
+			  </DropdownMenu.Portal>
+			)
+		)}
+	  </DropdownMenu.Root>
+	);	
 };
 
 
 export const Key: React.FC<{ data: Key; index: number }> = ({ data, index }) => {
-	const { mutate: mountKey } = useLibraryMutation('keys.mount');
-	const { mutate: unmountKey } = useLibraryMutation('keys.unmount');
-	const { mutate: deleteKey } = useLibraryMutation('keys.deleteFromLibrary');
-	const { mutate: setDefaultKey } = useLibraryMutation('keys.setDefault');
+	const mountKey = useLibraryMutation('keys.mount');
+	const unmountKey = useLibraryMutation('keys.unmount');
+	const deleteKey = useLibraryMutation('keys.deleteFromLibrary');
+	const setDefaultKey = useLibraryMutation('keys.setDefault');
 
 	return (
 		<div
@@ -149,17 +148,17 @@ export const Key: React.FC<{ data: Key; index: number }> = ({ data, index }) => 
 						<DotsThree className="w-4 h-4 text-ink-faint" />
 					</Button> }>
 					{data.mounted && (
-						<DropdownMenu.DropdownMenuItem className="!cursor-default select-none text-menu-ink focus:outline-none py-0.5 active:opacity-80" onClick={(e) => { unmountKey(data.id) }}>Unmount</DropdownMenu.DropdownMenuItem>
+						<DropdownMenu.DropdownMenuItem className="!cursor-default select-none text-menu-ink focus:outline-none py-0.5 active:opacity-80" onClick={(e) => { unmountKey.mutate(data.id) }}>Unmount</DropdownMenu.DropdownMenuItem>
 					)}
 
 					{!data.mounted && (
-						<DropdownMenu.DropdownMenuItem className="!cursor-default select-none text-menu-ink focus:outline-none py-0.5 active:opacity-80" onClick={(e) => { mountKey(data.id) }}>Mount</DropdownMenu.DropdownMenuItem>
+						<DropdownMenu.DropdownMenuItem className="!cursor-default select-none text-menu-ink focus:outline-none py-0.5 active:opacity-80" onClick={(e) => { mountKey.mutate(data.id) }}>Mount</DropdownMenu.DropdownMenuItem>
 					)}
 
-					<DropdownMenu.DropdownMenuItem className="!cursor-default select-none text-menu-ink focus:outline-none py-0.5 active:opacity-80" onClick={(e) => { deleteKey(data.id) }}>Delete from Library</DropdownMenu.DropdownMenuItem>
+					<DropdownMenu.DropdownMenuItem className="!cursor-default select-none text-menu-ink focus:outline-none py-0.5 active:opacity-80" onClick={(e) => { deleteKey.mutate(data.id) }}>Delete from Library</DropdownMenu.DropdownMenuItem>
 
 					{!data.default && (
-						<DropdownMenu.DropdownMenuItem className="!cursor-default select-none text-menu-ink focus:outline-none py-0.5 active:opacity-80" onClick={(e) => { setDefaultKey(data.id) }}>Set as Default</DropdownMenu.DropdownMenuItem>
+						<DropdownMenu.DropdownMenuItem className="!cursor-default select-none text-menu-ink focus:outline-none py-0.5 active:opacity-80" onClick={(e) => { setDefaultKey.mutate(data.id) }}>Set as Default</DropdownMenu.DropdownMenuItem>
 					)}
 				</KeyDropdown>
 			</div>

--- a/packages/interface/src/components/key/Key.tsx
+++ b/packages/interface/src/components/key/Key.tsx
@@ -1,7 +1,7 @@
-import { Button } from '@sd/ui';
+import { Button, ContextMenu } from '@sd/ui';
 import clsx from 'clsx';
 import { DotsThree, Eye, Key as KeyIcon } from 'phosphor-react';
-
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { DefaultProps } from '../primitive/types';
 import { Tooltip } from '../tooltip/Tooltip';
 
@@ -17,11 +17,82 @@ export interface Key {
 		objectCount?: number;
 		containerCount?: number;
 	};
+	default?: boolean; // need to make use of this within the UI
 	// Nodes this key is mounted on
 	nodes?: string[]; // will be node object
 }
 
+import { PropsWithChildren, useState } from 'react';
+import { animated, config, useTransition } from 'react-spring';
+import { useLibraryMutation } from '@sd/client';
+
+interface Props extends DropdownMenu.MenuContentProps {
+	trigger: React.ReactNode;
+	transformOrigin?: string;
+	disabled?: boolean;
+}
+
+export const KeyDropdown = ({
+	trigger,
+	children,
+	disabled,
+	transformOrigin,
+	className,
+	...props
+}: PropsWithChildren<Props>) => {
+	const [open, setOpen] = useState(false);
+
+	const transitions = useTransition(open, {
+		from: {
+			opacity: 0,
+			transform: `scale(0.9)`,
+			transformOrigin: transformOrigin || 'top'
+		},
+		enter: { opacity: 1, transform: 'scale(1)' },
+		leave: { opacity: -0.5, transform: 'scale(0.95)' },
+		config: { mass: 0.4, tension: 200, friction: 10 }
+	});
+
+	return (
+		<DropdownMenu.Root open={open} onOpenChange={setOpen}>
+		<DropdownMenu.Trigger>
+			{trigger}
+		</DropdownMenu.Trigger>
+		{transitions(
+				(styles, show) =>
+					show && (
+		<DropdownMenu.Portal forceMount>
+			<DropdownMenu.Content forceMount asChild>
+				<animated.div
+					// most of this is copied over from the `OverlayPanel`
+					className={clsx(
+						'flex flex-col',
+						'pl-4 pr-4 pt-2 pb-2 z-50 m-2 space-y-1',
+						'select-none cursor-default rounded-lg',
+						'text-left text-sm text-ink',
+						'bg-app-overlay/80 backdrop-blur',
+						// 'border border-app-overlay',
+						'shadow-2xl shadow-black/60 ',
+						className
+					)}
+					style={styles}
+				>
+				{children}
+				</animated.div>
+			</DropdownMenu.Content>
+		</DropdownMenu.Portal>
+		))}
+		</DropdownMenu.Root>
+	);
+};
+
+
 export const Key: React.FC<{ data: Key; index: number }> = ({ data, index }) => {
+	const { mutate: mountKey } = useLibraryMutation('keys.mount');
+	const { mutate: unmountKey } = useLibraryMutation('keys.unmount');
+	const { mutate: deleteKey } = useLibraryMutation('keys.deleteFromLibrary');
+	const { mutate: setDefaultKey } = useLibraryMutation('keys.setDefault');
+
 	return (
 		<div
 			className={clsx(
@@ -73,9 +144,24 @@ export const Key: React.FC<{ data: Key; index: number }> = ({ data, index }) => 
 						</Button>
 					</Tooltip>
 				)}
-				<Button size="icon">
-					<DotsThree className="w-4 h-4 text-ink-faint" />
-				</Button>
+				<KeyDropdown trigger={
+					<Button size="icon">
+						<DotsThree className="w-4 h-4 text-ink-faint" />
+					</Button> }>
+					{data.mounted && (
+						<DropdownMenu.DropdownMenuItem className="!cursor-default select-none text-menu-ink focus:outline-none py-0.5 active:opacity-80" onClick={(e) => { unmountKey(data.id) }}>Unmount</DropdownMenu.DropdownMenuItem>
+					)}
+
+					{!data.mounted && (
+						<DropdownMenu.DropdownMenuItem className="!cursor-default select-none text-menu-ink focus:outline-none py-0.5 active:opacity-80" onClick={(e) => { mountKey(data.id) }}>Mount</DropdownMenu.DropdownMenuItem>
+					)}
+
+					<DropdownMenu.DropdownMenuItem className="!cursor-default select-none text-menu-ink focus:outline-none py-0.5 active:opacity-80" onClick={(e) => { deleteKey(data.id) }}>Delete from Library</DropdownMenu.DropdownMenuItem>
+
+					{!data.default && (
+						<DropdownMenu.DropdownMenuItem className="!cursor-default select-none text-menu-ink focus:outline-none py-0.5 active:opacity-80" onClick={(e) => { setDefaultKey(data.id) }}>Set as Default</DropdownMenu.DropdownMenuItem>
+					)}
+				</KeyDropdown>
 			</div>
 		</div>
 	);

--- a/packages/interface/src/components/key/Key.tsx
+++ b/packages/interface/src/components/key/Key.tsx
@@ -113,6 +113,11 @@ export const Key: React.FC<{ data: Key; index: number }> = ({ data, index }) => 
 								{data.nodes?.length || 0 > 0 ? `${data.nodes?.length || 0} nodes` : 'This node'}
 							</div>
 						)}
+						{data.default && (
+							<div className="inline ml-2 px-1 text-[8pt] font-medium text-gray-300 bg-gray-500 rounded">
+								Default
+							</div>
+						)}
 					</div>
 					{/* <div className="text-xs text-gray-300 opacity-30">#{data.id}</div> */}
 					{data.stats ? (

--- a/packages/interface/src/components/key/KeyList.tsx
+++ b/packages/interface/src/components/key/KeyList.tsx
@@ -37,31 +37,6 @@ export function KeyList(props: KeyListProps) {
 					{/* <CategoryHeading>Mounted keys</CategoryHeading> */}
 					<div className="space-y-1.5">
 						<ListKeys></ListKeys>
-						{/* <Key
-							index={0}
-							data={{
-								id: 'af5570f5a1810b7a',
-								name: 'OBS Recordings',
-								mounted: true,
-
-								nodes: ['node1', 'node2'],
-								stats: { objectCount: 235, containerCount: 2 }
-							}}
-						/>
-						<Key
-							index={1}
-							data={{
-								id: 'af5570f5a1810b7a',
-								name: 'Unknown Key',
-								locked: true,
-								mounted: true,
-								stats: { objectCount: 45 }
-							}}
-						/>
-						<Key index={2} data={{ id: '7324695a52da67b1', name: 'Spacedrive Company' }} />
-						<Key index={3} data={{ id: 'b02303d68d05a562', name: 'Key 4' }} />
-						<Key index={3} data={{ id: 'b02303d68d05a562', name: 'Key 5' }} />
-						<Key index={3} data={{ id: 'b02303d68d05a562', name: 'Key 6' }} /> */}
 					</div>
 				</div>
 			</div>

--- a/packages/interface/src/components/key/KeyList.tsx
+++ b/packages/interface/src/components/key/KeyList.tsx
@@ -1,5 +1,5 @@
 import { useLibraryQuery, useLibraryMutation  } from '@sd/client';
-import { Button } from '@sd/ui';
+import { Button, CategoryHeading } from '@sd/ui';
 
 import { DefaultProps } from '../primitive/types';
 import { Key } from './Key';
@@ -7,14 +7,18 @@ import type { Key as QueryKey } from '@sd/client';
 
 export type KeyListProps = DefaultProps;
 
-const { mutate: unmountAll } = useLibraryMutation('keys.unmountAll');
-
 const ListKeys = () => {
 	const keys = useLibraryQuery(['keys.list']);
 	const mounted_uuids = useLibraryQuery(['keys.listMounted']);
 
 	const mountedKeys: QueryKey[] = keys.data?.filter((key) => mounted_uuids.data?.includes(key.uuid)) ?? []
 	const unmountedKeys: QueryKey[] = keys.data?.filter(key => !mounted_uuids.data?.includes(key.uuid)) ?? []
+
+	if(keys.data?.length === 0) {
+		return (
+			<CategoryHeading>No keys available.</CategoryHeading>
+		)
+	}
 
 	return (
 		<>
@@ -44,7 +48,9 @@ export function KeyList(props: KeyListProps) {
 			</div>
 			<div className="flex w-full p-2 border-t border-app-line rounded-b-md">
 				<Button size="sm" variant="gray" onClick={() => {
-					unmountAll(null);
+					//const { mutate: unmountAll } = useLibraryMutation('keys.unmountAll');
+
+					//unmountAll(null);
 				}}>
 					Unmount All
 				</Button>

--- a/packages/interface/src/components/key/KeyList.tsx
+++ b/packages/interface/src/components/key/KeyList.tsx
@@ -4,6 +4,7 @@ import { Button, CategoryHeading } from '@sd/ui';
 import { DefaultProps } from '../primitive/types';
 import { Key } from './Key';
 import type { Key as QueryKey } from '@sd/client';
+import { useMemo } from 'react';
 
 export type KeyListProps = DefaultProps;
 
@@ -12,8 +13,18 @@ const ListKeys = () => {
 	const mounted_uuids = useLibraryQuery(['keys.listMounted']);
 	const default_key = useLibraryQuery(['keys.getDefault']);
 
-	const mountedKeys: QueryKey[] = keys.data?.filter((key) => mounted_uuids.data?.includes(key.uuid)) ?? []
-	const unmountedKeys: QueryKey[] = keys.data?.filter(key => !mounted_uuids.data?.includes(key.uuid)) ?? []
+	const mountedKeys = useMemo(
+		() => keys.data?.filter((key) => mounted_uuids.data?.includes(key.uuid)) ?? [],
+		[keys, mounted_uuids]
+	);
+
+	const unmountedKeys = useMemo(
+		() => 	keys.data?.filter(key => !mounted_uuids.data?.includes(key.uuid)) ?? [],
+		[keys, mounted_uuids]
+	);
+
+	//const mountedKeys: QueryKey[] = keys.data?.filter((key) => mounted_uuids.data?.includes(key.uuid)) ?? []
+	//const unmountedKeys: QueryKey[] = keys.data?.filter(key => !mounted_uuids.data?.includes(key.uuid)) ?? []
 
 	if(keys.data?.length === 0) {
 		return (

--- a/packages/interface/src/components/key/KeyList.tsx
+++ b/packages/interface/src/components/key/KeyList.tsx
@@ -3,7 +3,6 @@ import { Button, CategoryHeading } from '@sd/ui';
 
 import { DefaultProps } from '../primitive/types';
 import { Key } from './Key';
-import type { Key as QueryKey } from '@sd/client';
 import { useMemo } from 'react';
 
 export type KeyListProps = DefaultProps;
@@ -11,6 +10,9 @@ export type KeyListProps = DefaultProps;
 const ListKeys = () => {
 	const keys = useLibraryQuery(['keys.list']);
 	const mounted_uuids = useLibraryQuery(['keys.listMounted']);
+
+	// use a separate route so we get the default key from the key manager, not the database
+	// sometimes the key won't be stored in the database
 	const default_key = useLibraryQuery(['keys.getDefault']);
 
 	const [mountedKeys, unmountedKeys] = useMemo(

--- a/packages/interface/src/components/key/KeyList.tsx
+++ b/packages/interface/src/components/key/KeyList.tsx
@@ -27,6 +27,7 @@ const ListKeys = () => {
 			return (
 				<Key index={index} data={{
 					id: key.uuid,
+					// could probably do with a better way to number these, maybe something that doesn't change
 					name: `Key ${index + 1}`,
 					mounted: mountedKeys.includes(key),
 					default: default_key.data === key.uuid,

--- a/packages/interface/src/components/key/KeyList.tsx
+++ b/packages/interface/src/components/key/KeyList.tsx
@@ -48,7 +48,7 @@ const ListKeys = () => {
 };
 
 export function KeyList(props: KeyListProps) {
-	const { mutate: unmountAll } = useLibraryMutation(['keys.unmountAll']);
+	const unmountAll = useLibraryMutation(['keys.unmountAll']);
 
 	return (
 		<div className="flex flex-col h-full max-h-[360px]">
@@ -62,7 +62,7 @@ export function KeyList(props: KeyListProps) {
 			</div>
 			<div className="flex w-full p-2 border-t border-app-line rounded-b-md">
 				<Button size="sm" variant="gray" onClick={() => {
-					unmountAll(null);
+					unmountAll.mutate(null);
 				}}>
 					Unmount All
 				</Button>

--- a/packages/interface/src/components/key/KeyList.tsx
+++ b/packages/interface/src/components/key/KeyList.tsx
@@ -10,6 +10,7 @@ export type KeyListProps = DefaultProps;
 const ListKeys = () => {
 	const keys = useLibraryQuery(['keys.list']);
 	const mounted_uuids = useLibraryQuery(['keys.listMounted']);
+	const default_key = useLibraryQuery(['keys.getDefault']);
 
 	const mountedKeys: QueryKey[] = keys.data?.filter((key) => mounted_uuids.data?.includes(key.uuid)) ?? []
 	const unmountedKeys: QueryKey[] = keys.data?.filter(key => !mounted_uuids.data?.includes(key.uuid)) ?? []
@@ -27,7 +28,8 @@ const ListKeys = () => {
 				<Key index={index} data={{
 					id: key.uuid,
 					name: `Key ${index + 1}`,
-					mounted: mountedKeys.includes(key)
+					mounted: mountedKeys.includes(key),
+					default: default_key.data === key.uuid,
 				}} />
 			)
 		})}

--- a/packages/interface/src/components/key/KeyList.tsx
+++ b/packages/interface/src/components/key/KeyList.tsx
@@ -20,9 +20,6 @@ const ListKeys = () => {
 		[keys, mounted_uuids]
 	);
 
-	//const mountedKeys: QueryKey[] = keys.data?.filter((key) => mounted_uuids.data?.includes(key.uuid)) ?? []
-	//const unmountedKeys: QueryKey[] = keys.data?.filter(key => !mounted_uuids.data?.includes(key.uuid)) ?? []
-
 	if(keys.data?.length === 0) {
 		return (
 			<CategoryHeading>No keys available.</CategoryHeading>

--- a/packages/interface/src/components/key/KeyList.tsx
+++ b/packages/interface/src/components/key/KeyList.tsx
@@ -1,9 +1,31 @@
+import { useLibraryQuery  } from '@sd/client';
 import { Button } from '@sd/ui';
 
 import { DefaultProps } from '../primitive/types';
 import { Key } from './Key';
 
 export type KeyListProps = DefaultProps;
+
+const ListKeys = () => {
+	const keys = useLibraryQuery(['keys.list']);
+	const mounted_uuids = useLibraryQuery(['keys.listMounted']);
+
+	return (
+		<>
+		{keys.data?.map((key, index) => {
+			const active = !!keys.data?.find((t) => t.id === key.id);
+
+			return (
+				<Key index={index} data={{
+					id: key.uuid,
+					name: `Key ${index + 1}`,
+					mounted: mounted_uuids.data?.includes(key.uuid)
+				}} />
+			)
+		})}
+		</>
+	)
+};
 
 export function KeyList(props: KeyListProps) {
 	return (
@@ -12,7 +34,8 @@ export function KeyList(props: KeyListProps) {
 				<div className="">
 					{/* <CategoryHeading>Mounted keys</CategoryHeading> */}
 					<div className="space-y-1.5">
-						<Key
+						<ListKeys></ListKeys>
+						{/* <Key
 							index={0}
 							data={{
 								id: 'af5570f5a1810b7a',
@@ -36,7 +59,7 @@ export function KeyList(props: KeyListProps) {
 						<Key index={2} data={{ id: '7324695a52da67b1', name: 'Spacedrive Company' }} />
 						<Key index={3} data={{ id: 'b02303d68d05a562', name: 'Key 4' }} />
 						<Key index={3} data={{ id: 'b02303d68d05a562', name: 'Key 5' }} />
-						<Key index={3} data={{ id: 'b02303d68d05a562', name: 'Key 6' }} />
+						<Key index={3} data={{ id: 'b02303d68d05a562', name: 'Key 6' }} /> */}
 					</div>
 				</div>
 			</div>

--- a/packages/interface/src/components/key/KeyList.tsx
+++ b/packages/interface/src/components/key/KeyList.tsx
@@ -13,13 +13,8 @@ const ListKeys = () => {
 	const mounted_uuids = useLibraryQuery(['keys.listMounted']);
 	const default_key = useLibraryQuery(['keys.getDefault']);
 
-	const mountedKeys = useMemo(
-		() => keys.data?.filter((key) => mounted_uuids.data?.includes(key.uuid)) ?? [],
-		[keys, mounted_uuids]
-	);
-
-	const unmountedKeys = useMemo(
-		() => 	keys.data?.filter(key => !mounted_uuids.data?.includes(key.uuid)) ?? [],
+	const [mountedKeys, unmountedKeys] = useMemo(
+		() => [keys.data?.filter((key) => mounted_uuids.data?.includes(key.uuid)) ?? [], keys.data?.filter(key => !mounted_uuids.data?.includes(key.uuid)) ?? []],
 		[keys, mounted_uuids]
 	);
 

--- a/packages/interface/src/components/key/KeyList.tsx
+++ b/packages/interface/src/components/key/KeyList.tsx
@@ -3,6 +3,7 @@ import { Button } from '@sd/ui';
 
 import { DefaultProps } from '../primitive/types';
 import { Key } from './Key';
+import type { Key as QueryKey } from '@sd/client';
 
 export type KeyListProps = DefaultProps;
 
@@ -10,16 +11,17 @@ const ListKeys = () => {
 	const keys = useLibraryQuery(['keys.list']);
 	const mounted_uuids = useLibraryQuery(['keys.listMounted']);
 
+	const mountedKeys: QueryKey[] = keys.data?.filter((key) => mounted_uuids.data?.includes(key.uuid)) ?? []
+	const unmountedKeys: QueryKey[] = keys.data?.filter(key => !mounted_uuids.data?.includes(key.uuid)) ?? []
+
 	return (
 		<>
-		{keys.data?.map((key, index) => {
-			const active = !!keys.data?.find((t) => t.id === key.id);
-
+		{[...mountedKeys, ...unmountedKeys]?.map((key, index) => {
 			return (
 				<Key index={index} data={{
 					id: key.uuid,
 					name: `Key ${index + 1}`,
-					mounted: mounted_uuids.data?.includes(key.uuid)
+					mounted: mountedKeys.includes(key)
 				}} />
 			)
 		})}

--- a/packages/interface/src/components/key/KeyList.tsx
+++ b/packages/interface/src/components/key/KeyList.tsx
@@ -30,6 +30,7 @@ const ListKeys = () => {
 					name: `Key ${index + 1}`,
 					mounted: mountedKeys.includes(key),
 					default: default_key.data === key.uuid,
+					// key stats need including here at some point
 				}} />
 			)
 		})}

--- a/packages/interface/src/components/key/KeyList.tsx
+++ b/packages/interface/src/components/key/KeyList.tsx
@@ -36,6 +36,8 @@ const ListKeys = () => {
 };
 
 export function KeyList(props: KeyListProps) {
+	const { mutate: unmountAll } = useLibraryMutation(['keys.unmountAll']);
+
 	return (
 		<div className="flex flex-col h-full max-h-[360px]">
 			<div className="p-3 custom-scroll overlay-scroll">
@@ -48,9 +50,7 @@ export function KeyList(props: KeyListProps) {
 			</div>
 			<div className="flex w-full p-2 border-t border-app-line rounded-b-md">
 				<Button size="sm" variant="gray" onClick={() => {
-					//const { mutate: unmountAll } = useLibraryMutation('keys.unmountAll');
-
-					//unmountAll(null);
+					unmountAll(null);
 				}}>
 					Unmount All
 				</Button>

--- a/packages/interface/src/components/key/KeyList.tsx
+++ b/packages/interface/src/components/key/KeyList.tsx
@@ -1,4 +1,4 @@
-import { useLibraryQuery  } from '@sd/client';
+import { useLibraryQuery, useLibraryMutation  } from '@sd/client';
 import { Button } from '@sd/ui';
 
 import { DefaultProps } from '../primitive/types';
@@ -6,6 +6,8 @@ import { Key } from './Key';
 import type { Key as QueryKey } from '@sd/client';
 
 export type KeyListProps = DefaultProps;
+
+const { mutate: unmountAll } = useLibraryMutation('keys.unmountAll');
 
 const ListKeys = () => {
 	const keys = useLibraryQuery(['keys.list']);
@@ -41,7 +43,9 @@ export function KeyList(props: KeyListProps) {
 				</div>
 			</div>
 			<div className="flex w-full p-2 border-t border-app-line rounded-b-md">
-				<Button size="sm" variant="gray">
+				<Button size="sm" variant="gray" onClick={() => {
+					unmountAll(null);
+				}}>
 					Unmount All
 				</Button>
 				<div className="flex-grow" />

--- a/packages/interface/src/components/key/KeyMounter.tsx
+++ b/packages/interface/src/components/key/KeyMounter.tsx
@@ -69,8 +69,8 @@ export function KeyMounter() {
 				<div className="flex flex-col">
 					<span className="text-xs font-bold">Encryption</span>
 					<Select className="mt-2" onChange={setEncryptionAlgo} value={encryptionAlgo}>
-						<SelectOption value="XChaCha20Poly1305">XChaCha20Poly1305</SelectOption>
-						<SelectOption value="Aes256Gcm">Aes256Gcm</SelectOption>
+						<SelectOption value="XChaCha20Poly1305">XChaCha20-Poly1305</SelectOption>
+						<SelectOption value="Aes256Gcm">AES-256-GCM</SelectOption>
 					</Select>
 				</div>
 				<div className="flex flex-col">

--- a/packages/interface/src/components/key/KeyMounter.tsx
+++ b/packages/interface/src/components/key/KeyMounter.tsx
@@ -2,6 +2,7 @@ import { InformationCircleIcon } from '@heroicons/react/24/outline';
 import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/solid';
 import { Button, CategoryHeading, Input, Select, SelectOption, Switch, cva, tw } from '@sd/ui';
 import { useEffect, useRef, useState } from 'react';
+import { useLibraryMutation, useLibraryQuery } from '@sd/client';
 
 import { Tooltip } from '../tooltip/Tooltip';
 
@@ -16,6 +17,8 @@ export function KeyMounter() {
 	const [key, setKey] = useState('');
 	const [encryptionAlgo, setEncryptionAlgo] = useState('XChaCha20Poly1305');
 	const [hashingAlgo, setHashingAlgo] = useState('Argon2id');
+
+	const { mutate: createKey } = useLibraryMutation('keys.add');
 
 	const CurrentEyeIcon = showKey ? EyeSlashIcon : EyeIcon;
 
@@ -84,7 +87,11 @@ export function KeyMounter() {
 			<p className="pt-1.5 ml-0.5 text-[8pt] leading-snug text-ink-faint w-[90%]">
 				Files encrypted with this key will be revealed and decrypted on the fly.
 			</p>
-			<Button className="w-full mt-2" variant="accent">
+			<Button className="w-full mt-2" variant="accent" onClick={() => {
+				createKey({algorithm: encryptionAlgo, hashing_algorithm: hashingAlgo, key: key });
+				setKey("");
+			}
+			}>
 				Mount Key
 			</Button>
 		</div>

--- a/packages/interface/src/components/key/KeyMounter.tsx
+++ b/packages/interface/src/components/key/KeyMounter.tsx
@@ -24,7 +24,7 @@ export function KeyMounter() {
 	const [encryptionAlgo, setEncryptionAlgo] = useState('XChaCha20Poly1305');
 	const [hashingAlgo, setHashingAlgo] = useState('Argon2id-s');
 
-	const { mutate: createKey } = useLibraryMutation('keys.add');
+	const createKey = useLibraryMutation('keys.add');
 	const CurrentEyeIcon = showKey ? EyeSlash : Eye;
 
 	// this keeps the input focused when switching tabs
@@ -109,7 +109,7 @@ export function KeyMounter() {
 						break;
 				}
 
-				createKey({algorithm, hashing_algorithm, key });
+				createKey.mutate({algorithm, hashing_algorithm, key });
 				setKey("");
 			}
 			}>

--- a/packages/interface/src/components/key/KeyMounter.tsx
+++ b/packages/interface/src/components/key/KeyMounter.tsx
@@ -2,6 +2,7 @@ import { Button, CategoryHeading, Input, Select, SelectOption, Switch, cva, tw }
 import { Eye, EyeSlash, Info } from 'phosphor-react';
 import { useEffect, useRef, useState } from 'react';
 import { useLibraryMutation, useLibraryQuery } from '@sd/client';
+import { Algorithm, HashingAlgorithm, Params } from '@sd/client';
 
 import { Tooltip } from '../tooltip/Tooltip';
 
@@ -21,7 +22,7 @@ export function KeyMounter() {
 
 	const [key, setKey] = useState('');
 	const [encryptionAlgo, setEncryptionAlgo] = useState('XChaCha20Poly1305');
-	const [hashingAlgo, setHashingAlgo] = useState('Argon2id');
+	const [hashingAlgo, setHashingAlgo] = useState('Argon2id-s');
 
 	const { mutate: createKey } = useLibraryMutation('keys.add');
 	const CurrentEyeIcon = showKey ? EyeSlash : Eye;
@@ -83,8 +84,9 @@ export function KeyMounter() {
 				<div className="flex flex-col">
 					<span className="text-xs font-bold">Hashing</span>
 					<Select className="mt-2" onChange={setHashingAlgo} value={hashingAlgo}>
-						<SelectOption value="Argon2id">Argon2id</SelectOption>
-						<SelectOption value="Bcrypt">Bcrypt</SelectOption>
+						<SelectOption value="Argon2id-s">Argon2id (standard)</SelectOption>
+						<SelectOption value="Argon2id-h">Argon2id (hardened)</SelectOption>
+						<SelectOption value="Argon2id-p">Argon2id (paranoid)</SelectOption>
 					</Select>
 				</div>
 			</div>
@@ -92,7 +94,22 @@ export function KeyMounter() {
 				Files encrypted with this key will be revealed and decrypted on the fly.
 			</p>
 			<Button className="w-full mt-2" variant="accent" onClick={() => {
-				createKey({algorithm: encryptionAlgo, hashing_algorithm: hashingAlgo, key: key });
+				let algorithm = encryptionAlgo as Algorithm;
+				let hashing_algorithm: HashingAlgorithm = { Argon2id: "Standard" };
+
+				switch(hashingAlgo) {
+					case "Argon2id-s":
+						hashing_algorithm = { Argon2id: "Standard" as Params };
+						break;
+					case "Argon2id-h":
+						hashing_algorithm = { Argon2id: "Hardened" as Params };
+						break;
+					case "Argon2id-p":
+						hashing_algorithm = { Argon2id: "Paranoid" as Params };
+						break;
+				}
+
+				createKey({algorithm, hashing_algorithm, key });
 				setKey("");
 			}
 			}>

--- a/packages/interface/src/components/key/KeyMounter.tsx
+++ b/packages/interface/src/components/key/KeyMounter.tsx
@@ -10,6 +10,12 @@ const KeyHeading = tw(CategoryHeading)`mb-1`;
 export function KeyMounter() {
 	const ref = useRef<HTMLInputElement>(null);
 
+	// we need to call these at least once somewhere
+	// if we don't, if a user mounts a key before first viewing the key list, no key will show in the list
+	// either call it in here or in the keymanager itself
+	const keys = useLibraryQuery(['keys.list']);
+	const mounted_uuids = useLibraryQuery(['keys.listMounted']);
+
 	const [showKey, setShowKey] = useState(false);
 	const [toggle, setToggle] = useState(true);
 


### PR DESCRIPTION
This PR is massive, please criticize it to shreds - it's important that we get this right.

The Key Manager now uses [DashMap](https://github.com/xacrimon/dashmap) in order to provide concurrency and better performance over `HashMap`.

There are a few known bugs/issues:

* The dropdown UI is pretty bad, and doesn't fit in too well with the rest of Spacedrive (and the TS formatting is bad too, I don't know how we format that though)
* The key numbering is volatile, and can/will be confusing
* We have no way to set key names within the UI
* We have no way to view the plaintext key within the UI
* Object/container stats are not attached (this isn't major, as they would all be 0 and therefore wouldn't show anyway)
* The UI offers no differentiation between the default key and normal keys
* There is a bug where you are unable to remove a key instantly while mounting another key
* We have no way to set the master password, and possibly no way to verify that it's correct until the user attempts to run an action. I will be adding a master password validation feature, which will essentially insert a ghost key into the library, which is only ever used to ensure the entered master password is correct. If we're going to give the user a master password during library onboarding, we'll need a way to make sure it's correct and doesn't deviate from what was provided.

Go ahead and close this if needs be, there is still quite a lot to do - I just didn't want this branch to be sat around forever.

Here is a preview of the current key manager (key mounting on dev builds isn't this fast, but they will be in prod):

https://user-images.githubusercontent.com/77554505/199038410-0d21c5c5-4ec6-48e3-aad8-2e139978c22f.mp4
