### PR TITLE
[ENG-282] Add Crypto docs

### DIFF
--- a/docs/developers/architecture/encryption.md
+++ b/docs/developers/architecture/encryption.md
@@ -1,0 +1,39 @@
+---
+index: 10
+---
+
+# Encryption
+
+Here you will find all information relevant to encryption and decryption within Spacedrive. This also documents single-file headers, and the information/values which may be stored.
+
+
+## Headers
+
+Headers store information that is critical to the decryption of the data. Most commonly, this consists of salts, nonces and version identifiers. Our header system allows us to optionally include other information, such as file metadata and preview media (video thumbnails and such).
+
+### Structure
+
+The current header structure is as follows:
+
+| Name               | Purpose                      | Size       |
+|--------------------|------------------------------|------------|
+| Magic Bytes        | To quickly identify the file | 7 bytes    |
+| Header Version     |                              | 2 bytes    |
+| Algorithm          | Encryption Algorithm         | 2 bytes    |
+| Nonce              | Nonce used for the data      | 8/20 bytes |
+| Padding            | To reach a total of 36 bytes | 5/17 bytes |
+| Keyslot Area       | To store 2x keyslots         | 192 bytes  |
+| Metadata Area      | To store metadata (optional) | Varies     |
+| Preview Media Area | To store PVM (optional)      | Varies     |
+
+The keyslot area:
+
+| Name              | Purpose                      | Size       |
+|-------------------|------------------------------|------------|
+| Keyslot Version   |                              | 2 bytes    |
+| Algorithm         | Encryption Algorithm         | 2 bytes    |
+| Hashing Algorithm |                              | 2 bytes    |
+| Salt              | Salt used for hashing        | 16 bytes   |
+| Master Key        | (encrypted)                  | 48 bytes   |
+| Nonce             | Nonce used for encrypting MK | 8/20 bytes |
+| Padding           | To reach 96 total bytes      | 6/12 bytes |

--- a/docs/developers/architecture/encryption.md
+++ b/docs/developers/architecture/encryption.md
@@ -6,12 +6,64 @@ index: 10
 
 Here you will find all information relevant to encryption and decryption within Spacedrive. This also documents single-file headers, and the information/values which may be stored.
 
+## Cryptography
+
+We take a strong stance on cryptography within Spacedrive, and we aim to provide a user-friendly experience while remaining as secure as possible.
+
+### In-depth Overview
+
+Key encryption makes use of an LE31 STREAM construction. This means that the last 4 bytes of the nonce consist of a 31 bit little-endian counter, and a 1 bit "last block" flag, totalling 4 bytes. The nonce (n) is still the correct size for the AEAD, but we only have to generate (n - 4) due to the counter.
+
+Each piece of data is read in `BLOCK_SIZE` (1MiB), as this offers the best performance/memory usage from our testing. If the read count is less than the block size, we encrypt the block as if it were the last, so the 1 bit "last block" flag gets enabled. This allows us to use the same stream reader everywhere, regardless of data size.
+
+The file size gain with this `BLOCK_SIZE` is 16 bytes per 1MiB of data, which is extremely negligible. These additional 16 bytes are used for authenticating the ciphertext, to make sure it has not changed. This means the decrypted plaintext will **always** be identical to the original, provided decryption does not produce any errors. The algorithm used for this depends on the encryption algorithm selected, but it is either GHASH or Poly1305.
+
+### RNGs
+
+Throughout every cryptographic function within Spacedrive that requires cryptographically-secure random values, we use the system's entropy along with `ChaCha20Rng`. More information on this RNG can be found [here](https://rust-random.github.io/rand/rand_chacha/struct.ChaCha20Rng.html).
+
+This is used for nonce, salt and master key generation to ensure none of these values are predictable to an attacker.
+
+### Encryption and Hashing Algorithms
+
+Cryptographic agility is never really recommended, so we don't provide too many options in this regard.
+
+For encryption, we currently offer: `XChaCha20-Poly1305` (as the default), and `AES-256-GCM`. `XChaCha20-Poly1305` was chosen as the default due to better performance overall, and much better performance and security on devices where cryptographic hardware acceleration is unavailable. You can read about AES cache timing attacks [here](https://cr.yp.to/antiforgery/cachetiming-20050414.pdf). `XChaCha20-Poly1305` is also capable of encrypting more data than `AES-256-GCM`.
+
+For hashing, we provide `Argon2id` at varying hashing levels (standard, hardened and paranoid). The internal `Argon2id` parameters are not set in stone yet, and may change. We chose `Argon2id` due to its memory-hardness, resistance to side channel attacks and resistance to TMTO attacks.
+
+### Cryptographic Hygiene
+
+In order to securely zero memory, we use a crate called `zeroize`. This is used throughout the entire `crypto` crate.
+
+We use the `Protected` wrapper for aiding the handling of sensitive information. This wrapper does not allow `Copy`, and automatically redacts stored information from debugging logs. It also implements zeroize-on-drop, meaning once the value goes out of scope/is dropped, the memory is securely zeroed out.
+### Libraries and Audits
+
+We make use of [RustCrypto](https://github.com/RustCrypto)'s AEAD and hashing libraries, as they are created with security in mind.
+
+NCC Group have audited the encryption libraries that we use, and those audits can be found [here](https://research.nccgroup.com/wp-content/uploads/2020/02/NCC_Group_MobileCoin_RustCrypto_AESGCM_ChaCha20Poly1305_Implementation_Review_2020-02-12_v1.0.pdf).
+
+### AAD
+
+We make use of AEADs for encryption, which means we are able to provide associated data while encrypting. This can be anything really, but the file will NOT decrypt without this information present.
+
+The associated data is not encrypted, it is just authenticated during encryption and is required to be present during decryption.
+
+We authenticate the associated data with *every* block of data, and this comes at no impactful performance cost.
+
+AAD for encrypting within Spacedrive consists of the first 36 bytes of the header (including the padding). If this part of the header is tampered with, your file will not decrypt at all.
+
+We only include the first 36 bytes of the header as the rest of the header is not static, and can change at any point. Keys may be changed, or preview media may be removed, so it's best to just use the critical parts that will not change.
 
 ## Headers
 
-Headers store information that is critical to the decryption of the data. Most commonly, this consists of salts, nonces and version identifiers. Our header system allows us to optionally include other information, such as file metadata and preview media (video thumbnails and such).
+Headers store information that is critical to the decryption of the data. Most commonly, this consists of salts, nonces and version identifiers.
 
 ### Structure
+
+The headers have support for lots of associated information. We can optionally store metadata and preview media within the header, and allow them to be accessible instantly.
+
+Using multiple keyslots also allows us to support more than one key for decrypting a file, and you can change them too!
 
 The current header structure is as follows:
 
@@ -37,3 +89,33 @@ The keyslot area:
 | Master Key        | (encrypted)                  | 48 bytes   |
 | Nonce             | Nonce used for encrypting MK | 8/20 bytes |
 | Padding           | To reach 96 total bytes      | 6/12 bytes |
+
+The metadata area:
+
+| Name             | Purpose                | Size       |
+|------------------|------------------------|------------|
+| Metadata Version |                        | 2 bytes    |
+| Algorithm        | Encryption Algorithm   | 2 bytes    |
+| Nonce            | Used for the data      | 8/20 bytes |
+| Padding          | To reach 28 bytes      | 4/16 bytes |
+| Length           | Length of the MD (u64) | 8 bytes    |
+| Metadata         | (encrypted)            | Varies     |
+
+The preview media area:
+
+| Name        | Purpose                 | Size       |
+|-------------|-------------------------|------------|
+| PVM Version |                         | 2 bytes    |
+| Algorithm   | Encryption Algorithm    | 2 bytes    |
+| Nonce       | Used for the data       | 8/20 bytes |
+| Padding     | To reach 28 bytes       | 4/16 bytes |
+| Length      | Length of the PVM (u64) | 8 bytes    |
+| Metadata    | (encrypted)             | Varies     |
+
+### Additional Header Objects
+
+Additional header objects, such as metadata and preview media, inherit the keyslot's master key. This is so that one hashed key is able to decrypt all data associated with the file, and provide immediate access to the user. This also means that changing a password will reflect upon all parts of the file, not just the data.
+
+Metadata can be anything that implements `serde::Serialize`, and the size does not matter.
+
+Preview media is intended to be a video thumbnail, or even a portion of a video. Raw bytes are the most suitable for this type, but storing something else here is not strictly forbidden.

--- a/docs/developers/architecture/encryption.md
+++ b/docs/developers/architecture/encryption.md
@@ -22,7 +22,7 @@ The file size gain with this `BLOCK_SIZE` is 16 bytes per 1MiB of data, which is
 
 Throughout every cryptographic function within Spacedrive that requires cryptographically-secure random values, we use the system's entropy along with `ChaCha20Rng`. More information on this RNG can be found [here](https://rust-random.github.io/rand/rand_chacha/struct.ChaCha20Rng.html).
 
-This is used for nonce, salt and master key generation to ensure none of these values are predictable to an attacker.
+This is used for nonce, salt, master key and master passphrase generation to ensure none of these values are predictable to an attacker.
 
 ### Encryption and Hashing Algorithms
 
@@ -47,7 +47,7 @@ NCC Group have audited the encryption libraries that we use, and those audits ca
 
 We make use of AEADs for encryption, which means we are able to provide associated data while encrypting. This can be anything really, but the file will NOT decrypt without this information present.
 
-The associated data is not encrypted, it is just authenticated during encryption and is required to be present during decryption.
+The associated data is not encrypted, it is just authenticated during encryption and is required to be present during decryption. This allows us to implement specific checks, so we can ensure nothing has been tampered with.
 
 We authenticate the associated data with *every* block of data, and this comes at no impactful performance cost.
 
@@ -64,6 +64,8 @@ Headers store information that is critical to the decryption of the data. Most c
 The headers have support for lots of associated information. We can optionally store metadata and preview media within the header, and allow them to be accessible instantly.
 
 Using multiple keyslots also allows us to support more than one key for decrypting a file, and you can change them too!
+
+These structures will likely change multiple times before we officially set them in stone. Things like metadata/preview media length encryption are planned, as well as other header objects entirely.
 
 The current header structure is as follows:
 
@@ -118,4 +120,4 @@ Additional header objects, such as metadata and preview media, inherit the keysl
 
 Metadata can be anything that implements `serde::Serialize`, and the size does not matter.
 
-Preview media is intended to be a video thumbnail, or even a portion of a video. Raw bytes are the most suitable for this type, but storing something else here is not strictly forbidden.
+Preview media is intended to be a video thumbnail, or even a portion of a video. Raw bytes are the most suitable for this type, but storing something else here is not strictly forbidden (it is advised against, though).

--- a/docs/developers/architecture/key-manager.md
+++ b/docs/developers/architecture/key-manager.md
@@ -1,0 +1,65 @@
+---
+index: 10
+---
+
+# Key Manager
+
+The key manager handles all keys used for encrypting and decrypting files/containers, and is essentially an entire password manager built into Spacedrive.
+
+To function, it requires a master key (which is provided during library creation). Do **not** lose this key, as it is not recoverable.
+
+The `keymount` and `keystore` refer to the area in memory where each type of keys are stored.
+
+## Audits
+
+NCC Group have audited the encryption libraries that we use, and those audits can be found [here](https://research.nccgroup.com/wp-content/uploads/2020/02/NCC_Group_MobileCoin_RustCrypto_AESGCM_ChaCha20Poly1305_Implementation_Review_2020-02-12_v1.0.pdf).
+
+## Master Password
+
+During library creation, the user will be provided with a master password.
+
+Each time Spacedrive is started, this master password is required. It is subsequently used to decrypt a randomly generated key, to ensure the password is correct. This verification process is not perfect.
+
+Support for changing a master key will be added at a later date, but for now it is not a priority.
+
+## Cryptographic Hygiene
+
+In order to securely zero memory, we use a crate called `zeroize`. This is used throughout the entire `crypto` crate.
+
+We use the `Protected` wrapper for aiding the handling of sensitive information. This wrapper does not allow `Copy`, and automatically redacts stored information from debugging logs. It also implements zeroize-on-drop, meaning once the value goes out of scope/is dropped, the memory is securely zeroed out.
+
+## Internal Architecture
+
+The key manager is made up of a few parts: two `DashMap`'s, and two `Mutex<Option>`'s. Although this sounds very simple, it is a pretty complex system, and provides high levels of security.
+
+Many functions within the key manager don't return values. This is by design, and prevents us from unnecessarily returning (potentially sensitive) information to a function that does not require it. The information may still be accessed, but with the use of a UUID and another function. This design also allows us to have tight control over accessing and logging, so we're able to provide information about when a key was last used and what for.
+
+We chose `DashMap` for the key manager, as opposed to the standard `HashMap`. `DashMap` provides us with much better performance than alternatives, while also offering concurrency. It aims to be a direct replacement for `RwLock<HashMap<K, V, S>>`, and it fits our needs perfectly.
+
+The key manager also stores the UUID for the default key, and the *hashed* master password. This allows us to near-instantly decrypt stored keys (although mounting still takes a while, depending on the parameters chosen).
+
+## Available Configuration
+
+Cryptographic agility is never really recommended, so we don't provide too many options in this regard.
+
+For encryption, we currently offer: `XChaCha20-Poly1305` (as the default), and `AES-256-GCM`. `XChaCha20-Poly1305` was chosen as the default due to better performance overall, and much better performance and security on devices where cryptographic hardware acceleration is unavailable. You can read about AES cache timing attacks [here](https://cr.yp.to/antiforgery/cachetiming-20050414.pdf).
+
+For hashing, we provide `Argon2id` at varying hashing levels (standard, hardened and paranoid). The internal `Argon2id` parameters are not set in stone yet, and may change.
+
+## Content Salts
+
+A content salt is specific to each key/parameter pair, and is stored within the library. When a key gets mounted, it is hashed with the content salt. We do this to prevent hashing the key each time it's going to be used.
+
+All data encrypted with this key/parameter pair will be (indirectly) encrypted with this hashed key, which allows us to near-instantly access and show encrypted file metadata, preview media and even the data itself.
+
+## Mounting
+
+There are two types of key mounting: adding and mounting, and just mounting.
+
+Adding and mounting first registers the key with the internal keystore, which securely generates things needed to store your key safely, before mounting the key.
+
+Just mounting the key means exactly that - the key is mounted (decrypted in-memory, and then hashed with your content salt) before being stored within the keymount.
+
+## Unmounting
+
+Unmounting is relatively simple, and it just removes the key from the keymount. Unmounting also removes any in-memory data that was decrypted with the (now umounted) key.

--- a/docs/developers/architecture/key-manager.md
+++ b/docs/developers/architecture/key-manager.md
@@ -10,11 +10,19 @@ To function, it requires a master password (which is provided during library cre
 
 More in-depth cryptographic information can be found on the [encryption page](./encryption).
 
-## Master Password
+## Master Password and the Secret Key
 
-During library creation, the user will be provided with a master password.
+During library creation, the user will be provided with a master password. This password consists of 7 randomly-selected words, chosen from the EFF large wordlist. This provides 7776^7 possible passphrases, which is a rather large amount.
 
-Each time Spacedrive is started, this master password is required. It is subsequently used to decrypt a randomly generated key, to ensure the password is correct. This verification process is not perfect.
+The user is also provided with a "secret key" during onboarding, and this is **required** for decryption of any keys. It is 16 random bytes, encoded in `base64`. The secret key is hashed alongside the master password, and aims to reduce the damage of an attacker learning your master password. If an attacker learns either pieces of information, your keys are still safe as they would have to brute-force the other. This increases security exponentially, provided both items are stored separately.
+
+If an attacker knows your master passphrase, they would still have to guess 256^16 bytes to gain access to your keys. If an attacker knows your secret key, they would still have to guess 7776^7 times in order to guarantee access to your data. In reality, they would likely find the correct combination without iterating through *all* available permutations, but this is still more than challenging for even the most well-equipped threat actors.
+
+Each time Spacedrive is restarted, this master password is required (as it is cleared from memory). It is subsequently used to decrypt a randomly generated "verification" key, to ensure the password is correct. This verification process is not perfect, but it allows us to ensure the user has the correct password/secret key combination before letting them add more keys.
+
+The master password is the heart of the operation, which is why it's generated for you. In the event of a master password compromise, provided the attacker doesn't have access to the secret key, your data is safe.
+
+If a key from the keystore is compromised, the damage is limited to the data encrypted with that specific key. In this event, it's probably best to decrypt all data with that key, and re-encrypt it with a new one. We eventually plan to make this extremely simple within Spacedrive.
 
 Support for changing a master password will be added at a later date, but for now it is not a priority.
 
@@ -22,19 +30,17 @@ Support for changing a master password will be added at a later date, but for no
 
 Designing the key manager, and our key system as a whole, was a difficult task. It needs to be three things: secure, performant, and not annoying for the user. The main way to do this is to implement a hierarchical system, similar to what we have done.
 
-The master password is the heart of the operation, which is why it's generated for you. In the event of a master password compromise, it's safe to assume that all underlying data is decryptable. Over time, we will refine the system and minimize this risk as much as possible (possibly by making the user store their master password's salt separately).
-
-If a key from the keystore is compromised, the damage is limited to the data encrypted with that specific key. In this event, it's probably best to decrypt all data with that key, and re-encrypt it with a new one. We eventually plan to make this extremely simple within Spacedrive.
+We chose specific password hashing parameters in order to provide a great performance/time relationship, and even "paranoid" keys don't take too long to hash (even though they use lots of memory).
 
 ## Internal Architecture
 
-The key manager is made up of a few parts: two `DashMap`'s, and two `Mutex<Option>`'s. Although this sounds very simple, it is a pretty complex system, and provides high levels of security.
+The key manager is made up of a few parts: two `DashMap`'s, and three `Mutex<Option>`'s. Although this is pretty simple, it allows us to provide rather high levels of security.
 
 Many functions within the key manager don't return values. This is by design, and prevents us from unnecessarily returning (potentially sensitive) information to a function that does not require it. The information may still be accessed, but with the use of a UUID and another function. This design also allows us to have tight control over accessing and logging, so we're able to provide information about when a key was last used and what for.
 
 We chose `DashMap` for the key manager, as opposed to the standard `HashMap`. `DashMap` provides us with much better performance than alternatives, while also offering concurrency. It aims to be a direct replacement for `RwLock<HashMap<K, V, S>>`, and it fits our needs perfectly.
 
-The key manager also stores the UUID for the default key, and the *hashed* master password. This allows us to near-instantly decrypt stored keys (although mounting still takes a while, depending on the parameters chosen).
+The key manager also stores the UUID for the default key, and the *hashed* master password. This allows us to near-instantly decrypt stored keys (although mounting still takes a while, depending on the parameters chosen). We also store the "verification key", in order to make sure the user has entered the correct password/secret key combination.
 
 ## Terminology
 

--- a/docs/developers/architecture/key-manager.md
+++ b/docs/developers/architecture/key-manager.md
@@ -8,11 +8,7 @@ The key manager handles all keys used for encrypting and decrypting files/contai
 
 To function, it requires a master password (which is provided during library creation). Do **not** lose this key, as it is not recoverable.
 
-The `keymount` and `keystore` refer to the area in memory where each key types are stored.
-
-## Audits
-
-NCC Group have audited the encryption libraries that we use, and those audits can be found [here](https://research.nccgroup.com/wp-content/uploads/2020/02/NCC_Group_MobileCoin_RustCrypto_AESGCM_ChaCha20Poly1305_Implementation_Review_2020-02-12_v1.0.pdf).
+More in-depth cryptographic information can be found on the [encryption page](./encryption).
 
 ## Master Password
 
@@ -30,12 +26,6 @@ The master password is the heart of the operation, which is why it's generated f
 
 If a key from the keystore is compromised, the damage is limited to the data encrypted with that specific key. In this event, it's probably best to decrypt all data with that key, and re-encrypt it with a new one. We eventually plan to make this extremely simple within Spacedrive.
 
-## Cryptographic Hygiene
-
-In order to securely zero memory, we use a crate called `zeroize`. This is used throughout the entire `crypto` crate.
-
-We use the `Protected` wrapper for aiding the handling of sensitive information. This wrapper does not allow `Copy`, and automatically redacts stored information from debugging logs. It also implements zeroize-on-drop, meaning once the value goes out of scope/is dropped, the memory is securely zeroed out.
-
 ## Internal Architecture
 
 The key manager is made up of a few parts: two `DashMap`'s, and two `Mutex<Option>`'s. Although this sounds very simple, it is a pretty complex system, and provides high levels of security.
@@ -46,27 +36,19 @@ We chose `DashMap` for the key manager, as opposed to the standard `HashMap`. `D
 
 The key manager also stores the UUID for the default key, and the *hashed* master password. This allows us to near-instantly decrypt stored keys (although mounting still takes a while, depending on the parameters chosen).
 
-## RNGs
+## Terminology
 
-Throughout every cryptographic function within Spacedrive that requires cryptographically-secure random values, we use the system's entropy along with `ChaCha20Rng`. More information on this RNG can be found [here](https://rust-random.github.io/rand/rand_chacha/struct.ChaCha20Rng.html).
+The `keymount` and `keystore` refer to the area in memory where each key types are stored.
 
-This is used for nonce, salt and master key generation to ensure none of these values are predictable to an attacker.
+Keystore contains fully encrypted keys, and associated information.
+
+The keymount contains encrypted keys, but also hashed keys (hashed with the content salt).
 
 ## Key Encryption
-
-Key encryption makes use of an LE31 STREAM construction. This means that the last 4 bytes of the nonce consist of a 31 bit little-endian counter, and a 1 bit "last block" flag, totalling 4 bytes. The nonce (n) is still the correct size for the AEAD, but we only have to generate (n - 4) due to the counter.
 
 Each key has two completely randomly generated nonces, which are used to encrypt both the master key (different from the master password) and the key itself.
 
 The hashed master password (the one provided by the user), is used to encrypt a master key (32-bytes generated with a CSPRNG). This master key is used to encrypt your plaintext key. We took this approach so keys themselves are encrypted with the highest possible entropy, and we can add support for changing the master password in the future.
-
-## Available Configuration
-
-Cryptographic agility is never really recommended, so we don't provide too many options in this regard.
-
-For encryption, we currently offer: `XChaCha20-Poly1305` (as the default), and `AES-256-GCM`. `XChaCha20-Poly1305` was chosen as the default due to better performance overall, and much better performance and security on devices where cryptographic hardware acceleration is unavailable. You can read about AES cache timing attacks [here](https://cr.yp.to/antiforgery/cachetiming-20050414.pdf).
-
-For hashing, we provide `Argon2id` at varying hashing levels (standard, hardened and paranoid). The internal `Argon2id` parameters are not set in stone yet, and may change.
 
 ## Content Salts
 


### PR DESCRIPTION
This PR adds detailed (but not fully extensive) documentation regarding the key manager and encryption in general.

It is a little out of sync with the key manager found in #450, but once we refine the key manager they will line up perfectly.

I have proof read this, but another pair of eyes never hurts.