### PR TITLE
fixed traffic lights bar showing all the time

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -80,7 +80,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 					use macos::*;
 
 					let window = window.ns_window().unwrap();
-					set_titlebar_style(window, true, true);
+					set_titlebar_style(window, true, false);
 					blur_window_background(window);
 				}
 			});

--- a/packages/interface/src/components/os/TrafficLights.tsx
+++ b/packages/interface/src/components/os/TrafficLights.tsx
@@ -14,15 +14,17 @@ export interface TrafficLightsProps extends DefaultProps {
 }
 
 export function MacTrafficLights(props: TrafficLightsProps) {
+	const {onClose, onMinimize, onFullscreen, className} = props;
 	const [focused] = useFocusState();
+
 	return (
 		<div
 			data-tauri-drag-region
-			className={clsx('flex flex-row space-x-[7.5px] group', props.className)}
+			className={clsx('flex flex-row space-x-[7.5px] group', className)}
 		>
-			<TrafficLight type="close" onClick={props.onClose} colorful={focused} />
-			<TrafficLight type="minimize" onClick={props.onMinimize} colorful={focused} />
-			<TrafficLight type="fullscreen" onClick={props.onFullscreen} colorful={focused} />
+			<TrafficLight type="close" onClick={onClose} colorful={focused} />
+			<TrafficLight type="minimize" onClick={onMinimize} colorful={focused} />
+			<TrafficLight type="fullscreen" onClick={onFullscreen} colorful={focused} />
 		</div>
 	);
 }


### PR DESCRIPTION
<!-- Put any information about this PR up here -->

Tested on 14" M1 Pro

<!-- Which issue does this PR close? -->

Fixes bug on MacOS that prevented title bar from hiding while being in fullscreen mode.

<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->

Closes #301 
