### PR TITLE
[ENG-308] Crypto optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anyhow"
 version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,6 +665,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,6 +775,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half 1.8.2",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,6 +821,27 @@ dependencies = [
  "glob",
  "libc",
  "libloading",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+dependencies = [
+ "bitflags",
+ "clap_lex",
+ "indexmap",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -979,6 +1039,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "criterion"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+dependencies = [
+ "anes",
+ "atty",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
 ]
 
 [[package]]
@@ -1504,7 +1600,7 @@ checksum = "8eb5f255b5980bb0c8cf676b675d1a99be40f316881444f44e0462eaf5df5ded"
 dependencies = [
  "bit_field",
  "flume",
- "half",
+ "half 2.1.0",
  "lebe",
  "miniz_oxide 0.6.2",
  "smallvec 1.10.0",
@@ -2113,6 +2209,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "half"
@@ -3535,6 +3637,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3659,6 +3767,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "overload"
@@ -4027,6 +4141,34 @@ dependencies = [
  "serde",
  "time 0.3.15",
  "xml-rs",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -5209,6 +5351,7 @@ dependencies = [
  "aes-gcm",
  "argon2",
  "chacha20poly1305",
+ "criterion",
  "dashmap",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -6345,6 +6488,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+
+[[package]]
 name = "thin-slice"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6427,6 +6576,16 @@ name = "time-macros"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "tinyvec"

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -38,5 +38,23 @@ dashmap = "5.4.0"
 rspc = { workspace = true, optional = true }
 specta = { workspace = true }
 
+[dev-dependencies]
+criterion = "0.4.0"
+
 [features]
 rpsc = ["rspc"]
+
+[[bench]]
+name = "aes-256-gcm"
+path = "benches/aes-256-gcm.rs"
+harness = false
+
+[[bench]]
+name = "xchacha20-poly1305"
+path = "benches/xchacha20-poly1305.rs"
+harness = false
+
+[[bench]]
+name = "argon2id"
+path = "benches/argon2id.rs"
+harness = false

--- a/crates/crypto/benches/aes-256-gcm.rs
+++ b/crates/crypto/benches/aes-256-gcm.rs
@@ -1,0 +1,56 @@
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use sd_crypto::{
+	crypto::stream::{Algorithm, StreamDecryption, StreamEncryption},
+	primitives::{generate_master_key, generate_nonce},
+};
+
+const ALGORITHM: Algorithm = Algorithm::Aes256Gcm;
+
+const KB: usize = 1024;
+
+const SIZES: [usize; 6] = [KB * 16, KB * 32, KB * 64, KB * 128, KB * 512, KB * 1024];
+
+fn bench(c: &mut Criterion) {
+	let mut group = c.benchmark_group("aes-256-gcm");
+
+	for size in SIZES {
+		let buf = vec![0u8; size];
+
+		let key = generate_master_key();
+		let nonce = generate_nonce(ALGORITHM);
+
+		let encrypted_bytes =
+			StreamEncryption::encrypt_bytes(key.clone(), &nonce, ALGORITHM, &buf, &[]).unwrap(); // bytes to decrypt
+
+		group.throughput(criterion::Throughput::Bytes(size as u64));
+
+		group.bench_function(BenchmarkId::new("encrypt", size), |b| {
+			b.iter_batched(
+				|| key.clone(),
+				|key| StreamEncryption::encrypt_bytes(key, &nonce, ALGORITHM, &buf, &[]).unwrap(),
+				BatchSize::SmallInput,
+			)
+		});
+
+		group.bench_function(BenchmarkId::new("decrypt", size), |b| {
+			b.iter_batched(
+				|| key.clone(),
+				|key| {
+					StreamDecryption::decrypt_bytes(key, &nonce, ALGORITHM, &encrypted_bytes, &[])
+						.unwrap()
+				},
+				BatchSize::SmallInput,
+			)
+		});
+	}
+
+	group.finish();
+}
+
+criterion_group!(
+	name = benches;
+	config = Criterion::default();
+	targets = bench
+);
+
+criterion_main!(benches);

--- a/crates/crypto/benches/aes-256-gcm.rs
+++ b/crates/crypto/benches/aes-256-gcm.rs
@@ -8,7 +8,16 @@ const ALGORITHM: Algorithm = Algorithm::Aes256Gcm;
 
 const KB: usize = 1024;
 
-const SIZES: [usize; 6] = [KB * 16, KB * 32, KB * 64, KB * 128, KB * 512, KB * 1024];
+const SIZES: [usize; 8] = [
+	KB * 16,
+	KB * 32,
+	KB * 64,
+	KB * 128,
+	KB * 512,
+	KB * 1024,
+	KB * 2048,
+	KB * 4096,
+];
 
 fn bench(c: &mut Criterion) {
 	let mut group = c.benchmark_group("aes-256-gcm");

--- a/crates/crypto/benches/argon2id.rs
+++ b/crates/crypto/benches/argon2id.rs
@@ -1,0 +1,39 @@
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use sd_crypto::{
+	keys::hashing::{HashingAlgorithm, Params},
+	primitives::{generate_master_key, generate_salt},
+	Protected,
+};
+
+const PARAMS: [Params; 3] = [Params::Standard, Params::Hardened, Params::Paranoid];
+
+fn bench(c: &mut Criterion) {
+	let mut group = c.benchmark_group("argon2id");
+
+	for param in PARAMS {
+		let key = Protected::new(generate_master_key().expose().to_vec());
+		let salt = generate_salt();
+		let hashing_algorithm = HashingAlgorithm::Argon2id(param);
+
+		group.bench_function(
+			BenchmarkId::new("hash", param.get_argon2_params().m_cost()),
+			|b| {
+				b.iter_batched(
+					|| (key.clone(), salt.clone()),
+					|(key, salt)| hashing_algorithm.hash(key, salt),
+					BatchSize::SmallInput,
+				)
+			},
+		);
+	}
+
+	group.finish();
+}
+
+criterion_group!(
+	name = benches;
+	config = Criterion::default();
+	targets = bench
+);
+
+criterion_main!(benches);

--- a/crates/crypto/benches/xchacha20-poly1305.rs
+++ b/crates/crypto/benches/xchacha20-poly1305.rs
@@ -1,0 +1,56 @@
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use sd_crypto::{
+	crypto::stream::{Algorithm, StreamDecryption, StreamEncryption},
+	primitives::{generate_master_key, generate_nonce},
+};
+
+const ALGORITHM: Algorithm = Algorithm::XChaCha20Poly1305;
+
+const KB: usize = 1024;
+
+const SIZES: [usize; 6] = [KB * 16, KB * 32, KB * 64, KB * 128, KB * 512, KB * 1024];
+
+fn bench(c: &mut Criterion) {
+	let mut group = c.benchmark_group("xchacha20-poly1305");
+
+	for size in SIZES {
+		let buf = vec![0u8; size];
+
+		let key = generate_master_key();
+		let nonce = generate_nonce(ALGORITHM);
+
+		let encrypted_bytes =
+			StreamEncryption::encrypt_bytes(key.clone(), &nonce, ALGORITHM, &buf, &[]).unwrap(); // bytes to decrypt
+
+		group.throughput(criterion::Throughput::Bytes(size as u64));
+
+		group.bench_function(BenchmarkId::new("encrypt", size), |b| {
+			b.iter_batched(
+				|| key.clone(),
+				|key| StreamEncryption::encrypt_bytes(key, &nonce, ALGORITHM, &buf, &[]).unwrap(),
+				BatchSize::SmallInput,
+			)
+		});
+
+		group.bench_function(BenchmarkId::new("decrypt", size), |b| {
+			b.iter_batched(
+				|| key.clone(),
+				|key| {
+					StreamDecryption::decrypt_bytes(key, &nonce, ALGORITHM, &encrypted_bytes, &[])
+						.unwrap()
+				},
+				BatchSize::SmallInput,
+			)
+		});
+	}
+
+	group.finish();
+}
+
+criterion_group!(
+	name = benches;
+	config = Criterion::default();
+	targets = bench
+);
+
+criterion_main!(benches);

--- a/crates/crypto/benches/xchacha20-poly1305.rs
+++ b/crates/crypto/benches/xchacha20-poly1305.rs
@@ -8,7 +8,16 @@ const ALGORITHM: Algorithm = Algorithm::XChaCha20Poly1305;
 
 const KB: usize = 1024;
 
-const SIZES: [usize; 6] = [KB * 16, KB * 32, KB * 64, KB * 128, KB * 512, KB * 1024];
+const SIZES: [usize; 8] = [
+	KB * 16,
+	KB * 32,
+	KB * 64,
+	KB * 128,
+	KB * 512,
+	KB * 1024,
+	KB * 2048,
+	KB * 4096,
+];
 
 fn bench(c: &mut Criterion) {
 	let mut group = c.benchmark_group("xchacha20-poly1305");


### PR DESCRIPTION
Finally, a small PR from me.

This bumps our performance up massively, with gains of +578.19% throughput while encrypting 16KiB buffers.

We also gain +30%~ performance with 1MiB buffers (for both encryption and decryption), which is the standard size that we use.

Even forgetting about the numbers (they could just be due to my system workload varying massively), we still have extremely nice improvements across the board with a few small changes.

Note: The main improvement was removing `zeroize` from each iteration of the stream reader loop. This was just there to zero out unencrypted information from memory, but I don't this has too much of an impact on security. Encryption keys and extraordinarily sensitive data are still zeroed out, as they should be.

![image](https://user-images.githubusercontent.com/77554505/204502334-92e4cb2f-27a1-4cdf-8291-287acd7eab81.png)
