### PR TITLE
Crypto Hotfixes

### DIFF
--- a/core/src/object/fs/encrypt.rs
+++ b/core/src/object/fs/encrypt.rs
@@ -4,7 +4,6 @@ use chrono::FixedOffset;
 use sd_crypto::{
 	crypto::stream::{Algorithm, StreamEncryption},
 	header::{file::FileHeader, keyslot::Keyslot},
-	keys::hashing::HashingAlgorithm,
 	primitives::{generate_master_key, LATEST_FILE_HEADER, LATEST_KEYSLOT, LATEST_METADATA},
 };
 use serde::{Deserialize, Serialize};
@@ -33,7 +32,6 @@ pub struct FileEncryptorJobInit {
 	pub object_id: i32,
 	pub key_uuid: uuid::Uuid,
 	pub algorithm: Algorithm,
-	pub hashing_algorithm: HashingAlgorithm,
 	pub metadata: bool,
 	pub preview_media: bool,
 	pub output_path: Option<PathBuf>,
@@ -169,9 +167,11 @@ impl StatefulJob for FileEncryptorJob {
 
 				let master_key = generate_master_key();
 
+				// i can't decide if the key's encryption should be inherited from the keymanager, or from the file's encryption type
+				// currently it's the file's encryption type
 				let keyslots = vec![Keyslot::new(
 					LATEST_KEYSLOT,
-					user_key_details.algorithm,
+					state.init.algorithm,
 					user_key_details.hashing_algorithm,
 					user_key_details.content_salt,
 					user_key,
@@ -179,7 +179,7 @@ impl StatefulJob for FileEncryptorJob {
 				)?];
 
 				let mut header =
-					FileHeader::new(LATEST_FILE_HEADER, user_key_details.algorithm, keyslots);
+					FileHeader::new(LATEST_FILE_HEADER, state.init.algorithm, keyslots);
 
 				if state.init.metadata || state.init.preview_media {
 					// if any are requested, we can make the query as it'll be used at least once
@@ -206,7 +206,7 @@ impl StatefulJob for FileEncryptorJob {
 
 						header.add_metadata(
 							LATEST_METADATA,
-							user_key_details.algorithm,
+							state.init.algorithm,
 							&master_key,
 							&metadata,
 						)?;

--- a/crates/crypto/src/keys/keymanager.rs
+++ b/crates/crypto/src/keys/keymanager.rs
@@ -352,7 +352,7 @@ impl KeyManager {
 					Err(Error::IncorrectPassword)
 				}?;
 
-				let master_key_nonce = generate_nonce(algorithm);
+				let master_key_nonce = generate_nonce(stored_key.algorithm);
 
 				// Encrypt the master key with the user's hashed password
 				let encrypted_master_key: [u8; 48] = to_array(StreamEncryption::encrypt_bytes(

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -88,7 +88,7 @@ export type ExplorerItem = { type: "Path" } & { id: number, is_dir: boolean, loc
 
 export interface FileDecryptorJobInit { location_id: number, object_id: number, output_path: string | null }
 
-export interface FileEncryptorJobInit { location_id: number, object_id: number, key_uuid: string, algorithm: Algorithm, hashing_algorithm: HashingAlgorithm, metadata: boolean, preview_media: boolean, output_path: string | null }
+export interface FileEncryptorJobInit { location_id: number, object_id: number, key_uuid: string, algorithm: Algorithm, metadata: boolean, preview_media: boolean, output_path: string | null }
 
 export interface FilePath { id: number, is_dir: boolean, location_id: number, materialized_path: string, name: string, extension: string | null, object_id: number | null, parent_id: number | null, key_id: number | null, date_created: string, date_modified: string, date_indexed: string }
 

--- a/packages/interface/src/components/dialog/PasswordChangeDialog.tsx
+++ b/packages/interface/src/components/dialog/PasswordChangeDialog.tsx
@@ -14,8 +14,6 @@ export const PasswordChangeDialog = (props: { trigger: ReactNode }) => {
 	type FormValues = {
 		masterPassword: string;
 		masterPassword2: string;
-		encryptionAlgo: string;
-		hashingAlgo: string;
 	};
 
 	const [secretKey, setSecretKey] = useState('');
@@ -23,9 +21,7 @@ export const PasswordChangeDialog = (props: { trigger: ReactNode }) => {
 	const { register, handleSubmit, getValues, setValue } = useForm<FormValues>({
 		defaultValues: {
 			masterPassword: '',
-			masterPassword2: '',
-			encryptionAlgo: 'XChaCha20Poly1305',
-			hashingAlgo: 'Argon2id-s'
+			masterPassword2: ''
 		}
 	});
 
@@ -33,10 +29,7 @@ export const PasswordChangeDialog = (props: { trigger: ReactNode }) => {
 		if (data.masterPassword !== data.masterPassword2) {
 			alert('Passwords are not the same.');
 		} else {
-			const [algorithm, hashing_algorithm] = getCryptoSettings(
-				data.encryptionAlgo,
-				data.hashingAlgo
-			);
+			const [algorithm, hashing_algorithm] = getCryptoSettings(encryptionAlgo, hashingAlgo);
 
 			changeMasterPassword.mutate(
 				{ algorithm, hashing_algorithm, password: data.masterPassword },
@@ -56,6 +49,8 @@ export const PasswordChangeDialog = (props: { trigger: ReactNode }) => {
 		}
 	};
 
+	const [encryptionAlgo, setEncryptionAlgo] = useState('XChaCha20Poly1305');
+	const [hashingAlgo, setHashingAlgo] = useState('Argon2id-s');
 	const [passwordMeterMasterPw, setPasswordMeterMasterPw] = useState(''); // this is needed as the password meter won't update purely with react-hook-for
 	const [showMasterPasswordDialog, setShowMasterPasswordDialog] = useState(false);
 	const [showSecretKeyDialog, setShowSecretKeyDialog] = useState(false);
@@ -123,8 +118,8 @@ export const PasswordChangeDialog = (props: { trigger: ReactNode }) => {
 							<span className="text-xs font-bold">Encryption</span>
 							<Select
 								className="mt-2"
-								value={getValues('encryptionAlgo')}
-								onChange={(e) => setValue('encryptionAlgo', e)}
+								value={encryptionAlgo}
+								onChange={(e) => setEncryptionAlgo(e)}
 							>
 								<SelectOption value="XChaCha20Poly1305">XChaCha20-Poly1305</SelectOption>
 								<SelectOption value="Aes256Gcm">AES-256-GCM</SelectOption>
@@ -132,11 +127,7 @@ export const PasswordChangeDialog = (props: { trigger: ReactNode }) => {
 						</div>
 						<div className="flex flex-col">
 							<span className="text-xs font-bold">Hashing</span>
-							<Select
-								className="mt-2"
-								value={getValues('hashingAlgo')}
-								onChange={(e) => setValue('hashingAlgo', e)}
-							>
+							<Select className="mt-2" value={hashingAlgo} onChange={(e) => setHashingAlgo(e)}>
 								<SelectOption value="Argon2id-s">Argon2id (standard)</SelectOption>
 								<SelectOption value="Argon2id-h">Argon2id (hardened)</SelectOption>
 								<SelectOption value="Argon2id-p">Argon2id (paranoid)</SelectOption>

--- a/packages/interface/src/components/key/Key.tsx
+++ b/packages/interface/src/components/key/Key.tsx
@@ -1,7 +1,11 @@
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+import { useLibraryMutation } from '@sd/client';
 import { Button, ContextMenu } from '@sd/ui';
 import clsx from 'clsx';
 import { DotsThree, Eye, Key as KeyIcon } from 'phosphor-react';
-import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+import { PropsWithChildren, useState } from 'react';
+import { animated, config, useTransition } from 'react-spring';
+
 import { DefaultProps } from '../primitive/types';
 import { Tooltip } from '../tooltip/Tooltip';
 
@@ -22,10 +26,6 @@ export interface Key {
 	nodes?: string[]; // will be node object
 }
 
-import { PropsWithChildren, useState } from 'react';
-import { animated, config, useTransition } from 'react-spring';
-import { useLibraryMutation } from '@sd/client';
-
 interface Props extends DropdownMenu.MenuContentProps {
 	trigger: React.ReactNode;
 	transformOrigin?: string;
@@ -43,48 +43,47 @@ export const KeyDropdown = ({
 	const [open, setOpen] = useState(false);
 
 	const transitions = useTransition(open, {
-	  from: {
-		opacity: 0,
-		transform: `scale(0.9)`,
-		transformOrigin: transformOrigin || "top",
-	  },
-	  enter: { opacity: 1, transform: "scale(1)" },
-	  leave: { opacity: -0.5, transform: "scale(0.95)" },
-	  config: { mass: 0.4, tension: 200, friction: 10 },
+		from: {
+			opacity: 0,
+			transform: `scale(0.9)`,
+			transformOrigin: transformOrigin || 'top'
+		},
+		enter: { opacity: 1, transform: 'scale(1)' },
+		leave: { opacity: -0.5, transform: 'scale(0.95)' },
+		config: { mass: 0.4, tension: 200, friction: 10 }
 	});
-	
-	return (
-	  <DropdownMenu.Root open={open} onOpenChange={setOpen}>
-		<DropdownMenu.Trigger>{trigger}</DropdownMenu.Trigger>
-		{transitions(
-		  (styles, show) =>
-			show && (
-			  <DropdownMenu.Portal forceMount>
-				<DropdownMenu.Content forceMount asChild>
-				  <animated.div
-					// most of this is copied over from the `OverlayPanel`
-					className={clsx(
-					  "flex flex-col",
-					  "pl-4 pr-4 pt-2 pb-2 z-50 m-2 space-y-1",
-					  "select-none cursor-default rounded-lg",
-					  "text-left text-sm text-ink",
-					  "bg-app-overlay/80 backdrop-blur",
-					  // 'border border-app-overlay',
-					  "shadow-2xl shadow-black/60 ",
-					  className
-					)}
-					style={styles}
-				  >
-					{children}
-				  </animated.div>
-				</DropdownMenu.Content>
-			  </DropdownMenu.Portal>
-			)
-		)}
-	  </DropdownMenu.Root>
-	);	
-};
 
+	return (
+		<DropdownMenu.Root open={open} onOpenChange={setOpen}>
+			<DropdownMenu.Trigger>{trigger}</DropdownMenu.Trigger>
+			{transitions(
+				(styles, show) =>
+					show && (
+						<DropdownMenu.Portal forceMount>
+							<DropdownMenu.Content forceMount asChild>
+								<animated.div
+									// most of this is copied over from the `OverlayPanel`
+									className={clsx(
+										'flex flex-col',
+										'pl-4 pr-4 pt-2 pb-2 z-50 m-2 space-y-1',
+										'select-none cursor-default rounded-lg',
+										'text-left text-sm text-ink',
+										'bg-app-overlay/80 backdrop-blur',
+										// 'border border-app-overlay',
+										'shadow-2xl shadow-black/60 ',
+										className
+									)}
+									style={styles}
+								>
+									{children}
+								</animated.div>
+							</DropdownMenu.Content>
+						</DropdownMenu.Portal>
+					)
+			)}
+		</DropdownMenu.Root>
+	);
+};
 
 export const Key: React.FC<{ data: Key; index: number }> = ({ data, index }) => {
 	const mountKey = useLibraryMutation('keys.mount');
@@ -148,24 +147,70 @@ export const Key: React.FC<{ data: Key; index: number }> = ({ data, index }) => 
 						</Button>
 					</Tooltip>
 				)}
-				<KeyDropdown trigger={
-					<Button size="icon">
-						<DotsThree className="w-4 h-4 text-ink-faint" />
-					</Button> }>
+				<KeyDropdown
+					trigger={
+						<Button size="icon">
+							<DotsThree className="w-4 h-4 text-ink-faint" />
+						</Button>
+					}
+				>
 					{data.mounted && (
-						<DropdownMenu.DropdownMenuItem className="!cursor-default select-none text-menu-ink focus:outline-none py-0.5 active:opacity-80" onClick={(e) => { unmountKey.mutate(data.id) }}>Unmount</DropdownMenu.DropdownMenuItem>
+						<DropdownMenu.DropdownMenuItem
+							className="!cursor-default select-none text-menu-ink focus:outline-none py-0.5 active:opacity-80"
+							onClick={(e) => {
+								unmountKey.mutate(data.id);
+							}}
+						>
+							Unmount
+						</DropdownMenu.DropdownMenuItem>
 					)}
 
 					{!data.mounted && (
-						<DropdownMenu.DropdownMenuItem className="!cursor-default select-none text-menu-ink focus:outline-none py-0.5 active:opacity-80" onClick={(e) => { mountKey.mutate(data.id) }}>Mount</DropdownMenu.DropdownMenuItem>
+						<DropdownMenu.DropdownMenuItem
+							className="!cursor-default select-none text-menu-ink focus:outline-none py-0.5 active:opacity-80"
+							onClick={(e) => {
+								mountKey.mutate(data.id);
+							}}
+						>
+							Mount
+						</DropdownMenu.DropdownMenuItem>
 					)}
 
-					<DropdownMenu.DropdownMenuItem className="!cursor-default select-none text-menu-ink focus:outline-none py-0.5 active:opacity-80" onClick={(e) => { deleteKey.mutate(data.id) }}>Delete from Library</DropdownMenu.DropdownMenuItem>
+					<DropdownMenu.DropdownMenuItem
+						className="!cursor-default select-none text-menu-ink focus:outline-none py-0.5 active:opacity-80"
+						onClick={(e) => {
+							deleteKey.mutate(data.id);
+						}}
+					>
+						Delete from Library
+					</DropdownMenu.DropdownMenuItem>
 
 					{!data.default && (
-						<DropdownMenu.DropdownMenuItem className="!cursor-default select-none text-menu-ink focus:outline-none py-0.5 active:opacity-80" onClick={(e) => { setDefaultKey.mutate(data.id) }}>Set as Default</DropdownMenu.DropdownMenuItem>
+						<DropdownMenu.DropdownMenuItem
+							className="!cursor-default select-none text-menu-ink focus:outline-none py-0.5 active:opacity-80"
+							onClick={(e) => {
+								setDefaultKey.mutate(data.id);
+							}}
+						>
+							Set as Default
+						</DropdownMenu.DropdownMenuItem>
 					)}
 				</KeyDropdown>
+			</div>
+		</div>
+	);
+};
+
+export const DummyKey = (props: { text: string }) => {
+	return (
+		<div className="flex items-center justify-between px-2 py-1.5 pt-2 pb-2 shadow-app-shade/10 text-sm bg-app-box shadow-lg rounded-lg">
+			<div className="flex items-center">
+				<KeyIcon className="w-5 h-5 ml-1 mr-3 text-gray-400/80" />
+				<div className="flex flex-col ">
+					<div className="flex flex-row items-center">
+						<div className="font-medium">{props.text}</div>
+					</div>
+				</div>
 			</div>
 		</div>
 	);

--- a/packages/interface/src/components/key/KeyList.tsx
+++ b/packages/interface/src/components/key/KeyList.tsx
@@ -3,13 +3,11 @@ import { Button, CategoryHeading } from '@sd/ui';
 import { useMemo } from 'react';
 
 import { DefaultProps } from '../primitive/types';
-import { Key } from './Key';
+import { DummyKey, Key } from './Key';
 
 export type KeyListProps = DefaultProps;
 
-export const ListOfKeys = (props: { noKeysMessage: boolean }) => {
-	const { noKeysMessage } = props;
-
+export const ListOfKeys = () => {
 	const keys = useLibraryQuery(['keys.list']);
 	const mountedUuids = useLibraryQuery(['keys.listMounted']);
 
@@ -25,8 +23,8 @@ export const ListOfKeys = (props: { noKeysMessage: boolean }) => {
 		[keys, mountedUuids]
 	);
 
-	if (keys.data?.length === 0 && noKeysMessage) {
-		return <CategoryHeading>No keys available.</CategoryHeading>;
+	if (keys.data?.length === 0) {
+		return <DummyKey text="No keys available" />;
 	}
 
 	return (
@@ -58,7 +56,7 @@ export const KeyList = (props: KeyListProps) => {
 				<div className="">
 					{/* <CategoryHeading>Mounted keys</CategoryHeading> */}
 					<div className="space-y-1.5">
-						<ListOfKeys noKeysMessage />
+						<ListOfKeys />
 					</div>
 				</div>
 			</div>

--- a/packages/interface/src/screens/settings/library/KeysSetting.tsx
+++ b/packages/interface/src/screens/settings/library/KeysSetting.tsx
@@ -186,11 +186,9 @@ export default function KeysSettings() {
 						</div>
 					}
 				/>
-				{hasMasterPw.data ? (
-					<div className="grid space-y-2">
-						<ListOfKeys noKeysMessage={false} />
-					</div>
-				) : null}
+				<div className="grid space-y-2">
+					<ListOfKeys />
+				</div>
 
 				<SettingsSubHeader title="Password Options" />
 				<div className="flex flex-row">

--- a/packages/interface/src/screens/settings/library/KeysSetting.tsx
+++ b/packages/interface/src/screens/settings/library/KeysSetting.tsx
@@ -252,3 +252,22 @@ export const getCryptoSettings = (
 
 	return [algorithm, hashing_algorithm];
 };
+
+// not sure of a suitable place for this function
+export const getHashingAlgorithmString = (hashingAlgorithm: HashingAlgorithm): string => {
+	let hashing_algorithm = '';
+
+	switch (hashingAlgorithm.Argon2id) {
+		case 'Standard':
+			hashing_algorithm = 'Argon2id-s';
+			break;
+		case 'Hardened':
+			hashing_algorithm = 'Argon2id-h';
+			break;
+		case 'Paranoid':
+			hashing_algorithm = 'Argon2id-p';
+			break;
+	}
+
+	return hashing_algorithm;
+};

--- a/packages/ui/src/Select.tsx
+++ b/packages/ui/src/Select.tsx
@@ -9,6 +9,7 @@ interface SelectProps {
 	size?: 'sm' | 'md' | 'lg';
 	className?: string;
 	onChange: (value: string) => void;
+	disabled?: boolean;
 }
 
 export function Select(props: PropsWithChildren<SelectProps>) {
@@ -17,6 +18,7 @@ export function Select(props: PropsWithChildren<SelectProps>) {
 			defaultValue={props.value}
 			value={props.value}
 			onValueChange={props.onChange}
+			disabled={props.disabled}
 		>
 			<SelectPrimitive.Trigger
 				className={clsx(


### PR DESCRIPTION
There is no issue associated with this PR, as it covers a range of random bugs that I came across during some testing.

The TL;DR:

* Master password changing had a bug where new nonces would be generated with an incorrect length, and master password changing would fail.
* Master password changing `Select` boxes weren't updating in the UI because of `react-hook-form`, so this was fixed.
* The UI when no keys were found was a little bad - the key manager dropdown had a bit of text, but the keys settings page had a huge blank gap. This has been replaced (see images)
* The file encrypt dialog erroneously let the user select a hashing algorithm - this had no purpose whatsoever, as the hashing algorithm is inherited from their selected key. This select box is now disabled, and the contents update based on which key the user selects.
* During file encryption, the encryption algorithm would erroneously be inherited from the key used to encrypt the file, and not the algorithm the user selected.

![Image showing a "no keys available" message in the keys settings page](https://user-images.githubusercontent.com/77554505/206446376-3fb2e9ed-8599-45b3-8e6b-9084347030b8.png)
![image showing a "no keys available" message in the key manager dropdown](https://user-images.githubusercontent.com/77554505/206446626-29d271d3-9a48-4809-8a5c-fb4139d03d0a.png)

