### PR TITLE
[ENG-315] Key viewer/general improvements

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -36,7 +36,9 @@ const platform: Platform = {
 	getThumbnailUrlById: (casId) => `spacedrive://thumbnail/${encodeURIComponent(casId)}`,
 	openLink: shell.open,
 	getOs,
-	openFilePickerDialog: () => dialog.open({ directory: true }),
+	openDirectoryPickerDialog: () => dialog.open({ directory: true }),
+	openFilePickerDialog: () => dialog.open(),
+	saveFilePickerDialog: () => dialog.save(),
 	showDevtools: () => invoke('show_devtools'),
 	openPath: (path) => shell.open(path)
 };

--- a/core/src/api/keys.rs
+++ b/core/src/api/keys.rs
@@ -143,10 +143,15 @@ pub(crate) fn mount() -> RouterBuilder {
 						.key_manager
 						.change_automount_status(args.uuid, args.status)?;
 
-					library.db.key().update(
-						key::uuid::equals(args.uuid.to_string()),
-						vec![key::SetParam::SetAutomount(args.status)],
-					);
+					library
+						.db
+						.key()
+						.update(
+							key::uuid::equals(args.uuid.to_string()),
+							vec![key::SetParam::SetAutomount(args.status)],
+						)
+						.exec()
+						.await?;
 
 					invalidate_query!(library, "keys.list");
 				}

--- a/core/src/api/keys.rs
+++ b/core/src/api/keys.rs
@@ -9,6 +9,7 @@ use sd_crypto::{
 };
 use serde::{Deserialize, Serialize};
 use specta::Type;
+use uuid::Uuid;
 
 use crate::util::db::write_storedkey_to_db;
 use crate::{invalidate_query, prisma::key};
@@ -26,7 +27,7 @@ pub struct KeyAddArgs {
 
 #[derive(Type, Deserialize)]
 pub struct KeyNameUpdateArgs {
-	uuid: uuid::Uuid,
+	uuid: Uuid,
 	name: String,
 }
 
@@ -62,6 +63,12 @@ pub struct OnboardingKeys {
 	secret_key: String,
 }
 
+#[derive(Type, Deserialize)]
+pub struct AutomountUpdateArgs {
+	uuid: Uuid,
+	status: bool,
+}
+
 pub(crate) fn mount() -> RouterBuilder {
 	RouterBuilder::new()
 		.library_query("list", |t| {
@@ -76,7 +83,7 @@ pub(crate) fn mount() -> RouterBuilder {
 			t(|_, _: (), library| async move { Ok(library.key_manager.get_mounted_uuids()) })
 		})
 		.library_query("getKey", |t| {
-			t(|_, key_uuid: uuid::Uuid, library| async move {
+			t(|_, key_uuid: Uuid, library| async move {
 				let key = library.key_manager.get_key(key_uuid)?;
 
 				let key_string = String::from_utf8(key.expose().clone()).map_err(|_| {
@@ -90,7 +97,7 @@ pub(crate) fn mount() -> RouterBuilder {
 			})
 		})
 		.library_mutation("mount", |t| {
-			t(|_, key_uuid: uuid::Uuid, library| async move {
+			t(|_, key_uuid: Uuid, library| async move {
 				library.key_manager.mount(key_uuid)?;
 				// we also need to dispatch jobs that automatically decrypt preview media and metadata here
 				invalidate_query!(library, "keys.listMounted");
@@ -113,7 +120,7 @@ pub(crate) fn mount() -> RouterBuilder {
 			})
 		})
 		.library_mutation("unmount", |t| {
-			t(|_, key_uuid: uuid::Uuid, library| async move {
+			t(|_, key_uuid: Uuid, library| async move {
 				library.key_manager.unmount(key_uuid)?;
 				// we also need to delete all in-memory decrypted data associated with this key
 				invalidate_query!(library, "keys.listMounted");
@@ -129,8 +136,26 @@ pub(crate) fn mount() -> RouterBuilder {
 				Ok(())
 			})
 		})
+		.library_mutation("updateAutomountStatus", |t| {
+			t(|_, args: AutomountUpdateArgs, library| async move {
+				if !library.key_manager.is_memory_only(args.uuid)? {
+					library
+						.key_manager
+						.change_automount_status(args.uuid, args.status)?;
+
+					library.db.key().update(
+						key::uuid::equals(args.uuid.to_string()),
+						vec![key::SetParam::SetAutomount(args.status)],
+					);
+
+					invalidate_query!(library, "keys.list");
+				}
+
+				Ok(())
+			})
+		})
 		.library_mutation("deleteFromLibrary", |t| {
-			t(|_, key_uuid: uuid::Uuid, library| async move {
+			t(|_, key_uuid: Uuid, library| async move {
 				if !library.key_manager.is_memory_only(key_uuid)? {
 					library
 						.db
@@ -160,7 +185,7 @@ pub(crate) fn mount() -> RouterBuilder {
 				library
 					.db
 					.key()
-					.delete_many(vec![key::uuid::equals(uuid::Uuid::nil().to_string())])
+					.delete_many(vec![key::uuid::equals(Uuid::nil().to_string())])
 					.exec()
 					.await?;
 
@@ -192,7 +217,7 @@ pub(crate) fn mount() -> RouterBuilder {
 				for key in automount {
 					library
 						.key_manager
-						.mount(uuid::Uuid::from_str(&key.uuid).map_err(|_| {
+						.mount(Uuid::from_str(&key.uuid).map_err(|_| {
 							rspc::Error::new(
 								rspc::ErrorCode::InternalServerError,
 								"Error deserializing UUID from string".into(),
@@ -206,7 +231,7 @@ pub(crate) fn mount() -> RouterBuilder {
 			})
 		})
 		.library_mutation("setDefault", |t| {
-			t(|_, key_uuid: uuid::Uuid, library| async move {
+			t(|_, key_uuid: Uuid, library| async move {
 				library.key_manager.set_default(key_uuid)?;
 
 				// if an old default is set, unset it as the default
@@ -280,6 +305,7 @@ pub(crate) fn mount() -> RouterBuilder {
 					args.algorithm,
 					args.hashing_algorithm,
 					!args.library_sync,
+					args.automount,
 				)?;
 
 				let stored_key = library.key_manager.access_keystore(uuid)?;
@@ -392,7 +418,7 @@ pub(crate) fn mount() -> RouterBuilder {
 				library
 					.db
 					.key()
-					.delete_many(vec![key::uuid::equals(uuid::Uuid::nil().to_string())])
+					.delete_many(vec![key::uuid::equals(Uuid::nil().to_string())])
 					.exec()
 					.await?;
 

--- a/core/src/library/library_manager.rs
+++ b/core/src/library/library_manager.rs
@@ -145,6 +145,7 @@ pub async fn create_keymanager(client: &PrismaClient) -> Result<KeyManager, Libr
 				)
 				.unwrap(),
 				memory_only: false,
+				automount: key.automount,
 			}
 		})
 		.collect();

--- a/crates/crypto/src/error.rs
+++ b/crates/crypto/src/error.rs
@@ -62,8 +62,10 @@ pub enum Error {
 	KeystoreMismatch,
 	#[error("mutex lock error")]
 	MutexLock,
-	#[error("no master password verification key")]
+	#[error("no verification key")]
 	NoVerificationKey,
+	#[error("key isn't flagged as memory only")]
+	KeyNotMemoryOnly,
 	#[error("wrong information provided to the key manager")]
 	IncorrectKeymanagerDetails,
 	#[error("string parse error")]

--- a/crates/crypto/src/keys/keymanager.rs
+++ b/crates/crypto/src/keys/keymanager.rs
@@ -78,6 +78,7 @@ pub struct StoredKey {
 	pub key_nonce: Vec<u8>,        // nonce used for encrypting the main key
 	pub key: Vec<u8>, // encrypted. the key stored in spacedrive (e.g. generated 64 char key)
 	pub memory_only: bool,
+	pub automount: bool,
 }
 
 /// This is a mounted key, and needs to be kept somewhat hidden.
@@ -200,6 +201,7 @@ impl KeyManager {
 			key_nonce: root_key_nonce,
 			key: encrypted_root_key,
 			memory_only: false,
+			automount: false,
 		};
 
 		let secret_key = Self::format_secret_key(&salt);
@@ -320,10 +322,9 @@ impl KeyManager {
 	}
 
 	pub fn is_memory_only(&self, uuid: Uuid) -> Result<bool> {
-		if let Some(key) = self.keystore.get(&uuid) {
-			Ok(key.memory_only)
-		} else {
-			Err(Error::KeyNotFound)
+		match self.keystore.get(&uuid) {
+			Some(key) => Ok(key.memory_only),
+			None => Err(Error::KeyNotFound),
 		}
 	}
 
@@ -377,6 +378,7 @@ impl KeyManager {
 			key_nonce: root_key_nonce,
 			key: encrypted_root_key,
 			memory_only: false,
+			automount: false,
 		};
 
 		*self.verification_key.lock()? = Some(verification_key.clone());
@@ -857,6 +859,21 @@ impl KeyManager {
 		}
 	}
 
+	pub fn change_automount_status(&self, uuid: Uuid, status: bool) -> Result<()> {
+		let updated_key = match self.keystore.get(&uuid) {
+			Some(key) => {
+				let mut updated_key = key.clone();
+				updated_key.automount = status;
+				Ok(updated_key)
+			}
+			None => Err(Error::KeyNotFound),
+		}?;
+
+		self.keystore.remove(&uuid);
+		self.keystore.insert(uuid, updated_key);
+		Ok(())
+	}
+
 	/// This function is for getting an entire collection of hashed keys.
 	///
 	/// These are ideal for passing over to decryption functions, as each decryption attempt is negligible, performance wise.
@@ -886,6 +903,7 @@ impl KeyManager {
 		algorithm: Algorithm,
 		hashing_algorithm: HashingAlgorithm,
 		memory_only: bool,
+		automount: bool,
 	) -> Result<Uuid> {
 		let uuid = uuid::Uuid::new_v4();
 
@@ -919,6 +937,7 @@ impl KeyManager {
 			key_nonce,
 			key: encrypted_key,
 			memory_only,
+			automount,
 		};
 
 		// Insert it into the Keystore

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -52,6 +52,7 @@ export type Procedures = {
         { key: "keys.setMasterPassword", input: LibraryArgs<SetMasterPasswordArgs>, result: null } | 
         { key: "keys.unmount", input: LibraryArgs<string>, result: null } | 
         { key: "keys.unmountAll", input: LibraryArgs<null>, result: null } | 
+        { key: "keys.updateAutomountStatus", input: LibraryArgs<AutomountUpdateArgs>, result: null } | 
         { key: "keys.updateKeyName", input: LibraryArgs<KeyNameUpdateArgs>, result: null } | 
         { key: "library.create", input: string, result: LibraryConfigWrapped } | 
         { key: "library.delete", input: string, result: null } | 
@@ -73,6 +74,8 @@ export type Procedures = {
 };
 
 export type Algorithm = "XChaCha20Poly1305" | "Aes256Gcm"
+
+export interface AutomountUpdateArgs { uuid: string, status: boolean }
 
 export interface BuildInfo { version: string, commit: string }
 
@@ -164,7 +167,7 @@ export interface SetNoteArgs { id: number, note: string | null }
 
 export interface Statistics { id: number, date_captured: string, total_object_count: number, library_db_size: string, total_bytes_used: string, total_bytes_capacity: string, total_unique_bytes: string, total_bytes_free: string, preview_media_bytes: string }
 
-export interface StoredKey { uuid: string, algorithm: Algorithm, hashing_algorithm: HashingAlgorithm, content_salt: Array<number>, master_key: Array<number>, master_key_nonce: Array<number>, key_nonce: Array<number>, key: Array<number>, memory_only: boolean }
+export interface StoredKey { uuid: string, algorithm: Algorithm, hashing_algorithm: HashingAlgorithm, content_salt: Array<number>, master_key: Array<number>, master_key_nonce: Array<number>, key_nonce: Array<number>, key: Array<number>, memory_only: boolean, automount: boolean }
 
 export interface Tag { id: number, pub_id: Array<number>, name: string | null, color: string | null, total_objects: number | null, redundancy_goal: number | null, date_created: string, date_modified: string }
 

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -50,6 +50,7 @@ export type Procedures = {
         { key: "keys.restoreKeystore", input: LibraryArgs<RestoreBackupArgs>, result: number } | 
         { key: "keys.setDefault", input: LibraryArgs<string>, result: null } | 
         { key: "keys.setMasterPassword", input: LibraryArgs<SetMasterPasswordArgs>, result: null } | 
+        { key: "keys.syncKeyToLibrary", input: LibraryArgs<string>, result: null } | 
         { key: "keys.unmount", input: LibraryArgs<string>, result: null } | 
         { key: "keys.unmountAll", input: LibraryArgs<null>, result: null } | 
         { key: "keys.updateAutomountStatus", input: LibraryArgs<AutomountUpdateArgs>, result: null } | 

--- a/packages/interface/src/components/dialog/BackupRestoreDialog.tsx
+++ b/packages/interface/src/components/dialog/BackupRestoreDialog.tsx
@@ -130,7 +130,7 @@ export const BackupRestoreDialog = (props: BackupRestorationDialogProps) => {
 										open: true,
 										title: 'Error',
 										description: '',
-										value: 'Opening system dialogs is not supported on this platform.',
+										value: "System dialogs aren't supported on this platform.",
 										inputBox: false
 									});
 									return;

--- a/packages/interface/src/components/dialog/BackupRestoreDialog.tsx
+++ b/packages/interface/src/components/dialog/BackupRestoreDialog.tsx
@@ -14,7 +14,7 @@ type FormValues = {
 
 export interface BackupRestorationDialogProps {
 	trigger: ReactNode;
-	setDialogData: (data: GenericAlertDialogProps) => void;
+	setAlertDialogData: (data: GenericAlertDialogProps) => void;
 }
 
 export const BackupRestoreDialog = (props: BackupRestorationDialogProps) => {
@@ -37,7 +37,7 @@ export const BackupRestoreDialog = (props: BackupRestorationDialogProps) => {
 				{
 					onSuccess: (total) => {
 						setShowBackupRestoreDialog(false);
-						props.setDialogData({
+						props.setAlertDialogData({
 							open: true,
 							title: 'Import Successful',
 							description: '',
@@ -47,7 +47,7 @@ export const BackupRestoreDialog = (props: BackupRestorationDialogProps) => {
 					},
 					onError: () => {
 						setShowBackupRestoreDialog(false);
-						props.setDialogData({
+						props.setAlertDialogData({
 							open: true,
 							title: 'Import Error',
 							description: '',
@@ -126,7 +126,13 @@ export const BackupRestoreDialog = (props: BackupRestorationDialogProps) => {
 							onClick={() => {
 								if (!platform.openFilePickerDialog) {
 									// TODO: Support opening locations on web
-									alert('Opening a dialogue is not supported on this platform!');
+									props.setAlertDialogData({
+										open: true,
+										title: 'Error',
+										description: '',
+										value: 'Opening system dialogs is not supported on this platform.',
+										inputBox: false
+									});
 									return;
 								}
 								platform.openFilePickerDialog().then((result) => {

--- a/packages/interface/src/components/dialog/BackupRestoreDialog.tsx
+++ b/packages/interface/src/components/dialog/BackupRestoreDialog.tsx
@@ -1,10 +1,10 @@
 import { useLibraryMutation } from '@sd/client';
 import { Button, Dialog, Input } from '@sd/ui';
-import { open } from '@tauri-apps/api/dialog';
 import { Eye, EyeSlash } from 'phosphor-react';
 import { ReactNode, useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 
+import { usePlatform } from '../../util/Platform';
 import { GenericAlertDialogProps } from './AlertDialog';
 
 type FormValues = {
@@ -18,7 +18,8 @@ export interface BackupRestorationDialogProps {
 }
 
 export const BackupRestoreDialog = (props: BackupRestorationDialogProps) => {
-	const { register, handleSubmit, getValues, setValue } = useForm<FormValues>({
+	const platform = usePlatform();
+	const { register, handleSubmit, setValue } = useForm<FormValues>({
 		defaultValues: {
 			masterPassword: '',
 			secretKey: ''
@@ -124,7 +125,12 @@ export const BackupRestoreDialog = (props: BackupRestorationDialogProps) => {
 							variant={filePath !== '' ? 'accent' : 'gray'}
 							type="button"
 							onClick={() => {
-								open()?.then((result) => {
+								if (!platform.openFilePickerDialog) {
+									// TODO: Support opening locations on web
+									alert('Opening a dialogue is not supported on this platform!');
+									return;
+								}
+								platform.openFilePickerDialog().then((result) => {
 									if (result) setFilePath(result as string);
 								});
 							}}

--- a/packages/interface/src/components/dialog/BackupRestoreDialog.tsx
+++ b/packages/interface/src/components/dialog/BackupRestoreDialog.tsx
@@ -19,7 +19,7 @@ export interface BackupRestorationDialogProps {
 
 export const BackupRestoreDialog = (props: BackupRestorationDialogProps) => {
 	const platform = usePlatform();
-	const { register, handleSubmit, setValue } = useForm<FormValues>({
+	const { register, handleSubmit, reset } = useForm<FormValues>({
 		defaultValues: {
 			masterPassword: '',
 			secretKey: ''
@@ -57,8 +57,7 @@ export const BackupRestoreDialog = (props: BackupRestorationDialogProps) => {
 					}
 				}
 			);
-			setValue('masterPassword', '');
-			setValue('secretKey', '');
+			reset();
 			setFilePath('');
 		}
 	};

--- a/packages/interface/src/components/dialog/DecryptFileDialog.tsx
+++ b/packages/interface/src/components/dialog/DecryptFileDialog.tsx
@@ -77,7 +77,13 @@ export const DecryptFileDialog = (props: DecryptDialogProps) => {
 								// if we allow the user to encrypt multiple files simultaneously, this should become a directory instead
 								if (!platform.saveFilePickerDialog) {
 									// TODO: Support opening locations on web
-									alert('Opening a dialogue is not supported on this platform!');
+									props.setAlertDialogData({
+										open: true,
+										title: 'Error',
+										description: '',
+										value: 'Opening system dialogs is not supported on this platform.',
+										inputBox: false
+									});
 									return;
 								}
 								platform.saveFilePickerDialog().then((result) => {

--- a/packages/interface/src/components/dialog/DecryptFileDialog.tsx
+++ b/packages/interface/src/components/dialog/DecryptFileDialog.tsx
@@ -81,7 +81,7 @@ export const DecryptFileDialog = (props: DecryptDialogProps) => {
 										open: true,
 										title: 'Error',
 										description: '',
-										value: 'Opening system dialogs is not supported on this platform.',
+										value: "System dialogs aren't supported on this platform.",
 										inputBox: false
 									});
 									return;

--- a/packages/interface/src/components/dialog/DecryptFileDialog.tsx
+++ b/packages/interface/src/components/dialog/DecryptFileDialog.tsx
@@ -1,8 +1,8 @@
 import { useLibraryMutation } from '@sd/client';
 import { Button, Dialog } from '@sd/ui';
-import { save } from '@tauri-apps/api/dialog';
 import { useState } from 'react';
 
+import { usePlatform } from '../../util/Platform';
 import { GenericAlertDialogProps } from './AlertDialog';
 
 interface DecryptDialogProps {
@@ -14,6 +14,7 @@ interface DecryptDialogProps {
 }
 
 export const DecryptFileDialog = (props: DecryptDialogProps) => {
+	const platform = usePlatform();
 	const { location_id, object_id } = props;
 	const decryptFile = useLibraryMutation('files.decryptFiles');
 	const [outputPath, setOutputpath] = useState('');
@@ -74,8 +75,12 @@ export const DecryptFileDialog = (props: DecryptDialogProps) => {
 							type="button"
 							onClick={() => {
 								// if we allow the user to encrypt multiple files simultaneously, this should become a directory instead
-								// not platform-safe, probably will break on web but `platform` doesn't have a save dialog option
-								save()?.then((result) => {
+								if (!platform.saveFilePickerDialog) {
+									// TODO: Support opening locations on web
+									alert('Opening a dialogue is not supported on this platform!');
+									return;
+								}
+								platform.saveFilePickerDialog().then((result) => {
 									if (result) setOutputpath(result as string);
 								});
 							}}

--- a/packages/interface/src/components/dialog/EncryptFileDialog.tsx
+++ b/packages/interface/src/components/dialog/EncryptFileDialog.tsx
@@ -1,12 +1,12 @@
 import { useLibraryMutation, useLibraryQuery } from '@sd/client';
 import { Button, Dialog, Select, SelectOption } from '@sd/ui';
-import { save } from '@tauri-apps/api/dialog';
 import { useState } from 'react';
 
 import {
 	getCryptoSettings,
 	getHashingAlgorithmString
 } from '../../screens/settings/library/KeysSetting';
+import { usePlatform } from '../../util/Platform';
 import { SelectOptionKeyList } from '../key/KeyList';
 import { Checkbox } from '../primitive/Checkbox';
 import { GenericAlertDialogProps } from './AlertDialog';
@@ -20,6 +20,7 @@ interface EncryptDialogProps {
 }
 
 export const EncryptFileDialog = (props: EncryptDialogProps) => {
+	const platform = usePlatform();
 	const { location_id, object_id } = props;
 	const keys = useLibraryQuery(['keys.list']);
 	const mountedUuids = useLibraryQuery(['keys.listMounted'], {
@@ -112,7 +113,6 @@ export const EncryptFileDialog = (props: EncryptDialogProps) => {
 								UpdateKey(e);
 							}}
 						>
-							{/* this only returns MOUNTED keys. we could include unmounted keys, but then we'd have to prompt the user to mount them too */}
 							{mountedUuids.data && <SelectOptionKeyList keys={mountedUuids.data} />}
 						</Select>
 					</div>
@@ -126,8 +126,12 @@ export const EncryptFileDialog = (props: EncryptDialogProps) => {
 							type="button"
 							onClick={() => {
 								// if we allow the user to encrypt multiple files simultaneously, this should become a directory instead
-								// not platform-safe, probably will break on web but `platform` doesn't have a save dialog option
-								save()?.then((result) => {
+								if (!platform.saveFilePickerDialog) {
+									// TODO: Support opening locations on web
+									alert('Opening a dialogue is not supported on this platform!');
+									return;
+								}
+								platform.saveFilePickerDialog().then((result) => {
 									if (result) setOutputpath(result as string);
 								});
 							}}

--- a/packages/interface/src/components/dialog/EncryptFileDialog.tsx
+++ b/packages/interface/src/components/dialog/EncryptFileDialog.tsx
@@ -128,7 +128,13 @@ export const EncryptFileDialog = (props: EncryptDialogProps) => {
 								// if we allow the user to encrypt multiple files simultaneously, this should become a directory instead
 								if (!platform.saveFilePickerDialog) {
 									// TODO: Support opening locations on web
-									alert('Opening a dialogue is not supported on this platform!');
+									props.setAlertDialogData({
+										open: true,
+										title: 'Error',
+										description: '',
+										value: 'Opening system dialogs is not supported on this platform.',
+										inputBox: false
+									});
 									return;
 								}
 								platform.saveFilePickerDialog().then((result) => {

--- a/packages/interface/src/components/dialog/EncryptFileDialog.tsx
+++ b/packages/interface/src/components/dialog/EncryptFileDialog.tsx
@@ -132,7 +132,7 @@ export const EncryptFileDialog = (props: EncryptDialogProps) => {
 										open: true,
 										title: 'Error',
 										description: '',
-										value: 'Opening system dialogs is not supported on this platform.',
+										value: "System dialogs aren't supported on this platform.",
 										inputBox: false
 									});
 									return;

--- a/packages/interface/src/components/dialog/KeyViewerDialog.tsx
+++ b/packages/interface/src/components/dialog/KeyViewerDialog.tsx
@@ -1,21 +1,33 @@
 import { useLibraryQuery } from '@sd/client';
-import { Button, Dialog, Input, Select } from '@sd/ui';
+import { Button, Dialog, Input, Select, SelectOption } from '@sd/ui';
 import { writeText } from '@tauri-apps/api/clipboard';
 import { Clipboard } from 'phosphor-react';
 import { ReactNode, useEffect, useState } from 'react';
 
+import { getHashingAlgorithmString } from '../../screens/settings/library/KeysSetting';
 import { SelectOptionKeyList } from '../key/KeyList';
 
 interface KeyViewerDialogProps {
 	trigger: ReactNode;
 }
 
-export const KeyTextBox = (props: { uuid: string; setKey: (value: string) => void }) => {
+export const KeyUpdater = (props: {
+	uuid: string;
+	setKey: (value: string) => void;
+	setEncryptionAlgo: (value: string) => void;
+	setHashingAlgo: (value: string) => void;
+}) => {
 	useLibraryQuery(['keys.getKey', props.uuid], {
 		onSuccess: (data) => {
 			props.setKey(data);
 		}
 	});
+
+	const keys = useLibraryQuery(['keys.list']);
+
+	const key = keys.data?.find((key) => key.uuid == props.uuid);
+	key && props.setEncryptionAlgo(key?.algorithm);
+	key && props.setHashingAlgo(getHashingAlgorithmString(key?.hashing_algorithm));
 
 	return <></>;
 };
@@ -32,6 +44,8 @@ export const KeyViewerDialog = (props: KeyViewerDialogProps) => {
 	const [showKeyViewerDialog, setShowKeyViewerDialog] = useState(false);
 	const [key, setKey] = useState('');
 	const [keyValue, setKeyValue] = useState('');
+	const [encryptionAlgo, setEncryptionAlgo] = useState('');
+	const [hashingAlgo, setHashingAlgo] = useState('');
 
 	return (
 		<>
@@ -46,6 +60,13 @@ export const KeyViewerDialog = (props: KeyViewerDialogProps) => {
 					setShowKeyViewerDialog(false);
 				}}
 			>
+				<KeyUpdater
+					uuid={key}
+					setKey={setKeyValue}
+					setEncryptionAlgo={setEncryptionAlgo}
+					setHashingAlgo={setHashingAlgo}
+				/>
+
 				<div className="grid w-full gap-4 mt-4 mb-3">
 					<div className="flex flex-col">
 						<span className="text-xs font-bold">Key</span>
@@ -60,9 +81,31 @@ export const KeyViewerDialog = (props: KeyViewerDialogProps) => {
 						</Select>
 					</div>
 				</div>
+				<div className="grid w-full grid-cols-2 gap-4 mt-4 mb-3">
+					<div className="flex flex-col">
+						<span className="text-xs font-bold">Encryption</span>
+						<Select
+							className="mt-2 text-gray-300"
+							value={encryptionAlgo}
+							disabled
+							onChange={() => {}}
+						>
+							<SelectOption value="XChaCha20Poly1305">XChaCha20-Poly1305</SelectOption>
+							<SelectOption value="Aes256Gcm">AES-256-GCM</SelectOption>
+						</Select>
+					</div>
+					<div className="flex flex-col">
+						<span className="text-xs font-bold">Hashing</span>
+						<Select className="mt-2 text-gray-300" value={hashingAlgo} disabled onChange={() => {}}>
+							<SelectOption value="Argon2id-s">Argon2id (standard)</SelectOption>
+							<SelectOption value="Argon2id-h">Argon2id (hardened)</SelectOption>
+							<SelectOption value="Argon2id-p">Argon2id (paranoid)</SelectOption>
+						</Select>
+					</div>
+				</div>
 				<div className="grid w-full gap-4 mt-4 mb-3">
 					<div className="flex flex-col">
-						<span className="text-xs font-bold">Value</span>
+						<span className="text-xs font-bold">Key Value</span>
 						<div className="relative flex flex-grow">
 							<Input value={keyValue} disabled className="flex-grow !py-0.5" />
 							<Button
@@ -76,9 +119,15 @@ export const KeyViewerDialog = (props: KeyViewerDialogProps) => {
 								<Clipboard className="w-4 h-4" />
 							</Button>
 						</div>
-						<KeyTextBox uuid={key} setKey={setKeyValue} />
 					</div>
 				</div>
+				{/* <div className="grid w-full gap-4 mt-4 mb-3">
+					<div className="flex flex-col">
+						<span className="text-xs font-bold">Properties</span>
+
+						<Input value={keyValue} disabled className="flex-grow !py-0.5" />
+					</div>
+				</div> */}
 			</Dialog>
 		</>
 	);

--- a/packages/interface/src/components/dialog/KeyViewerDialog.tsx
+++ b/packages/interface/src/components/dialog/KeyViewerDialog.tsx
@@ -2,7 +2,7 @@ import { useLibraryQuery } from '@sd/client';
 import { Button, Dialog, Input, Select, SelectOption } from '@sd/ui';
 import { writeText } from '@tauri-apps/api/clipboard';
 import { Clipboard } from 'phosphor-react';
-import { ReactNode, useEffect, useState } from 'react';
+import { ReactNode, useState } from 'react';
 
 import { getHashingAlgorithmString } from '../../screens/settings/library/KeysSetting';
 import { SelectOptionKeyList } from '../key/KeyList';
@@ -105,7 +105,7 @@ export const KeyViewerDialog = (props: KeyViewerDialogProps) => {
 				</div>
 				<div className="grid w-full gap-4 mt-4 mb-3">
 					<div className="flex flex-col">
-						<span className="text-xs font-bold">Key Value</span>
+						<span className="text-xs font-bold mb-2">Key Value</span>
 						<div className="relative flex flex-grow">
 							<Input value={keyValue} disabled className="flex-grow !py-0.5" />
 							<Button
@@ -121,13 +121,6 @@ export const KeyViewerDialog = (props: KeyViewerDialogProps) => {
 						</div>
 					</div>
 				</div>
-				{/* <div className="grid w-full gap-4 mt-4 mb-3">
-					<div className="flex flex-col">
-						<span className="text-xs font-bold">Properties</span>
-
-						<Input value={keyValue} disabled className="flex-grow !py-0.5" />
-					</div>
-				</div> */}
 			</Dialog>
 		</>
 	);

--- a/packages/interface/src/components/dialog/MasterPasswordChangeDialog.tsx
+++ b/packages/interface/src/components/dialog/MasterPasswordChangeDialog.tsx
@@ -74,9 +74,8 @@ export const MasterPasswordChangeDialog = (props: MasterPasswordChangeDialogProp
 
 	const [encryptionAlgo, setEncryptionAlgo] = useState('XChaCha20Poly1305');
 	const [hashingAlgo, setHashingAlgo] = useState('Argon2id-s');
-	const [passwordMeterMasterPw, setPasswordMeterMasterPw] = useState(''); // this is needed as the password meter won't update purely with react-hook-for
+	const [passwordMeterMasterPw, setPasswordMeterMasterPw] = useState(''); // this is needed as the password meter won't update purely with react-hook-form
 	const [showMasterPasswordDialog, setShowMasterPasswordDialog] = useState(false);
-	// const [showSecretKeyDialog, setShowSecretKeyDialog] = useState(false);
 	const changeMasterPassword = useLibraryMutation('keys.changeMasterPassword');
 	const [showMasterPassword1, setShowMasterPassword1] = useState(false);
 	const [showMasterPassword2, setShowMasterPassword2] = useState(false);

--- a/packages/interface/src/components/dialog/MasterPasswordChangeDialog.tsx
+++ b/packages/interface/src/components/dialog/MasterPasswordChangeDialog.tsx
@@ -13,7 +13,7 @@ import { GenericAlertDialogProps } from './AlertDialog';
 
 export interface MasterPasswordChangeDialogProps {
 	trigger: ReactNode;
-	setDialogData: (data: GenericAlertDialogProps) => void;
+	setAlertDialogData: (data: GenericAlertDialogProps) => void;
 }
 export const MasterPasswordChangeDialog = (props: MasterPasswordChangeDialogProps) => {
 	type FormValues = {
@@ -30,7 +30,7 @@ export const MasterPasswordChangeDialog = (props: MasterPasswordChangeDialogProp
 
 	const onSubmit: SubmitHandler<FormValues> = (data) => {
 		if (data.masterPassword !== data.masterPassword2) {
-			props.setDialogData({
+			props.setAlertDialogData({
 				open: true,
 				title: 'Error',
 				description: '',
@@ -45,7 +45,7 @@ export const MasterPasswordChangeDialog = (props: MasterPasswordChangeDialogProp
 				{
 					onSuccess: (sk) => {
 						setShowMasterPasswordDialog(false);
-						props.setDialogData({
+						props.setAlertDialogData({
 							open: true,
 							title: 'Secret Key',
 							description:
@@ -57,7 +57,7 @@ export const MasterPasswordChangeDialog = (props: MasterPasswordChangeDialogProp
 					onError: () => {
 						// this should never really happen
 						setShowMasterPasswordDialog(false);
-						props.setDialogData({
+						props.setAlertDialogData({
 							open: true,
 							title: 'Master Password Change Error',
 							description: '',

--- a/packages/interface/src/components/key/Key.tsx
+++ b/packages/interface/src/components/key/Key.tsx
@@ -3,7 +3,7 @@ import { useLibraryMutation } from '@sd/client';
 import { Button, ContextMenu } from '@sd/ui';
 import clsx from 'clsx';
 import { DotsThree, Eye, Key as KeyIcon } from 'phosphor-react';
-import { PropsWithChildren, useState } from 'react';
+import { MouseEventHandler, PropsWithChildren, ReactNode, useState } from 'react';
 import { animated, config, useTransition } from 'react-spring';
 
 import { DefaultProps } from '../primitive/types';
@@ -23,6 +23,7 @@ export interface Key {
 	};
 	default?: boolean;
 	memoryOnly?: boolean;
+	automount?: boolean;
 	// Nodes this key is mounted on
 	nodes?: string[]; // will be node object
 }
@@ -91,6 +92,7 @@ export const Key: React.FC<{ data: Key; index: number }> = ({ data, index }) => 
 	const unmountKey = useLibraryMutation('keys.unmount');
 	const deleteKey = useLibraryMutation('keys.deleteFromLibrary');
 	const setDefaultKey = useLibraryMutation('keys.setDefault');
+	const changeAutomountStatus = useLibraryMutation('keys.updateAutomountStatus');
 
 	return (
 		<div
@@ -155,50 +157,66 @@ export const Key: React.FC<{ data: Key; index: number }> = ({ data, index }) => 
 						</Button>
 					}
 				>
-					{data.mounted && (
-						<DropdownMenu.DropdownMenuItem
-							className="!cursor-default select-none text-menu-ink focus:outline-none py-0.5 active:opacity-80"
-							onClick={(e) => {
-								unmountKey.mutate(data.id);
-							}}
-						>
-							Unmount
-						</DropdownMenu.DropdownMenuItem>
-					)}
-
-					{!data.mounted && (
-						<DropdownMenu.DropdownMenuItem
-							className="!cursor-default select-none text-menu-ink focus:outline-none py-0.5 active:opacity-80"
-							onClick={(e) => {
-								mountKey.mutate(data.id);
-							}}
-						>
-							Mount
-						</DropdownMenu.DropdownMenuItem>
-					)}
-
-					<DropdownMenu.DropdownMenuItem
-						className="!cursor-default select-none text-menu-ink focus:outline-none py-0.5 active:opacity-80"
-						onClick={(e) => {
+					<KeyDropdownItem
+						onClick={() => {
+							unmountKey.mutate(data.id);
+						}}
+						hidden={!data.mounted}
+						value="Unmount"
+					/>
+					<KeyDropdownItem
+						onClick={() => {
+							mountKey.mutate(data.id);
+						}}
+						hidden={data.mounted}
+						value="Mount"
+					/>
+					<KeyDropdownItem
+						onClick={() => {
 							deleteKey.mutate(data.id);
 						}}
-					>
-						Delete from Library
-					</DropdownMenu.DropdownMenuItem>
-
-					{!data.default && (
-						<DropdownMenu.DropdownMenuItem
-							className="!cursor-default select-none text-menu-ink focus:outline-none py-0.5 active:opacity-80"
-							onClick={(e) => {
-								setDefaultKey.mutate(data.id);
-							}}
-						>
-							Set as Default
-						</DropdownMenu.DropdownMenuItem>
-					)}
+						value="Delete from Library"
+					/>
+					<KeyDropdownItem
+						onClick={() => {
+							setDefaultKey.mutate(data.id);
+						}}
+						hidden={data.default}
+						value="Set as Default"
+					/>
+					<KeyDropdownItem
+						onClick={() => {
+							changeAutomountStatus.mutate({ uuid: data.id, status: false });
+						}}
+						hidden={!data.automount || data.memoryOnly}
+						value="Disable Automount"
+					/>
+					<KeyDropdownItem
+						onClick={() => {
+							changeAutomountStatus.mutate({ uuid: data.id, status: true });
+						}}
+						hidden={data.automount || data.memoryOnly}
+						value="Enable Automount"
+					/>
 				</KeyDropdown>
 			</div>
 		</div>
+	);
+};
+
+export const KeyDropdownItem = (props: {
+	value: string;
+	hidden?: boolean | undefined;
+	onClick: () => void;
+}) => {
+	return (
+		<DropdownMenu.DropdownMenuItem
+			className="!cursor-default select-none text-menu-ink focus:outline-none py-0.5 active:opacity-80"
+			onClick={props.onClick}
+			hidden={props.hidden}
+		>
+			{props.value}
+		</DropdownMenu.DropdownMenuItem>
 	);
 };
 

--- a/packages/interface/src/components/key/Key.tsx
+++ b/packages/interface/src/components/key/Key.tsx
@@ -93,6 +93,7 @@ export const Key: React.FC<{ data: Key; index: number }> = ({ data, index }) => 
 	const deleteKey = useLibraryMutation('keys.deleteFromLibrary');
 	const setDefaultKey = useLibraryMutation('keys.setDefault');
 	const changeAutomountStatus = useLibraryMutation('keys.updateAutomountStatus');
+	const syncToLibrary = useLibraryMutation('keys.syncKeyToLibrary');
 
 	return (
 		<div
@@ -163,6 +164,13 @@ export const Key: React.FC<{ data: Key; index: number }> = ({ data, index }) => 
 						}}
 						hidden={!data.mounted}
 						value="Unmount"
+					/>
+					<KeyDropdownItem
+						onClick={() => {
+							syncToLibrary.mutate(data.id);
+						}}
+						hidden={!data.memoryOnly}
+						value="Sync to library"
 					/>
 					<KeyDropdownItem
 						onClick={() => {

--- a/packages/interface/src/components/key/KeyList.tsx
+++ b/packages/interface/src/components/key/KeyList.tsx
@@ -47,7 +47,8 @@ export const ListOfKeys = () => {
 							name: `Key ${key.uuid.substring(0, 8).toUpperCase()}`,
 							mounted: mountedKeys.includes(key),
 							default: defaultKey.data === key.uuid,
-							memoryOnly: key.memory_only
+							memoryOnly: key.memory_only,
+							automount: key.automount
 							// key stats need including here at some point
 						}}
 					/>

--- a/packages/interface/src/components/layout/Sidebar.tsx
+++ b/packages/interface/src/components/layout/Sidebar.tsx
@@ -356,12 +356,12 @@ function LibraryScopedSection() {
 					{(locations?.length || 0) < 4 && (
 						<button
 							onClick={() => {
-								if (!platform.openFilePickerDialog) {
+								if (!platform.openDirectoryPickerDialog) {
 									// TODO: Support opening locations on web
 									alert('Opening a dialogue is not supported on this platform!');
 									return;
 								}
-								platform.openFilePickerDialog().then((result) => {
+								platform.openDirectoryPickerDialog().then((result) => {
 									// TODO: Pass indexer rules ids to create location
 									if (result)
 										createLocation({

--- a/packages/interface/src/screens/settings/library/KeysSetting.tsx
+++ b/packages/interface/src/screens/settings/library/KeysSetting.tsx
@@ -7,7 +7,6 @@ import {
 	useLibraryQuery
 } from '@sd/client';
 import { Button, Input } from '@sd/ui';
-import { save } from '@tauri-apps/api/dialog';
 import clsx from 'clsx';
 import { Eye, EyeSlash, Lock, Plus } from 'phosphor-react';
 import { PropsWithChildren, useState } from 'react';
@@ -22,6 +21,7 @@ import { KeyMounter } from '../../../components/key/KeyMounter';
 import { SettingsContainer } from '../../../components/settings/SettingsContainer';
 import { SettingsHeader } from '../../../components/settings/SettingsHeader';
 import { SettingsSubHeader } from '../../../components/settings/SettingsSubHeader';
+import { usePlatform } from '../../../util/Platform';
 
 interface Props extends DropdownMenu.MenuContentProps {
 	trigger: React.ReactNode;
@@ -83,6 +83,7 @@ export const KeyMounterDropdown = ({
 };
 
 export default function KeysSettings() {
+	const platform = usePlatform();
 	const hasMasterPw = useLibraryQuery(['keys.hasMasterPassword']);
 	const setMasterPasswordMutation = useLibraryMutation('keys.setMasterPassword');
 	const unmountAll = useLibraryMutation('keys.unmountAll');
@@ -244,8 +245,12 @@ export default function KeysSettings() {
 							className="mr-2"
 							type="button"
 							onClick={() => {
-								// not platform-safe, probably will break on web but `platform` doesn't have a save dialog option
-								save()?.then((result) => {
+								if (!platform.saveFilePickerDialog) {
+									// TODO: Support opening locations on web
+									alert('Opening a dialogue is not supported on this platform!');
+									return;
+								}
+								platform.saveFilePickerDialog().then((result) => {
 									if (result) backupKeystore.mutate(result as string);
 								});
 							}}

--- a/packages/interface/src/screens/settings/library/KeysSetting.tsx
+++ b/packages/interface/src/screens/settings/library/KeysSetting.tsx
@@ -221,7 +221,7 @@ export default function KeysSettings() {
 					<SettingsSubHeader title="Password Options" />
 					<div className="flex flex-row">
 						<MasterPasswordChangeDialog
-							setDialogData={setAlertDialogData}
+							setAlertDialogData={setAlertDialogData}
 							trigger={
 								<Button size="sm" variant="gray" className="mr-2">
 									Change Master Password
@@ -247,7 +247,13 @@ export default function KeysSettings() {
 							onClick={() => {
 								if (!platform.saveFilePickerDialog) {
 									// TODO: Support opening locations on web
-									alert('Opening a dialogue is not supported on this platform!');
+									setAlertDialogData({
+										open: true,
+										title: 'Error',
+										description: '',
+										value: 'Opening system dialogs is not supported on this platform.',
+										inputBox: false
+									});
 									return;
 								}
 								platform.saveFilePickerDialog().then((result) => {
@@ -258,7 +264,7 @@ export default function KeysSettings() {
 							Backup
 						</Button>
 						<BackupRestoreDialog
-							setDialogData={setAlertDialogData}
+							setAlertDialogData={setAlertDialogData}
 							trigger={
 								<Button size="sm" variant="gray" className="mr-2">
 									Restore

--- a/packages/interface/src/screens/settings/library/KeysSetting.tsx
+++ b/packages/interface/src/screens/settings/library/KeysSetting.tsx
@@ -251,7 +251,7 @@ export default function KeysSettings() {
 										open: true,
 										title: 'Error',
 										description: '',
-										value: 'Opening system dialogs is not supported on this platform.',
+										value: "System dialogs aren't supported on this platform.",
 										inputBox: false
 									});
 									return;

--- a/packages/interface/src/screens/settings/library/LocationSettings.tsx
+++ b/packages/interface/src/screens/settings/library/LocationSettings.tsx
@@ -29,13 +29,13 @@ export default function LocationSettings() {
 							variant="accent"
 							size="sm"
 							onClick={() => {
-								if (!platform.openFilePickerDialog) {
+								if (!platform.openDirectoryPickerDialog) {
 									// TODO: Support opening locations on web
 									alert('Opening a dialogue is not supported on this platform!');
 									return;
 								}
 
-								platform.openFilePickerDialog().then((result) => {
+								platform.openDirectoryPickerDialog().then((result) => {
 									// TODO: Pass indexer rules ids to create location
 									if (result)
 										createLocation({

--- a/packages/interface/src/util/Platform.tsx
+++ b/packages/interface/src/util/Platform.tsx
@@ -10,7 +10,9 @@ export type Platform = {
 	openLink: (url: string) => void;
 	demoMode?: boolean; // TODO: Remove this in favour of demo mode being handled at the React Query level
 	getOs?(): Promise<OperatingSystem>;
+	openDirectoryPickerDialog?(): Promise<null | string | string[]>;
 	openFilePickerDialog?(): Promise<null | string | string[]>;
+	saveFilePickerDialog?(): Promise<string | null>;
 	showDevtools?(): void;
 	openPath?(path: string): void;
 };


### PR DESCRIPTION
This PR improves the key viewer, by providing the algorithm/hashing algorithm used for that key.

It also adds the option to toggle key automounting via the key dropdown, and it offers the user a chance to save a memory-only key to the database.

It further cleans up code in general, and the key dropdown menu items. `save()` and `open()` are now abstracted through `Platform`, and `open({directory: true})` was renamed to a directory-specific function (references to this have been updated).