### PR TITLE
[ENG-316] Decrypt with Password

### DIFF
--- a/core/src/api/keys.rs
+++ b/core/src/api/keys.rs
@@ -301,6 +301,7 @@ pub(crate) fn mount() -> RouterBuilder {
 					args.hashing_algorithm,
 					!args.library_sync,
 					args.automount,
+					None,
 				)?;
 
 				let stored_key = library.key_manager.access_keystore(uuid)?;

--- a/core/src/object/fs/decrypt.rs
+++ b/core/src/object/fs/decrypt.rs
@@ -1,6 +1,6 @@
 use std::{collections::VecDeque, path::PathBuf};
 
-use sd_crypto::{crypto::stream::StreamDecryption, header::file::FileHeader};
+use sd_crypto::{crypto::stream::StreamDecryption, header::file::FileHeader, Protected};
 use serde::{Deserialize, Serialize};
 use specta::Type;
 
@@ -8,7 +8,6 @@ use crate::{
 	job::{JobError, JobReportUpdate, JobResult, JobState, StatefulJob, WorkerContext},
 	prisma::{file_path, location},
 };
-
 pub struct FileDecryptorJob;
 #[derive(Serialize, Deserialize, Debug)]
 pub struct FileDecryptorJobState {}
@@ -19,6 +18,8 @@ pub struct FileDecryptorJobInit {
 	pub location_id: i32,
 	pub object_id: i32,
 	pub output_path: Option<PathBuf>,
+	pub password: Option<String>, // if this is set, we can assume the user chose password decryption
+	pub save_to_library: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -95,8 +96,6 @@ impl StatefulJob for FileDecryptorJob {
 		let step = &state.steps[0];
 		// handle overwriting checks, and making sure there's enough available space
 
-		let keys = ctx.library_ctx().key_manager.enumerate_hashed_keys();
-
 		let output_path = if let Some(path) = state.init.output_path.clone() {
 			path
 		} else {
@@ -125,7 +124,36 @@ impl StatefulJob for FileDecryptorJob {
 
 		let (header, aad) = FileHeader::deserialize(&mut reader)?;
 
-		let master_key = header.decrypt_master_key_from_prehashed(keys)?;
+		let master_key = if let Some(password) = state.init.password.clone() {
+			if let Some(save_to_library) = state.init.save_to_library {
+				let password = Protected::new(password.into_bytes());
+
+				// we can do this first, as `find_key_index` requires a successful decryption (just like `decrypt_master_key`)
+				if save_to_library {
+					let index = header.find_key_index(password.clone())?;
+
+					// inherit the encryption algorithm from the keyslot
+					ctx.library_ctx().key_manager.add_to_keystore(
+						password.clone(),
+						header.algorithm,
+						header.keyslots[index].hashing_algorithm,
+						false,
+						false,
+						Some(header.keyslots[index].salt),
+					)?;
+				}
+
+				header.decrypt_master_key(password.clone())?
+			} else {
+				return Err(JobError::JobDataNotFound(String::from(
+					"Password decryption selected, but save to library boolean was not included",
+				)));
+			}
+		} else {
+			let keys = ctx.library_ctx().key_manager.enumerate_hashed_keys();
+
+			header.decrypt_master_key_from_prehashed(keys)?
+		};
 
 		let decryptor = StreamDecryption::new(master_key, &header.nonce, header.algorithm)?;
 

--- a/core/src/object/fs/decrypt.rs
+++ b/core/src/object/fs/decrypt.rs
@@ -143,7 +143,7 @@ impl StatefulJob for FileDecryptorJob {
 					)?;
 				}
 
-				header.decrypt_master_key(password.clone())?
+				header.decrypt_master_key(password)?
 			} else {
 				return Err(JobError::JobDataNotFound(String::from(
 					"Password decryption selected, but save to library boolean was not included",

--- a/crates/crypto/src/header/file.rs
+++ b/crates/crypto/src/header/file.rs
@@ -33,7 +33,7 @@ use std::io::{Cursor, Read, Seek, SeekFrom, Write};
 
 use crate::{
 	crypto::stream::Algorithm,
-	primitives::{generate_nonce, MASTER_KEY_LEN},
+	primitives::{generate_nonce, to_array, MASTER_KEY_LEN},
 	Error, Protected, Result,
 };
 
@@ -104,7 +104,7 @@ impl FileHeader {
 		&self,
 		password: Protected<Vec<u8>>,
 	) -> Result<Protected<[u8; MASTER_KEY_LEN]>> {
-		let mut master_key = [0u8; MASTER_KEY_LEN];
+		let mut master_key: Option<Protected<[u8; MASTER_KEY_LEN]>> = None;
 
 		if self.keyslots.is_empty() {
 			return Err(Error::NoKeyslots);
@@ -112,15 +112,35 @@ impl FileHeader {
 
 		for keyslot in &self.keyslots {
 			if let Ok(decrypted_master_key) = keyslot.decrypt_master_key(&password) {
-				master_key.copy_from_slice(&decrypted_master_key);
+				master_key = Some(Protected::new(to_array(
+					decrypted_master_key.expose().clone(),
+				)?));
 			}
 		}
 
-		if master_key == [0u8; MASTER_KEY_LEN] {
-			Err(Error::IncorrectPassword)
+		if let Some(mk) = master_key {
+			Ok(mk)
 		} else {
-			Ok(Protected::new(master_key))
+			Err(Error::IncorrectPassword)
 		}
+	}
+
+	/// This is a helper function to find which keyslot a key belongs to.
+	///
+	/// You receive an error if the password doesn't match or if there are no keyslots.
+	#[allow(clippy::needless_pass_by_value)]
+	pub fn find_key_index(&self, password: Protected<Vec<u8>>) -> Result<usize> {
+		if self.keyslots.is_empty() {
+			return Err(Error::NoKeyslots);
+		}
+
+		for (i, keyslot) in self.keyslots.clone().iter().enumerate() {
+			if let Ok(_) = keyslot.decrypt_master_key(&password) {
+				return Ok(i);
+			}
+		}
+
+		return Err(Error::IncorrectPassword);
 	}
 
 	/// This is a helper function to serialize and write a header to a file.
@@ -142,7 +162,7 @@ impl FileHeader {
 		&self,
 		hashed_keys: Vec<Protected<[u8; 32]>>,
 	) -> Result<Protected<[u8; MASTER_KEY_LEN]>> {
-		let mut master_key = [0u8; MASTER_KEY_LEN];
+		let mut master_key: Option<Protected<[u8; MASTER_KEY_LEN]>> = None;
 
 		if self.keyslots.is_empty() {
 			return Err(Error::NoKeyslots);
@@ -153,15 +173,17 @@ impl FileHeader {
 				if let Ok(decrypted_master_key) =
 					keyslot.decrypt_master_key_from_prehashed(key.clone())
 				{
-					master_key.copy_from_slice(&decrypted_master_key);
+					master_key = Some(Protected::new(to_array(
+						decrypted_master_key.expose().clone(),
+					)?));
 				}
 			}
 		}
 
-		if master_key == [0u8; MASTER_KEY_LEN] {
-			Err(Error::IncorrectPassword)
+		if let Some(mk) = master_key {
+			Ok(mk)
 		} else {
-			Ok(Protected::new(master_key))
+			Err(Error::IncorrectPassword)
 		}
 	}
 

--- a/crates/crypto/src/header/file.rs
+++ b/crates/crypto/src/header/file.rs
@@ -135,12 +135,12 @@ impl FileHeader {
 		}
 
 		for (i, keyslot) in self.keyslots.clone().iter().enumerate() {
-			if let Ok(_) = keyslot.decrypt_master_key(&password) {
+			if keyslot.decrypt_master_key(&password).is_ok() {
 				return Ok(i);
 			}
 		}
 
-		return Err(Error::IncorrectPassword);
+		Err(Error::IncorrectPassword)
 	}
 
 	/// This is a helper function to serialize and write a header to a file.

--- a/crates/crypto/src/keys/keymanager.rs
+++ b/crates/crypto/src/keys/keymanager.rs
@@ -919,6 +919,8 @@ impl KeyManager {
 	/// Once added, you will need to use `KeyManager::access_keystore()` to retrieve it and add it to Prisma.
 	///
 	/// You may use the returned ID to identify this key.
+	///
+	/// You may optionally provide a content salt, if not one will be generated.
 	#[allow(clippy::needless_pass_by_value)]
 	pub fn add_to_keystore(
 		&self,
@@ -927,6 +929,7 @@ impl KeyManager {
 		hashing_algorithm: HashingAlgorithm,
 		memory_only: bool,
 		automount: bool,
+		content_salt: Option<[u8; SALT_LEN]>,
 	) -> Result<Uuid> {
 		let uuid = uuid::Uuid::new_v4();
 
@@ -934,7 +937,12 @@ impl KeyManager {
 		let key_nonce = generate_nonce(algorithm);
 		let master_key = generate_master_key();
 		let master_key_nonce = generate_nonce(algorithm);
-		let content_salt = generate_salt(); // for PVM/MD
+
+		let content_salt = if let Some(content_salt) = content_salt {
+			content_salt
+		} else {
+			generate_salt()
+		};
 
 		// Encrypt the master key with the user's hashed password
 		let encrypted_master_key: [u8; 48] = to_array(StreamEncryption::encrypt_bytes(

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -90,7 +90,7 @@ export interface ExplorerData { context: ExplorerContext, items: Array<ExplorerI
 
 export type ExplorerItem = { type: "Path" } & { id: number, is_dir: boolean, location_id: number, materialized_path: string, name: string, extension: string | null, object_id: number | null, parent_id: number | null, key_id: number | null, date_created: string, date_modified: string, date_indexed: string, object: Object | null } | { type: "Object" } & { id: number, cas_id: string, integrity_checksum: string | null, name: string | null, extension: string | null, kind: number, size_in_bytes: string, key_id: number | null, hidden: boolean, favorite: boolean, important: boolean, has_thumbnail: boolean, has_thumbstrip: boolean, has_video_preview: boolean, ipfs_id: string | null, note: string | null, date_created: string, date_modified: string, date_indexed: string, file_paths: Array<FilePath> }
 
-export interface FileDecryptorJobInit { location_id: number, object_id: number, output_path: string | null }
+export interface FileDecryptorJobInit { location_id: number, object_id: number, output_path: string | null, password: string | null, save_to_library: boolean | null }
 
 export interface FileEncryptorJobInit { location_id: number, object_id: number, key_uuid: string, algorithm: Algorithm, metadata: boolean, preview_media: boolean, output_path: string | null }
 

--- a/packages/interface/src/components/dialog/DecryptFileDialog.tsx
+++ b/packages/interface/src/components/dialog/DecryptFileDialog.tsx
@@ -1,8 +1,11 @@
+import { RadioGroup } from '@headlessui/react';
 import { useLibraryMutation } from '@sd/client';
-import { Button, Dialog } from '@sd/ui';
+import { Button, Dialog, Input, Switch } from '@sd/ui';
+import { Eye, EyeSlash, Info } from 'phosphor-react';
 import { useState } from 'react';
 
 import { usePlatform } from '../../util/Platform';
+import { Tooltip } from '../tooltip/Tooltip';
 import { GenericAlertDialogProps } from './AlertDialog';
 
 interface DecryptDialogProps {
@@ -18,6 +21,11 @@ export const DecryptFileDialog = (props: DecryptDialogProps) => {
 	const { location_id, object_id } = props;
 	const decryptFile = useLibraryMutation('files.decryptFiles');
 	const [outputPath, setOutputpath] = useState('');
+	const [decryptType, setDecryptType] = useState('key');
+	const [password, setPassword] = useState('');
+	const [saveToKeyManager, setSaveToKeyManager] = useState(true);
+	const [showPassword, setShowPassword] = useState(false);
+	const PasswordCurrentEyeIcon = showPassword ? EyeSlash : Eye;
 
 	return (
 		<>
@@ -64,6 +72,63 @@ export const DecryptFileDialog = (props: DecryptDialogProps) => {
 						);
 				}}
 			>
+				<RadioGroup value={decryptType} onChange={setDecryptType} className="mt-2">
+					<span className="text-xs font-bold">Key Type</span>
+					<div className="flex flex-row gap-2 mt-2">
+						<RadioGroup.Option value="key">
+							{({ checked }) => (
+								<Button type="button" size="sm" variant={checked ? 'accent' : 'gray'}>
+									Key Manager
+								</Button>
+							)}
+						</RadioGroup.Option>
+						<RadioGroup.Option value="password">
+							{({ checked }) => (
+								<Button type="button" size="sm" variant={checked ? 'accent' : 'gray'}>
+									Password
+								</Button>
+							)}
+						</RadioGroup.Option>
+					</div>
+				</RadioGroup>
+
+				{decryptType === 'password' && (
+					<>
+						<div className="relative flex flex-grow mt-3 mb-2">
+							<Input
+								className={`flex-grow w-max !py-0.5`}
+								placeholder="Password"
+								onChange={(e) => setPassword(e.target.value)}
+								value={password}
+								type={showPassword ? 'text' : 'password'}
+							/>
+							<Button
+								onClick={() => setShowPassword(!showPassword)}
+								size="icon"
+								className="border-none absolute right-[5px] top-[5px]"
+								type="button"
+							>
+								<PasswordCurrentEyeIcon className="w-4 h-4" />
+							</Button>
+						</div>
+
+						<div className="relative flex flex-grow mt-3 mb-2">
+							<div className="space-x-2">
+								<Switch
+									className="bg-app-selected"
+									size="sm"
+									checked={saveToKeyManager}
+									onCheckedChange={setSaveToKeyManager}
+								/>
+							</div>
+							<span className="ml-3 text-xs font-medium mt-0.5">Save to Key Manager</span>
+							<Tooltip label="This key will be saved to the key manager">
+								<Info className="w-4 h-4 ml-1.5 text-ink-faint mt-0.5" />
+							</Tooltip>
+						</div>
+					</>
+				)}
+
 				<div className="grid w-full grid-cols-2 gap-4 mt-4 mb-3">
 					<div className="flex flex-col">
 						<span className="text-xs font-bold">Output file</span>

--- a/packages/interface/src/components/dialog/DecryptFileDialog.tsx
+++ b/packages/interface/src/components/dialog/DecryptFileDialog.tsx
@@ -38,6 +38,9 @@ export const DecryptFileDialog = (props: DecryptDialogProps) => {
 				ctaLabel="Decrypt"
 				ctaAction={() => {
 					const output = outputPath !== '' ? outputPath : null;
+					const pw = decryptType === 'password' ? password : null;
+					const save = decryptType === 'password' ? saveToKeyManager : null;
+
 					props.setOpen(false);
 
 					location_id &&
@@ -46,7 +49,9 @@ export const DecryptFileDialog = (props: DecryptDialogProps) => {
 							{
 								location_id,
 								object_id,
-								output_path: output
+								output_path: output,
+								password: pw,
+								save_to_library: save
 							},
 							{
 								onSuccess: () => {
@@ -101,6 +106,7 @@ export const DecryptFileDialog = (props: DecryptDialogProps) => {
 								onChange={(e) => setPassword(e.target.value)}
 								value={password}
 								type={showPassword ? 'text' : 'password'}
+								required
 							/>
 							<Button
 								onClick={() => setShowPassword(!showPassword)}

--- a/packages/interface/src/components/dialog/KeyViewerDialog.tsx
+++ b/packages/interface/src/components/dialog/KeyViewerDialog.tsx
@@ -1,6 +1,7 @@
 import { useLibraryQuery } from '@sd/client';
 import { Button, Dialog, Input, Select, SelectOption } from '@sd/ui';
 import { writeText } from '@tauri-apps/api/clipboard';
+import { Buffer } from 'buffer';
 import { Clipboard } from 'phosphor-react';
 import { ReactNode, useState } from 'react';
 
@@ -16,6 +17,7 @@ export const KeyUpdater = (props: {
 	setKey: (value: string) => void;
 	setEncryptionAlgo: (value: string) => void;
 	setHashingAlgo: (value: string) => void;
+	setContentSalt: (value: string) => void;
 }) => {
 	useLibraryQuery(['keys.getKey', props.uuid], {
 		onSuccess: (data) => {
@@ -28,6 +30,7 @@ export const KeyUpdater = (props: {
 	const key = keys.data?.find((key) => key.uuid == props.uuid);
 	key && props.setEncryptionAlgo(key?.algorithm);
 	key && props.setHashingAlgo(getHashingAlgorithmString(key?.hashing_algorithm));
+	key && props.setContentSalt(Buffer.from(key.content_salt).toString('hex'));
 
 	return <></>;
 };
@@ -44,6 +47,7 @@ export const KeyViewerDialog = (props: KeyViewerDialogProps) => {
 	const [showKeyViewerDialog, setShowKeyViewerDialog] = useState(false);
 	const [key, setKey] = useState('');
 	const [keyValue, setKeyValue] = useState('');
+	const [contentSalt, setContentSalt] = useState('');
 	const [encryptionAlgo, setEncryptionAlgo] = useState('');
 	const [hashingAlgo, setHashingAlgo] = useState('');
 
@@ -65,6 +69,7 @@ export const KeyViewerDialog = (props: KeyViewerDialogProps) => {
 					setKey={setKeyValue}
 					setEncryptionAlgo={setEncryptionAlgo}
 					setHashingAlgo={setHashingAlgo}
+					setContentSalt={setContentSalt}
 				/>
 
 				<div className="grid w-full gap-4 mt-4 mb-3">
@@ -101,6 +106,24 @@ export const KeyViewerDialog = (props: KeyViewerDialogProps) => {
 							<SelectOption value="Argon2id-h">Argon2id (hardened)</SelectOption>
 							<SelectOption value="Argon2id-p">Argon2id (paranoid)</SelectOption>
 						</Select>
+					</div>
+				</div>
+				<div className="grid w-full gap-4 mt-4 mb-3">
+					<div className="flex flex-col">
+						<span className="text-xs font-bold mb-2">Content Salt (hex)</span>
+						<div className="relative flex flex-grow">
+							<Input value={contentSalt} disabled className="flex-grow !py-0.5" />
+							<Button
+								type="button"
+								onClick={() => {
+									writeText(contentSalt);
+								}}
+								size="icon"
+								className="border-none absolute right-[5px] top-[5px]"
+							>
+								<Clipboard className="w-4 h-4" />
+							</Button>
+						</div>
 					</div>
 				</div>
 				<div className="grid w-full gap-4 mt-4 mb-3">

--- a/packages/interface/src/components/explorer/ExplorerContextMenu.tsx
+++ b/packages/interface/src/components/explorer/ExplorerContextMenu.tsx
@@ -81,7 +81,6 @@ export default function ExplorerContextMenu(props: ExplorerContextMenuProps) {
 		}
 	}, [os]);
 
-	const decryptFiles = useLibraryMutation('files.decryptFiles');
 	const hasMasterPasswordQuery = useLibraryQuery(['keys.hasMasterPassword']);
 	const hasMasterPassword =
 		hasMasterPasswordQuery.data !== undefined && hasMasterPasswordQuery.data === true

--- a/packages/interface/src/components/explorer/ExplorerContextMenu.tsx
+++ b/packages/interface/src/components/explorer/ExplorerContextMenu.tsx
@@ -173,21 +173,13 @@ export default function ExplorerContextMenu(props: ExplorerContextMenuProps) {
 						icon={LockSimpleOpen}
 						keybind="⌘D"
 						onClick={() => {
-							if (hasMasterPassword && hasMountedKeys) {
+							if (hasMasterPassword) {
 								props.setShowDecryptDialog(true);
-							} else if (!hasMasterPassword) {
+							} else {
 								props.setAlertDialogData({
 									open: true,
 									title: 'Key manager locked',
 									value: 'The key manager is currently locked. Please unlock it and try again.',
-									inputBox: false,
-									description: ''
-								});
-							} else if (!hasMountedKeys) {
-								props.setAlertDialogData({
-									open: true,
-									title: 'No mounted keys',
-									value: 'No mounted keys were found. Please mount a key and try again.',
 									inputBox: false,
 									description: ''
 								});

--- a/packages/interface/src/components/key/KeyMounter.tsx
+++ b/packages/interface/src/components/key/KeyMounter.tsx
@@ -75,6 +75,9 @@ export function KeyMounter() {
 							setSliderValue(e);
 							setKey(GeneratePassword(e[0]));
 						}}
+						onClick={() => {
+							setKey(GeneratePassword(sliderValue[0]));
+						}}
 					/>
 				</div>
 				<span className="text-sm mt-2.5 font-medium">{sliderValue}</span>


### PR DESCRIPTION
This implements password decryption, and offers the user a chance to import the key and content salt into our key manager. This is super helpful for either one-off decryption, or importing lost key/content salt relations. This removes the check for any mounted keys before opening the decrypt dialog, but it disables keymanager-based decryption if no keys are mounted.

I may implement this for encryption too, just as a one-off "encrypt with this password" (this could also have the option to save the key to the key manager). I'm not too sure if this would be worthwhile though, as it's just as easy to create a memory-only key within the key manager.

I have tested this, and it successfully imports the key into the key manager.

This PR also adds the (hex encoded) content salt to the key viewer.