### PR TITLE
updated contributing.md to node 18

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ To run the landing page
 If you are having issues ensure you are using the following versions of Rust and Node:
 
 - Rust version: **1.64.0**
-- Node version: **16**
+- Node version: **18**
 
 ##### Mobile app
 


### PR DESCRIPTION
pr to update contributing guide to node 18* since 16 is no longer supported when running "pnpm i".