### PR TITLE
Notify2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1672,7 +1672,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "redox_syscall 0.2.16",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -1739,6 +1739,21 @@ name = "fs_extra"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+
+[[package]]
+name = "fsevent-stream"
+version = "0.2.3"
+source = "git+https://github.com/oscartbeaumont/fsevent-stream.git?rev=50fa6fd2e2df3098f37317deb6906ff1de31163d#50fa6fd2e2df3098f37317deb6906ff1de31163d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "futures-core",
+ "futures-util",
+ "log",
+ "once_cell",
+ "tokio",
+ "tokio-stream",
+]
 
 [[package]]
 name = "fuchsia-cprng"
@@ -2639,6 +2654,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf888f9575c290197b2c948dc9e9ff10bd1a39ad1ea8585f734585fa6b9d3f9"
+dependencies = [
+ "bitflags",
+ "futures-core",
+ "inotify-sys",
+ "libc",
+ "tokio",
+]
+
+[[package]]
 name = "inotify-sys"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3273,7 +3301,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -3508,7 +3536,7 @@ checksum = "ed2c66da08abae1c024c01d635253e402341b4060a12e99b31c7594063bf490a"
 dependencies = [
  "bitflags",
  "filetime",
- "inotify",
+ "inotify 0.9.6",
  "kqueue",
  "libc",
  "mio",
@@ -3525,6 +3553,16 @@ dependencies = [
  "dbus",
  "mac-notification-sys",
  "tauri-winrt-notification",
+]
+
+[[package]]
+name = "notify2"
+version = "0.0.1"
+dependencies = [
+ "core-foundation",
+ "fsevent-stream",
+ "inotify 0.10.0",
+ "tokio",
 ]
 
 [[package]]
@@ -3711,7 +3749,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4a3100141f1733ea40b53381b0ae3117330735ef22309a190ac57b9576ea716"
 dependencies = [
  "pathdiff",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -3936,7 +3974,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.2.16",
  "smallvec 1.10.0",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -5266,7 +5304,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
  "lazy_static",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -6687,9 +6725,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.2"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
 dependencies = [
  "autocfg 1.1.0",
  "bytes",
@@ -6702,7 +6740,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -6723,6 +6761,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -7453,7 +7502,7 @@ dependencies = [
  "cocoa",
  "objc",
  "raw-window-handle",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -7549,10 +7598,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
 name = "windows-tokens"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f838de2fe15fe6bac988e74b798f26499a8b21a9d97edec321e79b28d1d7f597"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -7585,6 +7655,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7711666096bd4096ffa835238905bb33fb87267910e154b18b44eaabb340f2"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7613,6 +7689,12 @@ name = "windows_i686_gnu"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "763fc57100a5f7042e3057e7e8d9bdd7860d330070251a73d003563a3bb49e1b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7645,6 +7727,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bc7cbfe58828921e10a9f446fcaaf649204dcfe6c1ddd712c5eebae6bda1106"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7675,6 +7763,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6868c165637d653ae1e8dc4d82c25d4f97dd6605eaa8d784b5c6e0ab2a252b65"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7703,6 +7803,12 @@ name = "windows_x86_64_msvc"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e4d40883ae9cae962787ca76ba76390ffa29214667a111db9e0a1ad8377e809"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,6 @@ openssl-sys = { git = "https://github.com/spacedriveapp/rust-openssl", rev = "92
 rspc = { git = "https://github.com/oscartbeaumont/rspc", rev = "73d60f9cb901661f9f0f8e953477b3558f2715d1" }   # TODO: Move back to crates.io when new jsonrpc executor is released
 normi = { git = "https://github.com/oscartbeaumont/rspc", rev = "73d60f9cb901661f9f0f8e953477b3558f2715d1" }  # TODO: When normi is released on crates.io
 specta = { git = "https://github.com/oscartbeaumont/rspc", rev = "73d60f9cb901661f9f0f8e953477b3558f2715d1" } # TODO: When normi is released on crates.io
+
+# For `./crates/notify2`
+fsevent-stream = { git = "https://github.com/oscartbeaumont/fsevent-stream.git", rev = "50fa6fd2e2df3098f37317deb6906ff1de31163d" } # TODO: PR upstream and move back to crates.io

--- a/crates/notify2/Cargo.toml
+++ b/crates/notify2/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "notify2"
+authors = ["Oscar Beaumont <oscar@otbeaumont.me>"]
+version = "0.0.1"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1.23.0", default-features = false, features = ["rt"] }
+
+[dev-dependencies]
+tokio = { version = "1.23.0", features = ["macros", "rt-multi-thread"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+core-foundation = "0.9.3"
+fsevent-stream = "0.2.3"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+inotify = "0.10.0"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+# TODO
+
+# This is defined on the workspace, left here for reference.
+# [patch.crates-io]
+# fsevent-stream = { git = "https://github.com/oscartbeaumont/fsevent-stream.git", rev = "50fa6fd2e2df3098f37317deb6906ff1de31163d" } # TODO: PR upstream and move back to crates.io

--- a/crates/notify2/examples/basic.rs
+++ b/crates/notify2/examples/basic.rs
@@ -1,0 +1,35 @@
+use std::path::PathBuf;
+
+use notify2::Watcher;
+
+#[tokio::main]
+async fn main() {
+	println!("Monitoring: './demo'");
+	let (mut rx, _watcher) = Watcher::new(
+		vec![
+			PathBuf::from(r"./demo"),
+			// PathBuf::from(r"./demo2"),
+			// PathBuf::from(r"/Volumes/Untitled"),
+		],
+		true,
+	)
+	.await;
+
+	// tokio::spawn(async move {
+	//     loop {
+	//         sleep(Duration::from_secs(5)).await;
+	//         println!("Action 1");
+	//         // drop(watcher);
+	//         watcher.add_paths(vec![PathBuf::from(r"./demo")]).await;
+	//         println!("Action 11");
+	//         sleep(Duration::from_secs(5)).await;
+	//         println!("Action 2");
+	//         watcher.remove_paths(vec![PathBuf::from(r"./demo")]).await;
+	//         println!("Action 22");
+	//     }
+	// });
+
+	while let Some(event) = rx.recv().await {
+		println!("{:?}", event);
+	}
+}

--- a/crates/notify2/src/event.rs
+++ b/crates/notify2/src/event.rs
@@ -1,0 +1,48 @@
+use std::path::PathBuf;
+
+use fsevent_stream::stream::StreamFlags;
+
+/// Type of the target of the event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Type {
+	Directory,
+	File,
+	Symlink,
+	Hardlink,
+}
+
+impl TryFrom<&StreamFlags> for Type {
+	type Error = ();
+
+	fn try_from(f: &StreamFlags) -> Result<Self, Self::Error> {
+		Ok(match *f {
+			f if f.contains(StreamFlags::IS_FILE) => Self::File,
+			f if f.contains(StreamFlags::IS_DIR) => Self::Directory,
+			f if f.contains(StreamFlags::IS_SYMLINK) => Self::Symlink,
+			f if f.contains(StreamFlags::IS_HARDLINK) => Self::Hardlink,
+			f if f.contains(StreamFlags::IS_LAST_HARDLINK) => Self::Hardlink,
+			_ => return Err(()),
+		})
+	}
+}
+
+/// Filesystem event that is emitted by the watcher.
+/// The goal of this library is that all of the events here act the same on all platforms.
+/// If that's not the case open an issue on GitHub!
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Event {
+	Create(Type, PathBuf),
+	Modify(Type, PathBuf),
+	Move {
+		ty: Type,
+		from: PathBuf,
+		to: PathBuf,
+	},
+	Delete(Type, PathBuf),
+	Mount(PathBuf),
+	Unmount(PathBuf),
+
+	// TODO: The behavior of this event is probs not going to be cross-platform without extra work so do that.
+	// macOS will subscribe/unsubscribe as the root is created and deleted. I don't think other platforms do that???
+	RootChange(PathBuf),
+}

--- a/crates/notify2/src/lib.rs
+++ b/crates/notify2/src/lib.rs
@@ -1,0 +1,29 @@
+//! notify2: A better file system watcher library for Rust!
+//!
+// TODO: Put library lints here + do crate docs
+
+mod event;
+pub use event::*;
+
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "linux")]
+pub use linux::*;
+
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "macos")]
+pub use macos::*;
+
+#[cfg(target_os = "windows")]
+mod windows;
+#[cfg(target_os = "windows")]
+pub use windows::*;
+
+// TODO: Use poor mans trait
+
+// const fn assert_fn<T, TRet>(_: fn(T) -> TRet) {}
+
+// const _: () = {
+//     assert_fn::<_, String>(TODO::demo);
+// };

--- a/crates/notify2/src/linux.rs
+++ b/crates/notify2/src/linux.rs
@@ -1,0 +1,3 @@
+// TODO: https://docs.rs/inotify/latest/inotify/
+
+std::compile_error!("Linux support is not yet implemented");

--- a/crates/notify2/src/macos.rs
+++ b/crates/notify2/src/macos.rs
@@ -1,0 +1,419 @@
+use core_foundation::{
+	array::CFArray,
+	base::{CFIndex, FromVoid},
+	dictionary::CFDictionary,
+	number::CFNumber,
+	runloop::{kCFRunLoopBeforeWaiting, kCFRunLoopDefaultMode, CFRunLoop},
+	string::CFString,
+};
+use fsevent_stream::{ffi::*, flags::StreamFlags, observer::create_oneshot_observer};
+use std::{
+	ffi::c_void,
+	fmt, fs, io,
+	ops::Deref,
+	panic::catch_unwind,
+	path::PathBuf,
+	sync::{
+		atomic::{AtomicBool, Ordering},
+		Arc,
+	},
+	thread::{self, JoinHandle},
+	time::Duration,
+};
+use tokio::{
+	runtime::Handle,
+	sync::{mpsc, oneshot, Mutex},
+};
+
+use crate::Event;
+
+struct WatcherInner {
+	/// paths we are listening to
+	paths: Mutex<Vec<PathBuf>>,
+	/// running is a flag used to indicate if the watcher is running or not. If it is true, and the watcher is stopped it will restart. If false, it will drop the thread.
+	running: AtomicBool,
+	/// start is a channel used to send a signal to the watcher thread to start again. This is to prevent an infinite loop of starting and stopping the watcher when no paths are provided.
+	start: Mutex<Option<oneshot::Sender<()>>>,
+	/// is a flag used to indicate if we should ignore file system events that are triggered by the current process.
+	ignore_current_process_events: bool,
+}
+
+/// macOS File System Watcher
+pub struct Watcher {
+	inner: Arc<WatcherInner>,
+	/// handle to the watcher thread. This is used to gracefully shutdown the watcher thread.
+	handle: Option<JoinHandle<()>>, // This will never be `None`!!! Option is required for `Drop` impl to work
+	/// runloop allows us to control the objc runloop from outside of the main thread. This allows us to stop the runloop for graceful shutdown or to restart it when new paths are added/removed.
+	runloop: SendWrapper<CFRunLoop>,
+	/// tx is the channel used to send events to the user. We only hold it here so it isn't dropped until the `Watcher` is dropped.
+	_tx: mpsc::Sender<Event>,
+}
+
+impl fmt::Debug for Watcher {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.write_str("Watcher")
+	}
+}
+
+impl Watcher {
+	/// Create a new watcher
+	/// You must ensure `Watcher` is not dropped until your done with filesystem watching.
+	/// The `mpsc::Receiver` will return `None` when the watcher is dropped as per `tokio::sync::mpsc` docs.
+	/// `ignore_self` allows you to ignore events that are triggered by the current process.
+	pub async fn new(
+		mut paths: Vec<PathBuf>,
+		ignore_current_process_events: bool,
+	) -> (mpsc::Receiver<Event>, Self) {
+		let (tx, rx) = mpsc::channel(1024);
+		paths.dedup();
+		let inner = Arc::new(WatcherInner {
+			paths: Mutex::new(paths),
+			running: AtomicBool::new(true),
+			start: Mutex::new(None),
+			ignore_current_process_events,
+		});
+
+		let (runloop_tx, runloop_rx) = oneshot::channel();
+		let handle = thread::spawn(Self::thread(
+			inner.clone(),
+			Context { tx: tx.clone() },
+			runloop_tx,
+		));
+		let runloop = runloop_rx.await.expect("receive runloop from worker"); // TODO: Error handling
+
+		(
+			rx,
+			Self {
+				inner,
+				handle: Some(handle),
+				runloop,
+				_tx: tx,
+			},
+		)
+	}
+
+	fn thread(
+		inner: Arc<WatcherInner>,
+		ctx: Context,
+		runloop_tx: oneshot::Sender<SendWrapper<CFRunLoop>>,
+	) -> impl FnOnce() + Send + 'static {
+		let handle = Handle::current();
+		move || {
+			let current_runloop = CFRunLoop::get_current();
+			let mut runloop_tx = Some(runloop_tx); // `Some(_)` on first request. `None` on subsequent requests.
+
+			if let Some(runloop_tx) = runloop_tx.take() {
+				// the calling to CFRunLoopRun will be terminated by CFRunLoopStop call in drop()
+				// Safety:
+				// - According to the Apple documentation, it's safe to move `CFRef`s across threads.
+				//   https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Multithreading/ThreadSafetySummary/ThreadSafetySummary.html
+				runloop_tx
+					.send(unsafe { SendWrapper::new(current_runloop.clone()) })
+					.expect("send runloop to stream"); // TODO: Error handling
+			}
+
+			let mut flags = kFSEventStreamCreateFlagNoDefer
+				| kFSEventStreamCreateFlagFileEvents
+				| kFSEventStreamCreateFlagWatchRoot
+				| kFSEventStreamCreateFlagUseExtendedData
+				| kFSEventStreamCreateFlagUseCFTypes;
+			if inner.ignore_current_process_events {
+				flags |= kFSEventStreamCreateFlagIgnoreSelf;
+			}
+
+			let mut since_when = kFSEventStreamEventIdSinceNow;
+			loop {
+				// When no paths are set this thread will get in a loop of starting and stopping the stream. This avoids it!
+				if handle.block_on(inner.paths.lock()).len() == 0 {
+					let (tx, rx) = oneshot::channel();
+					{
+						let mut start = handle.block_on(inner.start.lock());
+						*start = Some(tx);
+					}
+					handle.block_on(rx).unwrap();
+				}
+
+				// Warning: stream_context will be dropped by the FSEvents API. Reusing it will cause UB
+				let stream_context = SysFSEventStreamContext::new(ctx.clone(), release_context);
+				let mut stream = SysFSEventStream::new(
+					cf_ext_with_id_callback,
+					&stream_context,
+					// Warning: Passing an empty array of paths here is UB but we handle that above
+					handle.block_on(inner.paths.lock()).iter(),
+					since_when,
+					Duration::from_millis(100), // Gives us an extra level of batching and the user probs won't notice
+					flags,
+				)
+				.unwrap(); // TODO: Error handling
+
+				stream.schedule(&current_runloop, unsafe { kCFRunLoopDefaultMode });
+				stream.start();
+
+				CFRunLoop::run_current();
+				stream.stop();
+				stream.invalidate();
+
+				if inner.running.load(Ordering::Relaxed) {
+					println!("Restarting!"); // TODO: Debug logs
+					let id = unsafe { FSEventsGetCurrentEventId() };
+					since_when = id;
+
+					continue;
+				} else {
+					println!("Shutdown!"); // TODO: Debug logs
+					break;
+				}
+			}
+		}
+	}
+
+	/// Add paths to the watcher
+	pub async fn add_paths(&self, new_paths: Vec<PathBuf>) {
+		{
+			let mut paths = self.inner.paths.lock().await;
+			let mut new_paths = new_paths
+				.into_iter()
+				.filter(|v| !paths.contains(v))
+				.collect::<Vec<_>>();
+			new_paths.dedup();
+			if new_paths.is_empty() {
+				println!("Skip"); // TODO
+				return;
+			}
+			paths.append(&mut new_paths);
+		}
+
+		if let Some(start) = self.inner.start.lock().await.take() {
+			start.send(()).unwrap();
+		} else {
+			self.shutdown_inner();
+		}
+	}
+
+	/// Remove paths from the watcher
+	pub async fn remove_paths(&self, remove_paths: Vec<PathBuf>) {
+		if remove_paths.is_empty() {
+			return;
+		}
+
+		{
+			let mut paths = self.inner.paths.lock().await;
+			let remove_paths = remove_paths
+				.into_iter()
+				.filter(|v| paths.contains(v))
+				.collect::<Vec<_>>();
+			if remove_paths.is_empty() {
+				println!("Skip"); // TODO
+
+				return;
+			}
+			paths.retain(|v| !remove_paths.contains(v));
+		}
+
+		if let Some(start) = self.inner.start.lock().await.take() {
+			start.send(()).unwrap();
+		} else {
+			self.shutdown_inner();
+		}
+	}
+
+	fn shutdown_inner(&self) {
+		let (tx, rx) = std::sync::mpsc::channel();
+		let observer = create_oneshot_observer(kCFRunLoopBeforeWaiting, tx);
+		self.runloop
+			.add_observer(&observer, unsafe { kCFRunLoopDefaultMode });
+
+		if !self.runloop.is_waiting() {
+			// Wait the RunLoop to enter Waiting state.
+
+			// TODO: Sometimes this just never resolves in the `double_remove` test. Debug it further and fix it!
+
+			rx.recv_timeout(Duration::from_secs(4)) // TODO: We should probs use a tokio channel here so it doesn't block an async thread
+				.expect("channel to receive BeforeWaiting signal");
+		}
+
+		self.runloop
+			.remove_observer(&observer, unsafe { kCFRunLoopDefaultMode });
+		self.runloop.stop();
+	}
+}
+
+impl Drop for Watcher {
+	// This drop impl does a lot of blocking which is not ideal. Rust async drop could help here but it's not stable yet.
+	fn drop(&mut self) {
+		println!("DROP WATCHER");
+
+		// Tell the thread not to restart itself and instead drop the thread once done.
+		self.inner.running.store(false, Ordering::Relaxed);
+
+		// Trigger the thread to shut down.
+		if let Some(start) = self.inner.start.try_lock().ok().and_then(|mut v| v.take()) {
+			start.send(()).unwrap();
+		} else {
+			self.shutdown_inner();
+		}
+
+		// Wait for the thread to shut down.
+		if let Some(handle) = self.handle.take() {
+			handle.join().expect("thread to shut down"); // TODO: error handling
+		}
+	}
+}
+
+/// Context holds data that is passed to the callback function, allowing us to propagate events outward.
+#[derive(Debug, Clone)]
+struct Context {
+	// transmit channel to send events to the user
+	tx: mpsc::Sender<Event>,
+}
+
+extern "C" fn release_context(ctx: *mut std::ffi::c_void) {
+	unsafe {
+		println!("CTX {:?}", Box::from_raw(ctx as *mut Context));
+		// drop(Box::from_raw(ctx as *mut Context)); // TODO: Make this work so we aren't leaking memory
+	}
+}
+
+// Trust me bro
+struct SendWrapper<T>(T);
+
+impl<T> SendWrapper<T> {
+	const unsafe fn new(t: T) -> Self {
+		Self(t)
+	}
+}
+
+unsafe impl<T> Send for SendWrapper<T> {}
+
+impl<T> Deref for SendWrapper<T> {
+	type Target = T;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+
+impl<T> fmt::Debug for SendWrapper<T> {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.debug_struct("SendWrapper").finish()
+	}
+}
+
+#[allow(clippy::borrow_interior_mutable_const)]
+extern "C" fn cf_ext_with_id_callback(
+	_stream_ref: SysFSEventStreamRef,
+	info: *mut c_void,
+	num_events: usize,                     // size_t numEvents
+	paths: *mut c_void,                    // void *eventPaths
+	flags: *const FSEventStreamEventFlags, // const FSEventStreamEventFlags eventFlags[]
+	_ids: *const FSEventStreamEventId,     // const FSEventStreamEventId eventIds[]
+) {
+	drop(catch_unwind(move || {
+		let ctx = unsafe { &(*(info as *const Context)) };
+		let paths = unsafe { CFArray::<CFDictionary<CFString>>::from_void(paths) };
+
+		println!("{:?}", paths.len());
+
+		let mut buf = Vec::with_capacity(2); // 2 because it's most likely we get at most two of these in a single callback
+		for idx in 0..num_events {
+			let (dict, flags) = unsafe { (paths.get_unchecked(idx as CFIndex), *flags.add(idx)) };
+
+			let path = PathBuf::from(
+				(*unsafe {
+					CFString::from_void(*dict.get(&*kFSEventStreamEventExtendedDataPathKey))
+				})
+				.to_string(),
+			);
+			let flag = StreamFlags::from_bits(flags).unwrap(); // TODO: Error handling
+
+			println!("Received event: {} {}", flag, path.display());
+
+			let event = match flag {
+				flag if flag.contains(StreamFlags::OWN_EVENT) => continue,
+				flag if flag.contains(StreamFlags::MOUNT) => Event::Mount(path),
+				flag if flag.contains(StreamFlags::UNMOUNT) => Event::Unmount(path),
+				flag if flag.contains(StreamFlags::ROOT_CHANGED) => Event::RootChange(path),
+				flag if flag.contains(StreamFlags::ITEM_REMOVED) => {
+					Event::Delete((&flag).try_into().unwrap(), path)
+				}
+				flag if flag.contains(StreamFlags::ITEM_RENAMED) => {
+					// We throw these events into a buffer so we can detect both parts of the rename event
+					buf.push((
+						unsafe {
+							CFNumber::from_void(*dict.get(&*kFSEventStreamEventExtendedFileIDKey))
+						}
+						.to_i64()
+						.unwrap(), // TODO: Error handling
+						flag,
+						path,
+					));
+					continue;
+				}
+				// Warning: The `SteamFlags::INODE_META_MOD` flag is used to differentiate between a file being modified and a file being created.
+				// This is an assumption @Oscar has made given it makes sense the last modified time in the inode would only be changed on editing the file.
+				flag if flag.contains(StreamFlags::ITEM_CREATED)
+					&& !flag.contains(StreamFlags::INODE_META_MOD)
+					&& !flag.contains(StreamFlags::ITEM_CHANGE_OWNER) =>
+				{
+					Event::Create((&flag).try_into().unwrap(), path)
+				}
+				flag if flag.contains(StreamFlags::ITEM_MODIFIED)
+					| flag.contains(StreamFlags::ITEM_CHANGE_OWNER)
+					| flag.contains(StreamFlags::INODE_META_MOD)
+					| flag.contains(StreamFlags::FINDER_INFO_MOD)
+					| flag.contains(StreamFlags::ITEM_CHANGE_OWNER)
+					| flag.contains(StreamFlags::ITEM_XATTR_MOD) =>
+				{
+					Event::Modify((&flag).try_into().unwrap(), path)
+				}
+				flag if flag.contains(StreamFlags::HISTORY_DONE) => continue,
+				_ => {
+					println!("Unknown event: {:?}", flag); // TODO: Remove
+
+					continue;
+				}
+			};
+
+			if let Err(e) = ctx.tx.blocking_send(event) {
+				println!("Unable to send event from callback: {}", e); // TODO: Remove
+			}
+		}
+
+		// We are mutating the buffer while also iterating it so this is weird AF.
+		while let Some((inode, flag, path)) = buf.pop() {
+			// This code is assuming the earlier event is the `from` path and the later event is the `to` path which seems reasonable.
+			let event = match buf
+				.iter()
+				.position(|(inode2, _, _)| *inode2 == inode)
+				.map(|idx| buf.remove(idx))
+			{
+				Some((_inode2, _flag2, from)) => Event::Move {
+					ty: (&flag).try_into().unwrap(),
+					from,
+					to: path,
+				},
+				None => {
+					// Implementation copied from `fs::try_exists`
+					// We do this check because sometimes the listener sends a delete event as a rename event
+					match fs::metadata(&path) {
+						// File exists
+						Ok(_) => Event::Modify((&flag).try_into().unwrap(), path),
+						// File deleted
+						Err(error) if error.kind() == io::ErrorKind::NotFound => {
+							Event::Delete((&flag).try_into().unwrap(), path)
+						}
+						Err(error) => {
+							println!("Unable to get metadata for file: {}", error); // TODO: Remove
+
+							Event::Modify((&flag).try_into().unwrap(), path)
+						}
+					}
+				}
+			};
+
+			if let Err(e) = ctx.tx.blocking_send(event) {
+				println!("Unable to send event from callback: {}", e); // TODO: Remove
+			}
+		}
+	}));
+}

--- a/crates/notify2/src/windows.rs
+++ b/crates/notify2/src/windows.rs
@@ -1,0 +1,3 @@
+// TODO: https://github.com/notify-rs/notify/blob/main/notify/src/windows.rs
+
+std::compile_error!("Windows support is not yet implemented");

--- a/crates/notify2/tests/test.rs
+++ b/crates/notify2/tests/test.rs
@@ -1,0 +1,289 @@
+use std::{env, fs, path::PathBuf, process::Command, time::Duration};
+
+use notify2::{Event, Type, Watcher};
+use tokio::{sync::mpsc, time::sleep};
+use utils::{set_readyonly, TestDir};
+
+mod utils;
+
+async fn basic_tests(dir: &PathBuf, rx: &mut mpsc::Receiver<Event>) {
+	let paths = [
+		(dir.join("dir1"), Type::Directory),
+		(dir.join("file1.txt"), Type::File),
+		(dir.join("dir1").join("dir2"), Type::Directory),
+		(dir.join("dir1").join("file2.txt"), Type::File),
+	];
+
+	// Creation
+	for (path, ty) in paths.iter() {
+		match ty {
+			Type::Directory => fs::create_dir(&path),
+			Type::File => fs::write(&path, b"Monty"),
+			Type::Symlink => todo!(),  // TODO
+			Type::Hardlink => todo!(), // TODO
+		}
+		.unwrap();
+		sleep(Duration::from_millis(500)).await;
+
+		assert_eq!(
+			rx.recv().await,
+			Some(Event::Create(ty.clone(), path.clone()))
+		);
+	}
+	tokio::select! {
+		event = rx.recv() => {
+			assert!(false, "The receiver channel should not receive any more create events. Received event: {:?}", event);
+		},
+		_ = sleep(Duration::from_millis(500)) => {}
+	}
+
+	// Edit file content
+	for (path, ty) in paths.iter() {
+		match ty {
+			Type::Directory => return, // Can't edit content of file
+			Type::File => fs::write(&path, b"Monty2"),
+			Type::Symlink => todo!(),  // TODO
+			Type::Hardlink => todo!(), // TODO
+		}
+		.unwrap();
+
+		assert_eq!(
+			rx.recv().await,
+			Some(Event::Modify(ty.clone(), path.clone()))
+		);
+	}
+	tokio::select! {
+		event = rx.recv() => {
+			assert!(false, "The receiver channel should not receive any more edit file events. Received event: {:?}", event);
+		},
+		_ = sleep(Duration::from_millis(500)) => {}
+	}
+
+	// Edit file permissions
+	for (path, ty) in paths.iter() {
+		set_readyonly(&path, true);
+		sleep(Duration::from_millis(500)).await; // We do this so the OS doesn't deduplicate the event
+		set_readyonly(&path, false);
+
+		assert_eq!(
+			rx.recv().await,
+			Some(Event::Modify(ty.clone(), path.clone()))
+		);
+		assert_eq!(
+			rx.recv().await,
+			Some(Event::Modify(ty.clone(), path.clone()))
+		);
+	}
+	tokio::select! {
+		event = rx.recv() => {
+			assert!(false, "The receiver channel should not receive any more edit file permissions file events. Received event: {:?}", event);
+		},
+		_ = sleep(Duration::from_millis(500)) => {}
+	}
+
+	// Move/rename & Delete
+	// NOTE: `paths` is reversed because file metadata requires it to exist
+	for (path, ty) in paths.into_iter().rev() {
+		let new_path = path.with_file_name(format!(
+			"{}-new{}",
+			path.file_stem().unwrap().to_str().unwrap(),
+			path.extension()
+				.map(|v| format!(".{}", v.to_str().unwrap()))
+				.unwrap_or_default()
+		));
+
+		// Rename
+		fs::rename(&path, &new_path).unwrap();
+		assert_eq!(
+			rx.recv().await,
+			Some(Event::Move {
+				ty: ty.clone(),
+				from: path.clone(),
+				to: new_path.clone()
+			})
+		);
+
+		// Delete
+		match ty {
+			Type::Directory => fs::remove_dir(&new_path),
+			Type::File => fs::remove_file(&new_path),
+			Type::Symlink => todo!(),  // TODO
+			Type::Hardlink => todo!(), // TODO
+		}
+		.unwrap();
+		assert_eq!(rx.recv().await, Some(Event::Delete(ty, new_path)));
+	}
+	tokio::select! {
+		event = rx.recv() => {
+			assert!(false, "The receiver channel should not receive any more move or delete file events. Received event: {:?}", event);
+		},
+		_ = sleep(Duration::from_millis(500)) => {}
+	}
+}
+
+#[tokio::test]
+async fn remove_path() {
+	let (dir, _handle) = TestDir::new().await;
+	let (mut rx, watcher) = Watcher::new(vec![dir.clone()], false).await;
+	basic_tests(&dir, &mut rx).await;
+
+	// remove path
+	watcher.remove_paths(vec![dir.clone()]).await;
+	fs::write(dir.join("demo.txt"), b"Monty3").unwrap();
+	tokio::select! {
+		event = rx.recv() => {
+			assert!(false, "The receiver channel should not receive any more events after the path is removed. Received event: {:?}", event);
+		},
+		_ = sleep(Duration::from_millis(500)) => {}
+	}
+}
+
+#[tokio::test]
+async fn empty_watcher() {
+	let (mut rx, watcher) = Watcher::new(vec![], false).await;
+
+	tokio::select! {
+		event = rx.recv() => {
+			match event {
+				Some(event) => assert!(false, "The receiver channel should not receive any events while no paths are being watched. Received event: {:?}", event),
+				None => assert!(false, "The receiver channel should stay open until the watcher is dropped"),
+			}
+			assert!(false, "The receiver channel should stay open until the watcher is dropped")
+		},
+		_ = tokio::time::sleep(std::time::Duration::from_secs(2)) => {}
+	}
+
+	drop(watcher);
+	let event = rx.recv().await;
+	assert!(
+		event.is_none(),
+		"The receiver channel should be closed after the watcher is dropped"
+	);
+}
+
+#[tokio::test]
+async fn add_path_then_remove() {
+	let (dir, _handle) = TestDir::new().await;
+	let (mut rx, watcher) = Watcher::new(vec![], false).await;
+	fs::write(dir.join("demo-before.txt"), b"Monty").unwrap();
+	tokio::select! {
+		event = rx.recv() => {
+			assert!(false, "The receiver channel should not receive any more events after the path is removed. Received event: {:?}", event);
+		},
+		_ = sleep(Duration::from_millis(500)) => {}
+	}
+
+	// add path
+	watcher.add_paths(vec![dir.clone()]).await;
+	basic_tests(&dir, &mut rx).await;
+
+	// remove path
+	watcher.remove_paths(vec![dir.clone()]).await;
+	fs::write(dir.join("demo-after.txt"), b"Millie").unwrap();
+	tokio::select! {
+		event = rx.recv() => {
+			assert!(false, "The receiver channel should not receive any more events after the path is removed. Received event: {:?}", event);
+		},
+		_ = sleep(Duration::from_millis(500)) => {}
+	}
+}
+
+// TODO: This test fails because all events that happen while the path is removed are received when it is added back.
+// #[tokio::test]
+// async fn remove_path_then_add() {
+// 	let (dir, _handle) = TestDir::new().await;
+// 	let (mut rx, watcher) = Watcher::new(vec![dir.clone()], false).await;
+// 	basic_tests(&dir, &mut rx).await;
+
+// 	// remove path
+// 	watcher.remove_paths(vec![dir.clone()]).await;
+// 	fs::write(dir.join("demo-after.txt"), b"Millie").unwrap();
+// 	tokio::select! {
+// 		event = rx.recv() => {
+// 			assert!(false, "The receiver channel should not receive any more events after the path is removed. Received event: {:?}", event);
+// 		},
+// 		_ = sleep(Duration::from_millis(500)) => {}
+// 	}
+
+// 	// clear left overs from first run of `basic_tests`.
+// 	fs::remove_dir_all(&dir).unwrap();
+// 	fs::create_dir(&dir).unwrap();
+// 	sleep(Duration::from_millis(2000)).await;
+
+// 	// add path
+// 	watcher.add_paths(vec![dir.clone()]).await;
+// 	basic_tests(&dir, &mut rx).await;
+// }
+
+#[tokio::test]
+async fn double_add() {
+	let (dir, _handle) = TestDir::new().await;
+	let (mut rx, watcher) = Watcher::new(vec![dir.clone(), dir.clone()], false).await; // Attempt to create with dir twice
+	watcher.add_paths(vec![dir.clone()]).await; // Attempt to add directory that is already being watched
+	watcher
+		.add_paths(vec![dir.join("dir2").clone(), dir.join("dir2").clone()])
+		.await; // Attempt to add_paths the same dir twice
+	basic_tests(&dir, &mut rx).await; // Ensure no duplicate events happen
+}
+
+// TODO: Test test sometimes causes the runloop channel to freeze
+// #[tokio::test]
+// async fn double_remove() {
+// 	let (dir, _handle) = TestDir::new().await;
+// 	let (mut rx, watcher) = Watcher::new(vec![dir.clone()], false).await;
+// 	println!("DOUBLE REMOVE A");
+// 	watcher.remove_paths(vec![dir.clone(), dir.clone()]).await; // Attempt to remove directory that is being watched twice
+
+// 	fs::write(dir.join("demo.txt"), b"Millie").unwrap();
+// 	sleep(Duration::from_millis(250)).await;
+
+// 	tokio::select! {
+// 		event = rx.recv() => {
+// 			assert!(false, "The receiver channel should not receive any events once a directory is removed from the watcher. Received event: {:?}", event);
+// 		},
+// 		_ = sleep(Duration::from_millis(500)) => {}
+// 	}
+// }
+
+#[tokio::test]
+async fn ignore_events_from_current_process() {
+	let (dir, _handle) = TestDir::new().await;
+	let (mut rx, _watcher) = Watcher::new(vec![dir.clone()], true).await; // The true is the import part for this test
+
+	// Event created by current process
+	fs::write(dir.join("demo.txt"), b"Millie").unwrap();
+	tokio::select! {
+		event = rx.recv() => {
+			assert!(false, "The receiver channel should not receive any events created by the current process. Received event: {:?}", event);
+		},
+		_ = sleep(Duration::from_millis(500)) => {}
+	}
+
+	// Event created by external process
+	let file_path = dir.join("demo2.txt");
+	match env::consts::OS {
+		"linux" | "macos" => Command::new("touch")
+			.arg(file_path.to_str().unwrap())
+			.spawn()
+			.unwrap(),
+		"windows" => Command::new("cmd")
+			.arg("/C")
+			.arg("echo")
+			.arg("hello")
+			.arg(">")
+			.arg(file_path.to_str().unwrap())
+			.spawn()
+			.unwrap(),
+		_ => panic!("Unsupported OS"),
+	};
+	assert_eq!(
+		rx.recv().await.unwrap(),
+		Event::Create(Type::File, file_path)
+	);
+}
+
+// TODO: Test that events while the worker is restarting are emitted once it is resumed
+
+// TODO: Test SymLink and HardLink's in `basic_tests` function
+
+// TODO: Root create/delete -> Confirm how the watcher acts when the watched directory is removed/delete. A special event should be emitted for this.

--- a/crates/notify2/tests/utils.rs
+++ b/crates/notify2/tests/utils.rs
@@ -1,0 +1,55 @@
+use std::{
+	fs::{self, create_dir_all, read_dir, remove_dir, remove_dir_all},
+	path::PathBuf,
+	sync::atomic::{AtomicU32, Ordering},
+	time::Duration,
+};
+
+use tokio::time::sleep;
+
+/// The directory where all test data is created. It *should* be deleted after all tests are run.
+const TEST_DIR: &str = "./fsevents-test";
+
+/// The ID of the TestDir instance. Used to create a unique directory for each test so they can be run in parallel.
+static TEST_ID: AtomicU32 = AtomicU32::new(0);
+
+pub fn set_readyonly(path: &PathBuf, readonly: bool) {
+	let mut perms = fs::metadata(path).unwrap().permissions();
+	if readonly {
+		assert!(
+			!perms.readonly(),
+			"The directory should be readonly before starting the test!"
+		);
+	}
+	perms.set_readonly(readonly);
+	fs::set_permissions(path, perms).unwrap();
+}
+
+pub struct TestDir(u32, PathBuf);
+
+impl TestDir {
+	pub async fn new() -> (PathBuf, Self) {
+		let test_id = TEST_ID.fetch_add(1, Ordering::SeqCst);
+		let test_dir = PathBuf::from(TEST_DIR).join(test_id.to_string());
+		match remove_dir_all(&test_dir) {
+			Ok(_) => {}
+			Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+			Err(err) => panic!("Failed to remove test directory: {}", err),
+		}
+		create_dir_all(&test_dir).unwrap();
+		sleep(Duration::from_secs(1)).await; // Wait for the directory to be created so it doesn't show up in the watcher
+		(
+			fs::canonicalize(&test_dir).unwrap(),
+			Self(test_id, test_dir),
+		)
+	}
+}
+
+impl Drop for TestDir {
+	fn drop(&mut self) {
+		let _ = remove_dir_all(&self.1);
+		if read_dir(TEST_DIR).map(|v| v.count() == 0).unwrap_or(false) {
+			let _ = remove_dir(TEST_DIR);
+		}
+	}
+}


### PR DESCRIPTION
[WIP] Improved macOS file system watcher.

The `notify` crate we are currently using doesn't give us low-level information about the event and it also emits the events as the OS exposed them (which is generally wrong). I am working on a crate that will expose the events correctly to Spacedrive and internally is written in low-level API's so it can be efficient and make proper use of the information available to determine the proper type of the event.