### PR TITLE
[ENG-328] Keymanager mounting queue

### DIFF
--- a/core/src/api/keys.rs
+++ b/core/src/api/keys.rs
@@ -154,6 +154,7 @@ pub(crate) fn mount() -> RouterBuilder {
 				library.key_manager.set_master_password(
 					Protected::new(args.password),
 					args.secret_key.map(Protected::new),
+					|| invalidate_query!(library, "keys.isKeyManagerUnlocking"),
 				)?;
 
 				invalidate_query!(library, "keys.hasMasterPassword");

--- a/core/src/api/keys.rs
+++ b/core/src/api/keys.rs
@@ -207,7 +207,7 @@ pub(crate) fn mount() -> RouterBuilder {
 		.library_query("getDefault", |t| {
 			t(|_, _: (), library| async move { library.key_manager.get_default().ok() })
 		})
-		.library_query("isKeymanagerUnlocking", |t| {
+		.library_query("isKeyManagerUnlocking", |t| {
 			t(|_, _: (), library| async move { library.key_manager.is_queued(Uuid::nil()) })
 		})
 		.library_query("getQueue", |t| {

--- a/core/src/api/keys.rs
+++ b/core/src/api/keys.rs
@@ -207,6 +207,12 @@ pub(crate) fn mount() -> RouterBuilder {
 		.library_query("getDefault", |t| {
 			t(|_, _: (), library| async move { library.key_manager.get_default().ok() })
 		})
+		.library_query("isKeymanagerUnlocking", |t| {
+			t(|_, _: (), library| async move { Ok(library.key_manager.is_queued(Uuid::nil())?) })
+		})
+		.library_query("getQueue", |t| {
+			t(|_, _: (), library| async move { Ok(library.key_manager.get_queue()?) })
+		})
 		.library_mutation("unmountAll", |t| {
 			t(|_, _: (), library| async move {
 				library.key_manager.empty_keymount();

--- a/core/src/api/keys.rs
+++ b/core/src/api/keys.rs
@@ -210,9 +210,6 @@ pub(crate) fn mount() -> RouterBuilder {
 		.library_query("isKeyManagerUnlocking", |t| {
 			t(|_, _: (), library| async move { library.key_manager.is_queued(Uuid::nil()) })
 		})
-		.library_query("getQueue", |t| {
-			t(|_, _: (), library| async move { library.key_manager.get_queue() })
-		})
 		.library_mutation("unmountAll", |t| {
 			t(|_, _: (), library| async move {
 				library.key_manager.empty_keymount();
@@ -250,7 +247,6 @@ pub(crate) fn mount() -> RouterBuilder {
 					}
 				}
 
-				// mount the key
 				library.key_manager.mount(uuid)?;
 
 				invalidate_query!(library, "keys.list");

--- a/core/src/api/keys.rs
+++ b/core/src/api/keys.rs
@@ -208,10 +208,10 @@ pub(crate) fn mount() -> RouterBuilder {
 			t(|_, _: (), library| async move { library.key_manager.get_default().ok() })
 		})
 		.library_query("isKeymanagerUnlocking", |t| {
-			t(|_, _: (), library| async move { Ok(library.key_manager.is_queued(Uuid::nil())?) })
+			t(|_, _: (), library| async move { library.key_manager.is_queued(Uuid::nil()) })
 		})
 		.library_query("getQueue", |t| {
-			t(|_, _: (), library| async move { Ok(library.key_manager.get_queue()?) })
+			t(|_, _: (), library| async move { library.key_manager.get_queue() })
 		})
 		.library_mutation("unmountAll", |t| {
 			t(|_, _: (), library| async move {

--- a/crates/crypto/src/error.rs
+++ b/crates/crypto/src/error.rs
@@ -52,6 +52,8 @@ pub enum Error {
 	KeyAlreadyMounted,
 	#[error("key not mounted")]
 	KeyNotMounted,
+	#[error("key isn't in the queue")]
+	KeyNotQueued,
 	#[error("no default key has been set")]
 	NoDefaultKeySet,
 	#[error("no master password has been provided to the keymanager")]

--- a/crates/crypto/src/error.rs
+++ b/crates/crypto/src/error.rs
@@ -54,6 +54,8 @@ pub enum Error {
 	KeyNotMounted,
 	#[error("key isn't in the queue")]
 	KeyNotQueued,
+	#[error("key is already in the queue")]
+	KeyAlreadyQueued,
 	#[error("no default key has been set")]
 	NoDefaultKeySet,
 	#[error("no master password has been provided to the keymanager")]

--- a/crates/crypto/src/keys/keymanager.rs
+++ b/crates/crypto/src/keys/keymanager.rs
@@ -529,9 +529,7 @@ impl KeyManager {
 							},
 						);
 
-						dbg!("{:?}", self.get_queue());
 						self.remove_from_queue(uuid)?;
-						dbg!("{:?}", self.get_queue());
 
 						Ok(())
 					}

--- a/crates/crypto/src/keys/keymanager.rs
+++ b/crates/crypto/src/keys/keymanager.rs
@@ -96,6 +96,7 @@ pub struct KeyManager {
 	keystore: DashMap<Uuid, StoredKey>,
 	keymount: DashMap<Uuid, MountedKey>,
 	default: Mutex<Option<Uuid>>,
+	mounting: Mutex<Vec<Uuid>>,
 }
 
 /// The `KeyManager` functions should be used for all key-related management.
@@ -112,6 +113,7 @@ impl KeyManager {
 			keystore,
 			keymount,
 			default: Mutex::new(None),
+			mounting: Mutex::new(vec![]),
 		};
 
 		keymanager.populate_keystore(stored_keys)?;
@@ -749,5 +751,13 @@ impl KeyManager {
 	#[must_use]
 	pub fn get_mounted_uuids(&self) -> Vec<Uuid> {
 		self.keymount.iter().map(|key| key.uuid).collect()
+	}
+
+	pub fn get_queue(&self) -> Result<Vec<Uuid>> {
+		Ok((*self.mounting.lock()?).clone())
+	}
+
+	pub fn is_queued(&self, uuid: Uuid) -> Result<bool> {
+		Ok((*self.mounting.lock()?).iter().any(|k| k == &uuid))
 	}
 }

--- a/crates/crypto/src/keys/keymanager.rs
+++ b/crates/crypto/src/keys/keymanager.rs
@@ -429,7 +429,7 @@ impl KeyManager {
 		invalidate: F,
 	) -> Result<()>
 	where
-		F: Fn() -> (),
+		F: Fn(),
 	{
 		let uuid = Uuid::nil();
 

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -10,7 +10,6 @@ export type Procedures = {
         { key: "jobs.isRunning", input: LibraryArgs<null>, result: boolean } | 
         { key: "keys.getDefault", input: LibraryArgs<null>, result: string | null } | 
         { key: "keys.getKey", input: LibraryArgs<string>, result: string } | 
-        { key: "keys.getQueue", input: LibraryArgs<null>, result: Array<string> } | 
         { key: "keys.hasMasterPassword", input: LibraryArgs<null>, result: boolean } | 
         { key: "keys.isKeyManagerUnlocking", input: LibraryArgs<null>, result: boolean } | 
         { key: "keys.list", input: LibraryArgs<null>, result: Array<StoredKey> } | 

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -10,7 +10,9 @@ export type Procedures = {
         { key: "jobs.isRunning", input: LibraryArgs<null>, result: boolean } | 
         { key: "keys.getDefault", input: LibraryArgs<null>, result: string | null } | 
         { key: "keys.getKey", input: LibraryArgs<string>, result: string } | 
+        { key: "keys.getQueue", input: LibraryArgs<null>, result: Array<string> } | 
         { key: "keys.hasMasterPassword", input: LibraryArgs<null>, result: boolean } | 
+        { key: "keys.isKeymanagerUnlocking", input: LibraryArgs<null>, result: boolean } | 
         { key: "keys.list", input: LibraryArgs<null>, result: Array<StoredKey> } | 
         { key: "keys.listMounted", input: LibraryArgs<null>, result: Array<string> } | 
         { key: "library.getStatistics", input: LibraryArgs<null>, result: Statistics } | 

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -12,7 +12,7 @@ export type Procedures = {
         { key: "keys.getKey", input: LibraryArgs<string>, result: string } | 
         { key: "keys.getQueue", input: LibraryArgs<null>, result: Array<string> } | 
         { key: "keys.hasMasterPassword", input: LibraryArgs<null>, result: boolean } | 
-        { key: "keys.isKeymanagerUnlocking", input: LibraryArgs<null>, result: boolean } | 
+        { key: "keys.isKeyManagerUnlocking", input: LibraryArgs<null>, result: boolean } | 
         { key: "keys.list", input: LibraryArgs<null>, result: Array<StoredKey> } | 
         { key: "keys.listMounted", input: LibraryArgs<null>, result: Array<string> } | 
         { key: "library.getStatistics", input: LibraryArgs<null>, result: Statistics } | 

--- a/packages/interface/src/components/key/Key.tsx
+++ b/packages/interface/src/components/key/Key.tsx
@@ -1,10 +1,10 @@
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { useLibraryMutation } from '@sd/client';
-import { Button, ContextMenu } from '@sd/ui';
+import { Button } from '@sd/ui';
 import clsx from 'clsx';
 import { DotsThree, Eye, Key as KeyIcon } from 'phosphor-react';
-import { MouseEventHandler, PropsWithChildren, ReactNode, useState } from 'react';
-import { animated, config, useTransition } from 'react-spring';
+import { MutableRefObject, PropsWithChildren, useState } from 'react';
+import { animated, useTransition } from 'react-spring';
 
 import { DefaultProps } from '../primitive/types';
 import { Tooltip } from '../tooltip/Tooltip';
@@ -15,7 +15,7 @@ export type KeyManagerProps = DefaultProps;
 export interface Key {
 	id: string;
 	name: string;
-	queue: Set<string>;
+	queue: MutableRefObject<Set<string>>;
 	mounted?: boolean;
 	locked?: boolean;
 	stats?: {
@@ -96,8 +96,8 @@ export const Key: React.FC<{ data: Key; index: number }> = ({ data, index }) => 
 	const changeAutomountStatus = useLibraryMutation('keys.updateAutomountStatus');
 	const syncToLibrary = useLibraryMutation('keys.syncKeyToLibrary');
 
-	if (data.mounted && data.queue.has(data.id)) {
-		data.queue.delete(data.id);
+	if (data.mounted && data.queue.current.has(data.id)) {
+		data.queue.current.delete(data.id);
 	}
 
 	return (
@@ -144,7 +144,7 @@ export const Key: React.FC<{ data: Key; index: number }> = ({ data, index }) => 
 					) : (
 						!data.mounted && (
 							<div className="text-[8pt] font-medium text-ink-dull opacity-30">
-								{data.queue.has(data.id) ? 'Key mounting...' : 'Key not mounted'}
+								{data.queue.current.has(data.id) ? 'Key mounting...' : 'Key not mounted'}
 							</div>
 						)
 					)}
@@ -181,10 +181,10 @@ export const Key: React.FC<{ data: Key; index: number }> = ({ data, index }) => 
 					/>
 					<KeyDropdownItem
 						onClick={() => {
-							data.queue.add(data.id);
+							data.queue.current.add(data.id);
 							mountKey.mutate(data.id);
 						}}
-						hidden={data.mounted || data.queue.has(data.id)}
+						hidden={data.mounted || data.queue.current.has(data.id)}
 						value="Mount"
 					/>
 					<KeyDropdownItem

--- a/packages/interface/src/components/key/Key.tsx
+++ b/packages/interface/src/components/key/Key.tsx
@@ -15,7 +15,7 @@ export type KeyManagerProps = DefaultProps;
 export interface Key {
 	id: string;
 	name: string;
-	queue: MutableRefObject<Set<string>>;
+	queue: Set<string>;
 	mounted?: boolean;
 	locked?: boolean;
 	stats?: {
@@ -96,8 +96,8 @@ export const Key: React.FC<{ data: Key; index: number }> = ({ data, index }) => 
 	const changeAutomountStatus = useLibraryMutation('keys.updateAutomountStatus');
 	const syncToLibrary = useLibraryMutation('keys.syncKeyToLibrary');
 
-	if (data.mounted && data.queue.current.has(data.id)) {
-		data.queue.current.delete(data.id);
+	if (data.mounted && data.queue.has(data.id)) {
+		data.queue.delete(data.id);
 	}
 
 	return (
@@ -144,7 +144,7 @@ export const Key: React.FC<{ data: Key; index: number }> = ({ data, index }) => 
 					) : (
 						!data.mounted && (
 							<div className="text-[8pt] font-medium text-ink-dull opacity-30">
-								{data.queue.current.has(data.id) ? 'Key mounting...' : 'Key not mounted'}
+								{data.queue.has(data.id) ? 'Key mounting...' : 'Key not mounted'}
 							</div>
 						)
 					)}
@@ -181,10 +181,10 @@ export const Key: React.FC<{ data: Key; index: number }> = ({ data, index }) => 
 					/>
 					<KeyDropdownItem
 						onClick={() => {
-							data.queue.current.add(data.id);
+							data.queue.add(data.id);
 							mountKey.mutate(data.id);
 						}}
-						hidden={data.mounted || data.queue.current.has(data.id)}
+						hidden={data.mounted || data.queue.has(data.id)}
 						value="Mount"
 					/>
 					<KeyDropdownItem

--- a/packages/interface/src/components/key/Key.tsx
+++ b/packages/interface/src/components/key/Key.tsx
@@ -15,6 +15,7 @@ export type KeyManagerProps = DefaultProps;
 export interface Key {
 	id: string;
 	name: string;
+	queue: Set<string>;
 	mounted?: boolean;
 	locked?: boolean;
 	stats?: {
@@ -95,6 +96,10 @@ export const Key: React.FC<{ data: Key; index: number }> = ({ data, index }) => 
 	const changeAutomountStatus = useLibraryMutation('keys.updateAutomountStatus');
 	const syncToLibrary = useLibraryMutation('keys.syncKeyToLibrary');
 
+	if (data.mounted && data.queue.has(data.id)) {
+		data.queue.delete(data.id);
+	}
+
 	return (
 		<div
 			className={clsx(
@@ -138,7 +143,9 @@ export const Key: React.FC<{ data: Key; index: number }> = ({ data, index }) => 
 						</div>
 					) : (
 						!data.mounted && (
-							<div className="text-[8pt] font-medium text-ink-dull opacity-30">Key not mounted</div>
+							<div className="text-[8pt] font-medium text-ink-dull opacity-30">
+								{data.queue.has(data.id) ? 'Key mounting...' : 'Key not mounted'}
+							</div>
 						)
 					)}
 				</div>
@@ -174,9 +181,10 @@ export const Key: React.FC<{ data: Key; index: number }> = ({ data, index }) => 
 					/>
 					<KeyDropdownItem
 						onClick={() => {
+							data.queue.add(data.id);
 							mountKey.mutate(data.id);
 						}}
-						hidden={data.mounted}
+						hidden={data.mounted || data.queue.has(data.id)}
 						value="Mount"
 					/>
 					<KeyDropdownItem

--- a/packages/interface/src/components/key/KeyList.tsx
+++ b/packages/interface/src/components/key/KeyList.tsx
@@ -48,7 +48,7 @@ export const ListOfKeys = () => {
 						data={{
 							id: key.uuid,
 							name: `Key ${key.uuid.substring(0, 8).toUpperCase()}`,
-							queue: mountingQueue,
+							queue: mountingQueue.current,
 							mounted: mountedKeys.includes(key),
 							default: defaultKey.data === key.uuid,
 							memoryOnly: key.memory_only,

--- a/packages/interface/src/components/key/KeyList.tsx
+++ b/packages/interface/src/components/key/KeyList.tsx
@@ -1,6 +1,6 @@
-import { StoredKey, useLibraryMutation, useLibraryQuery } from '@sd/client';
-import { Button, CategoryHeading, SelectOption } from '@sd/ui';
-import { useMemo } from 'react';
+import { useLibraryMutation, useLibraryQuery } from '@sd/client';
+import { Button, SelectOption } from '@sd/ui';
+import { useMemo, useRef } from 'react';
 
 import { DefaultProps } from '../primitive/types';
 import { DummyKey, Key } from './Key';
@@ -19,7 +19,7 @@ export const SelectOptionKeyList = (props: { keys: string[] }) => (
 	</>
 );
 
-const mountingQueue = new Set<string>();
+const mountingQueue = useRef(new Set<string>());
 
 export const ListOfKeys = () => {
 	const keys = useLibraryQuery(['keys.list']);

--- a/packages/interface/src/components/key/KeyList.tsx
+++ b/packages/interface/src/components/key/KeyList.tsx
@@ -18,6 +18,9 @@ export const SelectOptionKeyList = (props: { keys: string[] }) => (
 		))}
 	</>
 );
+
+const mountingQueue = new Set<string>();
+
 export const ListOfKeys = () => {
 	const keys = useLibraryQuery(['keys.list']);
 	const mountedUuids = useLibraryQuery(['keys.listMounted']);
@@ -45,6 +48,7 @@ export const ListOfKeys = () => {
 						data={{
 							id: key.uuid,
 							name: `Key ${key.uuid.substring(0, 8).toUpperCase()}`,
+							queue: mountingQueue,
 							mounted: mountedKeys.includes(key),
 							default: defaultKey.data === key.uuid,
 							memoryOnly: key.memory_only,

--- a/packages/interface/src/components/key/KeyManager.tsx
+++ b/packages/interface/src/components/key/KeyManager.tsx
@@ -11,7 +11,12 @@ export type KeyManagerProps = DefaultProps;
 
 export function KeyManager(props: KeyManagerProps) {
 	const hasMasterPw = useLibraryQuery(['keys.hasMasterPassword']);
-	const setMasterPasswordMutation = useLibraryMutation('keys.setMasterPassword');
+	const isKeyManagerUnlocking = useLibraryQuery(['keys.isKeyManagerUnlocking']);
+	const setMasterPasswordMutation = useLibraryMutation('keys.setMasterPassword', {
+		onError: () => {
+			alert('Incorrect information provided.');
+		}
+	});
 	const unmountAll = useLibraryMutation('keys.unmountAll');
 	const clearMasterPassword = useLibraryMutation('keys.clearMasterPassword');
 
@@ -61,24 +66,16 @@ export function KeyManager(props: KeyManagerProps) {
 						<SKCurrentEyeIcon className="w-4 h-4" />
 					</Button>
 				</div>
-
 				<Button
 					className="w-full"
 					variant="accent"
-					disabled={setMasterPasswordMutation.isLoading}
+					disabled={setMasterPasswordMutation.isLoading || isKeyManagerUnlocking.data}
 					onClick={() => {
 						if (masterPassword !== '') {
 							const sk = secretKey || null;
 							setMasterPassword('');
 							setSecretKey('');
-							setMasterPasswordMutation.mutate(
-								{ password: masterPassword, secret_key: sk },
-								{
-									onError: () => {
-										alert('Incorrect information provided.');
-									}
-								}
-							);
+							setMasterPasswordMutation.mutate({ password: masterPassword, secret_key: sk });
 						}
 					}}
 				>

--- a/packages/interface/src/components/key/KeyManager.tsx
+++ b/packages/interface/src/components/key/KeyManager.tsx
@@ -79,7 +79,7 @@ export function KeyManager(props: KeyManagerProps) {
 						}
 					}}
 				>
-					Unlock
+					{isKeyManagerUnlocking ? 'Unlocking...' : 'Unlock'}
 				</Button>
 			</div>
 		);

--- a/packages/interface/src/components/key/KeyManager.tsx
+++ b/packages/interface/src/components/key/KeyManager.tsx
@@ -79,7 +79,7 @@ export function KeyManager(props: KeyManagerProps) {
 						}
 					}}
 				>
-					{isKeyManagerUnlocking ? 'Unlocking...' : 'Unlock'}
+					Unlock
 				</Button>
 			</div>
 		);

--- a/packages/interface/src/screens/settings/library/KeysSetting.tsx
+++ b/packages/interface/src/screens/settings/library/KeysSetting.tsx
@@ -167,7 +167,7 @@ export default function KeysSettings() {
 							}
 						}}
 					>
-						{isKeyManagerUnlocking.data! ? 'Unlocking...' : 'Unlock'}
+						Unlock
 					</Button>
 				</div>
 				<AlertDialog

--- a/packages/interface/src/screens/settings/library/KeysSetting.tsx
+++ b/packages/interface/src/screens/settings/library/KeysSetting.tsx
@@ -167,7 +167,7 @@ export default function KeysSettings() {
 							}
 						}}
 					>
-						Unlock
+						{isKeyManagerUnlocking.data! ? 'Unlocking...' : 'Unlock'}
 					</Button>
 				</div>
 				<AlertDialog


### PR DESCRIPTION
This PR adds a key manager mounting queue, and a few routes for checking the mount status of certain keys. It uses a Rust `DashSet` internally (for the hardcoded/externally immutable queue - this one will help protect us against malicious clients and DOS attacks due to memory-hard hashing algorithms).

The Rust queue is used for only one (external) route - checking if the key manager is currently being unlocked. This is used multiple times throughout the app, so a route will likely be best. The `set_master_password()` function also temporarily takes an `invalidate` closure, so we can invalidate the query correctly within the crypto crate. With this, users cannot attempt to unlock the key manager multiple times, no matter where in the app they are (or where they first started the unlock).

The Rust queue is used and updated heavily within the key manager, and protections have been added to relevant functions in order to protect against a malicious client (one where the React queue has been removed).

We also use a `const Set<string>` within React, so that the UI is reactive without cluttering RSPC. This `Set` is passed to each key individually, so they can view and update their status accordingly. Users won't be able to mount the same key multiple times. A "Mounting..." status was also added for keys that are in the process of being mounted, so that users stay informed.

I have tested these changes and didn't notice any oddities! Things work great.