### PR TITLE
use origin instead of url for web

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,12 +1,14 @@
-import { createWSClient, loggerLink, splitLink, wsLink } from '@rspc/client';
+import { createWSClient, loggerLink, wsLink } from '@rspc/client';
 import { getDebugState, hooks, queryClient } from '@sd/client';
 import SpacedriveInterface, { Platform, PlatformProvider } from '@sd/interface';
 import { useEffect } from 'react';
 
 globalThis.isDev = import.meta.env.DEV;
 
+const serverOrigin = import.meta.env.VITE_SDSERVER_ORIGIN || 'localhost:8080';
+
 const wsClient = createWSClient({
-	url: import.meta.env.VITE_SDSERVER_BASE_URL || 'ws://localhost:8080/rspc/ws'
+	url: `ws://${serverOrigin}/rspc/ws`
 });
 
 const client = hooks.createClient({
@@ -20,11 +22,12 @@ const client = hooks.createClient({
 	]
 });
 
+const http = isDev ? 'http' : 'https';
+
 const platform: Platform = {
 	platform: 'web',
 	getThumbnailUrlById: (casId) =>
-		`${import.meta.env.VITE_SDSERVER_BASE_URL || 'http://localhost:8080'
-		}/spacedrive/thumbnail/${encodeURIComponent(casId)}.webp`,
+		`${http}://${serverOrigin}/spacedrive/thumbnail/${encodeURIComponent(casId)}.webp`,
 	openLink: (url) => window.open(url, '_blank')?.focus(),
 	demoMode: true
 };

--- a/apps/web/src/env.d.ts
+++ b/apps/web/src/env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-	readonly VITE_SDSERVER_BASE_URL: string;
+	readonly VITE_SDSERVER_ORIGIN: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
`web` currently uses the `VITE_SDSERVER_BASE_URL` environment variable to know where the server is. This isn't great, since the server can connect over multiple protocols (http and ws) and has many paths.
Instead, we should be providing the _origin_ (ip/hostname + port) and interpolating it into the various protocols and routes.