### PR TITLE
[ENG-333] Handle .spacedrive existing instead of throwing error

### DIFF
--- a/core/src/object/fs/encrypt.rs
+++ b/core/src/object/fs/encrypt.rs
@@ -216,9 +216,11 @@ impl StatefulJob for FileEncryptorJob {
 							.find_unique(object::id::equals(obj_id))
 							.exec()
 							.await?
-							.ok_or(JobError::JobDataNotFound(String::from(
-								"can't find information about the object",
-							)))?;
+							.ok_or_else(|| {
+								JobError::JobDataNotFound(String::from(
+									"can't find information about the object",
+								))
+							})?;
 
 						if state.init.metadata {
 							let metadata = Metadata {


### PR DESCRIPTION
Removing metadata files that failed to be deserialized, this can happen due to an older version of these `.spacedrive` metadata files, before this feature was actually implemented, or if the file was corrupted.