### PR TITLE
Add clean command

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
 		"client": "pnpm --filter @sd/client -- ",
 		"prisma": "cd core && cargo prisma",
 		"codegen": "cargo test -p sd-core api::tests::test_and_export_rspc_bindings -- --exact",
-		"typecheck": "turbo run typecheck"
+		"typecheck": "turbo run typecheck",
+		"clean": "rimraf node_modules/ **/node_modules/ target/ **/.build/ **/.next/ **/dist/**"
 	},
 	"pnpm": {
 		"overrides": {
@@ -38,6 +39,7 @@
 		"lint-staged": "^13.1.0",
 		"markdown-link-check": "^3.10.3",
 		"prettier": "^2.8.3",
+		"rimraf": "^4.1.1",
 		"turbo": "^1.5.5",
 		"turbo-ignore": "^0.3.0",
 		"typescript": "^4.9.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ importers:
       lint-staged: ^13.1.0
       markdown-link-check: ^3.10.3
       prettier: ^2.8.3
+      rimraf: ^4.1.1
       turbo: ^1.5.5
       turbo-ignore: ^0.3.0
       typescript: ^4.9.4
@@ -29,6 +30,7 @@ importers:
       lint-staged: 13.1.0
       markdown-link-check: 3.10.3
       prettier: 2.8.3
+      rimraf: 4.1.1
       turbo: 1.7.0
       turbo-ignore: 0.3.0
       typescript: 4.9.4
@@ -18148,6 +18150,12 @@ packages:
     hasBin: true
     dependencies:
       glob: 7.2.3
+
+  /rimraf/4.1.1:
+    resolution: {integrity: sha512-Z4Y81w8atcvaJuJuBB88VpADRH66okZAuEm+Jtaufa+s7rZmIz+Hik2G53kGaNytE7lsfXyWktTmfVz0H9xuDg==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: true
 
   /ripemd160/2.0.2:
     resolution: {integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==}


### PR DESCRIPTION
In a team discussion earlier the idea was floated to create some form of `pnpm clean` command — this PR does just that, removing the following:

- root `/node_modules/`
- nested `**/node_modules/`
- rust compilation `/target/`
- swift compilation `**/.build/`
- next.js compilation/cache `**/.next/`
- subdirectories of nested desktop compilation `**/dist/**` (not removing directory because the `.gitignore` in there is purposeful)