### PR TITLE
[ENG-351] Tokio git patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6800,9 +6800,8 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+version = "1.24.2"
+source = "git+https://github.com/brxken128/tokio?rev=d3936848ccb32ac7df41614acfabe5139a6a7d75#d3936848ccb32ac7df41614acfabe5139a6a7d75"
 dependencies = [
  "autocfg 1.1.0",
  "bytes",
@@ -6815,14 +6814,13 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+version = "1.8.2"
+source = "git+https://github.com/brxken128/tokio?rev=d3936848ccb32ac7df41614acfabe5139a6a7d75#d3936848ccb32ac7df41614acfabe5139a6a7d75"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6801,7 +6801,7 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 [[package]]
 name = "tokio"
 version = "1.24.2"
-source = "git+https://github.com/brxken128/tokio?rev=d3936848ccb32ac7df41614acfabe5139a6a7d75#d3936848ccb32ac7df41614acfabe5139a6a7d75"
+source = "git+https://github.com/spacedriveapp/tokio?rev=d3936848ccb32ac7df41614acfabe5139a6a7d75#d3936848ccb32ac7df41614acfabe5139a6a7d75"
 dependencies = [
  "autocfg 1.1.0",
  "bytes",
@@ -6820,7 +6820,7 @@ dependencies = [
 [[package]]
 name = "tokio-macros"
 version = "1.8.2"
-source = "git+https://github.com/brxken128/tokio?rev=d3936848ccb32ac7df41614acfabe5139a6a7d75#d3936848ccb32ac7df41614acfabe5139a6a7d75"
+source = "git+https://github.com/spacedriveapp/tokio?rev=d3936848ccb32ac7df41614acfabe5139a6a7d75#d3936848ccb32ac7df41614acfabe5139a6a7d75"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ specta = { version = "0.0.4" }
 
 swift-rs = { git = "https://github.com/Brendonovich/swift-rs.git", rev = "833e29ba333f1dfe303eaa21de78c4f8c5a3f2ff" }
 
+tokio = { version = "1.24.2" }
+
 [patch.crates-io]
 # We use this patch so we can compile for the IOS simulator on M1
 openssl-sys = { git = "https://github.com/spacedriveapp/rust-openssl", rev = "92c3dec225a9e984884d5b30a517e5d44a24d03b" }
@@ -41,3 +43,5 @@ openssl-sys = { git = "https://github.com/spacedriveapp/rust-openssl", rev = "92
 rspc = { git = "https://github.com/oscartbeaumont/rspc", rev = "6243b5b6a1376940a40318340e5eaef22e4a2c22" }   # TODO: Move back to crates.io when new jsonrpc executor + `tokio::spawn` in the Tauri IPC plugin is released
 normi = { git = "https://github.com/oscartbeaumont/rspc", rev = "6243b5b6a1376940a40318340e5eaef22e4a2c22" }  # TODO: When normi is released on crates.io
 specta = { git = "https://github.com/oscartbeaumont/rspc", rev = "6243b5b6a1376940a40318340e5eaef22e4a2c22" } # TODO: When normi is released on crates.io
+
+tokio = { git = "https://github.com/brxken128/tokio", rev = "d3936848ccb32ac7df41614acfabe5139a6a7d75" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,4 +44,4 @@ rspc = { git = "https://github.com/oscartbeaumont/rspc", rev = "6243b5b6a1376940
 normi = { git = "https://github.com/oscartbeaumont/rspc", rev = "6243b5b6a1376940a40318340e5eaef22e4a2c22" }  # TODO: When normi is released on crates.io
 specta = { git = "https://github.com/oscartbeaumont/rspc", rev = "6243b5b6a1376940a40318340e5eaef22e4a2c22" } # TODO: When normi is released on crates.io
 
-tokio = { git = "https://github.com/brxken128/tokio", rev = "d3936848ccb32ac7df41614acfabe5139a6a7d75" }
+tokio = { git = "https://github.com/spacedriveapp/tokio", rev = "d3936848ccb32ac7df41614acfabe5139a6a7d75" } # TODO: move back once tokio raise their internal read buffer size (ENG-351 for more)

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ build = "build.rs"
 tauri = { version = "1.1.1", features = ["api-all", "macos-private-api"] }
 rspc = { workspace = true, features = ["tauri"] }
 sd-core = { path = "../../../core", features = ["ffmpeg", "location-watcher"] }
-tokio = { version = "1.21.2", features = ["sync"] }
+tokio = { workspace = true, features = ["sync"] }
 window-shadows = "0.2.0"
 tracing = "0.1.36"
 serde = "1.0.145"
@@ -25,9 +25,7 @@ swift-rs.workspace = true
 tauri-build = { version = "1.1.1", features = [] }
 
 [target.'cfg(target_os = "macos")'.build-dependencies]
-swift-rs = { workspace = true, features = [
-  "build",
-] }
+swift-rs = { workspace = true, features = ["build"] }
 
 [features]
 default = ["custom-protocol"]

--- a/apps/mobile/rust/mobile/Cargo.toml
+++ b/apps/mobile/rust/mobile/Cargo.toml
@@ -6,16 +6,16 @@ rust-version = "1.64.0"
 
 [features]
 android = ["sd-core/android"]
- 
+
 [dependencies]
 once_cell = "1.15.0"
 sd-core = { path = "../../../../core", features = [
   "mobile",
   "p2p",
 ], default-features = false }
-rspc.workspace= true
+rspc.workspace = true
 serde_json = "1.0.85"
-tokio = "1.21.2"
+tokio = { workspace = true }
 openssl = { version = "0.10.42", features = [
   "vendored",
 ] } # Override features of transitive dependencies

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 sd-core = { path = "../../core", features = ["ffmpeg"] }
 rspc = { workspace = true, features = ["axum"] }
 axum = "0.5.16"
-tokio = { version = "1.21.2", features = ["sync", "rt-multi-thread", "signal"] }
+tokio = { workspace = true, features = ["sync", "rt-multi-thread", "signal"] }
 tracing = "0.1.36"
 ctrlc = "3.2.3"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,9 +19,7 @@ ffmpeg = [
   "dep:ffmpeg-next",
   "dep:sd-ffmpeg",
 ] # This feature controls whether the Spacedrive Core contains functionality which requires FFmpeg.
-location-watcher = [
-  "dep:notify"
-]
+location-watcher = ["dep:notify"]
 
 [dependencies]
 hostname = "0.3.1"
@@ -46,10 +44,12 @@ uuid = { version = "1.1.2", features = ["v4", "serde"] }
 sysinfo = "0.26.4"
 thiserror = "1.0.37"
 
-tokio = { version = "1.21.2", features = [
+tokio = { workspace = true, features = [
   "sync",
   "rt-multi-thread",
   "io-util",
+  "macros",
+  "time",
 ] }
 include_dir = { version = "0.7.2", features = ["glob"] }
 async-trait = "^0.1.57"
@@ -58,7 +58,7 @@ webp = "0.2.2"
 ffmpeg-next = { version = "5.1.1", optional = true, features = [] }
 sd-ffmpeg = { path = "../crates/ffmpeg", optional = true }
 sd-crypto = { path = "../crates/crypto", features = ["rspc", "serde"] }
-sd-file-ext = { path = "../crates/file-ext"}
+sd-file-ext = { path = "../crates/file-ext" }
 sd-sync = { path = "../crates/sync" }
 fs_extra = "1.2.0"
 tracing = "0.1.36"
@@ -70,7 +70,9 @@ ctor = "0.1.23"
 globset = { version = "^0.4.9", features = ["serde1"] }
 itertools = "^0.10.5"
 enumflags2 = "0.7.5"
-notify = { version = "5.0.0", default-features = false, features = ["macos_fsevent"], optional = true }
+notify = { version = "5.0.0", default-features = false, features = [
+  "macos_fsevent",
+], optional = true }
 uhlc = "0.5.1"
 
 [dev-dependencies]

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -42,7 +42,7 @@ specta = { workspace = true, optional = true }
 
 hex = "0.4.3"
 
-tokio = { version = "1.21.2", features = ["io-util", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["io-util", "rt-multi-thread"] }
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/crates/ffmpeg/Cargo.toml
+++ b/crates/ffmpeg/Cargo.toml
@@ -15,8 +15,8 @@ resolver = "2"
 ffmpeg-sys-next = "5.1.1"
 thiserror = "1.0.37"
 webp = "0.2.2"
-tokio = { version = "1.21.2", features = ["fs", "rt"] }
+tokio = { workspace = true, features = ["fs", "rt"] }
 
 [dev-dependencies]
 tempfile = "3.3.0"
-tokio = { version = "1.21.2", features = ["fs", "rt", "macros"] }
+tokio = { workspace = true, features = ["fs", "rt", "macros"] }

--- a/crates/file-ext/Cargo.toml
+++ b/crates/file-ext/Cargo.toml
@@ -2,16 +2,19 @@
 name = "sd-file-ext"
 version = "0.0.0"
 edition = "2021"
-authors = ["Brendan Allen <brendan@spacedrive.com>", "Jamie Pine <jamie@spacedrive.com>"]
+authors = [
+    "Brendan Allen <brendan@spacedrive.com>",
+    "Jamie Pine <jamie@spacedrive.com>",
+]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 int-enum = "0.5.0"
-serde = {version = "1.0.145", features = ["derive"]}
+serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.85"
-strum = { version = "0.24", features = ["derive"]}
+strum = { version = "0.24", features = ["derive"] }
 strum_macros = "0.24"
-tokio = { version = "1.21.2", features = ["fs", "rt", "io-util"] }
+tokio = { workspace = true, features = ["fs", "rt", "io-util"] }
 
 [dev-dependencies]
-tokio = { version = "1.21.2", features = ["fs", "rt", "macros"] }
+tokio = { workspace = true, features = ["fs", "rt", "macros"] }

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -9,7 +9,7 @@ sd-tunnel-utils = { path = "./tunnel/utils" }
 dashmap = "5.3.4"
 rcgen = "0.9.2"
 rustls = "0.20.6"
-tokio = { version = "1.19.2", features = ["macros", "sync"] }
+tokio = { workspace = true, features = ["macros", "sync"] }
 if-watch = "1.1.1"
 thiserror = "1.0.31"
 mdns-sd = "0.5.5"
@@ -25,4 +25,4 @@ tracing = "0.1.35"
 specta = "0.0.2"
 
 [dev-dependencies]
-tokio = { version = "1.19.2", features = ["rt-multi-thread"] }
+tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/crates/p2p/tunnel/Cargo.toml
+++ b/crates/p2p/tunnel/Cargo.toml
@@ -14,11 +14,13 @@ quinn = "0.8.3"
 rcgen = "0.9.2"
 rustls = "0.20.6"
 serde = { version = "1.0.137", features = ["derive"] }
-tokio = { version = "1.19.2", features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing = "0.1.35"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 metrics = "0.19.0"
-metrics-exporter-prometheus = { version = "0.10.0", features = ["http-listener"] }
+metrics-exporter-prometheus = { version = "0.10.0", features = [
+    "http-listener",
+] }
 thiserror = "1.0.31"
 rmp-serde = "1.1.0"
 bb8-redis = "0.11.0"

--- a/crates/sync/example/Cargo.toml
+++ b/crates/sync/example/Cargo.toml
@@ -10,7 +10,7 @@ serde_json = "1.0.85"
 serde = { version = "1.0.145", features = ["derive"] }
 axum = "0.5.16"
 rspc = { workspace = true, features = ["axum"] }
-tokio = { version = "1.21.2", features = ["full"] }
+tokio = { workspace = true, features = ["full"] }
 prisma-client-rust = { workspace = true }
 dotenv = "0.15.0"
 tower-http = { version = "0.3.4", features = ["cors"] }


### PR DESCRIPTION
This PR forces all uses of `tokio` to be from the workspace, and the workspace uses `tokio v1.24.2` with the commits listed in [this branch](https://github.com/brxken128/tokio/tree/2mib-io-buffer).

The Linear issue contains more information, but I have tested that things build on Linux.

Windows, MacOS, Android and iOS have yet to be tested, but probably should be before this is merged.