### PR TITLE
[Fix] Dropdown focus when app is launching

### DIFF
--- a/packages/interface/src/components/layout/Sidebar.tsx
+++ b/packages/interface/src/components/layout/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { ReactComponent as Ellipsis } from '@sd/assets/svgs/ellipsis.svg';
 import clsx from 'clsx';
 import { CheckCircle, CirclesFour, Gear, Lock, Planet, Plus } from 'phosphor-react';
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, useEffect } from 'react';
 import { NavLink, NavLinkProps } from 'react-router-dom';
 import {
 	Location,
@@ -50,6 +50,16 @@ export function Sidebar() {
 	const os = useOperatingSystem();
 	const { library, libraries, isLoading: isLoadingLibraries, switchLibrary } = useCurrentLibrary();
 	const debugState = useDebugState();
+
+	useEffect(() => {
+		// Prevent the dropdown button to be auto focused on launch
+		// Hacky but it works
+		setTimeout(() => {
+			if (!document.activeElement || !('blur' in document.activeElement)) return;
+
+			(document.activeElement.blur as () => void)();
+		});
+	});
 
 	return (
 		<SidebarBody className={macOnly(os, 'bg-opacity-[0.75]')}>


### PR DESCRIPTION
Hey! 
Here is a fix for the dropdown button that is auto-focused when launching app. The fix is a bit hacky, but I saw a similar one [here](https://github.com/spacedriveapp/spacedrive/blob/b94eab8517d53e61ad2ae6016d90462fa9503abc/packages/interface/src/components/key/KeyMounter.tsx#L33-L37), so if you're fine with it, it's working.

Closes #191 