### PR TITLE
[ENG-357] Automatically mount associated key during decryption

### DIFF
--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -107,7 +107,7 @@ export interface FileCopierJobInit { source_location_id: number, source_path_id:
 
 export interface FileCutterJobInit { source_location_id: number, source_path_id: number, target_location_id: number, target_path: string }
 
-export interface FileDecryptorJobInit { location_id: number, path_id: number, output_path: string | null, password: string | null, save_to_library: boolean | null }
+export interface FileDecryptorJobInit { location_id: number, path_id: number, mount_associated_key: boolean, output_path: string | null, password: string | null, save_to_library: boolean | null }
 
 export interface FileDeleterJobInit { location_id: number, path_id: number }
 

--- a/packages/interface/src/components/dialog/DecryptFileDialog.tsx
+++ b/packages/interface/src/components/dialog/DecryptFileDialog.tsx
@@ -16,6 +16,7 @@ interface DecryptDialogProps extends UseDialogProps {
 const schema = z.object({
 	type: z.union([z.literal('password'), z.literal('key')]),
 	outputPath: z.string(),
+	mountAssociatedKey: z.boolean(),
 	password: z.string(),
 	saveToKeyManager: z.boolean()
 });
@@ -63,7 +64,8 @@ export const DecryptFileDialog = (props: DecryptDialogProps) => {
 			type: hasMountedKeys ? 'key' : 'password',
 			saveToKeyManager: true,
 			outputPath: '',
-			password: ''
+			password: '',
+			mountAssociatedKey: true
 		},
 		schema
 	});
@@ -73,6 +75,7 @@ export const DecryptFileDialog = (props: DecryptDialogProps) => {
 			location_id: props.location_id,
 			path_id: props.path_id,
 			output_path: data.outputPath !== '' ? data.outputPath : null,
+			mount_associated_key: data.mountAssociatedKey,
 			password: data.type === 'password' ? data.password : null,
 			save_to_library: data.type === 'password' ? data.saveToKeyManager : null
 		})
@@ -116,6 +119,24 @@ export const DecryptFileDialog = (props: DecryptDialogProps) => {
 					</RadioGroup.Option>
 				</div>
 			</RadioGroup>
+
+			{form.watch('type') === 'key' && (
+				<div className="relative flex flex-grow mt-3 mb-2">
+					<div className="space-x-2">
+						<Switch
+							className="bg-app-selected"
+							size="sm"
+							name=""
+							checked={form.watch('mountAssociatedKey')}
+							onCheckedChange={(e) => form.setValue('mountAssociatedKey', e)}
+						/>
+					</div>
+					<span className="ml-3 text-xs font-medium mt-0.5">Automatically mount key</span>
+					<Tooltip label="The key linked with the file will be automatically mounted">
+						<Info className="w-4 h-4 ml-1.5 text-ink-faint mt-0.5" />
+					</Tooltip>
+				</div>
+			)}
 
 			{form.watch('type') === 'password' && (
 				<>


### PR DESCRIPTION
This PR adds the (default) option to automatically mount a key while trying to decrypt a file.

It matches the content salts in the header's keyslots. If any content salt from a keyslot matches one of the keys in the key manager, it is mounted. Decryption then continues as normal.