### PR TITLE
[ENG-343] Navigate to `/` when library is switched

### DIFF
--- a/packages/client/src/hooks/useCurrentLibrary.tsx
+++ b/packages/client/src/hooks/useCurrentLibrary.tsx
@@ -1,4 +1,5 @@
 import { PropsWithChildren, createContext, useCallback, useContext, useMemo } from 'react';
+import { useNavigate } from 'react-router';
 import { subscribe, useSnapshot } from 'valtio';
 import { useBridgeQuery } from '../rspc';
 import { valtioPersist } from '../stores';
@@ -37,6 +38,8 @@ export function onLibraryChange(func: (newLibraryId: string | null) => void) {
 
 // this is a hook to get the current library loaded into the UI. It takes care of a bunch of invariants under the hood.
 export const useCurrentLibrary = () => {
+	const navigate = useNavigate();
+
 	const currentLibraryUuid = useSnapshot(currentLibraryUuidStore).id;
 	const ctx = useContext(CringeContext);
 	if (ctx === undefined)
@@ -69,9 +72,13 @@ export const useCurrentLibrary = () => {
 		}
 	});
 
-	const switchLibrary = useCallback((libraryUuid: string) => {
-		currentLibraryUuidStore.id = libraryUuid;
-	}, []);
+	const switchLibrary = useCallback(
+		(libraryUuid: string) => {
+			currentLibraryUuidStore.id = libraryUuid;
+			navigate('/');
+		},
+		[navigate]
+	);
 
 	// memorize library to avoid re-running find function
 	const library = useMemo(() => {


### PR DESCRIPTION
I'm not sure if this is the correct usage (with relation to `useCallback`), but it does work flawlessly.