### PR TITLE
[ENG-379] Explorer item resizer

### DIFF
--- a/core/src/api/locations.rs
+++ b/core/src/api/locations.rs
@@ -118,18 +118,6 @@ pub(crate) fn mount() -> impl RouterBuilderLike<Ctx> {
 					.exec()
 					.await?;
 
-				// library
-				// 	.queue_job(Job::new(
-				// 		ThumbnailJobInit {
-				// 			location_id: location.id,
-				// 			// recursive: false, // TODO: do this
-				// 			root_path: PathBuf::from(&directory.materialized_path),
-				// 			background: true,
-				// 		},
-				// 		ThumbnailJob {},
-				// 	))
-				// 	.await;
-
 				let mut items = Vec::with_capacity(file_paths.len());
 
 				for file_path in file_paths {
@@ -223,7 +211,7 @@ pub(crate) fn mount() -> impl RouterBuilderLike<Ctx> {
 
 				async_stream::stream! {
 					let online = location_manager.get_online().await;
-					dbg!(&online);
+					// dbg!(&online);
 					yield online;
 
 					while let Ok(locations) = rx.recv().await {

--- a/core/src/object/fs/decrypt.rs
+++ b/core/src/object/fs/decrypt.rs
@@ -9,7 +9,7 @@ use tokio::fs::File;
 
 use crate::job::{JobError, JobReportUpdate, JobResult, JobState, StatefulJob, WorkerContext};
 
-use super::{context_menu_fs_info, FsInfo, BYTES};
+use super::{context_menu_fs_info, FsInfo, BYTES_EXT};
 pub struct FileDecryptorJob;
 #[derive(Serialize, Deserialize, Debug)]
 pub struct FileDecryptorJobState {}
@@ -74,7 +74,7 @@ impl StatefulJob for FileDecryptorJob {
 			|| {
 				let mut path = info.fs_path.clone();
 				let extension = path.extension().map_or("decrypted", |ext| {
-					if ext == BYTES {
+					if ext == BYTES_EXT {
 						""
 					} else {
 						"decrypted"

--- a/core/src/object/fs/encrypt.rs
+++ b/core/src/object/fs/encrypt.rs
@@ -15,7 +15,7 @@ use specta::Type;
 use tokio::{fs::File, io::AsyncReadExt};
 use tracing::warn;
 
-use super::{context_menu_fs_info, FsInfo};
+use super::{context_menu_fs_info, FsInfo, BYTES_EXT};
 
 pub struct FileEncryptorJob;
 
@@ -108,7 +108,7 @@ impl StatefulJob for FileEncryptorJob {
 											"path contents when converted to string",
 										),
 									})?
-									.to_string() + ".bytes",
+									.to_string() + BYTES_EXT,
 							)
 						},
 					)?;

--- a/core/src/object/fs/mod.rs
+++ b/core/src/object/fs/mod.rs
@@ -30,6 +30,8 @@ pub enum ObjectType {
 	Directory,
 }
 
+pub const BYTES_EXT: &str = ".bytes";
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct FsInfo {
 	pub path_data: file_path_with_object::Data,

--- a/packages/interface/src/components/explorer/ExplorerContextMenu.tsx
+++ b/packages/interface/src/components/explorer/ExplorerContextMenu.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import {
 	ArrowBendUpRight,
 	Clipboard,
@@ -211,11 +212,12 @@ export function ExplorerContextMenu(props: PropsWithChildren) {
 
 export interface FileItemContextMenuProps extends PropsWithChildren {
 	data: ExplorerItem;
+	className?: string;
 }
 
 export function FileItemContextMenu({ data, ...props }: FileItemContextMenuProps) {
 	const { library } = useLibraryContext();
-	const store = useExplorerStore();
+	const store = getExplorerStore();
 	const params = useExplorerParams();
 	const platform = usePlatform();
 	const objectData = data ? (isObject(data) ? data.item : data.item.object) : null;
@@ -227,7 +229,7 @@ export function FileItemContextMenu({ data, ...props }: FileItemContextMenuProps
 	const copyFiles = useLibraryMutation('files.copyFiles');
 
 	return (
-		<div className="relative">
+		<div className={clsx('relative', props.className)}>
 			<CM.ContextMenu trigger={props.children}>
 				<CM.Item
 					label="Open"

--- a/packages/interface/src/components/explorer/ExplorerContextMenu.tsx
+++ b/packages/interface/src/components/explorer/ExplorerContextMenu.tsx
@@ -210,14 +210,18 @@ export function ExplorerContextMenu(props: PropsWithChildren) {
 	);
 }
 
-export interface FileItemContextMenuProps extends PropsWithChildren {
+export interface ExplorerItemContextMenuProps extends PropsWithChildren {
 	data: ExplorerItem;
 	className?: string;
 }
 
-export function FileItemContextMenu({ data, ...props }: FileItemContextMenuProps) {
+export function ExplorerItemContextMenu({
+	data,
+	className,
+	...props
+}: ExplorerItemContextMenuProps) {
 	const { library } = useLibraryContext();
-	const store = getExplorerStore();
+	const store = useExplorerStore();
 	const params = useExplorerParams();
 	const platform = usePlatform();
 	const objectData = data ? (isObject(data) ? data.item : data.item.object) : null;
@@ -229,7 +233,7 @@ export function FileItemContextMenu({ data, ...props }: FileItemContextMenuProps
 	const copyFiles = useLibraryMutation('files.copyFiles');
 
 	return (
-		<div className={clsx('relative', props.className)}>
+		<div className={clsx('relative', className)}>
 			<CM.ContextMenu trigger={props.children}>
 				<CM.Item
 					label="Open"

--- a/packages/interface/src/components/explorer/ExplorerOptionsPanel.tsx
+++ b/packages/interface/src/components/explorer/ExplorerOptionsPanel.tsx
@@ -30,7 +30,6 @@ export function ExplorerOptionsPanel() {
 		<div className="p-4 ">
 			{/* <Heading>Explorer Appearance</Heading> */}
 			<SubHeading>Item size</SubHeading>
-			{explorerStore.gridItemSize}
 			<Slider
 				onValueChange={(value) => {
 					getExplorerStore().gridItemSize = value[0] || 100;
@@ -39,7 +38,7 @@ export function ExplorerOptionsPanel() {
 				defaultValue={[explorerStore.gridItemSize]}
 				max={200}
 				step={10}
-				min={20}
+				min={60}
 			/>
 			<div className="my-2 mt-4 grid grid-cols-2 gap-2">
 				<div className="flex flex-col">

--- a/packages/interface/src/components/explorer/ExplorerOptionsPanel.tsx
+++ b/packages/interface/src/components/explorer/ExplorerOptionsPanel.tsx
@@ -1,5 +1,6 @@
 import { PropsWithChildren, useState } from 'react';
 import { Select, SelectOption } from '@sd/ui';
+import { getExplorerStore, useExplorerStore } from '../../hooks/useExplorerStore';
 import Slider from '../primitive/Slider';
 
 function Heading({ children }: PropsWithChildren) {
@@ -22,13 +23,24 @@ const sortOptions = {
 export function ExplorerOptionsPanel() {
 	const [sortBy, setSortBy] = useState('name');
 	const [stackBy, setStackBy] = useState('kind');
-	const [size, setSize] = useState([50]);
+
+	const explorerStore = useExplorerStore();
 
 	return (
 		<div className="p-4 ">
 			{/* <Heading>Explorer Appearance</Heading> */}
 			<SubHeading>Item size</SubHeading>
-			<Slider defaultValue={size} step={10} />
+			{explorerStore.gridItemSize}
+			<Slider
+				onValueChange={(value) => {
+					getExplorerStore().gridItemSize = value[0] || 100;
+					console.log({ value: value, gridItemSize: explorerStore.gridItemSize });
+				}}
+				defaultValue={[explorerStore.gridItemSize]}
+				max={200}
+				step={10}
+				min={20}
+			/>
 			<div className="my-2 mt-4 grid grid-cols-2 gap-2">
 				<div className="flex flex-col">
 					<SubHeading>Sort by</SubHeading>

--- a/packages/interface/src/components/explorer/ExplorerTopBar.tsx
+++ b/packages/interface/src/components/explorer/ExplorerTopBar.tsx
@@ -37,7 +37,7 @@ export interface TopBarButtonProps {
 // export const TopBarIcon = (icon: any) => tw(icon)`m-0.5 w-5 h-5 text-ink-dull`;
 
 const topBarButtonStyle = cva(
-	'text-ink hover:text-ink text-md hover:bg-app-selected radix-state-open:bg-app-selected mr-[1px] flex border-none p-0.5 font-medium outline-none transition-colors duration-100',
+	'text-ink hover:text-ink text-md hover:bg-app-selected radix-state-open:bg-app-selected mr-[1px] flex border-none !p-0.5 font-medium outline-none transition-colors duration-100',
 	{
 		variants: {
 			active: {
@@ -63,7 +63,12 @@ const TOP_BAR_ICON_STYLE = 'm-0.5 w-5 h-5 text-ink-dull';
 const TopBarButton = forwardRef<HTMLButtonElement, TopBarButtonProps>(
 	({ active, rounding, className, ...props }, ref) => {
 		return (
-			<Button {...props} ref={ref} className={topBarButtonStyle({ active, rounding, className })}>
+			<Button
+				// size="sm"
+				{...props}
+				ref={ref}
+				className={topBarButtonStyle({ active, rounding, className })}
+			>
 				{props.children}
 			</Button>
 		);

--- a/packages/interface/src/components/explorer/FileColumns.tsx
+++ b/packages/interface/src/components/explorer/FileColumns.tsx
@@ -11,14 +11,14 @@ export function ensureIsColumns<T extends IColumn[]>(data: T) {
 	return data;
 }
 
-export const columns = ensureIsColumns([
-	{ column: 'Name', key: 'name', width: 280 } as const,
-	// { column: 'Size', key: 'size_in_bytes', width: 120 } as const,
-	{ column: 'Type', key: 'extension', width: 150 } as const,
-	{ column: 'Size', key: 'size', width: 100 } as const,
-	{ column: 'Date Created', key: 'date_created', width: 150 } as const,
-	{ column: 'Content ID', key: 'cas_id', width: 150 } as const
-]);
+export const columns = [
+	{ column: 'Name', key: 'name', width: 280 },
+	// { column: 'Size', key: 'size_in_bytes', width: 120 },
+	{ column: 'Type', key: 'extension', width: 150 },
+	{ column: 'Size', key: 'size', width: 100 },
+	{ column: 'Date Created', key: 'date_created', width: 150 },
+	{ column: 'Content ID', key: 'cas_id', width: 150 }
+] as const satisfies Readonly<IColumn[]>;
 
 export type ColumnKey = (typeof columns)[number]['key'];
 

--- a/packages/interface/src/components/explorer/FileColumns.tsx
+++ b/packages/interface/src/components/explorer/FileColumns.tsx
@@ -11,14 +11,14 @@ export function ensureIsColumns<T extends IColumn[]>(data: T) {
 	return data;
 }
 
-export const columns = [
-	{ column: 'Name', key: 'name', width: 280 },
-	// { column: 'Size', key: 'size_in_bytes', width: 120 },
-	{ column: 'Type', key: 'extension', width: 150 },
-	{ column: 'Size', key: 'size', width: 100 },
-	{ column: 'Date Created', key: 'date_created', width: 150 },
-	{ column: 'Content ID', key: 'cas_id', width: 150 }
-] as const satisfies IColumn[];
+export const columns = ensureIsColumns([
+	{ column: 'Name', key: 'name', width: 280 } as const,
+	// { column: 'Size', key: 'size_in_bytes', width: 120 } as const,
+	{ column: 'Type', key: 'extension', width: 150 } as const,
+	{ column: 'Size', key: 'size', width: 100 } as const,
+	{ column: 'Date Created', key: 'date_created', width: 150 } as const,
+	{ column: 'Content ID', key: 'cas_id', width: 150 } as const
+]);
 
 export type ColumnKey = (typeof columns)[number]['key'];
 
@@ -30,7 +30,7 @@ export function ListViewHeader() {
 		>
 			{columns.map((col) => (
 				<div
-					key={col.key}
+					key={col.column}
 					className="flex items-center px-4 py-2 pr-2"
 					style={{ width: col.width, marginTop: -LIST_VIEW_HEADER_HEIGHT * 2 }}
 				>

--- a/packages/interface/src/components/explorer/FileColumns.tsx
+++ b/packages/interface/src/components/explorer/FileColumns.tsx
@@ -11,14 +11,14 @@ export function ensureIsColumns<T extends IColumn[]>(data: T) {
 	return data;
 }
 
-export const columns = ensureIsColumns([
-	{ column: 'Name', key: 'name', width: 280 } as const,
-	// { column: 'Size', key: 'size_in_bytes', width: 120 } as const,
-	{ column: 'Type', key: 'extension', width: 150 } as const,
-	{ column: 'Size', key: 'size', width: 100 } as const,
-	{ column: 'Date Created', key: 'date_created', width: 150 } as const,
-	{ column: 'Content ID', key: 'cas_id', width: 150 } as const
-]);
+export const columns = [
+	{ column: 'Name', key: 'name', width: 280 },
+	// { column: 'Size', key: 'size_in_bytes', width: 120 },
+	{ column: 'Type', key: 'extension', width: 150 },
+	{ column: 'Size', key: 'size', width: 100 },
+	{ column: 'Date Created', key: 'date_created', width: 150 },
+	{ column: 'Content ID', key: 'cas_id', width: 150 }
+] as const satisfies IColumn[];
 
 export type ColumnKey = (typeof columns)[number]['key'];
 

--- a/packages/interface/src/components/explorer/FileColumns.tsx
+++ b/packages/interface/src/components/explorer/FileColumns.tsx
@@ -1,0 +1,42 @@
+export interface IColumn {
+	column: string;
+	key: string;
+	width: number;
+}
+
+export const LIST_VIEW_HEADER_HEIGHT = 40;
+
+// Function ensure no types are lost, but guarantees that they are Column[]
+export function ensureIsColumns<T extends IColumn[]>(data: T) {
+	return data;
+}
+
+export const columns = ensureIsColumns([
+	{ column: 'Name', key: 'name', width: 280 } as const,
+	// { column: 'Size', key: 'size_in_bytes', width: 120 } as const,
+	{ column: 'Type', key: 'extension', width: 150 } as const,
+	{ column: 'Size', key: 'size', width: 100 } as const,
+	{ column: 'Date Created', key: 'date_created', width: 150 } as const,
+	{ column: 'Content ID', key: 'cas_id', width: 150 } as const
+]);
+
+export type ColumnKey = (typeof columns)[number]['key'];
+
+export function ListViewHeader() {
+	return (
+		<div
+			style={{ height: LIST_VIEW_HEADER_HEIGHT }}
+			className="mr-2 flex w-full flex-row rounded-lg border-2 border-transparent"
+		>
+			{columns.map((col) => (
+				<div
+					key={col.key}
+					className="flex items-center px-4 py-2 pr-2"
+					style={{ width: col.width, marginTop: -LIST_VIEW_HEADER_HEIGHT * 2 }}
+				>
+					<span className="text-xs font-medium ">{col.column}</span>
+				</div>
+			))}
+		</div>
+	);
+}

--- a/packages/interface/src/components/explorer/FileItem.tsx
+++ b/packages/interface/src/components/explorer/FileItem.tsx
@@ -3,7 +3,7 @@ import { HTMLAttributes } from 'react';
 import { ExplorerItem, ObjectKind, isObject } from '@sd/client';
 import { cva, tw } from '@sd/ui';
 import { getExplorerStore, useExplorerStore } from '~/hooks/useExplorerStore';
-import { FileItemContextMenu } from './ExplorerContextMenu';
+import { ExplorerItemContextMenu } from './ExplorerContextMenu';
 import { FileThumb } from './FileThumb';
 
 const NameArea = tw.div`flex justify-center`;
@@ -33,7 +33,7 @@ function FileItem({ data, selected, index, ...rest }: Props) {
 	const explorerStore = useExplorerStore();
 
 	return (
-		<FileItemContextMenu data={data}>
+		<ExplorerItemContextMenu data={data}>
 			<div
 				onContextMenu={(e) => {
 					if (index != undefined) {
@@ -66,7 +66,7 @@ function FileItem({ data, selected, index, ...rest }: Props) {
 					</span>
 				</NameArea>
 			</div>
-		</FileItemContextMenu>
+		</ExplorerItemContextMenu>
 	);
 }
 

--- a/packages/interface/src/components/explorer/FileItem.tsx
+++ b/packages/interface/src/components/explorer/FileItem.tsx
@@ -53,7 +53,7 @@ function FileItem({ data, selected, index, ...rest }: Props) {
 					className={clsx(
 						'mb-1 rounded-lg border-2 border-transparent text-center active:translate-y-[1px]',
 						{
-							'bg-app-selected/30': selected
+							'bg-app-selected/20': selected
 						}
 					)}
 				>

--- a/packages/interface/src/components/explorer/FileItem.tsx
+++ b/packages/interface/src/components/explorer/FileItem.tsx
@@ -2,9 +2,9 @@ import clsx from 'clsx';
 import { HTMLAttributes } from 'react';
 import { ExplorerItem, ObjectKind, isObject } from '@sd/client';
 import { cva, tw } from '@sd/ui';
-import { getExplorerStore } from '~/hooks/useExplorerStore';
+import { getExplorerStore, useExplorerStore } from '~/hooks/useExplorerStore';
 import { FileItemContextMenu } from './ExplorerContextMenu';
-import FileThumb from './FileThumb';
+import { FileThumb } from './FileThumb';
 
 const NameArea = tw.div`flex justify-center`;
 
@@ -30,6 +30,8 @@ function FileItem({ data, selected, index, ...rest }: Props) {
 	const isVid = ObjectKind[objectData?.kind || 0] === 'Video';
 	const item = data.item;
 
+	const explorerStore = useExplorerStore();
+
 	return (
 		<FileItemContextMenu data={data}>
 			<div
@@ -40,12 +42,13 @@ function FileItem({ data, selected, index, ...rest }: Props) {
 				}}
 				{...rest}
 				draggable
-				className={clsx('mb-3 inline-block w-[100px]', rest.className)}
+				style={{ width: explorerStore.gridItemSize }}
+				className={clsx('mb-3 inline-block', rest.className)}
 			>
 				<div
 					style={{
-						width: getExplorerStore().gridItemSize,
-						height: getExplorerStore().gridItemSize
+						width: explorerStore.gridItemSize,
+						height: explorerStore.gridItemSize
 					}}
 					className={clsx(
 						'mb-1 rounded-lg border-2 border-transparent text-center active:translate-y-[1px]',
@@ -54,26 +57,7 @@ function FileItem({ data, selected, index, ...rest }: Props) {
 						}
 					)}
 				>
-					<div
-						className={clsx(
-							'relative flex h-full shrink-0 items-center justify-center rounded border-2 border-transparent p-1'
-						)}
-					>
-						<FileThumb
-							className={clsx(
-								'border-app-line max-h-full w-auto max-w-full overflow-hidden rounded-sm border-2 object-cover shadow shadow-black/40',
-								isVid && 'rounded border-x-0 border-y-[7px] !border-black'
-							)}
-							data={data}
-							kind={ObjectKind[objectData?.kind || 0]}
-							size={getExplorerStore().gridItemSize}
-						/>
-						{item.extension && isVid && (
-							<div className="absolute bottom-4 right-2 rounded bg-black/60 py-0.5 px-1 text-[9px] font-semibold uppercase opacity-70">
-								{item.extension}
-							</div>
-						)}
-					</div>
+					<FileThumb data={data} size={explorerStore.gridItemSize} />
 				</div>
 				<NameArea>
 					<span className={nameContainerStyles({ selected })}>

--- a/packages/interface/src/components/explorer/FileRow.tsx
+++ b/packages/interface/src/components/explorer/FileRow.tsx
@@ -1,7 +1,9 @@
 import clsx from 'clsx';
 import { HTMLAttributes } from 'react';
-import { ExplorerItem } from '@sd/client';
-import FileThumb from './FileThumb';
+import { ExplorerItem, ObjectKind, isObject } from '@sd/client';
+import { getExplorerStore } from '../../hooks/useExplorerStore';
+import { FileItemContextMenu } from './ExplorerContextMenu';
+import { FileThumb } from './FileThumb';
 
 interface Props extends HTMLAttributes<HTMLDivElement> {
 	data: ExplorerItem;
@@ -11,24 +13,26 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
 
 function FileRow({ data, index, selected, ...props }: Props) {
 	return (
-		<div
-			{...props}
-			className={clsx(
-				'table-body-row mr-2 flex w-full flex-row rounded-lg border-2',
-				selected ? 'border-accent' : 'border-transparent',
-				index % 2 == 0 && 'bg-[#00000006] dark:bg-[#00000030]'
-			)}
-		>
-			{columns.map((col) => (
-				<div
-					key={col.key}
-					className="table-body-cell flex items-center px-4 py-2 pr-2"
-					style={{ width: col.width }}
-				>
-					<RenderCell data={data} colKey={col.key} />
-				</div>
-			))}
-		</div>
+		<FileItemContextMenu className="w-full" data={data}>
+			<div
+				{...props}
+				className={clsx(
+					'table-body-row mr-2 flex w-full flex-row rounded-lg border-2',
+					selected ? 'border-accent' : 'border-transparent',
+					index % 2 == 0 && 'bg-[#00000006] dark:bg-[#00000030]'
+				)}
+			>
+				{columns.map((col) => (
+					<div
+						key={col.key}
+						className="table-body-cell flex items-center px-4 py-2 pr-2"
+						style={{ width: col.width }}
+					>
+						<RenderCell data={data} colKey={col.key} />
+					</div>
+				))}
+			</div>
+		</FileItemContextMenu>
 	);
 }
 
@@ -36,12 +40,14 @@ const RenderCell: React.FC<{
 	colKey: ColumnKey;
 	data: ExplorerItem;
 }> = ({ colKey, data }) => {
+	const objectData = data ? (isObject(data) ? data.item : data.item.object) : null;
+
 	switch (colKey) {
 		case 'name':
 			return (
 				<div className="flex flex-row items-center overflow-hidden">
 					<div className="mr-3 flex h-6 w-6 shrink-0 items-center justify-center">
-						<FileThumb data={data} size={0} />
+						<FileThumb data={data} size={35} />
 					</div>
 					{/* {colKey == 'name' &&
             (() => {

--- a/packages/interface/src/components/explorer/FileRow.tsx
+++ b/packages/interface/src/components/explorer/FileRow.tsx
@@ -1,9 +1,13 @@
+import byteSize from 'byte-size';
 import clsx from 'clsx';
+import dayjs from 'dayjs';
 import { HTMLAttributes } from 'react';
-import { ExplorerItem, ObjectKind, isObject } from '@sd/client';
+import { ExplorerItem, ObjectKind, isObject, isPath } from '@sd/client';
 import { getExplorerStore } from '../../hooks/useExplorerStore';
-import { FileItemContextMenu } from './ExplorerContextMenu';
-import { FileThumb } from './FileThumb';
+import { ExplorerItemContextMenu } from './ExplorerContextMenu';
+import { ColumnKey, columns } from './FileColumns';
+import { FileThumb, getExplorerItemData } from './FileThumb';
+import { InfoPill } from './Inspector';
 
 interface Props extends HTMLAttributes<HTMLDivElement> {
 	data: ExplorerItem;
@@ -13,7 +17,7 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
 
 function FileRow({ data, index, selected, ...props }: Props) {
 	return (
-		<FileItemContextMenu className="w-full" data={data}>
+		<ExplorerItemContextMenu className="w-full" data={data}>
 			<div
 				{...props}
 				className={clsx(
@@ -32,7 +36,7 @@ function FileRow({ data, index, selected, ...props }: Props) {
 					</div>
 				))}
 			</div>
-		</FileItemContextMenu>
+		</ExplorerItemContextMenu>
 	);
 }
 
@@ -41,33 +45,45 @@ const RenderCell: React.FC<{
 	data: ExplorerItem;
 }> = ({ colKey, data }) => {
 	const objectData = data ? (isObject(data) ? data.item : data.item.object) : null;
+	const { cas_id } = getExplorerItemData(data);
 
 	switch (colKey) {
 		case 'name':
 			return (
 				<div className="flex flex-row items-center overflow-hidden">
-					<div className="mr-3 flex h-6 w-6 shrink-0 items-center justify-center">
+					<div className="mr-3 flex h-6 w-12 shrink-0 items-center justify-center">
 						<FileThumb data={data} size={35} />
 					</div>
-					{/* {colKey == 'name' &&
-            (() => {
-              switch (row.extension.toLowerCase()) {
-                case 'mov' || 'mp4':
-                  return <FilmIcon className="flex-shrink-0 w-5 h-5 mr-3 text-gray-300" />;
-
-                default:
-                  if (row.is_dir)
-                    return <FolderIcon className="flex-shrink-0 w-5 h-5 mr-3 text-gray-300" />;
-                  return <DocumentIcon className="flex-shrink-0 w-5 h-5 mr-3 text-gray-300" />;
-              }
-            })()} */}
-					<span className="truncate text-xs">{data.item[colKey]}</span>
+					<span className="truncate text-xs">
+						{data.item.name}.{data.item.extension}
+					</span>
 				</div>
 			);
-		// case 'size_in_bytes':
-		//   return <span className="text-xs text-left">{byteSize(Number(value || 0))}</span>;
+		case 'size':
+			return (
+				<span className="text-ink-dull text-left text-xs font-medium">
+					{byteSize(Number(objectData?.size_in_bytes || 0)).toString()}
+				</span>
+			);
+		case 'date_created':
+			return (
+				<span className="text-ink-dull text-left text-xs font-medium">
+					{dayjs(data.item?.date_created).format('MMM Do YYYY')}
+				</span>
+			);
+		case 'cas_id':
+			return <span className="text-ink-dull truncate text-left text-xs font-medium">{cas_id}</span>;
 		case 'extension':
-			return <span className="text-left text-xs">{data.item[colKey]}</span>;
+			return (
+				<div className="flex flex-row items-center space-x-3">
+					<InfoPill className="bg-app-button/50">
+						{isPath(data) && data.item.is_dir ? 'Folder' : ObjectKind[objectData?.kind || 0]}
+					</InfoPill>
+					{data.item.extension && (
+						<span className="text-tiny text-ink-dull">{data.item.extension}</span>
+					)}
+				</div>
+			);
 		// case 'meta_integrity_hash':
 		//   return <span className="truncate">{value}</span>;
 		// case 'tags':
@@ -77,24 +93,5 @@ const RenderCell: React.FC<{
 			return <></>;
 	}
 };
-
-interface IColumn {
-	column: string;
-	key: string;
-	width: number;
-}
-
-// Function ensure no types are lost, but guarantees that they are Column[]
-function ensureIsColumns<T extends IColumn[]>(data: T) {
-	return data;
-}
-
-const columns = ensureIsColumns([
-	{ column: 'Name', key: 'name', width: 280 } as const,
-	// { column: 'Size', key: 'size_in_bytes', width: 120 } as const,
-	{ column: 'Type', key: 'extension', width: 100 } as const
-]);
-
-type ColumnKey = (typeof columns)[number]['key'];
 
 export default FileRow;

--- a/packages/interface/src/components/explorer/FileRow.tsx
+++ b/packages/interface/src/components/explorer/FileRow.tsx
@@ -6,8 +6,9 @@ import { ExplorerItem, ObjectKind, isObject, isPath } from '@sd/client';
 import { getExplorerStore } from '../../hooks/useExplorerStore';
 import { ExplorerItemContextMenu } from './ExplorerContextMenu';
 import { ColumnKey, columns } from './FileColumns';
-import { FileThumb, getExplorerItemData } from './FileThumb';
+import { FileThumb } from './FileThumb';
 import { InfoPill } from './Inspector';
+import { getExplorerItemData } from './util';
 
 interface Props extends HTMLAttributes<HTMLDivElement> {
 	data: ExplorerItem;

--- a/packages/interface/src/components/explorer/FileRow.tsx
+++ b/packages/interface/src/components/explorer/FileRow.tsx
@@ -56,7 +56,8 @@ const RenderCell: React.FC<{
 						<FileThumb data={data} size={35} />
 					</div>
 					<span className="truncate text-xs">
-						{data.item.name}.{data.item.extension}
+						{data.item.name}
+						{data.item.extension && `.${data.item.extension}`}
 					</span>
 				</div>
 			);
@@ -80,9 +81,6 @@ const RenderCell: React.FC<{
 					<InfoPill className="bg-app-button/50">
 						{isPath(data) && data.item.is_dir ? 'Folder' : ObjectKind[objectData?.kind || 0]}
 					</InfoPill>
-					{data.item.extension && (
-						<span className="text-tiny text-ink-dull">{data.item.extension}</span>
-					)}
 				</div>
 			);
 		// case 'meta_integrity_hash':

--- a/packages/interface/src/components/explorer/FileThumb.tsx
+++ b/packages/interface/src/components/explorer/FileThumb.tsx
@@ -73,7 +73,7 @@ export function FileThumb({ data, size, className }: FileItemProps) {
 						: {}
 				}
 			/>
-			{extension && kind === 'Video' && (
+			{extension && kind === 'Video' && size > 80 && (
 				<div className="absolute bottom-[22%] right-2 rounded bg-black/60 py-0.5 px-1 text-[9px] font-semibold uppercase opacity-70">
 					{extension}
 				</div>
@@ -112,7 +112,7 @@ export function FileThumbImg({
 	if (url && hasThumbnail) {
 		return (
 			<img
-				style={{ ...imgStyle }}
+				style={{ ...imgStyle, maxWidth: size }}
 				decoding="async"
 				className={clsx('z-90 pointer-events-none bg-black', imgClassName)}
 				src={url}

--- a/packages/interface/src/components/explorer/FileThumb.tsx
+++ b/packages/interface/src/components/explorer/FileThumb.tsx
@@ -8,21 +8,9 @@ import Video from '@sd/assets/images/Video.png';
 import clsx from 'clsx';
 import { CSSProperties } from 'react';
 import { ExplorerItem, ObjectKind, isObject, isPath } from '@sd/client';
-import { useExplorerStore } from '~/hooks/useExplorerStore';
 import { usePlatform } from '~/util/Platform';
 import { Folder } from '../icons/Folder';
-
-export function getExplorerItemData(data: ExplorerItem) {
-	const objectData = data ? (isObject(data) ? data.item : data.item.object) : null;
-
-	return {
-		cas_id: (isObject(data) ? data.item.file_paths[0]?.cas_id : data.item.cas_id) || null,
-		isDir: isPath(data) && data.item.is_dir,
-		kind: ObjectKind[objectData?.kind || 0] || null,
-		hasThumbnail: data.has_thumbnail,
-		extension: data.item.extension
-	};
-}
+import { getExplorerItemData } from './util';
 
 // const icons = import.meta.glob('../../../../assets/icons/*.svg');
 interface FileItemProps {

--- a/packages/interface/src/components/explorer/FileThumb.tsx
+++ b/packages/interface/src/components/explorer/FileThumb.tsx
@@ -40,12 +40,10 @@ export function FileThumb({ data, size, className }: FileItemProps) {
 	// calculate 16:9 ratio for height from size
 	const videoHeight = Math.floor((size * 9) / 16) + videoBarsHeight * 2;
 
-	const videoHorizontalPadding = 0;
-
 	return (
 		<div
 			className={clsx(
-				'relative flex h-full shrink-0 items-center justify-center border-2 border-transparent p-1',
+				'relative flex h-full shrink-0 items-center justify-center border-2 border-transparent',
 				className
 			)}
 		>
@@ -58,8 +56,8 @@ export function FileThumb({ data, size, className }: FileItemProps) {
 				kind={kind}
 				imgClassName={clsx(
 					hasThumbnail &&
-						'max-h-full w-auto max-w-full overflow-hidden rounded-sm object-cover shadow shadow-black/30',
-					kind === 'Image' && 'border-app-line border-2',
+						'max-h-full w-auto max-w-full rounded-sm object-cover shadow shadow-black/30',
+					kind === 'Image' && size > 60 && 'border-app-line border-2',
 					kind === 'Video' && 'rounded border-x-0 !border-black'
 				)}
 				imgStyle={
@@ -67,7 +65,7 @@ export function FileThumb({ data, size, className }: FileItemProps) {
 						? {
 								borderTopWidth: videoBarsHeight,
 								borderBottomWidth: videoBarsHeight,
-								width: size - videoHorizontalPadding,
+								width: size,
 								height: videoHeight
 						  }
 						: {}
@@ -112,7 +110,7 @@ export function FileThumbImg({
 	if (url && hasThumbnail) {
 		return (
 			<img
-				style={{ ...imgStyle, maxWidth: size }}
+				style={{ ...imgStyle, maxWidth: size, width: size - 10 }}
 				decoding="async"
 				className={clsx('z-90 pointer-events-none bg-black', imgClassName)}
 				src={url}

--- a/packages/interface/src/components/explorer/FileThumb.tsx
+++ b/packages/interface/src/components/explorer/FileThumb.tsx
@@ -6,62 +6,104 @@ import Executable from '@sd/assets/images/Executable.png';
 import File from '@sd/assets/images/File.png';
 import Video from '@sd/assets/images/Video.png';
 import clsx from 'clsx';
-import { ExplorerItem, isObject, isPath } from '@sd/client';
+import { ExplorerItem, ObjectKind, isObject, isPath } from '@sd/client';
 import { useExplorerStore } from '~/hooks/useExplorerStore';
 import { usePlatform } from '~/util/Platform';
 import { Folder } from '../icons/Folder';
 
-interface Props {
-	data: ExplorerItem;
-	size: number;
-	className?: string;
-	style?: React.CSSProperties;
-	iconClassNames?: string;
-	kind?: string;
+export function getExplorerItemData(data: ExplorerItem) {
+	const objectData = data ? (isObject(data) ? data.item : data.item.object) : null;
+
+	return {
+		cas_id: (isObject(data) ? data.item.file_paths[0]?.cas_id : data.item.cas_id) || null,
+		isDir: isPath(data) && data.item.is_dir,
+		kind: ObjectKind[objectData?.kind || 0] || null,
+		hasThumbnail: data.has_thumbnail,
+		extension: data.item.extension
+	};
 }
 
 // const icons = import.meta.glob('../../../../assets/icons/*.svg');
+interface FileItemProps {
+	data: ExplorerItem;
+	size: number;
+	className?: string;
+}
+export function FileThumb({ data, size }: FileItemProps) {
+	const { cas_id, isDir, kind, hasThumbnail, extension } = getExplorerItemData(data);
+	return (
+		<div
+			className={clsx(
+				'relative flex h-full shrink-0 items-center justify-center rounded border-2 border-transparent p-1'
+			)}
+		>
+			<FileThumbImg
+				size={size}
+				hasThumbnail={hasThumbnail}
+				isDir={isDir}
+				cas_id={cas_id}
+				extension={extension}
+				kind={kind}
+				imgClassName={clsx(
+					hasThumbnail &&
+						'border-app-line max-h-full w-auto max-w-full overflow-hidden rounded-sm border-2 object-cover shadow shadow-black/40',
+					kind === 'Video' && 'rounded border-x-0 border-y-[7px] !border-black'
+				)}
+			/>
+			{extension && kind === 'Video' && (
+				<div className="absolute bottom-4 right-2 rounded bg-black/60 py-0.5 px-1 text-[9px] font-semibold uppercase opacity-70">
+					{extension}
+				</div>
+			)}
+		</div>
+	);
+}
+interface FileThumbImgProps {
+	isDir: boolean;
+	cas_id: string | null;
+	kind: string | null;
+	extension: string | null;
+	size: number;
+	hasThumbnail: boolean;
+	imgClassName?: string;
+	imgStyle?: string;
+}
 
-export default function FileThumb({ data, ...props }: Props) {
+export function FileThumbImg({
+	isDir,
+	cas_id,
+	kind,
+	size,
+	hasThumbnail,
+	extension,
+	imgClassName,
+	imgStyle
+}: FileThumbImgProps) {
 	const platform = usePlatform();
-	// const Icon = useMemo(() => {
-	// 	const icon = icons[`../../../../assets/icons/${item.extension}.svg`];
 
-	// 	const Icon = icon
-	// 		? lazy(() => icon().then((v) => ({ default: (v as any).ReactComponent })))
-	// 		: undefined;
-	// 	return Icon;
-	// }, [item.extension]);
+	if (isDir) return <Folder size={size * 0.7} />;
 
-	if (isPath(data) && data.item.is_dir) return <Folder size={props.size * 0.7} />;
+	if (!cas_id) return <div></div>;
+	const url = platform.getThumbnailUrlById(cas_id);
 
-	if (data.has_thumbnail) {
-		const cas_id = isObject(data) ? data.item.file_paths[0]?.cas_id : data.item.cas_id;
-
-		if (!cas_id) return <div></div>;
-
-		const url = platform.getThumbnailUrlById(cas_id);
-
-		if (url)
-			return (
-				<img
-					style={props.style}
-					decoding="async"
-					// width={props.size}
-					className={clsx('z-90 pointer-events-none', props.className)}
-					src={url}
-				/>
-			);
-	}
+	if (url && hasThumbnail)
+		return (
+			<img
+				style={imgStyle}
+				decoding="async"
+				className={clsx('z-90 pointer-events-none', imgClassName)}
+				src={url}
+			/>
+		);
 
 	let icon = File;
 	// Hacky (and temporary) way to integrate thumbnails
-	if (props.kind === 'Archive') icon = Archive;
-	else if (props.kind === 'Video') icon = Video;
-	else if (props.kind === 'Document' && data.item.extension === 'pdf') icon = DocumentPdf;
-	else if (props.kind === 'Executable') icon = Executable;
-	else if (props.kind === 'Encrypted') icon = Encrypted;
-	else if (props.kind === 'Compressed') icon = Compressed;
+	if (kind === 'Archive') icon = Archive;
+	else if (kind === 'Video') icon = Video;
+	else if (kind === 'Document' && extension === 'pdf') icon = DocumentPdf;
+	else if (kind === 'Executable') icon = Executable;
+	else if (kind === 'Encrypted') icon = Encrypted;
+	else if (kind === 'Compressed') icon = Compressed;
 
-	return <img src={icon} className={clsx('h-full overflow-hidden', props.iconClassNames)} />;
+	return <img src={icon} className={clsx('h-full overflow-hidden')} />;
 }

--- a/packages/interface/src/components/explorer/FileThumb.tsx
+++ b/packages/interface/src/components/explorer/FileThumb.tsx
@@ -7,7 +7,7 @@ import File from '@sd/assets/images/File.png';
 import Video from '@sd/assets/images/Video.png';
 import clsx from 'clsx';
 import { CSSProperties } from 'react';
-import { ExplorerItem, ObjectKind, isObject, isPath } from '@sd/client';
+import { ExplorerItem } from '@sd/client';
 import { usePlatform } from '~/util/Platform';
 import { Folder } from '../icons/Folder';
 import { getExplorerItemData } from './util';

--- a/packages/interface/src/components/explorer/FileThumb.tsx
+++ b/packages/interface/src/components/explorer/FileThumb.tsx
@@ -6,6 +6,7 @@ import Executable from '@sd/assets/images/Executable.png';
 import File from '@sd/assets/images/File.png';
 import Video from '@sd/assets/images/Video.png';
 import clsx from 'clsx';
+import { CSSProperties } from 'react';
 import { ExplorerItem, ObjectKind, isObject, isPath } from '@sd/client';
 import { useExplorerStore } from '~/hooks/useExplorerStore';
 import { usePlatform } from '~/util/Platform';
@@ -29,12 +30,23 @@ interface FileItemProps {
 	size: number;
 	className?: string;
 }
-export function FileThumb({ data, size }: FileItemProps) {
+
+export function FileThumb({ data, size, className }: FileItemProps) {
 	const { cas_id, isDir, kind, hasThumbnail, extension } = getExplorerItemData(data);
+
+	// 10 percent of the size
+	const videoBarsHeight = Math.floor(size / 10);
+
+	// calculate 16:9 ratio for height from size
+	const videoHeight = Math.floor((size * 9) / 16) + videoBarsHeight * 2;
+
+	const videoHorizontalPadding = 0;
+
 	return (
 		<div
 			className={clsx(
-				'relative flex h-full shrink-0 items-center justify-center rounded border-2 border-transparent p-1'
+				'relative flex h-full shrink-0 items-center justify-center border-2 border-transparent p-1',
+				className
 			)}
 		>
 			<FileThumbImg
@@ -46,12 +58,23 @@ export function FileThumb({ data, size }: FileItemProps) {
 				kind={kind}
 				imgClassName={clsx(
 					hasThumbnail &&
-						'border-app-line max-h-full w-auto max-w-full overflow-hidden rounded-sm border-2 object-cover shadow shadow-black/40',
-					kind === 'Video' && 'rounded border-x-0 border-y-[7px] !border-black'
+						'max-h-full w-auto max-w-full overflow-hidden rounded-sm object-cover shadow shadow-black/30',
+					kind === 'Image' && 'border-app-line border-2',
+					kind === 'Video' && 'rounded border-x-0 !border-black'
 				)}
+				imgStyle={
+					kind === 'Video'
+						? {
+								borderTopWidth: videoBarsHeight,
+								borderBottomWidth: videoBarsHeight,
+								width: size - videoHorizontalPadding,
+								height: videoHeight
+						  }
+						: {}
+				}
 			/>
 			{extension && kind === 'Video' && (
-				<div className="absolute bottom-4 right-2 rounded bg-black/60 py-0.5 px-1 text-[9px] font-semibold uppercase opacity-70">
+				<div className="absolute bottom-[22%] right-2 rounded bg-black/60 py-0.5 px-1 text-[9px] font-semibold uppercase opacity-70">
 					{extension}
 				</div>
 			)}
@@ -66,7 +89,7 @@ interface FileThumbImgProps {
 	size: number;
 	hasThumbnail: boolean;
 	imgClassName?: string;
-	imgStyle?: string;
+	imgStyle?: CSSProperties;
 }
 
 export function FileThumbImg({
@@ -86,15 +109,16 @@ export function FileThumbImg({
 	if (!cas_id) return <div></div>;
 	const url = platform.getThumbnailUrlById(cas_id);
 
-	if (url && hasThumbnail)
+	if (url && hasThumbnail) {
 		return (
 			<img
-				style={imgStyle}
+				style={{ ...imgStyle }}
 				decoding="async"
-				className={clsx('z-90 pointer-events-none', imgClassName)}
+				className={clsx('z-90 pointer-events-none bg-black', imgClassName)}
 				src={url}
 			/>
 		);
+	}
 
 	let icon = File;
 	// Hacky (and temporary) way to integrate thumbnails

--- a/packages/interface/src/components/explorer/Inspector.tsx
+++ b/packages/interface/src/components/explorer/Inspector.tsx
@@ -124,7 +124,7 @@ export const Inspector = ({ data, context, ...elementProps }: Props) => {
 						<MetaContainer>
 							<div className="flex flex-wrap gap-1">
 								<InfoPill>{isDir ? 'Folder' : ObjectKind[objectData?.kind || 0]}</InfoPill>
-								{item && <InfoPill>{item.extension}</InfoPill>}
+								{item?.extension && <InfoPill>{item.extension}</InfoPill>}
 								{tags?.data?.map((tag) => (
 									<InfoPill
 										className="!text-white"

--- a/packages/interface/src/components/explorer/Inspector.tsx
+++ b/packages/interface/src/components/explorer/Inspector.tsx
@@ -80,8 +80,7 @@ export const Inspector = ({ data, context, ...elementProps }: Props) => {
 				<>
 					<div
 						className={clsx(
-							'mb-[10px] flex h-52 w-full items-center justify-center overflow-hidden rounded-lg',
-							objectData?.kind === 7 && objectData?.has_thumbnail && 'bg-black'
+							'mb-[10px] flex h-52 w-full items-center justify-center overflow-hidden rounded-lg'
 						)}
 					>
 						<FileThumb

--- a/packages/interface/src/components/explorer/Inspector.tsx
+++ b/packages/interface/src/components/explorer/Inspector.tsx
@@ -83,12 +83,7 @@ export const Inspector = ({ data, context, ...elementProps }: Props) => {
 							'mb-[10px] flex h-52 w-full items-center justify-center overflow-hidden rounded-lg'
 						)}
 					>
-						<FileThumb
-							// iconClassNames="my-3 max-h-[150px]"
-							size={240}
-							className="!rounded-2xl"
-							data={data}
-						/>
+						<FileThumb size={240} data={data} />
 					</div>
 					<div className="bg-app-box shadow-app-shade/10 border-app-line flex w-full select-text flex-col overflow-hidden rounded-lg border py-0.5">
 						<h3 className="truncate px-3 pt-2 pb-1 text-base font-bold">

--- a/packages/interface/src/components/explorer/Inspector.tsx
+++ b/packages/interface/src/components/explorer/Inspector.tsx
@@ -14,7 +14,7 @@ import {
 import { Button, tw } from '@sd/ui';
 import { DefaultProps } from '../primitive/types';
 import { Tooltip } from '../tooltip/Tooltip';
-import FileThumb from './FileThumb';
+import { FileThumb } from './FileThumb';
 import { Divider } from './inspector/Divider';
 import FavoriteButton from './inspector/FavoriteButton';
 import Note from './inspector/Note';
@@ -85,9 +85,8 @@ export const Inspector = ({ data, context, ...elementProps }: Props) => {
 						)}
 					>
 						<FileThumb
-							iconClassNames="my-3 max-h-[150px]"
+							// iconClassNames="my-3 max-h-[150px]"
 							size={230}
-							kind={ObjectKind[objectData?.kind || 0]}
 							className="flex shrink grow-0"
 							data={data}
 						/>

--- a/packages/interface/src/components/explorer/Inspector.tsx
+++ b/packages/interface/src/components/explorer/Inspector.tsx
@@ -86,8 +86,8 @@ export const Inspector = ({ data, context, ...elementProps }: Props) => {
 					>
 						<FileThumb
 							// iconClassNames="my-3 max-h-[150px]"
-							size={230}
-							className="flex shrink grow-0"
+							size={240}
+							className="!rounded-2xl"
 							data={data}
 						/>
 					</div>

--- a/packages/interface/src/components/explorer/VirtualizedList.tsx
+++ b/packages/interface/src/components/explorer/VirtualizedList.tsx
@@ -8,7 +8,7 @@ import FileItem from './FileItem';
 import FileRow from './FileRow';
 
 const TOP_BAR_HEIGHT = 46;
-const GRID_TEXT_AREA_HEIGHT = 25;
+// const GRID_TEXT_AREA_HEIGHT = 25;
 
 interface Props {
 	context: ExplorerContext;
@@ -36,13 +36,23 @@ export const VirtualizedList = memo(({ data, context, onScroll }: Props) => {
 	}, [explorerStore.showInspector]);
 
 	// sizing calculations
-	const amountOfColumns = Math.floor(width / explorerStore.gridItemSize) || 8,
+	const GRID_TEXT_AREA_HEIGHT = explorerStore.gridItemSize / 4;
+	const amountOfColumns = Math.floor(width / explorerStore.gridItemSize) || 4,
 		amountOfRows =
 			explorerStore.layoutMode === 'grid' ? Math.ceil(data.length / amountOfColumns) : data.length,
 		itemSize =
 			explorerStore.layoutMode === 'grid'
 				? explorerStore.gridItemSize + GRID_TEXT_AREA_HEIGHT
 				: explorerStore.listItemSize;
+
+	console.log({
+		gridItemSize: explorerStore.gridItemSize,
+		itemSize,
+		dataLength: data.length,
+		amountOfRows,
+		amountOfColumns,
+		width
+	});
 
 	useEffect(() => {
 		const el = scrollRef.current;
@@ -92,28 +102,6 @@ export const VirtualizedList = memo(({ data, context, onScroll }: Props) => {
 			getExplorerStore().selectedRowIndex = explorerStore.selectedRowIndex + 1;
 	});
 
-	// const Header = () => (
-	// 	<div>
-	// 		{props.context.name && (
-	// 			<h1 className="pt-20 pl-4 text-xl font-bold ">{props.context.name}</h1>
-	// 		)}
-	// 		<div className="table-head">
-	// 			<div className="flex flex-row p-2 table-head-row">
-	// 				{columns.map((col) => (
-	// 					<div
-	// 						key={col.key}
-	// 						className="relative flex flex-row items-center pl-2 table-head-cell group"
-	// 						style={{ width: col.width }}
-	// 					>
-	// 						<EllipsisHorizontalIcon className="absolute hidden w-5 h-5 -ml-5 cursor-move group-hover:block drag-handle opacity-10" />
-	// 						<span className="text-sm font-medium text-gray-500">{col.column}</span>
-	// 					</div>
-	// 				))}
-	// 			</div>
-	// 		</div>
-	// 	</div>
-	// );
-
 	return (
 		<div style={{ marginTop: -TOP_BAR_HEIGHT }} className="w-full cursor-default pl-4">
 			<div
@@ -143,7 +131,7 @@ export const VirtualizedList = memo(({ data, context, onScroll }: Props) => {
 							{explorerStore.layoutMode === 'list' ? (
 								<WrappedItem
 									kind="list"
-									isSelected={getExplorerStore().selectedRowIndex === virtualRow.index}
+									isSelected={explorerStore.selectedRowIndex === virtualRow.index}
 									index={virtualRow.index}
 									item={data[virtualRow.index]!}
 								/>
@@ -194,7 +182,6 @@ const WrappedItem = memo(({ item, index, isSelected, kind }: WrappedItemProps) =
 	const onClick = useCallback(
 		(e: React.MouseEvent<HTMLDivElement>) => {
 			e.stopPropagation();
-
 			getExplorerStore().selectedRowIndex = isSelected ? -1 : index;
 		},
 		[isSelected, index]

--- a/packages/interface/src/components/explorer/VirtualizedList.tsx
+++ b/packages/interface/src/components/explorer/VirtualizedList.tsx
@@ -106,8 +106,8 @@ export const VirtualizedList = memo(({ data, context, onScroll }: Props) => {
 				<div
 					ref={innerRef}
 					style={{
-						height: `${rowVirtualizer.getTotalSize()}px`,
-						marginTop: `${TOP_BAR_HEIGHT + LIST_VIEW_HEADER_HEIGHT}px`
+						height: rowVirtualizer.getTotalSize(),
+						marginTop: TOP_BAR_HEIGHT + LIST_VIEW_HEADER_HEIGHT
 					}}
 					className="relative w-full"
 				>

--- a/packages/interface/src/components/explorer/VirtualizedList.tsx
+++ b/packages/interface/src/components/explorer/VirtualizedList.tsx
@@ -141,17 +141,15 @@ export const VirtualizedList = memo(({ data, context, onScroll }: Props) => {
 									const item = data[index];
 									const isSelected = explorerStore.selectedRowIndex === index;
 									return (
-										<div key={index} className="">
-											<div className="flex">
-												{item && (
-													<WrappedItem
-														kind="grid"
-														isSelected={isSelected}
-														index={index}
-														item={item}
-													/>
-												)}
-											</div>
+										<div key={index} className="flex">
+											{item && (
+												<WrappedItem
+													kind="grid"
+													isSelected={isSelected}
+													index={index}
+													item={item}
+												/>
+											)}
 										</div>
 									);
 								})

--- a/packages/interface/src/components/explorer/VirtualizedList.tsx
+++ b/packages/interface/src/components/explorer/VirtualizedList.tsx
@@ -45,15 +45,6 @@ export const VirtualizedList = memo(({ data, context, onScroll }: Props) => {
 				? explorerStore.gridItemSize + GRID_TEXT_AREA_HEIGHT
 				: explorerStore.listItemSize;
 
-	console.log({
-		gridItemSize: explorerStore.gridItemSize,
-		itemSize,
-		dataLength: data.length,
-		amountOfRows,
-		amountOfColumns,
-		width
-	});
-
 	useEffect(() => {
 		const el = scrollRef.current;
 		if (!el) return;

--- a/packages/interface/src/components/explorer/VirtualizedList.tsx
+++ b/packages/interface/src/components/explorer/VirtualizedList.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from 'react-router-dom';
 import { useKey, useOnWindowResize } from 'rooks';
 import { ExplorerContext, ExplorerItem, isPath } from '@sd/client';
 import { ExplorerLayoutMode, getExplorerStore, useExplorerStore } from '~/hooks/useExplorerStore';
+import { LIST_VIEW_HEADER_HEIGHT, ListViewHeader } from './FileColumns';
 import FileItem from './FileItem';
 import FileRow from './FileRow';
 
@@ -106,10 +107,11 @@ export const VirtualizedList = memo(({ data, context, onScroll }: Props) => {
 					ref={innerRef}
 					style={{
 						height: `${rowVirtualizer.getTotalSize()}px`,
-						marginTop: `${TOP_BAR_HEIGHT}px`
+						marginTop: `${TOP_BAR_HEIGHT + LIST_VIEW_HEADER_HEIGHT}px`
 					}}
 					className="relative w-full"
 				>
+					<ListViewHeader />
 					{rowVirtualizer.getVirtualItems().map((virtualRow) => (
 						<div
 							style={{
@@ -119,14 +121,15 @@ export const VirtualizedList = memo(({ data, context, onScroll }: Props) => {
 							className="absolute top-0 left-0 flex w-full"
 							key={virtualRow.key}
 						>
-							{explorerStore.layoutMode === 'list' ? (
+							{explorerStore.layoutMode === 'list' && (
 								<WrappedItem
 									kind="list"
 									isSelected={explorerStore.selectedRowIndex === virtualRow.index}
 									index={virtualRow.index}
 									item={data[virtualRow.index]!}
 								/>
-							) : (
+							)}
+							{explorerStore.layoutMode === 'grid' &&
 								[...Array(amountOfColumns)].map((_, i) => {
 									const index = virtualRow.index * amountOfColumns + i;
 									const item = data[index];
@@ -143,8 +146,7 @@ export const VirtualizedList = memo(({ data, context, onScroll }: Props) => {
 											)}
 										</div>
 									);
-								})
-							)}
+								})}
 						</div>
 					))}
 				</div>

--- a/packages/interface/src/components/explorer/util.ts
+++ b/packages/interface/src/components/explorer/util.ts
@@ -1,0 +1,13 @@
+import { ExplorerItem, ObjectKind, isObject, isPath } from '@sd/client';
+
+export function getExplorerItemData(data: ExplorerItem) {
+	const objectData = data ? (isObject(data) ? data.item : data.item.object) : null;
+
+	return {
+		cas_id: (isObject(data) ? data.item.file_paths[0]?.cas_id : data.item.cas_id) || null,
+		isDir: isPath(data) && data.item.is_dir,
+		kind: ObjectKind[objectData?.kind || 0] || null,
+		hasThumbnail: data.has_thumbnail,
+		extension: data.item.extension
+	};
+}

--- a/packages/interface/src/hooks/useExplorerStore.tsx
+++ b/packages/interface/src/hooks/useExplorerStore.tsx
@@ -52,11 +52,11 @@ const explorerStore = proxy({
 });
 
 export function useExplorerStore() {
-	const { library } = useLibraryContext();
+	// const { library } = useLibraryContext();
 
-	useEffect(() => {
-		explorerStore.reset();
-	}, [library.uuid]);
+	// useEffect(() => {
+	// 	explorerStore.reset();
+	// }, [library.uuid]);
 
 	return useSnapshot(explorerStore);
 }


### PR DESCRIPTION
Adds the ability to resize items in the explorer grid view
- Added item resizer
- Fixed explorer store bug
- Refactored file image component
- Fixed explorer thumbnail rendering
- Improved list view, added more columns and column headings

Note: there is a bug where icons do not render in the FileIcon component, images, video and folders are fine, but custom icons require a forced re-render to show (you can trigger it using the context menu). This only happens on list view and in the inspector, grid view is fine.

https://user-images.githubusercontent.com/32987599/221331773-4cadb0af-3570-41d2-b89f-b7b30c2672fd.mov

<img width="1539" alt="Screenshot 2023-02-24 at 7 20 51 PM" src="https://user-images.githubusercontent.com/32987599/221333558-8dd2b50c-bd78-4ee9-a861-a8d0c750b74f.png">
