### PR TITLE
platform-restrict android code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2945,6 +2945,20 @@ dependencies = [
 
 [[package]]
 name = "jni"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+dependencies = [
+ "cesu8",
+ "combine 4.6.6",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "jni"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "039022cdf4d7b1cf548d31f60ae783138e5fd42013f6271049d7df7afadef96c"
@@ -5687,6 +5701,11 @@ dependencies = [
 [[package]]
 name = "sd-mobile-android"
 version = "0.1.0"
+dependencies = [
+ "jni 0.19.0",
+ "sd-mobile-core",
+ "tracing",
+]
 
 [[package]]
 name = "sd-mobile-core"
@@ -6653,7 +6672,7 @@ dependencies = [
  "gtk",
  "image",
  "instant",
- "jni",
+ "jni 0.20.0",
  "lazy_static",
  "libc",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2945,20 +2945,6 @@ dependencies = [
 
 [[package]]
 name = "jni"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
-dependencies = [
- "cesu8",
- "combine 4.6.6",
- "jni-sys",
- "log",
- "thiserror",
- "walkdir",
-]
-
-[[package]]
-name = "jni"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "039022cdf4d7b1cf548d31f60ae783138e5fd42013f6271049d7df7afadef96c"
@@ -5701,11 +5687,6 @@ dependencies = [
 [[package]]
 name = "sd-mobile-android"
 version = "0.1.0"
-dependencies = [
- "jni 0.19.0",
- "sd-mobile-core",
- "tracing",
-]
 
 [[package]]
 name = "sd-mobile-core"
@@ -6672,7 +6653,7 @@ dependencies = [
  "gtk",
  "image",
  "instant",
- "jni 0.20.0",
+ "jni",
  "lazy_static",
  "libc",
  "log",

--- a/apps/mobile/crates/android/Cargo.toml
+++ b/apps/mobile/crates/android/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.64.0"
 # Android can use dynamic linking since all FFI is done via JNI
 crate-type = ["cdylib"]
 
-[target.'cfg(target_os = "android")'.depedencies]
+[target.'cfg(target_os = "android")'.dependencies]
 # FFI
 jni = "0.19.0"
 

--- a/apps/mobile/crates/android/Cargo.toml
+++ b/apps/mobile/crates/android/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.64.0"
 # Android can use dynamic linking since all FFI is done via JNI
 crate-type = ["cdylib"]
 
-[dependencies]
+[target.'cfg(target_os = "android")'.depedencies]
 # FFI
 jni = "0.19.0"
 

--- a/apps/mobile/crates/android/src/lib.rs
+++ b/apps/mobile/crates/android/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg(target_os = "android")]
+
 use std::panic;
 
 use jni::{


### PR DESCRIPTION
#590 made swift stuff only build on iOS and macOS, this PR makes android stuff only build for android targets. `cargo build --all` should work on macOS and hopefully other OSes too.