### PR TITLE
generate + use ModelSyncData enum

### DIFF
--- a/.github/actions/generate-prisma-client/action.yaml
+++ b/.github/actions/generate-prisma-client/action.yaml
@@ -8,7 +8,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: ./core/src/prisma*.rs
-        key: prisma-0-${{ runner.os }}-${{ hashFiles('./core/prisma/*', './Cargo.toml') }}
+        key: prisma-0-${{ runner.os }}-${{ hashFiles('./core/prisma/*', './crates/sync-generator/*', './Cargo.toml') }}
 
     - name: Generate Prisma client
       working-directory: core


### PR DESCRIPTION
Instead of manually matching on sync + model type, we now have the matching done via a generated enum and just manually match on that. Just automating more of stuff we already do.