### PR TITLE
[ENG-430] *Nix setup script improvements

### DIFF
--- a/.github/scripts/setup-system.sh
+++ b/.github/scripts/setup-system.sh
@@ -136,13 +136,10 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 		# Tauri dependencies
 		# openssl is manually declared here as i don't think openssl and openssl-devel are actually dependant on eachother
 		# openssl also has a habit of being missing from some of my fresh Fedora installs - i've had to install it at least twice
-		# TODO(brxken128): check if the lack of the plain `openssl` package breaks building
-		FEDORA_TAURI_DEPS="openssl openssl-devel curl wget libappindicator-gtk3 librsvg2-devel"
+		FEDORA_TAURI_DEPS="openssl-devel curl wget libappindicator-gtk3 librsvg2-devel"
 
-		# the perl package/dependencies are required for building the openssl-sys rust crate
-		# TODO(brxken128): test whether or not it's easier to manage the perl deps individually, there's not *too* many,
-		# and it'd be a lot lighter than the entire perl collection
-		FEDORA_OPENSSL_SYS_DEPS="perl"
+		# required for building the openssl-sys crate
+		FEDORA_OPENSSL_SYS_DEPS="perl-FindBin perl-File-Compare perl-IPC-Cmd perl-File-Copy"
 
 		# FFmpeg dependencies
 		FEDORA_FFMPEG_DEPS="ffmpeg ffmpeg-devel"

--- a/.github/scripts/setup-system.sh
+++ b/.github/scripts/setup-system.sh
@@ -153,7 +153,7 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 		# Protobuf compiler
 		FEDORA_LIBP2P_DEPS="protobuf-compiler"
 
-		sudo dnf check-update
+		sudo dnf update
 
 		if ! sudo dnf install $FEDORA_37_TAURI_WEBKIT && ! sudo dnf install $FEDORA_36_TAURI_WEBKIT; then
 			log_err "We were unable to install the webkit2gtk4.0-devel/webkit2gtk3-devel package. Please open an issue if you feel that this is incorrect. https://github.com/spacedriveapp/spacedrive/issues"
@@ -179,19 +179,10 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
 
 	echo "Installing Homebrew dependencies..."
 
+	BREW_DEPS="ffmpeg"
 	BREW_LIBP2P_DEPS="protobuf"
 
-	brew install $BREW_LIBP2P_DEPS
-
-	if ! brew list | grep -q "ffmpeg"; then
-		echo "Installing FFmpeg..."
-
-		brew install -q ffmpeg
-
-		echo "FFmpeg has been installed and is now being used on your system."
-	else
-		echo "FFmpeg is already installed."
-	fi
+	brew install -q $BREW_DEPS $BREW_LIBP2P_DEPS
 else
 	log_err "Your OS ($OSTYPE) is not supported by this script. We would welcome a PR or some help adding your OS to this script. https://github.com/spacedriveapp/spacedrive/issues"
 	exit 1

--- a/.github/scripts/setup-system.sh
+++ b/.github/scripts/setup-system.sh
@@ -127,6 +127,12 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 		echo "Detected dnf!"
 		echo "Installing dependencies with dnf..."
 
+		# `webkit2gtk4.0-devel` also provides `webkit2gtk3-devel`, it's just under a different package in fedora versions >= 37.
+		# https://koji.fedoraproject.org/koji/packageinfo?tagOrder=-blocked&packageID=26162#taglist
+		# https://packages.fedoraproject.org/pkgs/webkitgtk/webkit2gtk4.0-devel/fedora-38.html#provides
+		FEDORA_37_TAURI_WEBKIT="webkit2gtk4.0-devel.x86_64"
+		FEDORA_36_TAURI_WEBKIT="webkit2gtk3-devel.x86_64"
+
 		# Tauri dependencies
 		FEDORA_TAURI_DEPS="webkit2gtk3-devel.x86_64 openssl-devel curl wget libappindicator-gtk3 librsvg2-devel"
 
@@ -140,6 +146,12 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 		PROTOBUF="protobuf-compiler"
 
 		sudo dnf check-update
+
+		if ! sudo dnf install $FEDORA_37_TAURI_WEBKIT && ! sudo dnf install $FEDORA_36_TAURI_WEBKIT; then
+			log_err "We were unable to install the webkit2gtk3-devel package. Please open an issue if you feel that this is incorrect. https://github.com/spacedriveapp/spacedrive/issues"
+			exit 1
+		fi
+
 		sudo dnf install $FEDORA_TAURI_DEPS $FEDORA_FFMPEG_DEPS $FEDORA_BINDGEN_DEPS $PROTOBUF
 		sudo dnf group install "C Development Tools and Libraries"
 	else

--- a/.github/scripts/setup-system.sh
+++ b/.github/scripts/setup-system.sh
@@ -166,19 +166,18 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
 
 	echo "Installing Homebrew dependencies..."
 
-	FFMPEG_VERSION="5.1.0"
 	PROTOBUF="protobuf"
 
 	brew install $PROTOBUF
 
-	if ! brew list ffmpeg | grep -q "/ffmpeg/$FFMPEG_VERSION/"; then
-		echo "Installing FFmpeg version $FFMPEG_VERSION..."
+	if ! brew list | grep -q "ffmpeg"; then
+		echo "Installing FFmpeg..."
 
-		brew install -q "ffmpeg@$FFMPEG_VERSION"
+		brew install -q ffmpeg
 
-		echo "FFmpeg version $FFMPEG_VERSION has been installed and is now being used on your system."
+		echo "FFmpeg has been installed and is now being used on your system."
 	else
-		echo "FFmpeg version $FFMPEG_VERSION is already installed."
+		echo "FFmpeg is already installed."
 	fi
 else
 	log_err "Your OS ($OSTYPE) is not supported by this script. We would welcome a PR or some help adding your OS to this script. https://github.com/spacedriveapp/spacedrive/issues"

--- a/.github/scripts/setup-system.sh
+++ b/.github/scripts/setup-system.sh
@@ -106,9 +106,10 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 		ARCH_TAURI_DEPS="webkit2gtk base-devel curl wget openssl appmenu-gtk-module gtk3 libappindicator-gtk3 librsvg libvips" # Tauri deps https://tauri.studio/guides/getting-started/setup/linux#1-system-dependencies
 		ARCH_FFMPEG_DEPS="ffmpeg" # FFmpeg dependencies
 		ARCH_BINDGEN_DEPS="clang" # Bindgen dependencies - it's used by a dependency of Spacedrive
+		PROTOBUF="protobuf" # Protobuf compiler - https://github.com/archlinux/svntogit-packages/blob/packages/protobuf/trunk/PKGBUILD provides `libprotoc`
 
 		sudo pacman -Syu
-		sudo pacman -S --needed $ARCH_TAURI_DEPS $ARCH_FFMPEG_DEPS $ARCH_BINDGEN_DEPS
+		sudo pacman -S --needed $ARCH_TAURI_DEPS $ARCH_FFMPEG_DEPS $ARCH_BINDGEN_DEPS $PROTOBUF
 	elif command -v dnf >/dev/null; then
 		echo "Detected dnf!"
 		echo "Installing dependencies with dnf..."
@@ -116,9 +117,10 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 		FEDORA_TAURI_DEPS="webkit2gtk3-devel.x86_64 openssl-devel curl wget libappindicator-gtk3 librsvg2-devel" # Tauri dependencies
 		FEDORA_FFMPEG_DEPS="ffmpeg ffmpeg-devel" # FFmpeg dependencies
 		FEDORA_BINDGEN_DEPS="clang" # Bindgen dependencies - it's used by a dependency of Spacedrive
+		PROTOBUF="protobuf-compiler" # Protobuf compiler
 
 		sudo dnf check-update
-		sudo dnf install $FEDORA_TAURI_DEPS $FEDORA_FFMPEG_DEPS $FEDORA_BINDGEN_DEPS
+		sudo dnf install $FEDORA_TAURI_DEPS $FEDORA_FFMPEG_DEPS $FEDORA_BINDGEN_DEPS $PROTOBUF
 		sudo dnf group install "C Development Tools and Libraries"
 	else
 		log_err "Your Linux distro '$(lsb_release -s -d)' is not supported by this script. We would welcome a PR or some help adding your OS to this script. https://github.com/spacedriveapp/spacedrive/issues"

--- a/.github/scripts/setup-system.sh
+++ b/.github/scripts/setup-system.sh
@@ -114,21 +114,12 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 		echo "Detected dnf!"
 		echo "Installing dependencies with dnf..."
 
-
-		# `webkit2gtk4.0-devel` also provides `webkit2gtk3-devel`, it is just under a different package in fedora versions >= 37.
-		# https://koji.fedoraproject.org/koji/packageinfo?tagOrder=-blocked&packageID=26162#taglist
-		# https://packages.fedoraproject.org/pkgs/webkitgtk/webkit2gtk4.0-devel/fedora-38.html#provides
-		FEDORA_37_TAURI_WEBKIT="webkit2gtk4.0-devel.x86_64"
-		FEDORA_36_TAURI_WEBKIT="webkit2gtk3-devel.x86_64"
-
-		FEDORA_TAURI_DEPS="openssl-devel curl wget libappindicator-gtk3 librsvg2-devel" # Tauri dependencies
+		FEDORA_TAURI_DEPS="webkit2gtk3-devel.x86_64 openssl-devel curl wget libappindicator-gtk3 librsvg2-devel" # Tauri dependencies
 		FEDORA_FFMPEG_DEPS="ffmpeg ffmpeg-devel" # FFmpeg dependencies
 		FEDORA_BINDGEN_DEPS="clang" # Bindgen dependencies - it's used by a dependency of Spacedrive
 		PROTOBUF="protobuf-compiler" # Protobuf compiler
 
 		sudo dnf check-update
-		sudo dnf install $FEDORA_37_TAURI_WEBKIT || sudo dnf install $FEDORA_36_TAURI_WEBKIT || log_err "We were unable to install the `webkit2gtk3-devel" package. Please open an issue if you feel that this is incorrect. https://github.com/spacedriveapp/spacedrive/issues" && exit 1
-
 		sudo dnf install $FEDORA_TAURI_DEPS $FEDORA_FFMPEG_DEPS $FEDORA_BINDGEN_DEPS $PROTOBUF
 		sudo dnf group install "C Development Tools and Libraries"
 	else

--- a/.github/scripts/setup-system.sh
+++ b/.github/scripts/setup-system.sh
@@ -101,10 +101,10 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 		DEBIAN_BINDGEN_DEPS="pkg-config clang"
 
 		# Protobuf compiler
-		PROTOBUF="protobuf-compiler"
+		DEBIAN_LIBP2P_DEPS="protobuf-compiler"
 
 		sudo apt-get -y update
-		sudo apt-get -y install ${SPACEDRIVE_CUSTOM_APT_FLAGS:-} $DEBIAN_TAURI_DEPS $DEBIAN_FFMPEG_DEPS $DEBIAN_BINDGEN_DEPS $PROTOBUF
+		sudo apt-get -y install ${SPACEDRIVE_CUSTOM_APT_FLAGS:-} $DEBIAN_TAURI_DEPS $DEBIAN_FFMPEG_DEPS $DEBIAN_BINDGEN_DEPS $DEBIAN_LIBP2P_DEPS
 	elif command -v pacman >/dev/null; then
 		echo "Detected pacman!"
 		echo "Installing dependencies with pacman..."
@@ -119,10 +119,10 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 		ARCH_BINDGEN_DEPS="clang"
 
 		# Protobuf compiler - https://github.com/archlinux/svntogit-packages/blob/packages/protobuf/trunk/PKGBUILD provides `libprotoc`
-		PROTOBUF="protobuf"
+		ARCH_LIBP2P_DEPS="protobuf"
 
 		sudo pacman -Syu
-		sudo pacman -S --needed $ARCH_TAURI_DEPS $ARCH_FFMPEG_DEPS $ARCH_BINDGEN_DEPS $PROTOBUF
+		sudo pacman -S --needed $ARCH_TAURI_DEPS $ARCH_FFMPEG_DEPS $ARCH_BINDGEN_DEPS $ARCH_LIBP2P_DEPS
 	elif command -v dnf >/dev/null; then
 		echo "Detected dnf!"
 		echo "Installing dependencies with dnf..."
@@ -143,7 +143,7 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 		FEDORA_BINDGEN_DEPS="clang"
 
 		# Protobuf compiler
-		PROTOBUF="protobuf-compiler"
+		FEDORA_LIBP2P_DEPS="protobuf-compiler"
 
 		sudo dnf check-update
 
@@ -157,7 +157,7 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 			exit 1
 		fi
 
-		sudo dnf install $FEDORA_TAURI_DEPS $FEDORA_BINDGEN_DEPS $PROTOBUF
+		sudo dnf install $FEDORA_TAURI_DEPS $FEDORA_BINDGEN_DEPS $FEDORA_LIBP2P_DEPS
 		sudo dnf group install "C Development Tools and Libraries"
 	else
 		log_err "Your Linux distro '$(lsb_release -s -d)' is not supported by this script. We would welcome a PR or some help adding your OS to this script. https://github.com/spacedriveapp/spacedrive/issues"
@@ -171,9 +171,9 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
 
 	echo "Installing Homebrew dependencies..."
 
-	PROTOBUF="protobuf"
+	BREW_LIBP2P_DEPS="protobuf"
 
-	brew install $PROTOBUF
+	brew install $BREW_LIBP2P_DEPS
 
 	if ! brew list | grep -q "ffmpeg"; then
 		echo "Installing FFmpeg..."

--- a/.github/scripts/setup-system.sh
+++ b/.github/scripts/setup-system.sh
@@ -130,11 +130,19 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 		# `webkit2gtk4.0-devel` also provides `webkit2gtk3-devel`, it's just under a different package in fedora versions >= 37.
 		# https://koji.fedoraproject.org/koji/packageinfo?tagOrder=-blocked&packageID=26162#taglist
 		# https://packages.fedoraproject.org/pkgs/webkitgtk/webkit2gtk4.0-devel/fedora-38.html#provides
-		FEDORA_37_TAURI_WEBKIT="webkit2gtk4.0-devel.x86_64"
-		FEDORA_36_TAURI_WEBKIT="webkit2gtk3-devel.x86_64"
+		FEDORA_37_TAURI_WEBKIT="webkit2gtk4.0-devel"
+		FEDORA_36_TAURI_WEBKIT="webkit2gtk3-devel"
 
 		# Tauri dependencies
+		# openssl is manually declared here as i don't think openssl and openssl-devel are actually dependant on eachother
+		# openssl also has a habit of being missing from some of my fresh Fedora installs - i've had to install it at least twice
+		# TODO(brxken128): check if the lack of the plain `openssl` package breaks building
 		FEDORA_TAURI_DEPS="openssl openssl-devel curl wget libappindicator-gtk3 librsvg2-devel"
+
+		# the perl package/dependencies are required for building the openssl-sys rust crate
+		# TODO(brxken128): test whether or not it's easier to manage the perl deps individually, there's not *too* many,
+		# and it'd be a lot lighter than the entire perl collection
+		FEDORA_OPENSSL_SYS_DEPS="perl"
 
 		# FFmpeg dependencies
 		FEDORA_FFMPEG_DEPS="ffmpeg ffmpeg-devel"
@@ -153,7 +161,7 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 		fi
 
 		if ! sudo dnf install $FEDORA_FFMPEG_DEPS; then
-			log_err "We were unable to install FFmpeg and FFmpeg-development packages. This is likely because the RPMFusion free repository is not enabled. https://docs.fedoraproject.org/en-US/quick-docs/setup_rpmfusion/"
+			log_err "We were unable to install the FFmpeg and FFmpeg-devel packages. This is likely because the RPM Fusion free repository is not enabled. https://docs.fedoraproject.org/en-US/quick-docs/setup_rpmfusion/"
 			exit 1
 		fi
 

--- a/.github/scripts/setup-system.sh
+++ b/.github/scripts/setup-system.sh
@@ -134,7 +134,7 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 		FEDORA_36_TAURI_WEBKIT="webkit2gtk3-devel.x86_64"
 
 		# Tauri dependencies
-		FEDORA_TAURI_DEPS="webkit2gtk3-devel.x86_64 openssl-devel curl wget libappindicator-gtk3 librsvg2-devel"
+		FEDORA_TAURI_DEPS="openssl-devel curl wget libappindicator-gtk3 librsvg2-devel"
 
 		# FFmpeg dependencies
 		FEDORA_FFMPEG_DEPS="ffmpeg ffmpeg-devel"

--- a/.github/scripts/setup-system.sh
+++ b/.github/scripts/setup-system.sh
@@ -2,13 +2,13 @@
 
 set -e
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 
-function log_err {
+function log_err() {
 	echo "$@" >&2
 }
 
-function script_failure {
+function script_failure() {
 	log_err "An error occurred$([ -z "$1" ] && " on line $1" || " (unknown)")."
 	log_err "Setup failed."
 }
@@ -63,8 +63,7 @@ if [ "$1" == "mobile" ]; then
 	fi
 
 	# Android requires python
-	if ! command -v python3 >/dev/null
-	then
+	if ! command -v python3 >/dev/null; then
 		log_err "python3 command could not be found. This is required for Android mobile development."
 		log_err "Ensure python3 is available in your \$PATH and try again."
 		exit 1
@@ -73,15 +72,15 @@ if [ "$1" == "mobile" ]; then
 	# Android targets
 	echo "Setting up Android targets for Rust..."
 
-	rustup target add armv7-linux-androideabi   # for arm
-	rustup target add aarch64-linux-android     # for arm64
-	rustup target add i686-linux-android        # for x86
-	rustup target add x86_64-linux-android      # for x86_64
-	rustup target add x86_64-unknown-linux-gnu  # for linux-x86-64
-	rustup target add aarch64-apple-darwin      # for darwin arm64 (if you have an M1 Mac)
-	rustup target add x86_64-apple-darwin       # for darwin x86_64 (if you have an Intel Mac)
-	rustup target add x86_64-pc-windows-gnu     # for win32-x86-64-gnu
-	rustup target add x86_64-pc-windows-msvc    # for win32-x86-64-msvc
+	rustup target add armv7-linux-androideabi  # for arm
+	rustup target add aarch64-linux-android    # for arm64
+	rustup target add i686-linux-android       # for x86
+	rustup target add x86_64-linux-android     # for x86_64
+	rustup target add x86_64-unknown-linux-gnu # for linux-x86-64
+	rustup target add aarch64-apple-darwin     # for darwin arm64 (if you have an M1 Mac)
+	rustup target add x86_64-apple-darwin      # for darwin x86_64 (if you have an Intel Mac)
+	rustup target add x86_64-pc-windows-gnu    # for win32-x86-64-gnu
+	rustup target add x86_64-pc-windows-msvc   # for win32-x86-64-msvc
 
 	echo "Done setting up mobile targets."
 	echo
@@ -91,11 +90,18 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 	if command -v apt-get >/dev/null; then
 		echo "Detected apt!"
 		echo "Installing dependencies with apt..."
-		
-		DEBIAN_TAURI_DEPS="libwebkit2gtk-4.0-dev build-essential curl wget libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev" # Tauri dependencies
-		DEBIAN_FFMPEG_DEPS="libavcodec-dev libavdevice-dev libavfilter-dev libavformat-dev libavutil-dev libswscale-dev libswresample-dev ffmpeg" # FFmpeg dependencies
-		DEBIAN_BINDGEN_DEPS="pkg-config clang" # Bindgen dependencies - it's used by a dependency of Spacedrive
-		PROTOBUF="protobuf-compiler" # Protobuf compiler
+
+		# Tauri dependencies
+		DEBIAN_TAURI_DEPS="libwebkit2gtk-4.0-dev build-essential curl wget libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev"
+
+		# FFmpeg dependencies
+		DEBIAN_FFMPEG_DEPS="libavcodec-dev libavdevice-dev libavfilter-dev libavformat-dev libavutil-dev libswscale-dev libswresample-dev ffmpeg"
+
+		# Bindgen dependencies - it's used by a dependency of Spacedrive
+		DEBIAN_BINDGEN_DEPS="pkg-config clang"
+
+		# Protobuf compiler
+		PROTOBUF="protobuf-compiler"
 
 		sudo apt-get -y update
 		sudo apt-get -y install ${SPACEDRIVE_CUSTOM_APT_FLAGS:-} $DEBIAN_TAURI_DEPS $DEBIAN_FFMPEG_DEPS $DEBIAN_BINDGEN_DEPS $PROTOBUF
@@ -103,10 +109,17 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 		echo "Detected pacman!"
 		echo "Installing dependencies with pacman..."
 
-		ARCH_TAURI_DEPS="webkit2gtk base-devel curl wget openssl appmenu-gtk-module gtk3 libappindicator-gtk3 librsvg libvips" # Tauri deps https://tauri.studio/guides/getting-started/setup/linux#1-system-dependencies
-		ARCH_FFMPEG_DEPS="ffmpeg" # FFmpeg dependencies
-		ARCH_BINDGEN_DEPS="clang" # Bindgen dependencies - it's used by a dependency of Spacedrive
-		PROTOBUF="protobuf" # Protobuf compiler - https://github.com/archlinux/svntogit-packages/blob/packages/protobuf/trunk/PKGBUILD provides `libprotoc`
+		# Tauri deps https://tauri.studio/guides/getting-started/setup/linux#1-system-dependencies
+		ARCH_TAURI_DEPS="webkit2gtk base-devel curl wget openssl appmenu-gtk-module gtk3 libappindicator-gtk3 librsvg libvips"
+
+		# FFmpeg dependencies
+		ARCH_FFMPEG_DEPS="ffmpeg"
+
+		# Bindgen dependencies - it's used by a dependency of Spacedrive
+		ARCH_BINDGEN_DEPS="clang"
+
+		# Protobuf compiler - https://github.com/archlinux/svntogit-packages/blob/packages/protobuf/trunk/PKGBUILD provides `libprotoc`
+		PROTOBUF="protobuf"
 
 		sudo pacman -Syu
 		sudo pacman -S --needed $ARCH_TAURI_DEPS $ARCH_FFMPEG_DEPS $ARCH_BINDGEN_DEPS $PROTOBUF
@@ -114,10 +127,17 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 		echo "Detected dnf!"
 		echo "Installing dependencies with dnf..."
 
-		FEDORA_TAURI_DEPS="webkit2gtk3-devel.x86_64 openssl-devel curl wget libappindicator-gtk3 librsvg2-devel" # Tauri dependencies
-		FEDORA_FFMPEG_DEPS="ffmpeg ffmpeg-devel" # FFmpeg dependencies
-		FEDORA_BINDGEN_DEPS="clang" # Bindgen dependencies - it's used by a dependency of Spacedrive
-		PROTOBUF="protobuf-compiler" # Protobuf compiler
+		# Tauri dependencies
+		FEDORA_TAURI_DEPS="webkit2gtk3-devel.x86_64 openssl-devel curl wget libappindicator-gtk3 librsvg2-devel"
+
+		# FFmpeg dependencies
+		FEDORA_FFMPEG_DEPS="ffmpeg ffmpeg-devel"
+
+		# Bindgen dependencies - it's used by a dependency of Spacedrive
+		FEDORA_BINDGEN_DEPS="clang"
+
+		# Protobuf compiler
+		PROTOBUF="protobuf-compiler"
 
 		sudo dnf check-update
 		sudo dnf install $FEDORA_TAURI_DEPS $FEDORA_FFMPEG_DEPS $FEDORA_BINDGEN_DEPS $PROTOBUF
@@ -127,31 +147,31 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 		exit 1
 	fi
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-		if ! command -v brew >/dev/null; then
-			log_err "Homebrew was not found. Please install it using the instructions at https://brew.sh and try again."
-			exit 1
-		fi
+	if ! command -v brew >/dev/null; then
+		log_err "Homebrew was not found. Please install it using the instructions at https://brew.sh and try again."
+		exit 1
+	fi
 
-		echo "Installing Homebrew dependencies..."
+	echo "Installing Homebrew dependencies..."
 
-		if ! brew tap -q | grep -qx "spacedriveapp/deps" >/dev/null; then
-			echo "Creating Homebrew tap \`spacedriveapp/deps\`..."
-			brew tap-new spacedriveapp/deps
-		fi
+	if ! brew tap -q | grep -qx "spacedriveapp/deps" >/dev/null; then
+		echo "Creating Homebrew tap \`spacedriveapp/deps\`..."
+		brew tap-new spacedriveapp/deps
+	fi
 
-		FFMPEG_VERSION="5.0.1"
+	FFMPEG_VERSION="5.0.1"
 
-		if ! brew list --full-name -1 | grep -x "spacedriveapp/deps/ffmpeg@$FFMPEG_VERSION" >/dev/null; then
-			echo "Extracting FFmpeg version $FFMPEG_VERSION..."
+	if ! brew list --full-name -1 | grep -x "spacedriveapp/deps/ffmpeg@$FFMPEG_VERSION" >/dev/null; then
+		echo "Extracting FFmpeg version $FFMPEG_VERSION..."
 
-			brew extract -q --force --version $FFMPEG_VERSION ffmpeg spacedriveapp/deps
-			brew unlink -q ffmpeg || true
-			brew install -q "spacedriveapp/deps/ffmpeg@$FFMPEG_VERSION"
+		brew extract -q --force --version $FFMPEG_VERSION ffmpeg spacedriveapp/deps
+		brew unlink -q ffmpeg || true
+		brew install -q "spacedriveapp/deps/ffmpeg@$FFMPEG_VERSION"
 
-			brew install protobuf
+		brew install protobuf
 
-			echo "FFmpeg version $FFMPEG_VERSION has been installed and is now being used on your system."
-		fi
+		echo "FFmpeg version $FFMPEG_VERSION has been installed and is now being used on your system."
+	fi
 else
 	log_err "Your OS ($OSTYPE) is not supported by this script. We would welcome a PR or some help adding your OS to this script. https://github.com/spacedriveapp/spacedrive/issues"
 	exit 1

--- a/.github/scripts/setup-system.sh
+++ b/.github/scripts/setup-system.sh
@@ -114,12 +114,21 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 		echo "Detected dnf!"
 		echo "Installing dependencies with dnf..."
 
-		FEDORA_TAURI_DEPS="webkit2gtk3-devel.x86_64 openssl-devel curl wget libappindicator-gtk3 librsvg2-devel" # Tauri dependencies
+
+		# `webkit2gtk4.0-devel` also provides `webkit2gtk3-devel`, it is just under a different package in fedora versions >= 37.
+		# https://koji.fedoraproject.org/koji/packageinfo?tagOrder=-blocked&packageID=26162#taglist
+		# https://packages.fedoraproject.org/pkgs/webkitgtk/webkit2gtk4.0-devel/fedora-38.html#provides
+		FEDORA_37_TAURI_WEBKIT="webkit2gtk4.0-devel.x86_64"
+		FEDORA_36_TAURI_WEBKIT="webkit2gtk3-devel.x86_64"
+
+		FEDORA_TAURI_DEPS="openssl-devel curl wget libappindicator-gtk3 librsvg2-devel" # Tauri dependencies
 		FEDORA_FFMPEG_DEPS="ffmpeg ffmpeg-devel" # FFmpeg dependencies
 		FEDORA_BINDGEN_DEPS="clang" # Bindgen dependencies - it's used by a dependency of Spacedrive
 		PROTOBUF="protobuf-compiler" # Protobuf compiler
 
 		sudo dnf check-update
+		sudo dnf install $FEDORA_37_TAURI_WEBKIT || sudo dnf install $FEDORA_36_TAURI_WEBKIT || log_err "We were unable to install the `webkit2gtk3-devel" package. Please open an issue if you feel that this is incorrect. https://github.com/spacedriveapp/spacedrive/issues" && exit 1
+
 		sudo dnf install $FEDORA_TAURI_DEPS $FEDORA_FFMPEG_DEPS $FEDORA_BINDGEN_DEPS $PROTOBUF
 		sudo dnf group install "C Development Tools and Libraries"
 	else

--- a/.github/scripts/setup-system.sh
+++ b/.github/scripts/setup-system.sh
@@ -148,7 +148,7 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 		sudo dnf check-update
 
 		if ! sudo dnf install $FEDORA_37_TAURI_WEBKIT && ! sudo dnf install $FEDORA_36_TAURI_WEBKIT; then
-			log_err "We were unable to install the webkit2gtk3-devel package. Please open an issue if you feel that this is incorrect. https://github.com/spacedriveapp/spacedrive/issues"
+			log_err "We were unable to install the webkit2gtk3-devel/webkit2gtk4.0-devel package. Please open an issue if you feel that this is incorrect. https://github.com/spacedriveapp/spacedrive/issues"
 			exit 1
 		fi
 
@@ -166,23 +166,19 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
 
 	echo "Installing Homebrew dependencies..."
 
-	if ! brew tap -q | grep -qx "spacedriveapp/deps" >/dev/null; then
-		echo "Creating Homebrew tap \`spacedriveapp/deps\`..."
-		brew tap-new spacedriveapp/deps
-	fi
+	FFMPEG_VERSION="5.1.0"
+	PROTOBUF="protobuf"
 
-	FFMPEG_VERSION="5.0.1"
+	brew install $PROTOBUF
 
-	if ! brew list --full-name -1 | grep -x "spacedriveapp/deps/ffmpeg@$FFMPEG_VERSION" >/dev/null; then
-		echo "Extracting FFmpeg version $FFMPEG_VERSION..."
+	if ! brew list ffmpeg | grep -q "/ffmpeg/$FFMPEG_VERSION/"; then
+		echo "Installing FFmpeg version $FFMPEG_VERSION..."
 
-		brew extract -q --force --version $FFMPEG_VERSION ffmpeg spacedriveapp/deps
-		brew unlink -q ffmpeg || true
-		brew install -q "spacedriveapp/deps/ffmpeg@$FFMPEG_VERSION"
-
-		brew install protobuf
+		brew install -q "ffmpeg@$FFMPEG_VERSION"
 
 		echo "FFmpeg version $FFMPEG_VERSION has been installed and is now being used on your system."
+	else
+		echo "FFmpeg version $FFMPEG_VERSION is already installed."
 	fi
 else
 	log_err "Your OS ($OSTYPE) is not supported by this script. We would welcome a PR or some help adding your OS to this script. https://github.com/spacedriveapp/spacedrive/issues"

--- a/.github/scripts/setup-system.sh
+++ b/.github/scripts/setup-system.sh
@@ -134,7 +134,7 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 		FEDORA_36_TAURI_WEBKIT="webkit2gtk3-devel.x86_64"
 
 		# Tauri dependencies
-		FEDORA_TAURI_DEPS="openssl-devel curl wget libappindicator-gtk3 librsvg2-devel"
+		FEDORA_TAURI_DEPS="openssl openssl-devel curl wget libappindicator-gtk3 librsvg2-devel"
 
 		# FFmpeg dependencies
 		FEDORA_FFMPEG_DEPS="ffmpeg ffmpeg-devel"
@@ -148,11 +148,16 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 		sudo dnf check-update
 
 		if ! sudo dnf install $FEDORA_37_TAURI_WEBKIT && ! sudo dnf install $FEDORA_36_TAURI_WEBKIT; then
-			log_err "We were unable to install the webkit2gtk3-devel/webkit2gtk4.0-devel package. Please open an issue if you feel that this is incorrect. https://github.com/spacedriveapp/spacedrive/issues"
+			log_err "We were unable to install the webkit2gtk4.0-devel/webkit2gtk3-devel package. Please open an issue if you feel that this is incorrect. https://github.com/spacedriveapp/spacedrive/issues"
 			exit 1
 		fi
 
-		sudo dnf install $FEDORA_TAURI_DEPS $FEDORA_FFMPEG_DEPS $FEDORA_BINDGEN_DEPS $PROTOBUF
+		if ! sudo dnf install $FEDORA_FFMPEG_DEPS; then
+			log_err "We were unable to install FFmpeg and FFmpeg-development packages. This is likely because the RPMFusion free repository is not enabled. https://docs.fedoraproject.org/en-US/quick-docs/setup_rpmfusion/"
+			exit 1
+		fi
+
+		sudo dnf install $FEDORA_TAURI_DEPS $FEDORA_BINDGEN_DEPS $PROTOBUF
 		sudo dnf group install "C Development Tools and Libraries"
 	else
 		log_err "Your Linux distro '$(lsb_release -s -d)' is not supported by this script. We would welcome a PR or some help adding your OS to this script. https://github.com/spacedriveapp/spacedrive/issues"

--- a/crates/ffmpeg/Cargo.toml
+++ b/crates/ffmpeg/Cargo.toml
@@ -12,7 +12,6 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# if this updates, the system setup script needs updating too
 ffmpeg-sys-next = "5.1.1"
 
 thiserror = "1.0.37"

--- a/crates/ffmpeg/Cargo.toml
+++ b/crates/ffmpeg/Cargo.toml
@@ -12,7 +12,9 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+# if this updates, the system setup script needs updating too
 ffmpeg-sys-next = "5.1.1"
+
 thiserror = "1.0.37"
 webp = "0.2.2"
 tokio = { workspace = true, features = ["fs", "rt"] }


### PR DESCRIPTION
This PR fixes a few issues, mostly relevant to Fedora but should also resolve MacOS/brew "keg not found" errors. It removes the need for us to build `ffmpeg` within the script, as it wasn't doing much anyway (we were building ffmpeg `5.0.1`, but our project requires `5.1.0`). MacOS CI time is now shorter by 5-7~ minutes.

This additionally adds the `protoc` compiler to both Fedora and Arch targets.

~~I'm going to test my Fedora changes in a virtual machine, as there's a few parts I'm unsure over (and I think they could be optimized - currently we're pulling in the entire `perl` package set, but building only needs a few of them).~~ - done, changed to a handful of packages instead as that produces a working fully build.

I've also used `shfmt` to format the script.