### PR TITLE
fix docs sidebar search input

### DIFF
--- a/apps/landing/src/components/DocsSidebar.tsx
+++ b/apps/landing/src/components/DocsSidebar.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import { MagnifyingGlass } from 'phosphor-react';
-import { Input } from '@sd/ui';
+import { Input, SearchInput } from '@sd/ui';
 import { DocsNavigation } from '../pages/docs/api';
 import config from '../pages/docs/docs';
 
@@ -16,11 +16,11 @@ export default function DocsSidebar(props: Props) {
 
 	return (
 		<nav className="mr-8 flex w-full flex-col sm:w-52">
-			<div onClick={() => alert('Search coming soon...')} className="relative w-full">
-				<MagnifyingGlass weight="bold" className="absolute top-3 left-3" />
-				<Input className="pointer-events-none mb-5 w-full pl-9" placeholder="Search" />
-				<span className="absolute  right-3 top-[9px] text-sm font-semibold text-gray-400">⌘K</span>
+			<div onClick={() => alert('Search coming soon...')} className="relative mb-5">
+				<SearchInput placeholder="Search..." disabled />
+				<span className="absolute top-2 right-3 text-xs font-semibold text-gray-400">⌘K</span>
 			</div>
+
 			<div className="mb-6 flex flex-col">
 				{props.navigation.map((section) => {
 					const isActive = section.slug === activeSection;


### PR DESCRIPTION
Fixes the docs sidebar search input as the current one is out of place.

<img width="242" alt="image" src="https://user-images.githubusercontent.com/43032218/225574247-950c2143-965e-4da3-b4c6-c89ac095962e.png">

<img width="237" alt="image" src="https://user-images.githubusercontent.com/43032218/225574349-88c75871-2d19-47e1-ae2c-0e9d9af8b8ce.png">
