### PR TITLE
fix careers phosphor icons

### DIFF
--- a/apps/landing/src/pages/careers.page.tsx
+++ b/apps/landing/src/pages/careers.page.tsx
@@ -131,7 +131,7 @@ function Page() {
 								key={value.title + index}
 								className="bg-gray-550/50 flex flex-col rounded-md border border-gray-500 p-10"
 							>
-								<value.icon className="m-0 w-8" />
+								<value.icon className="text-[32px]" weight="bold" />
 								<h3 className="mt-4 mb-1 text-2xl font-bold leading-snug">{value.title}</h3>
 								<p className="text-gray-350 mt-1 mb-0">{value.desc}</p>
 							</div>
@@ -149,7 +149,7 @@ function Page() {
 								style={{ backgroundColor: value.color + '10', borderColor: value.color + '30' }}
 								className="bg-gray-550/30 flex flex-col rounded-md border p-8"
 							>
-								<value.icon className="m-0 w-8" color={value.color} />
+								<value.icon className="text-[32px]" weight="bold" color={value.color} />
 								<h3 className="mt-4 mb-1">{value.title}</h3>
 								<p className="mt-1 mb-0 text-sm text-white opacity-60">{value.desc}</p>
 							</div>


### PR DESCRIPTION
Fixes current icons on the  [careers](https://www.spacedrive.com/careers) page.

<img width="1037" alt="image" src="https://user-images.githubusercontent.com/43032218/225581292-654f4694-251e-4d19-8fa4-2ce22f6cc819.png">

<img width="1156" alt="image" src="https://user-images.githubusercontent.com/43032218/225581411-e75a74f6-7ace-4105-84c5-d6f322fcdf12.png">

