### PR TITLE
[desktop] fix tag & location name overflow

### DIFF
--- a/interface/app/$libraryId/Layout/Sidebar/index.tsx
+++ b/interface/app/$libraryId/Layout/Sidebar/index.tsx
@@ -114,7 +114,7 @@ const LibrarySection = () => {
 								/>
 							</div>
 
-							<span className="shrink-0 grow">{location.name}</span>
+							<span className="truncate">{location.name}</span>
 						</SidebarLink>
 					);
 				})}
@@ -133,10 +133,10 @@ const LibrarySection = () => {
 						{tags.data?.slice(0, 6).map((tag, index) => (
 							<SidebarLink key={index} to={`tag/${tag.id}`} className="">
 								<div
-									className="h-[12px] w-[12px] rounded-full"
+									className="h-[12px] w-[12px] shrink-0 rounded-full"
 									style={{ backgroundColor: tag.color || '#efefef' }}
 								/>
-								<span className="ml-1.5 text-sm">{tag.name}</span>
+								<span className="ml-1.5 truncate text-sm">{tag.name}</span>
 							</SidebarLink>
 						))}
 					</div>


### PR DESCRIPTION
Currently, long location names aren't truncated, and the color tag also isn't visible in the case of tags. 
This PR resolves both issues.

![image](https://user-images.githubusercontent.com/43032218/226125823-80b8ca09-c103-40de-97aa-dd7cd5fab4f1.png)

![image](https://user-images.githubusercontent.com/43032218/226125845-0a7de26d-7647-4ae7-8d5e-5e6be1ea9e5d.png)
