### PR TITLE
[Desktop] Fix initial edit location load

### DIFF
--- a/interface/app/$libraryId/settings/library/locations/$id.tsx
+++ b/interface/app/$libraryId/settings/library/locations/$id.tsx
@@ -1,6 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { Archive, ArrowsClockwise, Info, Trash } from 'phosphor-react';
-import { useFormState } from 'react-hook-form';
 import { useParams } from 'react-router';
 import { useLibraryMutation, useLibraryQuery } from '@sd/client';
 import { Button, Divider, forms, tw } from '@sd/ui';
@@ -69,7 +68,7 @@ export const Component = () => {
 
 	const fullRescan = useLibraryMutation('locations.fullRescan');
 
-	const { isDirty } = useFormState({ control: form.control });
+	const { isDirty } = form.formState;
 
 	return (
 		<Form form={form} onSubmit={onSubmit} className="h-full w-full">


### PR DESCRIPTION
This PR fixes the issue where sometimes the initial load of the edit location form doesn't reset the form as `isDirty = true`

https://user-images.githubusercontent.com/43032218/226167716-31060b0b-9483-41a3-abf2-f6d4d66ceee4.mp4

