### PR TITLE
Fix adding Locations that already have a `.spacedrive` file

### DIFF
--- a/core/src/location/error.rs
+++ b/core/src/location/error.rs
@@ -78,12 +78,13 @@ impl From<LocationError> for rspc::Error {
 				rspc::Error::with_cause(ErrorCode::BadRequest, err.to_string(), err)
 			}
 
+			// Custom error message is used to differenciate these errors in the frontend
+			// TODO: A better solution would be for rspc to support sending custom data alongside errors
 			LocationError::NeedRelink { .. } => {
-				rspc::Error::with_cause(ErrorCode::Conflict, err.to_string(), err)
+				rspc::Error::with_cause(ErrorCode::Conflict, "NEED_RELINK".to_owned(), err)
 			}
-
 			LocationError::AddLibraryToMetadata(_) => {
-				rspc::Error::with_cause(ErrorCode::NotFound, err.to_string(), err)
+				rspc::Error::with_cause(ErrorCode::Conflict, "ADD_LIBRARY".to_owned(), err)
 			}
 
 			_ => rspc::Error::with_cause(ErrorCode::InternalServerError, err.to_string(), err),

--- a/core/src/location/error.rs
+++ b/core/src/location/error.rs
@@ -73,11 +73,17 @@ impl From<LocationError> for rspc::Error {
 			}
 
 			// User's fault errors
-			LocationError::NotDirectory(_)
 			// | LocationError::MissingLocalPath(_)
-			| LocationError::NeedRelink { .. }
-			| LocationError::AddLibraryToMetadata(_) => {
+			LocationError::NotDirectory(_) => {
 				rspc::Error::with_cause(ErrorCode::BadRequest, err.to_string(), err)
+			}
+
+			LocationError::NeedRelink { .. } => {
+				rspc::Error::with_cause(ErrorCode::Conflict, err.to_string(), err)
+			}
+
+			LocationError::AddLibraryToMetadata(_) => {
+				rspc::Error::with_cause(ErrorCode::NotFound, err.to_string(), err)
 			}
 
 			_ => rspc::Error::with_cause(ErrorCode::InternalServerError, err.to_string(), err),

--- a/interface/app/$libraryId/settings/library/locations/AddLocationButton.tsx
+++ b/interface/app/$libraryId/settings/library/locations/AddLocationButton.tsx
@@ -12,7 +12,9 @@ export const AddLocationButton = (props: ButtonProps) => {
 				{...props}
 				onClick={() =>
 					openDirectoryPickerDialog(platform)
-						.then((path) => dialogManager.create((dp) => <AddLocationDialog path={path} {...dp} />))
+						.then((path) => {
+							if (path) dialogManager.create((dp) => <AddLocationDialog path={path} {...dp} />);
+						})
 						.catch((error) =>
 							showAlertDialog({
 								title: 'Error',

--- a/interface/app/$libraryId/settings/library/locations/AddLocationButton.tsx
+++ b/interface/app/$libraryId/settings/library/locations/AddLocationButton.tsx
@@ -13,14 +13,10 @@ export const AddLocationButton = (props: ButtonProps) => {
 				onClick={() =>
 					openDirectoryPickerDialog(platform)
 						.then((path) => {
-							if (path) dialogManager.create((dp) => <AddLocationDialog path={path} {...dp} />);
+							if (path !== '')
+								dialogManager.create((dp) => <AddLocationDialog path={path ?? ''} {...dp} />);
 						})
-						.catch((error) =>
-							showAlertDialog({
-								title: 'Error',
-								value: String(error)
-							})
-						)
+						.catch((error) => showAlertDialog({ title: 'Error', value: String(error) }))
 				}
 			>
 				Add Location

--- a/interface/app/$libraryId/settings/library/locations/AddLocationButton.tsx
+++ b/interface/app/$libraryId/settings/library/locations/AddLocationButton.tsx
@@ -1,7 +1,7 @@
 import { Button, ButtonProps, dialogManager } from '@sd/ui';
 import { showAlertDialog } from '~/components/AlertDialog';
 import { usePlatform } from '~/util/Platform';
-import { AddLocationDialog } from './AddLocationDialog';
+import { AddLocationDialog, openDirectoryPickerDialog } from './AddLocationDialog';
 
 export const AddLocationButton = (props: ButtonProps) => {
 	const platform = usePlatform();
@@ -10,24 +10,16 @@ export const AddLocationButton = (props: ButtonProps) => {
 		<>
 			<Button
 				{...props}
-				onClick={async () => {
-					let path = '';
-					if (platform.openDirectoryPickerDialog) {
-						const _path = await platform.openDirectoryPickerDialog();
-						if (!_path) return;
-						if (typeof _path !== 'string') {
-							// TODO: Should support for adding multiple locations simultaneously be added?
+				onClick={() =>
+					openDirectoryPickerDialog(platform)
+						.then((path) => dialogManager.create((dp) => <AddLocationDialog path={path} {...dp} />))
+						.catch((error) =>
 							showAlertDialog({
 								title: 'Error',
-								value: "Can't add multiple locations"
-							});
-							return;
-						}
-						path = _path;
-					}
-
-					await dialogManager.create((dp) => <AddLocationDialog path={path} {...dp} />);
-				}}
+								value: String(error)
+							})
+						)
+				}
 			>
 				Add Location
 			</Button>

--- a/interface/app/$libraryId/settings/library/locations/AddLocationDialog.tsx
+++ b/interface/app/$libraryId/settings/library/locations/AddLocationDialog.tsx
@@ -1,5 +1,6 @@
+import { ErrorMessage } from '@hookform/error-message';
 import { RSPCError } from '@rspc/client';
-import { ChangeEvent, useEffect, useRef, useState } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 import { Controller, UseFormReturn } from 'react-hook-form';
 import { useLibraryMutation, useLibraryQuery } from '@sd/client';
 import { CheckBox, Dialog, UseDialogProps, useDialog } from '@sd/ui';
@@ -15,19 +16,26 @@ interface Props extends UseDialogProps {
 	path: string;
 }
 
-const LOCATION_ERROR_MESSAGES: Record<number, string | undefined> = {
+const REMOTE_ERROR_FORM_FIELD = 'root.serverError';
+const REMOTE_ERROR_FORM_MESSAGES = {
 	// \u000A is a line break, It works with css white-space: pre-line
-	404: 'Location is already linked to another Library.\u000ADo you want to add it to this Library too?',
-	409: 'Location already present.\u000ADo you want to relink it?'
+	ADD_LIBRARY:
+		'Location is already linked to another Library.\u000ADo you want to add it to this Library too?',
+	NEED_RELINK: 'Location already present.\u000ADo you want to relink it?'
 };
 
-export const openDirectoryPickerDialog = async (platform: Platform): Promise<string> => {
-	if (!platform.openDirectoryPickerDialog) return '';
+type RemoteErrorFormMessage = keyof typeof REMOTE_ERROR_FORM_MESSAGES;
+
+const isRemoteErrorFormMessage = (message: unknown): message is RemoteErrorFormMessage =>
+	typeof message === 'string' && Object.hasOwnProperty.call(REMOTE_ERROR_FORM_MESSAGES, message);
+
+export const openDirectoryPickerDialog = async (platform: Platform): Promise<null | string> => {
+	if (!platform.openDirectoryPickerDialog) return null;
 
 	const path = await platform.openDirectoryPickerDialog();
 	if (!path) return '';
 	if (typeof path !== 'string')
-		// TODO: Should support for adding multiple locations simultaneously be added?
+		// TODO: Should adding multiple locations simultaneously be implemented?
 		throw new Error('Adding multiple locations simultaneously is not supported');
 
 	return path;
@@ -36,11 +44,11 @@ export const openDirectoryPickerDialog = async (platform: Platform): Promise<str
 export const AddLocationDialog = (props: Props) => {
 	const dialog = useDialog(props);
 	const platform = usePlatform();
-	const [exceptionCode, setExceptionCode] = useState<0 | 404 | 409>(0);
 	const createLocation = useLibraryMutation('locations.create');
 	const relinkLocation = useLibraryMutation('locations.relink');
 	const indexerRulesList = useLibraryQuery(['locations.indexer_rules.list']);
 	const addLocationToLibrary = useLibraryMutation('locations.addLibrary');
+	const [remoteError, setRemoteError] = useState<null | RemoteErrorFormMessage>(null);
 
 	const form = useZodForm({
 		schema,
@@ -50,82 +58,78 @@ export const AddLocationDialog = (props: Props) => {
 		}
 	});
 
-	useEffect(() => {
-		const subscription = form.watch((_, { name }) => {
-			// Clear custom location error when user changes location path
-			if (name === 'path') {
-				form.clearErrors('root.serverError');
-				setExceptionCode(0);
-			}
-		});
-		return () => subscription.unsubscribe();
-	}, [form, form.watch]);
+	// Block to prevent single-use constants poluting parent scope
+	{
+		// Destructuring so eslint stop complaining about useEffect missing `form` dependency
+		const { watch, clearErrors } = form;
+		useEffect(() => {
+			// Clear custom remote error when user performs any change on the form
+			const subscription = watch(() => {
+				clearErrors(REMOTE_ERROR_FORM_FIELD);
+				setRemoteError(null);
+			});
+			return () => subscription.unsubscribe();
+		}, [watch, clearErrors]);
+	}
 
-	const addLocation = async ({ path, indexer_rules_ids }: FormFieldValues<typeof form>) => {
-		try {
-			await createLocation.mutateAsync({ path, indexer_rules_ids });
-		} catch (err) {
-			const error = err instanceof Error ? err : new Error(String(err));
+	const onLocationSubmit = async ({ path, indexer_rules_ids }: FormFieldValues<typeof form>) => {
+		switch (remoteError) {
+			case null:
+				await createLocation.mutateAsync({ path, indexer_rules_ids });
+				break;
+			case 'NEED_RELINK':
+				await relinkLocation.mutateAsync(path);
+				// TODO: Update relinked location with new indexer rules, don't have a way to get location id yet though
+				// await updateLocation.mutateAsync({
+				// 	id: locationId,
+				// 	name: null,
+				// 	hidden: null,
+				// 	indexer_rules_ids,
+				// 	sync_preview_media: null,
+				// 	generate_preview_media: null
+				// });
+				break;
+			case 'ADD_LIBRARY':
+				await addLocationToLibrary.mutateAsync({ path, indexer_rules_ids });
+				break;
+			default:
+				throw new Error('Unimplemented custom remote error handling');
+		}
+	};
 
-			if ('cause' in error && error.cause instanceof RSPCError) {
-				const { code } = error.cause.shape;
-				if (code !== 0) {
+	const onLocationSubmitError = async (error: Error) => {
+		if ('cause' in error && error.cause instanceof RSPCError) {
+			// TODO: error.code property is not yet implemented in RSPCError
+			// https://github.com/oscartbeaumont/rspc/blob/60a4fa93187c20bc5cb565cc6ee30b2f0903840e/packages/client/src/interop/error.ts#L59
+			// So we grab it from the shape for now
+			const { code } = error.cause.shape;
+			if (code !== 500) {
+				let { message } = error;
+
+				if (code == 409 && isRemoteErrorFormMessage(message)) {
+					setRemoteError(message);
+					message = REMOTE_ERROR_FORM_MESSAGES[message];
+
 					/**
-					 * TODO: On code 409 (NeedRelink), we should query the backend for
+					 * TODO: On NEED_RELINK, we should query the backend for
 					 * the current location indexer_rules_ids, then update the checkboxes
 					 * accordingly. However we don't have the location id at this point.
 					 * Maybe backend could return the location id in the error?
 					 */
-
-					setExceptionCode(code);
-					form.reset({}, { keepValues: true });
-					form.setError('root.serverError', {
-						type: 'custom',
-						message: LOCATION_ERROR_MESSAGES[code] ?? 'Unknown error'
-					});
-
-					// Throw error to prevent dialog from closing
-					throw error;
 				}
+
+				form.reset({}, { keepValues: true, keepErrors: true, keepIsValid: true });
+				form.setError(REMOTE_ERROR_FORM_FIELD, { type: 'remote', message: message });
+
+				// Throw error to prevent dialog from closing
+				throw error;
 			}
-
-			showAlertDialog({
-				title: 'Error',
-				value: error.message ?? 'Failed to add location'
-			});
 		}
-	};
 
-	const confirmAfterError = async ({ path, indexer_rules_ids }: FormFieldValues<typeof form>) => {
-		try {
-			switch (exceptionCode) {
-				case 409: {
-					await relinkLocation.mutateAsync(path);
-					// TODO: Update relinked location with new indexer rules
-					// await updateLocation.mutateAsync({
-					// 	id: locationId,
-					// 	name: null,
-					// 	hidden: null,
-					// 	indexer_rules_ids,
-					// 	sync_preview_media: null,
-					// 	generate_preview_media: null
-					// });
-					break;
-				}
-				case 404: {
-					await addLocationToLibrary.mutateAsync({ path, indexer_rules_ids });
-					break;
-				}
-			}
-		} catch (err) {
-			const error = err instanceof Error ? err : new Error(String(err));
-			showAlertDialog({
-				title: 'Error',
-				value: error.message ?? 'Failed to add location'
-			});
-		} finally {
-			setExceptionCode(0);
-		}
+		showAlertDialog({
+			title: 'Error',
+			value: error.message || 'Failed to add location'
+		});
 	};
 
 	return (
@@ -134,27 +138,22 @@ export const AddLocationDialog = (props: Props) => {
 			title="New Location"
 			description={
 				platform.platform === 'web'
-					? '"As you are using the browser version of Spacedrive you will (for now) need to specify an absolute URL of a directory local to the remote node."'
+					? 'As you are using the browser version of Spacedrive you will (for now) need to specify an absolute URL of a directory local to the remote node.'
 					: ''
 			}
-			onSubmit={form.handleSubmit((values) =>
-				exceptionCode === 0 ? addLocation(values) : confirmAfterError(values)
+			onSubmit={form.handleSubmit((fields) =>
+				onLocationSubmit(fields).catch(onLocationSubmitError)
 			)}
 			ctaLabel="Add"
 		>
-			<div className="relative flex flex-col">
+			<div className="relative mb-3 flex flex-col">
 				<p className="my-2 text-sm font-bold">Path:</p>
 				<Input
 					type="text"
 					onClick={() =>
 						openDirectoryPickerDialog(platform)
-							.then((path) => void (path && form.setValue('path', path)))
-							.catch((error) =>
-								showAlertDialog({
-									title: 'Error',
-									value: String(error)
-								})
-							)
+							.then((path) => path && form.setValue('path', path))
+							.catch((error) => showAlertDialog({ title: 'Error', value: String(error) }))
 					}
 					readOnly={platform.platform !== 'web'}
 					required
@@ -163,7 +162,7 @@ export const AddLocationDialog = (props: Props) => {
 				/>
 			</div>
 
-			<div className="relative mt-3 mb-1 flex flex-col">
+			<div className="relative mb-3 flex flex-col">
 				<p className="my-2 text-sm font-bold">File indexing rules:</p>
 				<div className="mb-3 grid w-full grid-cols-2 gap-4">
 					<Controller
@@ -198,11 +197,14 @@ export const AddLocationDialog = (props: Props) => {
 				</div>
 			</div>
 
-			{form.formState.errors.root?.serverError && (
-				<span className="mt-6 inline-block w-full whitespace-pre-wrap text-center text-sm font-semibold text-red-500">
-					{form.formState.errors.root.serverError.message}
-				</span>
-			)}
+			<ErrorMessage
+				name={REMOTE_ERROR_FORM_FIELD}
+				render={({ message }) => (
+					<span className="inline-block w-full whitespace-pre-wrap text-center text-sm font-semibold text-red-500">
+						{message}
+					</span>
+				)}
+			/>
 		</Dialog>
 	);
 };

--- a/interface/app/$libraryId/settings/library/locations/AddLocationDialog.tsx
+++ b/interface/app/$libraryId/settings/library/locations/AddLocationDialog.tsx
@@ -123,6 +123,8 @@ export const AddLocationDialog = (props: Props) => {
 				title: 'Error',
 				value: error.message ?? 'Failed to add location'
 			});
+		} finally {
+			setExceptionCode(0);
 		}
 	};
 
@@ -141,7 +143,7 @@ export const AddLocationDialog = (props: Props) => {
 			ctaLabel="Add"
 		>
 			<div className="relative flex flex-col">
-				<p className="mt-2 text-[0.9rem]">Path:</p>
+				<p className="my-2 text-sm font-bold">Path:</p>
 				<Input
 					type="text"
 					onClick={() =>
@@ -156,14 +158,14 @@ export const AddLocationDialog = (props: Props) => {
 					}
 					readOnly={platform.platform !== 'web'}
 					required
-					className="mt-3 w-full grow cursor-pointer"
+					className="grow cursor-pointer !py-0.5"
 					{...form.register('path')}
 				/>
 			</div>
 
-			<div className="relative flex flex-col">
-				<p className="mt-6 text-[0.9rem]">File indexing rules:</p>
-				<div className="mt-4 mb-3 grid w-full grid-cols-2 gap-4">
+			<div className="relative mt-3 mb-1 flex flex-col">
+				<p className="my-2 text-sm font-bold">File indexing rules:</p>
+				<div className="mb-3 grid w-full grid-cols-2 gap-4">
 					<Controller
 						name="indexer_rules_ids"
 						control={form.control}
@@ -185,8 +187,9 @@ export const AddLocationDialog = (props: Props) => {
 													);
 												}
 											}}
+											className="bg-app-selected"
 										/>
-										<span className="mr-3 ml-0.5 mt-0.5 text-sm font-bold">{rule.name}</span>
+										<span className="mt-1 text-xs font-medium">{rule.name}</span>
 									</div>
 								))}
 							</>
@@ -196,7 +199,7 @@ export const AddLocationDialog = (props: Props) => {
 			</div>
 
 			{form.formState.errors.root?.serverError && (
-				<span className="mt-6 inline-block w-full whitespace-pre-wrap text-center text-[0.9rem] text-red-400">
+				<span className="mt-6 inline-block w-full whitespace-pre-wrap text-center text-sm font-semibold text-red-500">
 					{form.formState.errors.root.serverError.message}
 				</span>
 			)}

--- a/interface/app/$libraryId/settings/library/locations/AddLocationDialog.tsx
+++ b/interface/app/$libraryId/settings/library/locations/AddLocationDialog.tsx
@@ -1,5 +1,6 @@
 import { ErrorMessage } from '@hookform/error-message';
 import { RSPCError } from '@rspc/client';
+import { useQueryClient } from '@tanstack/react-query';
 import { ChangeEvent, useEffect, useState } from 'react';
 import { Controller, UseFormReturn } from 'react-hook-form';
 import { useLibraryMutation, useLibraryQuery } from '@sd/client';
@@ -44,6 +45,7 @@ export const openDirectoryPickerDialog = async (platform: Platform): Promise<nul
 export const AddLocationDialog = (props: Props) => {
 	const dialog = useDialog(props);
 	const platform = usePlatform();
+	const queryClient = useQueryClient();
 	const createLocation = useLibraryMutation('locations.create');
 	const relinkLocation = useLibraryMutation('locations.relink');
 	const indexerRulesList = useLibraryQuery(['locations.indexer_rules.list']);
@@ -142,7 +144,10 @@ export const AddLocationDialog = (props: Props) => {
 					: ''
 			}
 			onSubmit={form.handleSubmit((fields) =>
-				onLocationSubmit(fields).catch(onLocationSubmitError)
+				onLocationSubmit(fields).then(
+					() => queryClient.invalidateQueries(['library.list']),
+					onLocationSubmitError
+				)
 			)}
 			ctaLabel="Add"
 		>

--- a/interface/package.json
+++ b/interface/package.json
@@ -18,8 +18,8 @@
 	"dependencies": {
 		"@fontsource/inter": "^4.5.13",
 		"@headlessui/react": "^1.7.3",
+		"@hookform/error-message": "^2.0.1",
 		"@hookform/resolvers": "^2.9.10",
-		"crypto-random-string": "^5.0.0",
 		"@radix-ui/react-progress": "^1.0.1",
 		"@radix-ui/react-slider": "^1.1.0",
 		"@radix-ui/react-toast": "^1.1.2",
@@ -40,6 +40,7 @@
 		"byte-size": "^8.1.0",
 		"class-variance-authority": "^0.4.0",
 		"clsx": "^1.2.1",
+		"crypto-random-string": "^5.0.0",
 		"dayjs": "^1.11.5",
 		"phosphor-react": "^1.4.1",
 		"react": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -376,6 +376,7 @@ importers:
     specifiers:
       '@fontsource/inter': ^4.5.13
       '@headlessui/react': ^1.7.3
+      '@hookform/error-message': ^2.0.1
       '@hookform/resolvers': ^2.9.10
       '@radix-ui/react-progress': ^1.0.1
       '@radix-ui/react-slider': ^1.1.0
@@ -432,6 +433,7 @@ importers:
     dependencies:
       '@fontsource/inter': 4.5.15
       '@headlessui/react': 1.7.7_biqbaboplfbrettd7655fr4n2y
+      '@hookform/error-message': 2.0.1_onwixewhqm6cnvx5lymjpv2ekm
       '@hookform/resolvers': 2.9.11_react-hook-form@7.43.5
       '@radix-ui/react-progress': 1.0.1_biqbaboplfbrettd7655fr4n2y
       '@radix-ui/react-slider': 1.1.0_biqbaboplfbrettd7655fr4n2y
@@ -4512,6 +4514,18 @@ packages:
       tailwindcss: ^3.0
     dependencies:
       tailwindcss: 3.2.4_postcss@8.4.21
+    dev: false
+
+  /@hookform/error-message/2.0.1_onwixewhqm6cnvx5lymjpv2ekm:
+    resolution: {integrity: sha512-U410sAr92xgxT1idlu9WWOVjndxLdgPUHEB8Schr27C9eh7/xUnITWpCMF93s+lGiG++D4JnbSnrb5A21AdSNg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      react-hook-form: ^7.0.0
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      react-hook-form: 7.43.5_react@18.2.0
     dev: false
 
   /@hookform/resolvers/2.9.11_react-hook-form@7.43.5:


### PR DESCRIPTION
Hello,

This PR addresses the issue of adding locations that already have a `.spacedrive` file, either because they belong to other Libraries or because their linked directory has been moved.

I implemented logic to handle both the `NeedRelink` and `AddLibraryToMetadata` errors raised by the backend when adding a new Location. When either of these errors occurs, a form error message is displayed to the user in `AddLocationDialog`, informing them that the location they are trying to add is either from another Library or needs to be relinked:
![image](https://user-images.githubusercontent.com/9082460/226285156-44dd9b51-da77-4ded-a857-5bccc7cc3bf4.png)
![image](https://user-images.githubusercontent.com/9082460/226284930-c49f682b-41dd-439c-96e9-5d6cf1ecae62.png)

I decided to use the form's built-in error UI because the user's flow is similar to encountering a validation error when entering incorrect data, so I thought it would be more natural than a confirmation dialog.

If the user continues with adding the Location, the appropriate method is called on the backend: either `locations.relink` or `locations.addLibrary`. The `addLibrary` logic is working correctly, as far as I tested. However, the `relink` method has some caveats. Because I couldn't find a way to get the ID of the Location that will be relinked, it was not possible to update its indexer rules after relinking. Therefore, any rule changes made by the user in the form will be ignored during a relink. Additionally, I encountered some edge cases while testing this functionality with some unusual scenarios (such as restoring a `.spacedrive` file of a removed Location or moving a Location directory with the desktop app closed). The first resulted in an error, and the second caused the desktop app to stop opening until I restored the directory to its original location. As I'm unsure what the expected behavior is for these situations, I will open separate issues for them.

In addition to these changes, I also made the following improvements:
- Fixed a bug in `AddLocationDialog` that caused the indexer rules checkboxes not to track external changes made to the form state.
- Made minor changes to the errors raised by the backend when executing `locations.create`, giving them unique codes that the frontend can use to differentiate them.
- Abstracted the duplicated `openDirectoryPickerDialog` logic in `AddLocationButton` and `AddLocationDialog` into a function.
- Adjust `AddLocationDialog` style to match other Dialogs in the app

Closes #625.
