### PR TITLE
rspc v3 syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2329,9 +2329,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2339,9 +2339,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
 
 [[package]]
 name = "futures-executor"
@@ -2377,6 +2377,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-locks"
+version = "0.7.1"
+source = "git+https://github.com/oscartbeaumont/futures-locks?rev=a2e880337e6bfb3140a261932667149607e3ada9#a2e880337e6bfb3140a261932667149607e3ada9"
+dependencies = [
+ "futures-channel",
+ "tokio",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2400,9 +2409,9 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
 
 [[package]]
 name = "futures-task"
@@ -2992,7 +3001,24 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 [[package]]
 name = "httpz"
 version = "0.0.3"
-source = "git+https://github.com/oscartbeaumont/httpz.git?rev=a5020adecb15b55d84a8330b4680eba82fa6b820#a5020adecb15b55d84a8330b4680eba82fa6b820"
+source = "git+https://github.com/oscartbeaumont/httpz?rev=a5185f2ed2fdefeb2f582dce38a692a1bf76d1d6#a5185f2ed2fdefeb2f582dce38a692a1bf76d1d6"
+dependencies = [
+ "axum",
+ "form_urlencoded",
+ "futures",
+ "http",
+ "hyper",
+ "percent-encoding",
+ "tauri",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "httpz"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6769d2cb10425c442c41a787d1a3719744770a188cfa7885cd4d8126fa13f37a"
 dependencies = [
  "async-tungstenite",
  "axum",
@@ -3003,22 +3029,6 @@ dependencies = [
  "http",
  "hyper",
  "sha1",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "httpz"
-version = "0.0.3"
-source = "git+https://github.com/oscartbeaumont/httpz?rev=a5185f2ed2fdefeb2f582dce38a692a1bf76d1d6#a5185f2ed2fdefeb2f582dce38a692a1bf76d1d6"
-dependencies = [
- "axum",
- "form_urlencoded",
- "futures",
- "http",
- "hyper",
- "percent-encoding",
- "tauri",
  "thiserror",
  "tokio",
 ]
@@ -4019,6 +4029,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf0c9b980bf4f3a37fd7b1c066941dd1b1d0152ce6ee6e8fe8c49b9f6810d862"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58093314a45e00c77d5c508f76e77c3396afbbc0d01506e7fae47b018bac2b1d"
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4607,6 +4633,27 @@ dependencies = [
  "dbus",
  "mac-notification-sys",
  "tauri-winrt-notification",
+]
+
+[[package]]
+name = "nougat"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97b57b9ced431322f054fc673f1d3c7fa52d80efd9df74ad2fc759f044742510"
+dependencies = [
+ "macro_rules_attribute",
+ "nougat-proc_macros",
+]
+
+[[package]]
+name = "nougat-proc_macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c84f77a45e99a2f9b492695d99e1c23844619caa5f3e57647cffacad773ca257"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -6320,12 +6367,13 @@ dependencies = [
 
 [[package]]
 name = "rspc"
-version = "0.1.2"
-source = "git+https://github.com/oscartbeaumont/rspc?rev=c03872c0ba29d2429e9c059dfb235cdd03e15e8c#c03872c0ba29d2429e9c059dfb235cdd03e15e8c"
+version = "0.1.3"
 dependencies = [
- "async-stream",
  "futures",
- "httpz 0.0.3 (git+https://github.com/oscartbeaumont/httpz.git?rev=a5020adecb15b55d84a8330b4680eba82fa6b820)",
+ "futures-channel",
+ "futures-locks",
+ "httpz 0.0.4",
+ "nougat",
  "serde",
  "serde_json",
  "specta",
@@ -6611,7 +6659,7 @@ dependencies = [
  "globset",
  "hostname",
  "http-range",
- "httpz 0.0.3 (git+https://github.com/oscartbeaumont/httpz?rev=a5185f2ed2fdefeb2f582dce38a692a1bf76d1d6)",
+ "httpz 0.0.3",
  "image",
  "include_dir",
  "int-enum",
@@ -6951,9 +6999,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "indexmap",
  "itoa 1.0.4",
@@ -7072,7 +7120,7 @@ dependencies = [
  "axum",
  "ctrlc",
  "http",
- "httpz 0.0.3 (git+https://github.com/oscartbeaumont/httpz?rev=a5185f2ed2fdefeb2f582dce38a692a1bf76d1d6)",
+ "httpz 0.0.3",
  "hyper",
  "rspc",
  "sd-core",
@@ -7285,7 +7333,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "http",
- "httpz 0.0.3 (git+https://github.com/oscartbeaumont/httpz?rev=a5185f2ed2fdefeb2f582dce38a692a1bf76d1d6)",
+ "httpz 0.0.3",
  "percent-encoding",
  "rand 0.8.5",
  "rspc",
@@ -7303,8 +7351,8 @@ dependencies = [
 
 [[package]]
 name = "specta"
-version = "0.0.6"
-source = "git+https://github.com/oscartbeaumont/rspc?rev=c03872c0ba29d2429e9c059dfb235cdd03e15e8c#c03872c0ba29d2429e9c059dfb235cdd03e15e8c"
+version = "1.0.0"
+source = "git+https://github.com/oscartbeaumont/specta?rev=6b4c282ff654374b7f12832ee4433db731cdff1c#6b4c282ff654374b7f12832ee4433db731cdff1c"
 dependencies = [
  "chrono",
  "document-features",
@@ -7316,14 +7364,15 @@ dependencies = [
  "serde_json",
  "specta-macros",
  "thiserror",
+ "tokio",
  "uhlc",
  "uuid 1.2.1",
 ]
 
 [[package]]
 name = "specta-macros"
-version = "0.0.6"
-source = "git+https://github.com/oscartbeaumont/rspc?rev=c03872c0ba29d2429e9c059dfb235cdd03e15e8c#c03872c0ba29d2429e9c059dfb235cdd03e15e8c"
+version = "1.0.0"
+source = "git+https://github.com/oscartbeaumont/specta?rev=6b4c282ff654374b7f12832ee4433db731cdff1c#6b4c282ff654374b7f12832ee4433db731cdff1c"
 dependencies = [
  "Inflector",
  "itertools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,7 +725,7 @@ dependencies = [
 [[package]]
 name = "builtin-psl-connectors"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "connection-string",
  "either",
@@ -1674,7 +1674,7 @@ dependencies = [
 [[package]]
 name = "datamodel-renderer"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "base64 0.13.1",
  "once_cell",
@@ -1802,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "diagnostics"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "colored",
  "indoc",
@@ -1890,7 +1890,7 @@ dependencies = [
 [[package]]
 name = "dml"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "chrono",
  "cuid",
@@ -1908,7 +1908,7 @@ dependencies = [
 [[package]]
 name = "dmmf"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "bigdecimal",
  "indexmap",
@@ -3000,25 +3000,8 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "httpz"
-version = "0.0.3"
-source = "git+https://github.com/oscartbeaumont/httpz?rev=a5185f2ed2fdefeb2f582dce38a692a1bf76d1d6#a5185f2ed2fdefeb2f582dce38a692a1bf76d1d6"
-dependencies = [
- "axum",
- "form_urlencoded",
- "futures",
- "http",
- "hyper",
- "percent-encoding",
- "tauri",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "httpz"
 version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6769d2cb10425c442c41a787d1a3719744770a188cfa7885cd4d8126fa13f37a"
+source = "git+https://github.com/oscartbeaumont/httpz?rev=be67ead9320095bdecf90cae75fded2411509b0f#be67ead9320095bdecf90cae75fded2411509b0f"
 dependencies = [
  "async-tungstenite",
  "axum",
@@ -3028,7 +3011,9 @@ dependencies = [
  "futures",
  "http",
  "hyper",
+ "percent-encoding",
  "sha1",
+ "tauri",
  "thiserror",
  "tokio",
 ]
@@ -3319,7 +3304,7 @@ dependencies = [
 [[package]]
 name = "introspection-connector"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3490,7 +3475,7 @@ dependencies = [
 [[package]]
 name = "json-rpc-api-build"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "backtrace",
  "heck 0.3.3",
@@ -4220,7 +4205,7 @@ dependencies = [
 [[package]]
 name = "migration-connector"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "chrono",
  "enumflags2 0.7.5",
@@ -4235,7 +4220,7 @@ dependencies = [
 [[package]]
 name = "migration-core"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5115,7 +5100,7 @@ dependencies = [
 [[package]]
 name = "parser-database"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "diagnostics",
  "either",
@@ -5511,8 +5496,8 @@ dependencies = [
 
 [[package]]
 name = "prisma-client-rust"
-version = "0.6.4"
-source = "git+https://github.com/Brendonovich/prisma-client-rust?rev=c965b89f1a07a6931d90f4b5556421f7ffcda03b#c965b89f1a07a6931d90f4b5556421f7ffcda03b"
+version = "0.6.6"
+source = "git+https://github.com/Brendonovich/prisma-client-rust?tag=0.6.6#76693baa675bcb38213901984b306d92c4e8a168"
 dependencies = [
  "base64 0.13.1",
  "bigdecimal",
@@ -5526,6 +5511,7 @@ dependencies = [
  "indexmap",
  "migration-core",
  "paste",
+ "prisma-client-rust-macros",
  "prisma-models",
  "psl",
  "query-connector",
@@ -5545,8 +5531,8 @@ dependencies = [
 
 [[package]]
 name = "prisma-client-rust-cli"
-version = "0.6.4"
-source = "git+https://github.com/Brendonovich/prisma-client-rust?rev=c965b89f1a07a6931d90f4b5556421f7ffcda03b#c965b89f1a07a6931d90f4b5556421f7ffcda03b"
+version = "0.6.6"
+source = "git+https://github.com/Brendonovich/prisma-client-rust?tag=0.6.6#76693baa675bcb38213901984b306d92c4e8a168"
 dependencies = [
  "directories",
  "flate2",
@@ -5564,9 +5550,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prisma-client-rust-macros"
+version = "0.6.6"
+source = "git+https://github.com/Brendonovich/prisma-client-rust?tag=0.6.6#76693baa675bcb38213901984b306d92c4e8a168"
+dependencies = [
+ "convert_case 0.6.0",
+]
+
+[[package]]
 name = "prisma-client-rust-sdk"
-version = "0.6.4"
-source = "git+https://github.com/Brendonovich/prisma-client-rust?rev=c965b89f1a07a6931d90f4b5556421f7ffcda03b#c965b89f1a07a6931d90f4b5556421f7ffcda03b"
+version = "0.6.6"
+source = "git+https://github.com/Brendonovich/prisma-client-rust?tag=0.6.6#76693baa675bcb38213901984b306d92c4e8a168"
 dependencies = [
  "convert_case 0.5.0",
  "dml",
@@ -5587,7 +5581,7 @@ dependencies = [
 [[package]]
 name = "prisma-models"
 version = "0.0.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -5603,7 +5597,7 @@ dependencies = [
 [[package]]
 name = "prisma-value"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "base64 0.12.3",
  "bigdecimal",
@@ -5767,7 +5761,7 @@ dependencies = [
 [[package]]
 name = "psl"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "builtin-psl-connectors",
  "dml",
@@ -5777,7 +5771,7 @@ dependencies = [
 [[package]]
 name = "psl-core"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -5810,7 +5804,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint?rev=6df49f14efe99696e577ffb9902c83b09bec8de2#6df49f14efe99696e577ffb9902c83b09bec8de2"
+source = "git+https://github.com/Brendonovich/quaint?tag=0.6.5#2bf0c3620f76d83982c17e567b71da6fc9d65d14"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -5854,7 +5848,7 @@ dependencies = [
 [[package]]
 name = "query-connector"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5874,7 +5868,7 @@ dependencies = [
 [[package]]
 name = "query-core"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -5918,7 +5912,7 @@ dependencies = [
 [[package]]
 name = "query-engine-metrics"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "metrics 0.18.1",
  "metrics-exporter-prometheus",
@@ -6227,7 +6221,7 @@ dependencies = [
 [[package]]
 name = "request-handlers"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "bigdecimal",
  "connection-string",
@@ -6368,11 +6362,12 @@ dependencies = [
 [[package]]
 name = "rspc"
 version = "0.1.3"
+source = "git+https://github.com/oscartbeaumont/rspc?branch=0.1.3#4964eab6695be6d9975af0b55302078dc04d66eb"
 dependencies = [
  "futures",
  "futures-channel",
  "futures-locks",
- "httpz 0.0.4",
+ "httpz",
  "nougat",
  "serde",
  "serde_json",
@@ -6568,7 +6563,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "once_cell",
  "prisma-models",
@@ -6578,7 +6573,7 @@ dependencies = [
 [[package]]
 name = "schema-ast"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "diagnostics",
  "pest",
@@ -6588,7 +6583,7 @@ dependencies = [
 [[package]]
 name = "schema-builder"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "itertools",
  "lazy_static",
@@ -6659,7 +6654,7 @@ dependencies = [
  "globset",
  "hostname",
  "http-range",
- "httpz 0.0.3",
+ "httpz",
  "image",
  "include_dir",
  "int-enum",
@@ -7120,7 +7115,7 @@ dependencies = [
  "axum",
  "ctrlc",
  "http",
- "httpz 0.0.3",
+ "httpz",
  "hyper",
  "rspc",
  "sd-core",
@@ -7333,7 +7328,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "http",
- "httpz 0.0.3",
+ "httpz",
  "percent-encoding",
  "rand 0.8.5",
  "rspc",
@@ -7351,8 +7346,8 @@ dependencies = [
 
 [[package]]
 name = "specta"
-version = "1.0.0"
-source = "git+https://github.com/oscartbeaumont/specta?rev=6b4c282ff654374b7f12832ee4433db731cdff1c#6b4c282ff654374b7f12832ee4433db731cdff1c"
+version = "1.0.2"
+source = "git+https://github.com/oscartbeaumont/specta.git?rev=df67cd18ea7a79819387e4c6a329b0e3929fb79e#df67cd18ea7a79819387e4c6a329b0e3929fb79e"
 dependencies = [
  "chrono",
  "document-features",
@@ -7371,8 +7366,8 @@ dependencies = [
 
 [[package]]
 name = "specta-macros"
-version = "1.0.0"
-source = "git+https://github.com/oscartbeaumont/specta?rev=6b4c282ff654374b7f12832ee4433db731cdff1c#6b4c282ff654374b7f12832ee4433db731cdff1c"
+version = "1.0.2"
+source = "git+https://github.com/oscartbeaumont/specta.git?rev=df67cd18ea7a79819387e4c6a329b0e3929fb79e#df67cd18ea7a79819387e4c6a329b0e3929fb79e"
 dependencies = [
  "Inflector",
  "itertools",
@@ -7410,12 +7405,12 @@ dependencies = [
 [[package]]
 name = "sql-ddl"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 
 [[package]]
 name = "sql-introspection-connector"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7439,7 +7434,7 @@ dependencies = [
 [[package]]
 name = "sql-migration-connector"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "chrono",
  "connection-string",
@@ -7466,7 +7461,7 @@ dependencies = [
 [[package]]
 name = "sql-query-connector"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7497,7 +7492,7 @@ dependencies = [
 [[package]]
 name = "sql-schema-describer"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "async-trait",
  "bigdecimal",
@@ -8651,7 +8646,7 @@ dependencies = [
 [[package]]
 name = "user-facing-error-macros"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8661,7 +8656,7 @@ dependencies = [
 [[package]]
 name = "user-facing-errors"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "backtrace",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,25 +13,25 @@ members = [
 ]
 
 [workspace.dependencies]
-prisma-client-rust =  { git = "https://github.com/Brendonovich/prisma-client-rust", rev = "c965b89f1a07a6931d90f4b5556421f7ffcda03b", features = [
+prisma-client-rust =  { git = "https://github.com/Brendonovich/prisma-client-rust", tag = "0.6.6", features = [
   "rspc",
   "sqlite-create-many",
   "migrations",
   "sqlite",
 ], default-features = false }
-prisma-client-rust-cli = { git = "https://github.com/Brendonovich/prisma-client-rust", rev = "c965b89f1a07a6931d90f4b5556421f7ffcda03b", features = [
+prisma-client-rust-cli = { git = "https://github.com/Brendonovich/prisma-client-rust", tag = "0.6.6", features = [
   "rspc",
   "sqlite-create-many",
   "migrations",
   "sqlite",
 ], default-features = false }
-prisma-client-rust-sdk = { git = "https://github.com/Brendonovich/prisma-client-rust", rev = "c965b89f1a07a6931d90f4b5556421f7ffcda03b", features = [
+prisma-client-rust-sdk = { git = "https://github.com/Brendonovich/prisma-client-rust", tag = "0.6.6", features = [
   "sqlite",
 ], default-features = false }
 
 rspc = { version = "0.1.2" }
 specta = { version = "1.0.0" }
-httpz = { version = "0.0.3" }
+httpz = { version = "0.0.4" }
 
 swift-rs = { version = "1.0.1" }
 
@@ -45,7 +45,6 @@ if-watch = { git = "https://github.com/oscartbeaumont/if-watch", rev = "410e8e1d
 
 mdns-sd = { git = "https://github.com/oscartbeaumont/mdns-sd", rev = "45515a98e9e408c102871abaa5a9bff3bee0cbe8" } # TODO: Do upstream PR
 
-
-rspc = { path = "../rspc-rs" }
-specta = { git = "https://github.com/oscartbeaumont/specta", rev = "6b4c282ff654374b7f12832ee4433db731cdff1c" }
-httpz = { git = "https://github.com/oscartbeaumont/httpz", rev = "a5185f2ed2fdefeb2f582dce38a692a1bf76d1d6" }
+rspc = { git = "https://github.com/oscartbeaumont/rspc", branch = "0.1.3" }
+specta = { git = "https://github.com/oscartbeaumont/specta.git", rev = "df67cd18ea7a79819387e4c6a329b0e3929fb79e" }
+httpz = { git = "https://github.com/oscartbeaumont/httpz", rev = "be67ead9320095bdecf90cae75fded2411509b0f" } # TODO: Move back to crates.io release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ prisma-client-rust-sdk = { git = "https://github.com/Brendonovich/prisma-client-
 ], default-features = false }
 
 rspc = { version = "0.1.2" }
-specta = { version = "0.0.6" }
+specta = { version = "1.0.0" }
 httpz = { version = "0.0.3" }
 
 swift-rs = { version = "1.0.1" }
@@ -45,6 +45,7 @@ if-watch = { git = "https://github.com/oscartbeaumont/if-watch", rev = "410e8e1d
 
 mdns-sd = { git = "https://github.com/oscartbeaumont/mdns-sd", rev = "45515a98e9e408c102871abaa5a9bff3bee0cbe8" } # TODO: Do upstream PR
 
-rspc = { git = "https://github.com/oscartbeaumont/rspc", rev = "c03872c0ba29d2429e9c059dfb235cdd03e15e8c" }   # TODO: Move back to crates.io when new jsonrpc executor + `tokio::spawn` in the Tauri IPC plugin + upgraded Tauri version is released
-specta = { git = "https://github.com/oscartbeaumont/rspc", rev = "c03872c0ba29d2429e9c059dfb235cdd03e15e8c" }
+
+rspc = { path = "../rspc-rs" }
+specta = { git = "https://github.com/oscartbeaumont/specta", rev = "6b4c282ff654374b7f12832ee4433db731cdff1c" }
 httpz = { git = "https://github.com/oscartbeaumont/httpz", rev = "a5185f2ed2fdefeb2f582dce38a692a1bf76d1d6" }

--- a/apps/mobile/crates/core/src/lib.rs
+++ b/apps/mobile/crates/core/src/lib.rs
@@ -3,7 +3,7 @@ use once_cell::sync::{Lazy, OnceCell};
 use rspc::internal::jsonrpc::*;
 use sd_core::{api::Router, Node};
 use serde_json::{from_str, from_value, to_string, Value};
-use std::{collections::HashMap, marker::Send, sync::Arc};
+use std::{borrow::Cow, collections::HashMap, marker::Send, sync::Arc};
 use tokio::{
 	runtime::Runtime,
 	sync::{
@@ -55,34 +55,36 @@ pub fn handle_core_msg(
 			}
 		};
 
-		let responses = join_all(reqs.into_iter().map(|request| {
-			let node = node.clone();
-			let router = router.clone();
-			async move {
-				let mut channel = EVENT_SENDER.get().unwrap().clone();
-				let mut resp = Sender::ResponseAndChannel(None, &mut channel);
+		// let responses = join_all(reqs.into_iter().map(|request| {
+		// 	let node = node.clone();
+		// 	let router = router.clone();
+		// 	async move {
+		// 		let mut channel = EVENT_SENDER.get().unwrap().clone();
+		// 		let mut resp = Sender::ResponseAndChannel(None, &mut channel);
 
-				handle_json_rpc(
-					node.get_request_context(),
-					request,
-					&router,
-					&mut resp,
-					&mut SubscriptionMap::Mutex(&SUBSCRIPTIONS),
-				)
-				.await;
+		// 		handle_json_rpc(
+		// 			node.get_request_context(),
+		// 			request,
+		// 			Cow::Borrowed(router),
+		// 			&mut resp,
+		// 			&mut SubscriptionMap::Mutex(&SUBSCRIPTIONS),
+		// 		)
+		// 		.await;
 
-				match resp {
-					Sender::ResponseAndChannel(resp, _) => resp,
-					_ => unreachable!(),
-				}
-			}
-		}))
-		.await;
+		// 		match resp {
+		// 			Sender::ResponseAndChannel(resp, _) => resp,
+		// 			_ => unreachable!(),
+		// 		}
+		// 	}
+		// }))
+		// .await;
 
-		callback(Ok(serde_json::to_string(
-			&responses.into_iter().flatten().collect::<Vec<_>>(),
-		)
-		.unwrap()));
+		// callback(Ok(serde_json::to_string(
+		// 	&responses.into_iter().flatten().collect::<Vec<_>>(),
+		// )
+		// .unwrap()));
+
+		todo!();
 	});
 }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -29,7 +29,7 @@ sd-file-ext = { path = "../crates/file-ext" }
 sd-sync = { path = "../crates/sync" }
 sd-p2p = { path = "../crates/p2p", features = ["specta", "serde"] }
 
-rspc = { workspace = true, features = ["uuid", "chrono", "tracing"] }
+rspc = { workspace = true, features = ["uuid", "chrono", "tracing", "alpha"] }
 httpz = { workspace = true }
 prisma-client-rust = { workspace = true }
 specta = { workspace = true }

--- a/core/src/api/keys.rs
+++ b/core/src/api/keys.rs
@@ -1,3 +1,4 @@
+use rspc::alpha::AlphaRouter;
 use sd_crypto::keys::keymanager::{StoredKey, StoredKeyType};
 use sd_crypto::primitives::SECRET_KEY_IDENTIFIER;
 use sd_crypto::types::{Algorithm, HashingAlgorithm, SecretKeyString};
@@ -12,7 +13,8 @@ use uuid::Uuid;
 use crate::util::db::write_storedkey_to_db;
 use crate::{invalidate_query, prisma::key};
 
-use super::{utils::LibraryRequest, RouterBuilder};
+use super::utils::library;
+use super::{t, Ctx};
 
 #[derive(Type, Deserialize)]
 pub struct KeyAddArgs {
@@ -49,39 +51,46 @@ pub struct AutomountUpdateArgs {
 	status: bool,
 }
 
-pub(crate) fn mount() -> RouterBuilder {
-	RouterBuilder::new()
-		.library_query("list", |t| {
-			t(|_, _: (), library| async move { Ok(library.key_manager.dump_keystore()) })
+pub(crate) fn mount() -> AlphaRouter<Ctx> {
+	t.router()
+		.procedure("list", {
+			t.with(library())
+				.query(|(_, library), _: ()| async move { Ok(library.key_manager.dump_keystore()) })
 		})
 		// do not unlock the key manager until this route returns true
-		.library_query("isUnlocked", |t| {
-			t(|_, _: (), library| async move { Ok(library.key_manager.is_unlocked().await) })
+		.procedure("isUnlocked", {
+			t.with(library()).query(|(_, library), _: ()| async move {
+				Ok(library.key_manager.is_unlocked().await)
+			})
 		})
 		// this is so we can show the key as mounted in the UI
-		.library_query("listMounted", |t| {
-			t(|_, _: (), library| async move { Ok(library.key_manager.get_mounted_uuids()) })
-		})
-		.library_query("getKey", |t| {
-			t(|_, key_uuid: Uuid, library| async move {
-				Ok(library
-					.key_manager
-					.get_key(key_uuid)
-					.await?
-					.expose()
-					.clone())
+		.procedure("listMounted", {
+			t.with(library()).query(|(_, library), _: ()| async move {
+				Ok(library.key_manager.get_mounted_uuids())
 			})
 		})
-		.library_mutation("mount", |t| {
-			t(|_, key_uuid: Uuid, library| async move {
-				library.key_manager.mount(key_uuid).await?;
-				// we also need to dispatch jobs that automatically decrypt preview media and metadata here
-				invalidate_query!(library, "keys.listMounted");
-				Ok(())
-			})
+		.procedure("getKey", {
+			t.with(library())
+				.query(|(_, library), key_uuid: Uuid| async move {
+					Ok(library
+						.key_manager
+						.get_key(key_uuid)
+						.await?
+						.expose()
+						.clone())
+				})
 		})
-		.library_query("getSecretKey", |t| {
-			t(|_, _: (), library| async move {
+		.procedure("mount", {
+			t.with(library())
+				.mutation(|(_, library), key_uuid: Uuid| async move {
+					library.key_manager.mount(key_uuid).await?;
+					// we also need to dispatch jobs that automatically decrypt preview media and metadata here
+					invalidate_query!(library, "keys.listMounted");
+					Ok(())
+				})
+		})
+		.procedure("getSecretKey", {
+			t.with(library()).query(|(_, library), _: ()| async move {
 				if library
 					.key_manager
 					.keyring_contains_valid_secret_key(library.id)
@@ -101,277 +110,296 @@ pub(crate) fn mount() -> RouterBuilder {
 				}
 			})
 		})
-		.library_mutation("unmount", |t| {
-			t(|_, key_uuid: Uuid, library| async move {
-				library.key_manager.unmount(key_uuid)?;
-				// we also need to delete all in-memory decrypted data associated with this key
-				invalidate_query!(library, "keys.listMounted");
-				Ok(())
-			})
+		.procedure("unmount", {
+			t.with(library())
+				.mutation(|(_, library), key_uuid: Uuid| async move {
+					library.key_manager.unmount(key_uuid)?;
+					// we also need to delete all in-memory decrypted data associated with this key
+					invalidate_query!(library, "keys.listMounted");
+					Ok(())
+				})
 		})
-		.library_mutation("clearMasterPassword", |t| {
-			t(|_, _: (), library| async move {
-				// This technically clears the root key, but it means the same thing to the frontend
-				library.key_manager.clear_root_key().await?;
+		.procedure("clearMasterPassword", {
+			t.with(library())
+				.mutation(|(_, library), _: ()| async move {
+					// This technically clears the root key, but it means the same thing to the frontend
+					library.key_manager.clear_root_key().await?;
 
-				invalidate_query!(library, "keys.isUnlocked");
-				Ok(())
-			})
+					invalidate_query!(library, "keys.isUnlocked");
+					Ok(())
+				})
 		})
-		.library_mutation("syncKeyToLibrary", |t| {
-			t(|_, key_uuid: Uuid, library| async move {
-				let key = library.key_manager.sync_to_database(key_uuid).await?;
+		.procedure("syncKeyToLibrary", {
+			t.with(library())
+				.mutation(|(_, library), key_uuid: Uuid| async move {
+					let key = library.key_manager.sync_to_database(key_uuid).await?;
 
-				// does not check that the key doesn't exist before writing
-				write_storedkey_to_db(&library.db, &key).await?;
+					// does not check that the key doesn't exist before writing
+					write_storedkey_to_db(&library.db, &key).await?;
 
-				invalidate_query!(library, "keys.list");
-				Ok(())
-			})
+					invalidate_query!(library, "keys.list");
+					Ok(())
+				})
 		})
-		.library_mutation("updateAutomountStatus", |t| {
-			t(|_, args: AutomountUpdateArgs, library| async move {
-				if !library.key_manager.is_memory_only(args.uuid).await? {
+		.procedure("updateAutomountStatus", {
+			t.with(library())
+				.mutation(|(_, library), args: AutomountUpdateArgs| async move {
+					if !library.key_manager.is_memory_only(args.uuid).await? {
+						library
+							.key_manager
+							.change_automount_status(args.uuid, args.status)
+							.await?;
+
+						library
+							.db
+							.key()
+							.update(
+								key::uuid::equals(args.uuid.to_string()),
+								vec![key::SetParam::SetAutomount(args.status)],
+							)
+							.exec()
+							.await?;
+
+						invalidate_query!(library, "keys.list");
+					}
+
+					Ok(())
+				})
+		})
+		.procedure("deleteFromLibrary", {
+			t.with(library())
+				.mutation(|(_, library), key_uuid: Uuid| async move {
+					if !library.key_manager.is_memory_only(key_uuid).await? {
+						library
+							.db
+							.key()
+							.delete(key::uuid::equals(key_uuid.to_string()))
+							.exec()
+							.await?;
+					}
+
+					library.key_manager.remove_key(key_uuid).await?;
+
+					// we also need to delete all in-memory decrypted data associated with this key
+					invalidate_query!(library, "keys.list");
+					invalidate_query!(library, "keys.listMounted");
+					invalidate_query!(library, "keys.getDefault");
+					Ok(())
+				})
+		})
+		.procedure("unlockKeyManager", {
+			t.with(library())
+				.mutation(|(_, library), args: UnlockKeyManagerArgs| async move {
+					let secret_key =
+						(!args.secret_key.expose().is_empty()).then_some(args.secret_key);
+
 					library
 						.key_manager
-						.change_automount_status(args.uuid, args.status)
+						.unlock(
+							args.password,
+							secret_key.map(SecretKeyString),
+							library.id,
+							|| invalidate_query!(library, "keys.isKeyManagerUnlocking"),
+						)
+						.await?;
+
+					invalidate_query!(library, "keys.isUnlocked");
+
+					let automount = library
+						.db
+						.key()
+						.find_many(vec![key::automount::equals(true)])
+						.exec()
+						.await?;
+
+					for key in automount {
+						library
+							.key_manager
+							.mount(Uuid::from_str(&key.uuid).map_err(|_| Error::Serialization)?)
+							.await?;
+
+						invalidate_query!(library, "keys.listMounted");
+					}
+
+					Ok(())
+				})
+		})
+		.procedure("setDefault", {
+			t.with(library())
+				.mutation(|(_, library), key_uuid: Uuid| async move {
+					library.key_manager.set_default(key_uuid).await?;
+
+					library
+						.db
+						.key()
+						.update_many(
+							vec![key::default::equals(true)],
+							vec![key::SetParam::SetDefault(false)],
+						)
+						.exec()
 						.await?;
 
 					library
 						.db
 						.key()
 						.update(
-							key::uuid::equals(args.uuid.to_string()),
-							vec![key::SetParam::SetAutomount(args.status)],
+							key::uuid::equals(key_uuid.to_string()),
+							vec![key::SetParam::SetDefault(true)],
 						)
 						.exec()
 						.await?;
 
-					invalidate_query!(library, "keys.list");
-				}
-
-				Ok(())
+					invalidate_query!(library, "keys.getDefault");
+					Ok(())
+				})
+		})
+		.procedure("getDefault", {
+			t.with(library()).query(|(_, library), _: ()| async move {
+				library.key_manager.get_default().await.ok()
 			})
 		})
-		.library_mutation("deleteFromLibrary", |t| {
-			t(|_, key_uuid: Uuid, library| async move {
-				if !library.key_manager.is_memory_only(key_uuid).await? {
+		.procedure("isKeyManagerUnlocking", {
+			t.with(library()).query(|(_, library), _: ()| async move {
+				library.key_manager.is_unlocking().await.ok()
+			})
+		})
+		.procedure("unmountAll", {
+			t.with(library())
+				.mutation(|(_, library), _: ()| async move {
+					library.key_manager.empty_keymount();
+					invalidate_query!(library, "keys.listMounted");
+					Ok(())
+				})
+		})
+		// this also mounts the key
+		.procedure("add", {
+			t.with(library())
+				.mutation(|(_, library), args: KeyAddArgs| async move {
+					// register the key with the keymanager
+					let uuid = library
+						.key_manager
+						.add_to_keystore(
+							args.key,
+							args.algorithm,
+							args.hashing_algorithm,
+							!args.library_sync,
+							args.automount,
+							None,
+						)
+						.await?;
+
+					if args.library_sync {
+						write_storedkey_to_db(
+							&library.db,
+							&library.key_manager.access_keystore(uuid).await?,
+						)
+						.await?;
+
+						if args.automount {
+							library
+								.db
+								.key()
+								.update(
+									key::uuid::equals(uuid.to_string()),
+									vec![key::SetParam::SetAutomount(true)],
+								)
+								.exec()
+								.await?;
+						}
+					}
+
+					library.key_manager.mount(uuid).await?;
+
+					invalidate_query!(library, "keys.list");
+					invalidate_query!(library, "keys.listMounted");
+					Ok(())
+				})
+		})
+		.procedure("backupKeystore", {
+			t.with(library())
+				.mutation(|(_, library), path: PathBuf| async move {
+					// dump all stored keys that are in the key manager (maybe these should be taken from prisma as this will include even "non-sync with library" keys)
+					let mut stored_keys = library.key_manager.dump_keystore();
+
+					// include the verification key at the time of backup
+					stored_keys.push(library.key_manager.get_verification_key().await?);
+
+					// exclude all memory-only keys
+					stored_keys.retain(|k| !k.memory_only);
+
+					let mut output_file = File::create(path).await.map_err(Error::Io)?;
+					output_file
+						.write_all(
+							&serde_json::to_vec(&stored_keys).map_err(|_| Error::Serialization)?,
+						)
+						.await
+						.map_err(Error::Io)?;
+					Ok(())
+				})
+		})
+		.procedure("restoreKeystore", {
+			t.with(library())
+				.mutation(|(_, library), args: RestoreBackupArgs| async move {
+					let mut input_file = File::open(args.path).await.map_err(Error::Io)?;
+
+					let mut backup = Vec::new();
+
+					input_file
+						.read_to_end(&mut backup)
+						.await
+						.map_err(Error::Io)?;
+
+					let stored_keys: Vec<StoredKey> =
+						serde_json::from_slice(&backup).map_err(|_| Error::Serialization)?;
+
+					let updated_keys = library
+						.key_manager
+						.import_keystore_backup(
+							args.password,
+							SecretKeyString(args.secret_key),
+							&stored_keys,
+						)
+						.await?;
+
+					for key in &updated_keys {
+						write_storedkey_to_db(&library.db, key).await?;
+					}
+
+					invalidate_query!(library, "keys.list");
+					invalidate_query!(library, "keys.listMounted");
+
+					Ok(TryInto::<u32>::try_into(updated_keys.len()).unwrap()) // We convert from `usize` (bigint type) to `u32` (number type) because rspc doesn't support bigints.
+				})
+		})
+		.procedure("changeMasterPassword", {
+			t.with(library())
+				.mutation(|(_, library), args: MasterPasswordChangeArgs| async move {
+					let verification_key = library
+						.key_manager
+						.change_master_password(
+							args.password,
+							args.algorithm,
+							args.hashing_algorithm,
+							library.id,
+						)
+						.await?;
+
+					invalidate_query!(library, "keys.getSecretKey");
+
+					// remove old root key if present
 					library
 						.db
 						.key()
-						.delete(key::uuid::equals(key_uuid.to_string()))
+						.delete_many(vec![key::key_type::equals(
+							serde_json::to_string(&StoredKeyType::Root).unwrap(),
+						)])
 						.exec()
 						.await?;
-				}
 
-				library.key_manager.remove_key(key_uuid).await?;
+					// write the new verification key
+					write_storedkey_to_db(&library.db, &verification_key).await?;
 
-				// we also need to delete all in-memory decrypted data associated with this key
-				invalidate_query!(library, "keys.list");
-				invalidate_query!(library, "keys.listMounted");
-				invalidate_query!(library, "keys.getDefault");
-				Ok(())
-			})
-		})
-		.library_mutation("unlockKeyManager", |t| {
-			t(|_, args: UnlockKeyManagerArgs, library| async move {
-				let secret_key = (!args.secret_key.expose().is_empty()).then_some(args.secret_key);
-
-				library
-					.key_manager
-					.unlock(
-						args.password,
-						secret_key.map(SecretKeyString),
-						library.id,
-						|| invalidate_query!(library, "keys.isKeyManagerUnlocking"),
-					)
-					.await?;
-
-				invalidate_query!(library, "keys.isUnlocked");
-
-				let automount = library
-					.db
-					.key()
-					.find_many(vec![key::automount::equals(true)])
-					.exec()
-					.await?;
-
-				for key in automount {
-					library
-						.key_manager
-						.mount(Uuid::from_str(&key.uuid).map_err(|_| Error::Serialization)?)
-						.await?;
-
-					invalidate_query!(library, "keys.listMounted");
-				}
-
-				Ok(())
-			})
-		})
-		.library_mutation("setDefault", |t| {
-			t(|_, key_uuid: Uuid, library| async move {
-				library.key_manager.set_default(key_uuid).await?;
-
-				library
-					.db
-					.key()
-					.update_many(
-						vec![key::default::equals(true)],
-						vec![key::SetParam::SetDefault(false)],
-					)
-					.exec()
-					.await?;
-
-				library
-					.db
-					.key()
-					.update(
-						key::uuid::equals(key_uuid.to_string()),
-						vec![key::SetParam::SetDefault(true)],
-					)
-					.exec()
-					.await?;
-
-				invalidate_query!(library, "keys.getDefault");
-				Ok(())
-			})
-		})
-		.library_query("getDefault", |t| {
-			t(|_, _: (), library| async move { library.key_manager.get_default().await.ok() })
-		})
-		.library_query("isKeyManagerUnlocking", |t| {
-			t(|_, _: (), library| async move { library.key_manager.is_unlocking().await.ok() })
-		})
-		.library_mutation("unmountAll", |t| {
-			t(|_, _: (), library| async move {
-				library.key_manager.empty_keymount();
-				invalidate_query!(library, "keys.listMounted");
-				Ok(())
-			})
-		})
-		// this also mounts the key
-		.library_mutation("add", |t| {
-			t(|_, args: KeyAddArgs, library| async move {
-				// register the key with the keymanager
-				let uuid = library
-					.key_manager
-					.add_to_keystore(
-						args.key,
-						args.algorithm,
-						args.hashing_algorithm,
-						!args.library_sync,
-						args.automount,
-						None,
-					)
-					.await?;
-
-				if args.library_sync {
-					write_storedkey_to_db(
-						&library.db,
-						&library.key_manager.access_keystore(uuid).await?,
-					)
-					.await?;
-
-					if args.automount {
-						library
-							.db
-							.key()
-							.update(
-								key::uuid::equals(uuid.to_string()),
-								vec![key::SetParam::SetAutomount(true)],
-							)
-							.exec()
-							.await?;
-					}
-				}
-
-				library.key_manager.mount(uuid).await?;
-
-				invalidate_query!(library, "keys.list");
-				invalidate_query!(library, "keys.listMounted");
-				Ok(())
-			})
-		})
-		.library_mutation("backupKeystore", |t| {
-			t(|_, path: PathBuf, library| async move {
-				// dump all stored keys that are in the key manager (maybe these should be taken from prisma as this will include even "non-sync with library" keys)
-				let mut stored_keys = library.key_manager.dump_keystore();
-
-				// include the verification key at the time of backup
-				stored_keys.push(library.key_manager.get_verification_key().await?);
-
-				// exclude all memory-only keys
-				stored_keys.retain(|k| !k.memory_only);
-
-				let mut output_file = File::create(path).await.map_err(Error::Io)?;
-				output_file
-					.write_all(&serde_json::to_vec(&stored_keys).map_err(|_| Error::Serialization)?)
-					.await
-					.map_err(Error::Io)?;
-				Ok(())
-			})
-		})
-		.library_mutation("restoreKeystore", |t| {
-			t(|_, args: RestoreBackupArgs, library| async move {
-				let mut input_file = File::open(args.path).await.map_err(Error::Io)?;
-
-				let mut backup = Vec::new();
-
-				input_file
-					.read_to_end(&mut backup)
-					.await
-					.map_err(Error::Io)?;
-
-				let stored_keys: Vec<StoredKey> =
-					serde_json::from_slice(&backup).map_err(|_| Error::Serialization)?;
-
-				let updated_keys = library
-					.key_manager
-					.import_keystore_backup(
-						args.password,
-						SecretKeyString(args.secret_key),
-						&stored_keys,
-					)
-					.await?;
-
-				for key in &updated_keys {
-					write_storedkey_to_db(&library.db, key).await?;
-				}
-
-				invalidate_query!(library, "keys.list");
-				invalidate_query!(library, "keys.listMounted");
-
-				Ok(TryInto::<u32>::try_into(updated_keys.len()).unwrap()) // We convert from `usize` (bigint type) to `u32` (number type) because rspc doesn't support bigints.
-			})
-		})
-		.library_mutation("changeMasterPassword", |t| {
-			t(|_, args: MasterPasswordChangeArgs, library| async move {
-				let verification_key = library
-					.key_manager
-					.change_master_password(
-						args.password,
-						args.algorithm,
-						args.hashing_algorithm,
-						library.id,
-					)
-					.await?;
-
-				invalidate_query!(library, "keys.getSecretKey");
-
-				// remove old root key if present
-				library
-					.db
-					.key()
-					.delete_many(vec![key::key_type::equals(
-						serde_json::to_string(&StoredKeyType::Root).unwrap(),
-					)])
-					.exec()
-					.await?;
-
-				// write the new verification key
-				write_storedkey_to_db(&library.db, &verification_key).await?;
-
-				Ok(())
-			})
+					Ok(())
+				})
 		})
 }

--- a/core/src/api/libraries.rs
+++ b/core/src/api/libraries.rs
@@ -1,7 +1,6 @@
 use crate::{
-	api::Ctx,
 	invalidate_query,
-	library::{Library, LibraryConfig},
+	library::LibraryConfig,
 	prisma::statistics,
 	volume::{get_volumes, save_volume},
 };
@@ -12,34 +11,37 @@ use sd_crypto::{
 };
 
 use chrono::Utc;
-use rspc::{Error, ErrorCode, Type};
+use rspc::{alpha::AlphaRouter, Error, ErrorCode, Type};
 use serde::Deserialize;
 use tracing::debug;
 use uuid::Uuid;
 
 use super::{
-	utils::{get_size, LibraryRequest},
-	RouterBuilder,
+	t,
+	utils::{get_size, library},
+	Ctx,
 };
 
-pub(crate) fn mount() -> RouterBuilder {
-	<RouterBuilder>::new()
-		.query("list", |t| {
-			t(|ctx: Ctx, _: ()| async move { ctx.library_manager.get_all_libraries_config().await })
-		})
-		.library_query("getStatistics", |t| {
-			t(|_, _: (), library: Library| async move {
+pub(crate) fn mount() -> AlphaRouter<Ctx> {
+	t.router()
+		.procedure(
+			"list",
+			t.query(
+				|ctx, _: ()| async move { ctx.library_manager.get_all_libraries_config().await },
+			),
+		)
+		.procedure(
+			"getStatistics",
+			t.with(library()).query(|(_, library), _: ()| async move {
 				let _statistics = library
 					.db
 					.statistics()
 					.find_unique(statistics::id::equals(library.node_local_id))
 					.exec()
 					.await?;
-
 				// TODO: get from database, not sys
 				let volumes = get_volumes();
 				save_volume(&library).await?;
-
 				let mut available_capacity: u64 = 0;
 				let mut total_capacity: u64 = 0;
 				if let Ok(volumes) = volumes {
@@ -48,7 +50,6 @@ pub(crate) fn mount() -> RouterBuilder {
 						available_capacity += volume.available_capacity;
 					}
 				}
-
 				let library_db_size = get_size(
 					library
 						.config()
@@ -58,12 +59,10 @@ pub(crate) fn mount() -> RouterBuilder {
 				)
 				.await
 				.unwrap_or(0);
-
 				let thumbnail_folder_size =
 					get_size(library.config().data_directory().join("thumbnails"))
 						.await
 						.unwrap_or(0);
-
 				use statistics::*;
 				let params = vec![
 					id::set(1), // Each library is a database so only one of these ever exists
@@ -76,7 +75,6 @@ pub(crate) fn mount() -> RouterBuilder {
 					total_bytes_free::set(available_capacity.to_string()),
 					preview_media_bytes::set(thumbnail_folder_size.to_string()),
 				];
-
 				Ok(library
 					.db
 					.statistics()
@@ -87,88 +85,89 @@ pub(crate) fn mount() -> RouterBuilder {
 					)
 					.exec()
 					.await?)
-			})
-		})
-		.mutation("create", |t| {
+			}),
+		)
+		.procedure(
+			"create",
+			t.mutation({
+				#[derive(Deserialize, Type)]
+				#[serde(tag = "type", content = "value")]
+				#[specta(inline)]
+				enum AuthOption {
+					Password(Protected<String>),
+					TokenizedPassword(String),
+				}
+				#[derive(Deserialize, Type)]
+				pub struct CreateLibraryArgs {
+					name: String,
+					auth: AuthOption,
+					algorithm: Algorithm,
+					hashing_algorithm: HashingAlgorithm,
+				}
+				|ctx, args: CreateLibraryArgs| async move {
+					debug!("Creating library");
+					let password = match args.auth {
+						AuthOption::Password(password) => password,
+						AuthOption::TokenizedPassword(tokenized_pw) => {
+							let token = Uuid::parse_str(&tokenized_pw).map_err(|err| {
+								Error::with_cause(
+									ErrorCode::BadRequest,
+									"Failed to parse UUID".to_string(),
+									err,
+								)
+							})?;
+							Protected::new(ctx.secure_temp_keystore.claim(token).map_err(
+								|err| {
+									Error::with_cause(
+										ErrorCode::InternalServerError,
+										"Failed to claim token from keystore".to_string(),
+										err,
+									)
+								},
+							)?)
+						}
+					};
+					let new_library = ctx
+						.library_manager
+						.create(
+							LibraryConfig {
+								name: args.name.to_string(),
+								..Default::default()
+							},
+							OnboardingConfig {
+								password,
+								algorithm: args.algorithm,
+								hashing_algorithm: args.hashing_algorithm,
+							},
+						)
+						.await?;
+					invalidate_query!(
+						// SAFETY: This unwrap is alright as we just created the library
+						ctx.library_manager.get_ctx(new_library.uuid).await.unwrap(),
+						"library.getStatistics"
+					);
+					Ok(new_library)
+				}
+			}),
+		)
+		.procedure("edit", {
 			#[derive(Deserialize, Type)]
-			#[serde(tag = "type", content = "value")]
-			#[specta(inline)]
-			enum AuthOption {
-				Password(Protected<String>),
-				TokenizedPassword(String),
-			}
-
-			#[derive(Deserialize, Type)]
-			pub struct CreateLibraryArgs {
-				name: String,
-				auth: AuthOption,
-				algorithm: Algorithm,
-				hashing_algorithm: HashingAlgorithm,
-			}
-
-			t(|ctx: Ctx, args: CreateLibraryArgs| async move {
-				debug!("Creating library");
-
-				let password = match args.auth {
-					AuthOption::Password(password) => password,
-					AuthOption::TokenizedPassword(tokenized_pw) => {
-						let token = Uuid::parse_str(&tokenized_pw).map_err(|err| {
-							Error::with_cause(
-								ErrorCode::BadRequest,
-								"Failed to parse UUID".to_string(),
-								err,
-							)
-						})?;
-						Protected::new(ctx.secure_temp_keystore.claim(token).map_err(|err| {
-							Error::with_cause(
-								ErrorCode::InternalServerError,
-								"Failed to claim token from keystore".to_string(),
-								err,
-							)
-						})?)
-					}
-				};
-
-				let new_library = ctx
-					.library_manager
-					.create(
-						LibraryConfig {
-							name: args.name.to_string(),
-							..Default::default()
-						},
-						OnboardingConfig {
-							password,
-							algorithm: args.algorithm,
-							hashing_algorithm: args.hashing_algorithm,
-						},
-					)
-					.await?;
-
-				invalidate_query!(
-					// SAFETY: This unwrap is alright as we just created the library
-					ctx.library_manager.get_ctx(new_library.uuid).await.unwrap(),
-					"library.getStatistics"
-				);
-
-				Ok(new_library)
-			})
-		})
-		.mutation("edit", |t| {
-			#[derive(Type, Deserialize)]
 			pub struct EditLibraryArgs {
 				pub id: Uuid,
 				pub name: Option<String>,
 				pub description: Option<String>,
 			}
-
-			t(|ctx: Ctx, args: EditLibraryArgs| async move {
+			t.mutation(|ctx, args: EditLibraryArgs| async move {
 				Ok(ctx
 					.library_manager
 					.edit(args.id, args.name, args.description)
 					.await?)
 			})
 		})
-		.mutation("delete", |t| {
-			t(|ctx: Ctx, id: Uuid| async move { Ok(ctx.library_manager.delete_library(id).await?) })
-		})
+		.procedure(
+			"delete",
+			t.mutation(
+				|ctx, id: Uuid| async move { Ok(ctx.library_manager.delete_library(id).await?) },
+			),
+		)
 }

--- a/core/src/api/locations.rs
+++ b/core/src/api/locations.rs
@@ -10,10 +10,10 @@ use crate::{
 
 use std::path::PathBuf;
 
-use rspc::{self, ErrorCode, RouterBuilderLike, Type};
+use rspc::{self, alpha::AlphaRouter, ErrorCode, Type};
 use serde::{Deserialize, Serialize};
 
-use super::{utils::LibraryRequest, Ctx, RouterBuilder};
+use super::{t, utils::library, Ctx};
 
 #[derive(Serialize, Deserialize, Type, Debug)]
 #[serde(tag = "type")]
@@ -46,10 +46,10 @@ pub struct ExplorerData {
 file_path::include!(file_path_with_object { object });
 object::include!(object_with_file_paths { file_paths });
 
-pub(crate) fn mount() -> impl RouterBuilderLike<Ctx> {
-	<RouterBuilder>::new()
-		.library_query("list", |t| {
-			t(|_, _: (), library| async move {
+pub(crate) fn mount() -> AlphaRouter<Ctx> {
+	t.router()
+		.procedure("list", {
+			t.with(library()).query(|(_, library), _: ()| async move {
 				Ok(library
 					.db
 					.location()
@@ -59,18 +59,19 @@ pub(crate) fn mount() -> impl RouterBuilderLike<Ctx> {
 					.await?)
 			})
 		})
-		.library_query("getById", |t| {
-			t(|_, location_id: i32, library| async move {
-				Ok(library
-					.db
-					.location()
-					.find_unique(location::id::equals(location_id))
-					.include(location_with_indexer_rules::include())
-					.exec()
-					.await?)
-			})
+		.procedure("getById", {
+			t.with(library())
+				.query(|(_, library), location_id: i32| async move {
+					Ok(library
+						.db
+						.location()
+						.find_unique(location::id::equals(location_id))
+						.include(location_with_indexer_rules::include())
+						.exec()
+						.await?)
+				})
 		})
-		.library_query("getExplorerData", |t| {
+		.procedure("getExplorerData", {
 			#[derive(Clone, Serialize, Deserialize, Type, Debug)]
 			pub struct LocationExplorerArgs {
 				pub location_id: i32,
@@ -79,137 +80,145 @@ pub(crate) fn mount() -> impl RouterBuilderLike<Ctx> {
 				pub cursor: Option<String>,
 			}
 
-			t(|_, mut args: LocationExplorerArgs, library| async move {
-				let Library { db, .. } = &library;
+			t.with(library())
+				.query(|(_, library), mut args: LocationExplorerArgs| async move {
+					let Library { db, .. } = &library;
 
-				let location = find_location(&library, args.location_id)
-					.exec()
-					.await?
-					.ok_or(LocationError::IdNotFound(args.location_id))?;
-
-				if !args.path.ends_with('/') {
-					args.path += "/";
-				}
-
-				let directory = db
-					.file_path()
-					.find_first(vec![
-						file_path::location_id::equals(location.id),
-						file_path::materialized_path::equals(args.path),
-						file_path::is_dir::equals(true),
-					])
-					.exec()
-					.await?
-					.ok_or_else(|| {
-						rspc::Error::new(ErrorCode::NotFound, "Directory not found".into())
-					})?;
-
-				let file_paths = db
-					.file_path()
-					.find_many(vec![
-						file_path::location_id::equals(location.id),
-						file_path::parent_id::equals(Some(directory.id)),
-					])
-					.include(file_path_with_object::include())
-					.exec()
-					.await?;
-
-				let mut items = Vec::with_capacity(file_paths.len());
-
-				for file_path in file_paths {
-					let has_thumbnail = if let Some(cas_id) = &file_path.cas_id {
-						library
-							.thumbnail_exists(cas_id)
-							.await
-							.map_err(LocationError::IOError)?
-					} else {
-						false
-					};
-
-					items.push(ExplorerItem::Path {
-						has_thumbnail,
-						item: file_path,
-					});
-				}
-
-				Ok(ExplorerData {
-					context: ExplorerContext::Location(location),
-					items,
-				})
-			})
-		})
-		.library_mutation("create", |t| {
-			t(|_, args: LocationCreateArgs, library| async move {
-				let location = args.create(&library).await?;
-				scan_location(&library, location).await?;
-				Ok(())
-			})
-		})
-		.library_mutation("update", |t| {
-			t(|_, args: LocationUpdateArgs, library| async move {
-				args.update(&library).await.map_err(Into::into)
-			})
-		})
-		.library_mutation("delete", |t| {
-			t(|_, location_id: i32, library| async move {
-				delete_location(&library, location_id)
-					.await
-					.map_err(Into::into)
-			})
-		})
-		.library_mutation("relink", |t| {
-			t(|_, location_path: PathBuf, library| async move {
-				relink_location(&library, location_path)
-					.await
-					.map_err(Into::into)
-			})
-		})
-		.library_mutation("addLibrary", |t| {
-			t(|_, args: LocationCreateArgs, library| async move {
-				let location = args.add_library(&library).await?;
-				scan_location(&library, location).await?;
-				Ok(())
-			})
-		})
-		.library_mutation("fullRescan", |t| {
-			t(|_, location_id: i32, library| async move {
-				// rescan location
-				scan_location(
-					&library,
-					find_location(&library, location_id)
-						.include(location_with_indexer_rules::include())
+					let location = find_location(&library, args.location_id)
 						.exec()
 						.await?
-						.ok_or(LocationError::IdNotFound(location_id))?,
-				)
-				.await
-				.map_err(Into::into)
-			})
+						.ok_or(LocationError::IdNotFound(args.location_id))?;
+
+					if !args.path.ends_with('/') {
+						args.path += "/";
+					}
+
+					let directory = db
+						.file_path()
+						.find_first(vec![
+							file_path::location_id::equals(location.id),
+							file_path::materialized_path::equals(args.path),
+							file_path::is_dir::equals(true),
+						])
+						.exec()
+						.await?
+						.ok_or_else(|| {
+							rspc::Error::new(ErrorCode::NotFound, "Directory not found".into())
+						})?;
+
+					let file_paths = db
+						.file_path()
+						.find_many(vec![
+							file_path::location_id::equals(location.id),
+							file_path::parent_id::equals(Some(directory.id)),
+						])
+						.include(file_path_with_object::include())
+						.exec()
+						.await?;
+
+					let mut items = Vec::with_capacity(file_paths.len());
+
+					for file_path in file_paths {
+						let has_thumbnail = if let Some(cas_id) = &file_path.cas_id {
+							library
+								.thumbnail_exists(cas_id)
+								.await
+								.map_err(LocationError::IOError)?
+						} else {
+							false
+						};
+
+						items.push(ExplorerItem::Path {
+							has_thumbnail,
+							item: file_path,
+						});
+					}
+
+					Ok(ExplorerData {
+						context: ExplorerContext::Location(location),
+						items,
+					})
+				})
 		})
-		.library_mutation("quickRescan", |t| {
+		.procedure("create", {
+			t.with(library())
+				.mutation(|(_, library), args: LocationCreateArgs| async move {
+					let location = args.create(&library).await?;
+					scan_location(&library, location).await?;
+					Ok(())
+				})
+		})
+		.procedure("update", {
+			t.with(library())
+				.mutation(|(_, library), args: LocationUpdateArgs| async move {
+					args.update(&library).await.map_err(Into::into)
+				})
+		})
+		.procedure("delete", {
+			t.with(library())
+				.mutation(|(_, library), location_id: i32| async move {
+					delete_location(&library, location_id)
+						.await
+						.map_err(Into::into)
+				})
+		})
+		.procedure("relink", {
+			t.with(library())
+				.mutation(|(_, library), location_path: PathBuf| async move {
+					relink_location(&library, location_path)
+						.await
+						.map_err(Into::into)
+				})
+		})
+		.procedure("addLibrary", {
+			t.with(library())
+				.mutation(|(_, library), args: LocationCreateArgs| async move {
+					let location = args.add_library(&library).await?;
+					scan_location(&library, location).await?;
+					Ok(())
+				})
+		})
+		.procedure("fullRescan", {
+			t.with(library())
+				.mutation(|(_, library), location_id: i32| async move {
+					// rescan location
+					scan_location(
+						&library,
+						find_location(&library, location_id)
+							.include(location_with_indexer_rules::include())
+							.exec()
+							.await?
+							.ok_or(LocationError::IdNotFound(location_id))?,
+					)
+					.await
+					.map_err(Into::into)
+				})
+		})
+		.procedure("quickRescan", {
 			#[derive(Clone, Serialize, Deserialize, Type, Debug)]
 			pub struct LightScanArgs {
 				pub location_id: i32,
 				pub sub_path: String,
 			}
 
-			t(|_, args: LightScanArgs, library| async move {
-				// light rescan location
-				light_scan_location(
-					&library,
-					find_location(&library, args.location_id)
-						.include(location_with_indexer_rules::include())
-						.exec()
-						.await?
-						.ok_or(LocationError::IdNotFound(args.location_id))?,
-					&args.sub_path,
-				)
-				.await
-				.map_err(Into::into)
-			})
+			t.with(library())
+				.mutation(|(_, library), args: LightScanArgs| async move {
+					// light rescan location
+					light_scan_location(
+						&library,
+						find_location(&library, args.location_id)
+							.include(location_with_indexer_rules::include())
+							.exec()
+							.await?
+							.ok_or(LocationError::IdNotFound(args.location_id))?,
+						&args.sub_path,
+					)
+					.await
+					.map_err(Into::into)
+				})
 		})
-		.subscription("online", |t| {
-			t(|ctx, _: ()| {
+		.procedure("online", {
+			t.subscription(|ctx, _: ()| {
 				let location_manager = ctx.library_manager.node_context.location_manager.clone();
 
 				let mut rx = location_manager.online_rx();
@@ -228,52 +237,55 @@ pub(crate) fn mount() -> impl RouterBuilderLike<Ctx> {
 		.merge("indexer_rules.", mount_indexer_rule_routes())
 }
 
-fn mount_indexer_rule_routes() -> RouterBuilder {
-	<RouterBuilder>::new()
-		.library_mutation("create", |t| {
-			t(|_, args: IndexerRuleCreateArgs, library| async move {
-				args.create(&library).await.map_err(Into::into)
-			})
+fn mount_indexer_rule_routes() -> AlphaRouter<Ctx> {
+	t.router()
+		.procedure("create", {
+			t.with(library())
+				.mutation(|(_, library), args: IndexerRuleCreateArgs| async move {
+					args.create(&library).await.map_err(Into::into)
+				})
 		})
-		.library_mutation("delete", |t| {
-			t(|_, indexer_rule_id: i32, library| async move {
-				library
-					.db
-					.indexer_rules_in_location()
-					.delete_many(vec![indexer_rules_in_location::indexer_rule_id::equals(
-						indexer_rule_id,
-					)])
-					.exec()
-					.await?;
+		.procedure("delete", {
+			t.with(library())
+				.mutation(|(_, library), indexer_rule_id: i32| async move {
+					library
+						.db
+						.indexer_rules_in_location()
+						.delete_many(vec![indexer_rules_in_location::indexer_rule_id::equals(
+							indexer_rule_id,
+						)])
+						.exec()
+						.await?;
 
-				library
-					.db
-					.indexer_rule()
-					.delete(indexer_rule::id::equals(indexer_rule_id))
-					.exec()
-					.await?;
+					library
+						.db
+						.indexer_rule()
+						.delete(indexer_rule::id::equals(indexer_rule_id))
+						.exec()
+						.await?;
 
-				Ok(())
-			})
+					Ok(())
+				})
 		})
-		.library_query("get", |t| {
-			t(|_, indexer_rule_id: i32, library| async move {
-				library
-					.db
-					.indexer_rule()
-					.find_unique(indexer_rule::id::equals(indexer_rule_id))
-					.exec()
-					.await?
-					.ok_or_else(|| {
-						rspc::Error::new(
-							ErrorCode::NotFound,
-							format!("Indexer rule <id={indexer_rule_id}> not found"),
-						)
-					})
-			})
+		.procedure("get", {
+			t.with(library())
+				.query(|(_, library), indexer_rule_id: i32| async move {
+					library
+						.db
+						.indexer_rule()
+						.find_unique(indexer_rule::id::equals(indexer_rule_id))
+						.exec()
+						.await?
+						.ok_or_else(|| {
+							rspc::Error::new(
+								ErrorCode::NotFound,
+								format!("Indexer rule <id={indexer_rule_id}> not found"),
+							)
+						})
+				})
 		})
-		.library_query("list", |t| {
-			t(|_, _: (), library| async move {
+		.procedure("list", {
+			t.with(library()).query(|(_, library), _: ()| async move {
 				library
 					.db
 					.indexer_rule()
@@ -284,17 +296,18 @@ fn mount_indexer_rule_routes() -> RouterBuilder {
 			})
 		})
 		// list indexer rules for location, returning the indexer rule
-		.library_query("listForLocation", |t| {
-			t(|_, location_id: i32, library| async move {
-				library
-					.db
-					.indexer_rule()
-					.find_many(vec![indexer_rule::locations::some(vec![
-						indexer_rules_in_location::location_id::equals(location_id),
-					])])
-					.exec()
-					.await
-					.map_err(Into::into)
-			})
+		.procedure("listForLocation", {
+			t.with(library())
+				.query(|(_, library), location_id: i32| async move {
+					library
+						.db
+						.indexer_rule()
+						.find_many(vec![indexer_rule::locations::some(vec![
+							indexer_rules_in_location::location_id::equals(location_id),
+						])])
+						.exec()
+						.await
+						.map_err(Into::into)
+				})
 		})
 }

--- a/core/src/api/nodes.rs
+++ b/core/src/api/nodes.rs
@@ -1,9 +1,10 @@
-use super::RouterBuilder;
-use rspc::Type;
+use rspc::{alpha::AlphaRouter, Type};
 use serde::{Deserialize, Serialize};
 
-pub(crate) fn mount() -> RouterBuilder {
-	<RouterBuilder>::new().mutation("tokenizeSensitiveKey", |t| {
+use super::{t, Ctx};
+
+pub(crate) fn mount() -> AlphaRouter<Ctx> {
+	t.router().procedure("tokenizeSensitiveKey", {
 		#[derive(Deserialize, Type)]
 		pub struct TokenizeKeyArgs {
 			pub secret_key: String,
@@ -13,7 +14,7 @@ pub(crate) fn mount() -> RouterBuilder {
 			pub token: String,
 		}
 
-		t(|ctx, args: TokenizeKeyArgs| async move {
+		t.mutation(|ctx, args: TokenizeKeyArgs| async move {
 			let token = ctx.secure_temp_keystore.tokenize(args.secret_key);
 
 			Ok(TokenizeResponse {

--- a/core/src/api/utils/invalidate.rs
+++ b/core/src/api/utils/invalidate.rs
@@ -61,11 +61,11 @@ impl InvalidRequests {
 			for req in &invalidate_requests.queries {
 				if let Some(query_ty) = queries.get(req.key) {
 					if let Some(input) = &req.input_ty {
-						if &query_ty.ty.input != input {
+						if &query_ty.ty.arg_ty != input {
 							panic!(
 								"Error at '{}': Attempted to invalid query '{}' but the argument type does not match the type defined on the router.",
 								req.macro_src, req.key
-                        	);
+		                	);
 						}
 					}
 				} else {

--- a/core/src/api/utils/invalidate.rs
+++ b/core/src/api/utils/invalidate.rs
@@ -61,7 +61,7 @@ impl InvalidRequests {
 			for req in &invalidate_requests.queries {
 				if let Some(query_ty) = queries.get(req.key) {
 					if let Some(input) = &req.input_ty {
-						if &query_ty.ty.arg_ty != input {
+						if &query_ty.ty.input != input {
 							panic!(
 								"Error at '{}': Attempted to invalid query '{}' but the argument type does not match the type defined on the router.",
 								req.macro_src, req.key

--- a/core/src/api/volumes.rs
+++ b/core/src/api/volumes.rs
@@ -1,7 +1,10 @@
+use rspc::alpha::AlphaRouter;
+
 use crate::volume::get_volumes;
 
-use super::RouterBuilder;
+use super::{t, Ctx};
 
-pub(crate) fn mount() -> RouterBuilder {
-	RouterBuilder::new().query("list", |t| t(|_, _: ()| Ok(get_volumes()?)))
+pub(crate) fn mount() -> AlphaRouter<Ctx> {
+	t.router()
+		.procedure("list", t.query(|_, _: ()| Ok(get_volumes()?)))
 }

--- a/crates/crypto/src/protected.rs
+++ b/crates/crypto/src/protected.rs
@@ -30,42 +30,41 @@
 //!
 use std::{fmt::Debug, mem::swap};
 use zeroize::Zeroize;
+
 #[derive(Clone)]
-pub struct Protected<T>
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[cfg_attr(any(feature = "serde", feature = "specta"), derive(rspc::Type))]
+#[cfg_attr(any(feature = "serde", feature = "specta"), serde(transparent))]
+pub struct Protected<T>(T)
 where
-	T: Zeroize,
-{
-	data: T,
-}
+	T: Zeroize;
 
 impl<T> Protected<T>
 where
 	T: Zeroize,
 {
 	pub const fn new(value: T) -> Self {
-		Self { data: value }
+		Self(value)
 	}
 
 	pub const fn expose(&self) -> &T {
-		&self.data
+		&self.0
 	}
 
 	pub fn zeroize(mut self) {
-		self.data.zeroize();
+		self.0.zeroize();
 	}
 }
 
 impl From<Vec<u8>> for Protected<Vec<u8>> {
 	fn from(value: Vec<u8>) -> Self {
-		Self { data: value }
+		Self(value)
 	}
 }
 
 impl From<Protected<String>> for Protected<Vec<u8>> {
 	fn from(value: Protected<String>) -> Self {
-		Self {
-			data: value.expose().as_bytes().to_vec(),
-		}
+		Self(value.expose().as_bytes().to_vec())
 	}
 }
 
@@ -75,7 +74,7 @@ where
 {
 	pub fn into_inner(mut self) -> T {
 		let mut out = Default::default();
-		swap(&mut self.data, &mut out);
+		swap(&mut self.0, &mut out);
 		out
 	}
 }
@@ -85,7 +84,7 @@ where
 	T: Zeroize,
 {
 	fn drop(&mut self) {
-		self.data.zeroize();
+		self.0.zeroize();
 	}
 }
 
@@ -95,43 +94,5 @@ where
 {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.write_str("[REDACTED]")
-	}
-}
-
-#[cfg(feature = "serde")]
-impl<'de, T> serde::Deserialize<'de> for Protected<T>
-where
-	T: serde::Deserialize<'de> + Zeroize,
-{
-	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-	where
-		D: serde::Deserializer<'de>,
-	{
-		Ok(Self::new(T::deserialize(deserializer)?))
-	}
-}
-
-#[cfg(feature = "rspc")]
-use rspc::internal::specta;
-
-#[cfg(feature = "rspc")]
-impl<T> specta::Type for Protected<T>
-where
-	T: specta::Type + Zeroize,
-{
-	const NAME: &'static str = T::NAME;
-	const SID: specta::TypeSid = specta::sid!();
-	const IMPL_LOCATION: specta::ImplLocation = specta::impl_location!();
-
-	fn inline(opts: specta::DefOpts, generics: &[specta::DataType]) -> specta::DataType {
-		T::inline(opts, generics)
-	}
-
-	fn reference(opts: specta::DefOpts, generics: &[specta::DataType]) -> specta::DataType {
-		T::reference(opts, generics)
-	}
-
-	fn definition(opts: specta::DefOpts) -> specta::DataTypeExt {
-		T::definition(opts)
 	}
 }

--- a/crates/p2p/src/utils/peer_id.rs
+++ b/crates/p2p/src/utils/peer_id.rs
@@ -1,9 +1,13 @@
 use std::{fmt::Display, str::FromStr};
 
 #[derive(Debug, Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(transparent))]
-pub struct PeerId(pub(crate) libp2p::PeerId);
+#[cfg_attr(all(feature = "specta", feature = "serde"), serde(transparent))]
+pub struct PeerId(
+	#[cfg_attr(all(feature = "specta", feature = "serde"), specta(type = String))]
+	pub(crate)  libp2p::PeerId,
+);
 
 impl FromStr for PeerId {
 	type Err = libp2p::core::ParseError;
@@ -16,27 +20,5 @@ impl FromStr for PeerId {
 impl Display for PeerId {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		write!(f, "{}", self.0)
-	}
-}
-
-// TODO: Replace this with transparent when the new Specta release is merged
-// TODO: 	#[cfg_attr(feature = "specta", derive(specta::Type))]
-// TODO: 	pub struct PeerId(#[cfg_attr(feature = "specta", specta(type = String))] pub(crate) libp2p::PeerId);
-#[cfg(feature = "specta")]
-impl specta::Type for PeerId {
-	const NAME: &'static str = "PeerId";
-	const SID: specta::TypeSid = specta::sid!();
-	const IMPL_LOCATION: specta::ImplLocation = specta::impl_location!();
-
-	fn inline(opts: specta::DefOpts, generics: &[specta::DataType]) -> specta::DataType {
-		<String as specta::Type>::inline(opts, generics)
-	}
-
-	fn reference(opts: specta::DefOpts, generics: &[specta::DataType]) -> specta::DataType {
-		<String as specta::Type>::reference(opts, generics)
-	}
-
-	fn definition(opts: specta::DefOpts) -> specta::DataTypeExt {
-		<String as specta::Type>::definition(opts)
 	}
 }

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -4,7 +4,7 @@
 export type Procedures = {
     queries: 
         { key: "buildInfo", input: never, result: BuildInfo } | 
-        { key: "files.get", input: LibraryArgs<GetArgs>, result: { id: number, pub_id: number[], name: string | null, extension: string | null, kind: number, size_in_bytes: string, key_id: number | null, hidden: boolean, favorite: boolean, important: boolean, has_thumbnail: boolean, has_thumbstrip: boolean, has_video_preview: boolean, ipfs_id: string | null, note: string | null, date_created: string, date_modified: string, date_indexed: string, file_paths: FilePath[], media_data: MediaData | null } | null } | 
+        { key: "files.get", input: LibraryArgs<GetArgs>, result: { id: number; pub_id: number[]; name: string | null; extension: string | null; kind: number; size_in_bytes: string; key_id: number | null; hidden: boolean; favorite: boolean; important: boolean; has_thumbnail: boolean; has_thumbstrip: boolean; has_video_preview: boolean; ipfs_id: string | null; note: string | null; date_created: string; date_modified: string; date_indexed: string; file_paths: FilePath[]; media_data: MediaData | null } | null } | 
         { key: "jobs.getHistory", input: LibraryArgs<null>, result: JobReport[] } | 
         { key: "jobs.getRunning", input: LibraryArgs<null>, result: JobReport[] } | 
         { key: "jobs.isRunning", input: LibraryArgs<null>, result: boolean } | 
@@ -22,7 +22,7 @@ export type Procedures = {
         { key: "locations.indexer_rules.get", input: LibraryArgs<number>, result: IndexerRule } | 
         { key: "locations.indexer_rules.list", input: LibraryArgs<null>, result: IndexerRule[] } | 
         { key: "locations.indexer_rules.listForLocation", input: LibraryArgs<number>, result: IndexerRule[] } | 
-        { key: "locations.list", input: LibraryArgs<null>, result: { id: number, pub_id: number[], node_id: number, name: string, path: string, total_capacity: number | null, available_capacity: number | null, is_archived: boolean, generate_preview_media: boolean, sync_preview_media: boolean, hidden: boolean, date_created: string, node: Node }[] } | 
+        { key: "locations.list", input: LibraryArgs<null>, result: { id: number; pub_id: number[]; node_id: number; name: string; path: string; total_capacity: number | null; available_capacity: number | null; is_archived: boolean; generate_preview_media: boolean; sync_preview_media: boolean; hidden: boolean; date_created: string; node: Node }[] } | 
         { key: "nodeState", input: never, result: NodeState } | 
         { key: "tags.get", input: LibraryArgs<number>, result: Tag | null } | 
         { key: "tags.getExplorerData", input: LibraryArgs<number>, result: ExplorerData } | 
@@ -82,16 +82,43 @@ export type Procedures = {
         { key: "p2p.events", input: never, result: P2PEvent }
 };
 
+export type Protected<T> = T
+
 /**
- *  These are all possible algorithms that can be used for encryption and decryption
+ *  This denotes the `StoredKey` version.
  */
-export type Algorithm = "XChaCha20Poly1305" | "Aes256Gcm"
+export type StoredKeyVersion = "V1"
 
-export type AuthOption = { type: "Password", value: string } | { type: "TokenizedPassword", value: string }
+export type CreateLibraryArgs = { name: string; auth: AuthOption; algorithm: Algorithm; hashing_algorithm: HashingAlgorithm }
 
-export type AutomountUpdateArgs = { uuid: string, status: boolean }
+export type PeerMetadata = { name: string; operating_system: OperatingSystem | null; version: string | null; email: string | null; img_url: string | null }
 
-export type BuildInfo = { version: string, commit: string }
+export type MasterPasswordChangeArgs = { password: Protected<string>; algorithm: Algorithm; hashing_algorithm: HashingAlgorithm }
+
+export type PeerId = string
+
+export type FilePath = { id: number; is_dir: boolean; cas_id: string | null; integrity_checksum: string | null; location_id: number; materialized_path: string; name: string; extension: string; object_id: number | null; parent_id: number | null; key_id: number | null; date_created: string; date_modified: string; date_indexed: string }
+
+export type TokenizeKeyArgs = { secret_key: string }
+
+/**
+ *  This denotes the type of key. `Root` keys can be used to unlock the key manager, and `User` keys are ordinary keys.
+ */
+export type StoredKeyType = "User" | "Root"
+
+export type FileCopierJobInit = { source_location_id: number; source_path_id: number; target_location_id: number; target_path: string; target_file_name_suffix: string | null }
+
+export type Statistics = { id: number; date_captured: string; total_object_count: number; library_db_size: string; total_bytes_used: string; total_bytes_capacity: string; total_unique_bytes: string; total_bytes_free: string; preview_media_bytes: string }
+
+export type LocationExplorerArgs = { location_id: number; path: string; limit: number; cursor: string | null }
+
+export type ObjectValidatorArgs = { id: number; path: string }
+
+/**
+ *  Represents the operating system which the remote peer is running.
+ *  This is not used internally and predominantly is designed to be used for display purposes by the embedding application.
+ */
+export type OperatingSystem = "Windows" | "Linux" | "MacOS" | "Ios" | "Android" | { Other: string }
 
 /**
  *  ConfigMetadata is a part of node configuration that is loaded before the main configuration and contains information about the schema of the config.
@@ -99,49 +126,7 @@ export type BuildInfo = { version: string, commit: string }
  */
 export type ConfigMetadata = { version: string | null }
 
-export type CreateLibraryArgs = { name: string, auth: AuthOption, algorithm: Algorithm, hashing_algorithm: HashingAlgorithm }
-
-export type EditLibraryArgs = { id: string, name: string | null, description: string | null }
-
-/**
- *  This should be used for passing an encrypted key around.
- * 
- *  This is always `ENCRYPTED_KEY_LEN` (which is `KEY_LEM` + `AEAD_TAG_LEN`)
- */
-export type EncryptedKey = number[]
-
-export type ExplorerContext = ({ type:  "Location" } & Location) | ({ type:  "Tag" } & Tag)
-
-export type ExplorerData = { context: ExplorerContext, items: ExplorerItem[] }
-
-export type ExplorerItem = { type: "Path", has_thumbnail: boolean, item: file_path_with_object } | { type: "Object", has_thumbnail: boolean, item: object_with_file_paths }
-
-export type FileCopierJobInit = { source_location_id: number, source_path_id: number, target_location_id: number, target_path: string, target_file_name_suffix: string | null }
-
-export type FileCutterJobInit = { source_location_id: number, source_path_id: number, target_location_id: number, target_path: string }
-
-export type FileDecryptorJobInit = { location_id: number, path_id: number, mount_associated_key: boolean, output_path: string | null, password: string | null, save_to_library: boolean | null }
-
-export type FileDeleterJobInit = { location_id: number, path_id: number }
-
-export type FileEncryptorJobInit = { location_id: number, path_id: number, key_uuid: string, algorithm: Algorithm, metadata: boolean, preview_media: boolean, output_path: string | null }
-
-export type FileEraserJobInit = { location_id: number, path_id: number, passes: string }
-
-export type FilePath = { id: number, is_dir: boolean, cas_id: string | null, integrity_checksum: string | null, location_id: number, materialized_path: string, name: string, extension: string, object_id: number | null, parent_id: number | null, key_id: number | null, date_created: string, date_modified: string, date_indexed: string }
-
-export type GenerateThumbsForLocationArgs = { id: number, path: string }
-
-export type GetArgs = { id: number }
-
-/**
- *  This defines all available password hashing algorithms.
- */
-export type HashingAlgorithm = { name: "Argon2id", params: Params } | { name: "BalloonBlake3", params: Params }
-
-export type IdentifyUniqueFilesArgs = { id: number, path: string }
-
-export type IndexerRule = { id: number, kind: number, name: string, parameters: number[], date_created: string, date_modified: string }
+export type TagCreateArgs = { name: string; color: string }
 
 /**
  *  `IndexerRuleCreateArgs` is the argument received from the client using rspc to create a new indexer rule.
@@ -153,40 +138,21 @@ export type IndexerRule = { id: number, kind: number, name: string, parameters: 
  *  In case of `RuleKind::AcceptIfChildrenDirectoriesArePresent` or `RuleKind::RejectIfChildrenDirectoriesArePresent` the
  *  `parameters` field must be a vector of strings containing the names of the directories.
  */
-export type IndexerRuleCreateArgs = { kind: RuleKind, name: string, parameters: number[] }
+export type IndexerRuleCreateArgs = { kind: RuleKind; name: string; parameters: number[] }
 
-export type InvalidateOperationEvent = { key: string, arg: any }
+export type LightScanArgs = { location_id: number; sub_path: string }
 
-export type JobReport = { id: string, name: string, data: number[] | null, metadata: any | null, date_created: string, date_modified: string, status: JobStatus, task_count: number, completed_task_count: number, message: string, seconds_elapsed: number }
+export type InvalidateOperationEvent = { key: string; arg: any }
 
-export type JobStatus = "Queued" | "Running" | "Completed" | "Canceled" | "Failed" | "Paused"
+export type UnlockKeyManagerArgs = { password: Protected<string>; secret_key: Protected<string> }
 
-export type KeyAddArgs = { algorithm: Algorithm, hashing_algorithm: HashingAlgorithm, key: string, library_sync: boolean, automount: boolean }
+export type SetFavoriteArgs = { id: number; favorite: boolean }
 
-/**
- *  Can wrap a query argument to require it to contain a `library_id` and provide helpers for working with libraries.
- */
-export type LibraryArgs<T> = { library_id: string, arg: T }
+export type SpacedropArgs = { peer_id: PeerId; file_path: string }
 
-/**
- *  LibraryConfig holds the configuration for a specific library. This is stored as a '{uuid}.sdlibrary' file.
- */
-export type LibraryConfig = ({ version: string | null }) & { name: string, description: string }
+export type RuleKind = "AcceptFilesByGlob" | "RejectFilesByGlob" | "AcceptIfChildrenDirectoriesArePresent" | "RejectIfChildrenDirectoriesArePresent"
 
-export type LibraryConfigWrapped = { uuid: string, config: LibraryConfig }
-
-export type LightScanArgs = { location_id: number, sub_path: string }
-
-export type Location = { id: number, pub_id: number[], node_id: number, name: string, path: string, total_capacity: number | null, available_capacity: number | null, is_archived: boolean, generate_preview_media: boolean, sync_preview_media: boolean, hidden: boolean, date_created: string }
-
-/**
- *  `LocationCreateArgs` is the argument received from the client using `rspc` to create a new location.
- *  It has the actual path and a vector of indexer rules ids, to create many-to-many relationships
- *  between the location and indexer rules.
- */
-export type LocationCreateArgs = { path: string, indexer_rules_ids: number[] }
-
-export type LocationExplorerArgs = { location_id: number, path: string, limit: number, cursor: string | null }
+export type FileDeleterJobInit = { location_id: number; path_id: number }
 
 /**
  *  `LocationUpdateArgs` is the argument received from the client using `rspc` to update a location.
@@ -196,42 +162,28 @@ export type LocationExplorerArgs = { location_id: number, path: string, limit: n
  *  It is important to note that only the indexer rule ids in this vector will be used from now on.
  *  Old rules that aren't in this vector will be purged.
  */
-export type LocationUpdateArgs = { id: number, name: string | null, generate_preview_media: boolean | null, sync_preview_media: boolean | null, hidden: boolean | null, indexer_rules_ids: number[] }
+export type LocationUpdateArgs = { id: number; name: string | null; generate_preview_media: boolean | null; sync_preview_media: boolean | null; hidden: boolean | null; indexer_rules_ids: number[] }
 
-export type MasterPasswordChangeArgs = { password: string, algorithm: Algorithm, hashing_algorithm: HashingAlgorithm }
+export type IndexerRule = { id: number; kind: number; name: string; parameters: number[]; date_created: string; date_modified: string }
 
-export type MediaData = { id: number, pixel_width: number | null, pixel_height: number | null, longitude: number | null, latitude: number | null, fps: number | null, capture_device_make: string | null, capture_device_model: string | null, capture_device_software: string | null, duration_seconds: number | null, codecs: string | null, streams: number | null }
+export type JobStatus = "Queued" | "Running" | "Completed" | "Canceled" | "Failed" | "Paused"
 
-export type Node = { id: number, pub_id: number[], name: string, platform: number, version: string | null, last_seen: string, timezone: string | null, date_created: string }
+export type ExplorerData = { context: ExplorerContext; items: ExplorerItem[] }
 
 /**
  *  NodeConfig is the configuration for a node. This is shared between all libraries and is stored in a JSON file on disk.
  */
-export type NodeConfig = ({ version: string | null }) & { id: string, name: string, p2p_port: number | null, p2p_email: string | null, p2p_img_url: string | null }
-
-export type NodeState = (({ version: string | null }) & { id: string, name: string, p2p_port: number | null, p2p_email: string | null, p2p_img_url: string | null }) & { data_path: string }
+export type NodeConfig = ({ version: string | null }) & { id: string; name: string; p2p_port: number | null; p2p_email: string | null; p2p_img_url: string | null }
 
 /**
- *  This should be used for providing a nonce to encrypt/decrypt functions.
- * 
- *  You may also generate a nonce for a given algorithm with `Nonce::generate()`
+ *  This defines all available password hashing algorithms.
  */
-export type Nonce = { XChaCha20Poly1305: number[] } | { Aes256Gcm: number[] }
-
-export type Object = { id: number, pub_id: number[], name: string | null, extension: string | null, kind: number, size_in_bytes: string, key_id: number | null, hidden: boolean, favorite: boolean, important: boolean, has_thumbnail: boolean, has_thumbstrip: boolean, has_video_preview: boolean, ipfs_id: string | null, note: string | null, date_created: string, date_modified: string, date_indexed: string }
-
-export type ObjectValidatorArgs = { id: number, path: string }
+export type HashingAlgorithm = { name: "Argon2id"; params: Params } | { name: "BalloonBlake3"; params: Params }
 
 /**
- *  Represents the operating system which the remote peer is running.
- *  This is not used internally and predominantly is designed to be used for display purposes by the embedding application.
+ *  LibraryConfig holds the configuration for a specific library. This is stored as a '{uuid}.sdlibrary' file.
  */
-export type OperatingSystem = "Windows" | "Linux" | "MacOS" | "Ios" | "Android" | { Other: string }
-
-/**
- *  TODO: P2P event for the frontend
- */
-export type P2PEvent = { type: "DiscoveredPeer", peer_id: string, metadata: PeerMetadata }
+export type LibraryConfig = ({ version: string | null }) & { name: string; description: string }
 
 /**
  *  These parameters define the password-hashing level.
@@ -240,11 +192,70 @@ export type P2PEvent = { type: "DiscoveredPeer", peer_id: string, metadata: Peer
  */
 export type Params = "Standard" | "Hardened" | "Paranoid"
 
-export type PeerMetadata = { name: string, operating_system: OperatingSystem | null, version: string | null, email: string | null, img_url: string | null }
+/**
+ *  TODO: P2P event for the frontend
+ */
+export type P2PEvent = { type: "DiscoveredPeer"; peer_id: PeerId; metadata: PeerMetadata }
 
-export type RestoreBackupArgs = { password: string, secret_key: string, path: string }
+export type JobReport = { id: string; name: string; data: number[] | null; metadata: any | null; date_created: string; date_modified: string; status: JobStatus; task_count: number; completed_task_count: number; message: string; seconds_elapsed: number }
 
-export type RuleKind = "AcceptFilesByGlob" | "RejectFilesByGlob" | "AcceptIfChildrenDirectoriesArePresent" | "RejectIfChildrenDirectoriesArePresent"
+export type FileCutterJobInit = { source_location_id: number; source_path_id: number; target_location_id: number; target_path: string }
+
+export type NodeState = (({ version: string | null }) & { id: string; name: string; p2p_port: number | null; p2p_email: string | null; p2p_img_url: string | null }) & { data_path: string }
+
+export type Volume = { name: string; mount_point: string; total_capacity: string; available_capacity: string; is_removable: boolean; disk_type: string | null; file_system: string | null; is_root_filesystem: boolean }
+
+/**
+ *  These are all possible algorithms that can be used for encryption and decryption
+ */
+export type Algorithm = "XChaCha20Poly1305" | "Aes256Gcm"
+
+export type LibraryConfigWrapped = { uuid: string; config: LibraryConfig }
+
+export type file_path_with_object = { id: number; is_dir: boolean; cas_id: string | null; integrity_checksum: string | null; location_id: number; materialized_path: string; name: string; extension: string; object_id: number | null; parent_id: number | null; key_id: number | null; date_created: string; date_modified: string; date_indexed: string; object: Object | null }
+
+export type GetArgs = { id: number }
+
+export type ExplorerItem = { type: "Path"; has_thumbnail: boolean; item: file_path_with_object } | { type: "Object"; has_thumbnail: boolean; item: object_with_file_paths }
+
+export type Location = { id: number; pub_id: number[]; node_id: number; name: string; path: string; total_capacity: number | null; available_capacity: number | null; is_archived: boolean; generate_preview_media: boolean; sync_preview_media: boolean; hidden: boolean; date_created: string }
+
+/**
+ *  This should be used for passing an encrypted key around.
+ * 
+ *  This is always `ENCRYPTED_KEY_LEN` (which is `KEY_LEM` + `AEAD_TAG_LEN`)
+ */
+export type EncryptedKey = number[]
+
+/**
+ *  This should be used for providing a nonce to encrypt/decrypt functions.
+ * 
+ *  You may also generate a nonce for a given algorithm with `Nonce::generate()`
+ */
+export type Nonce = { XChaCha20Poly1305: number[] } | { Aes256Gcm: number[] }
+
+export type EditLibraryArgs = { id: string; name: string | null; description: string | null }
+
+/**
+ *  Can wrap a query argument to require it to contain a `library_id` and provide helpers for working with libraries.
+ */
+export type LibraryArgs<T> = { library_id: string; arg: T }
+
+export type location_with_indexer_rules = { id: number; pub_id: number[]; node_id: number; name: string; path: string; total_capacity: number | null; available_capacity: number | null; is_archived: boolean; generate_preview_media: boolean; sync_preview_media: boolean; hidden: boolean; date_created: string; indexer_rules: { indexer_rule: IndexerRule }[] }
+
+export type Node = { id: number; pub_id: number[]; name: string; platform: number; version: string | null; last_seen: string; timezone: string | null; date_created: string }
+
+export type FileEncryptorJobInit = { location_id: number; path_id: number; key_uuid: string; algorithm: Algorithm; metadata: boolean; preview_media: boolean; output_path: string | null }
+
+export type KeyAddArgs = { algorithm: Algorithm; hashing_algorithm: HashingAlgorithm; key: Protected<string>; library_sync: boolean; automount: boolean }
+
+export type ExplorerContext = ({ type: "Location" } & Location) | ({ type: "Tag" } & Tag)
+
+export type BuildInfo = { version: string; commit: string }
+
+export type IdentifyUniqueFilesArgs = { id: number; path: string }
+
+export type FileDecryptorJobInit = { location_id: number; path_id: number; mount_associated_key: boolean; output_path: string | null; password: string | null; save_to_library: boolean | null }
 
 /**
  *  This should be used for passing a salt around.
@@ -253,49 +264,42 @@ export type RuleKind = "AcceptFilesByGlob" | "RejectFilesByGlob" | "AcceptIfChil
  */
 export type Salt = number[]
 
-export type SetFavoriteArgs = { id: number, favorite: boolean }
+export type TagUpdateArgs = { id: number; name: string | null; color: string | null }
 
-export type SetNoteArgs = { id: number, note: string | null }
+export type TokenizeResponse = { token: string }
 
-export type SpacedropArgs = { peer_id: string, file_path: string }
-
-export type Statistics = { id: number, date_captured: string, total_object_count: number, library_db_size: string, total_bytes_used: string, total_bytes_capacity: string, total_unique_bytes: string, total_bytes_free: string, preview_media_bytes: string }
+export type TagAssignArgs = { object_id: number; tag_id: number; unassign: boolean }
 
 /**
  *  This is a stored key, and can be freely written to the database.
  * 
  *  It contains no sensitive information that is not encrypted.
  */
-export type StoredKey = { uuid: string, version: StoredKeyVersion, key_type: StoredKeyType, algorithm: Algorithm, hashing_algorithm: HashingAlgorithm, content_salt: Salt, master_key: EncryptedKey, master_key_nonce: Nonce, key_nonce: Nonce, key: number[], salt: Salt, memory_only: boolean, automount: boolean }
+export type StoredKey = { uuid: string; version: StoredKeyVersion; key_type: StoredKeyType; algorithm: Algorithm; hashing_algorithm: HashingAlgorithm; content_salt: Salt; master_key: EncryptedKey; master_key_nonce: Nonce; key_nonce: Nonce; key: number[]; salt: Salt; memory_only: boolean; automount: boolean }
+
+export type GenerateThumbsForLocationArgs = { id: number; path: string }
 
 /**
- *  This denotes the type of key. `Root` keys can be used to unlock the key manager, and `User` keys are ordinary keys.
+ *  `LocationCreateArgs` is the argument received from the client using `rspc` to create a new location.
+ *  It has the actual path and a vector of indexer rules ids, to create many-to-many relationships
+ *  between the location and indexer rules.
  */
-export type StoredKeyType = "User" | "Root"
+export type LocationCreateArgs = { path: string; indexer_rules_ids: number[] }
 
-/**
- *  This denotes the `StoredKey` version.
- */
-export type StoredKeyVersion = "V1"
+export type MediaData = { id: number; pixel_width: number | null; pixel_height: number | null; longitude: number | null; latitude: number | null; fps: number | null; capture_device_make: string | null; capture_device_model: string | null; capture_device_software: string | null; duration_seconds: number | null; codecs: string | null; streams: number | null }
 
-export type Tag = { id: number, pub_id: number[], name: string | null, color: string | null, total_objects: number | null, redundancy_goal: number | null, date_created: string, date_modified: string }
+export type Tag = { id: number; pub_id: number[]; name: string | null; color: string | null; total_objects: number | null; redundancy_goal: number | null; date_created: string; date_modified: string }
 
-export type TagAssignArgs = { object_id: number, tag_id: number, unassign: boolean }
+export type AutomountUpdateArgs = { uuid: string; status: boolean }
 
-export type TagCreateArgs = { name: string, color: string }
+export type Object = { id: number; pub_id: number[]; name: string | null; extension: string | null; kind: number; size_in_bytes: string; key_id: number | null; hidden: boolean; favorite: boolean; important: boolean; has_thumbnail: boolean; has_thumbstrip: boolean; has_video_preview: boolean; ipfs_id: string | null; note: string | null; date_created: string; date_modified: string; date_indexed: string }
 
-export type TagUpdateArgs = { id: number, name: string | null, color: string | null }
+export type SetNoteArgs = { id: number; note: string | null }
 
-export type TokenizeKeyArgs = { secret_key: string }
+export type RestoreBackupArgs = { password: Protected<string>; secret_key: Protected<string>; path: string }
 
-export type TokenizeResponse = { token: string }
+export type object_with_file_paths = { id: number; pub_id: number[]; name: string | null; extension: string | null; kind: number; size_in_bytes: string; key_id: number | null; hidden: boolean; favorite: boolean; important: boolean; has_thumbnail: boolean; has_thumbstrip: boolean; has_video_preview: boolean; ipfs_id: string | null; note: string | null; date_created: string; date_modified: string; date_indexed: string; file_paths: FilePath[] }
 
-export type UnlockKeyManagerArgs = { password: string, secret_key: string }
+export type FileEraserJobInit = { location_id: number; path_id: number; passes: string }
 
-export type Volume = { name: string, mount_point: string, total_capacity: string, available_capacity: string, is_removable: boolean, disk_type: string | null, file_system: string | null, is_root_filesystem: boolean }
-
-export type file_path_with_object = { id: number, is_dir: boolean, cas_id: string | null, integrity_checksum: string | null, location_id: number, materialized_path: string, name: string, extension: string, object_id: number | null, parent_id: number | null, key_id: number | null, date_created: string, date_modified: string, date_indexed: string, object: Object | null }
-
-export type location_with_indexer_rules = { id: number, pub_id: number[], node_id: number, name: string, path: string, total_capacity: number | null, available_capacity: number | null, is_archived: boolean, generate_preview_media: boolean, sync_preview_media: boolean, hidden: boolean, date_created: string, indexer_rules: { indexer_rule: IndexerRule }[] }
-
-export type object_with_file_paths = { id: number, pub_id: number[], name: string | null, extension: string | null, kind: number, size_in_bytes: string, key_id: number | null, hidden: boolean, favorite: boolean, important: boolean, has_thumbnail: boolean, has_thumbstrip: boolean, has_video_preview: boolean, ipfs_id: string | null, note: string | null, date_created: string, date_modified: string, date_indexed: string, file_paths: FilePath[] }
+export type AuthOption = { type: "Password"; value: Protected<string> } | { type: "TokenizedPassword"; value: string }


### PR DESCRIPTION
This is an experimental branch using the alpha version of the rspc v3 syntax. It also comes with the new version of [Specta](https://github.com/oscartbeaumont/specta) which provides stupidly better error handling and a large number of bug fixes.

I spent the weekend working with @Brendonovich on this and we have got some stuff working which will greatly help with the maintainability of our rspc integration as it means we can remove all uses of private rspc APIs (of which we have a lot). Currently, it takes me 2-6 hours of updating Spacedrive when rspc does any non-minor changes which is pretty bad.

These changes also come with a shift in the mental model which should make more sense and allow us to make better use of middleware which will help to solve many challenges such as authentication as we get further into launching our product.

TODO:
 - [ ] Get frontend talking with Rust again
 - [ ] Fix RN transport