### PR TITLE
[Desktop, UI] Dropdown/Context menu and explorer item/inspector improvements

### DIFF
--- a/interface/app/$libraryId/Explorer/AssignTagMenuItems.tsx
+++ b/interface/app/$libraryId/Explorer/AssignTagMenuItems.tsx
@@ -1,0 +1,114 @@
+import { useVirtualizer } from '@tanstack/react-virtual';
+import clsx from 'clsx';
+import { Plus } from 'phosphor-react';
+import { useRef } from 'react';
+import { useLibraryMutation, useLibraryQuery, usePlausibleEvent } from '@sd/client';
+import { ContextMenu, DropdownMenu, dialogManager, useContextMenu, useDropdownMenu } from '@sd/ui';
+import { useScrolled } from '~/hooks/useScrolled';
+import { usePlatform } from '~/util/Platform';
+import CreateDialog from '../settings/library/tags/CreateDialog';
+
+export default (props: { objectId: number }) => {
+	const platform = usePlatform();
+	const submitPlausibleEvent = usePlausibleEvent({ platformType: platform.platform });
+
+	const tags = useLibraryQuery(['tags.list'], { suspense: true });
+	const tagsForObject = useLibraryQuery(['tags.getForObject', props.objectId], { suspense: true });
+
+	const assignTag = useLibraryMutation('tags.assign', {
+		onSuccess: () => {
+			submitPlausibleEvent({ event: { type: 'tagAssign' } });
+		}
+	});
+
+	const parentRef = useRef<HTMLDivElement>(null);
+	const rowVirtualizer = useVirtualizer({
+		count: tags.data?.length || 0,
+		getScrollElement: () => parentRef.current,
+		estimateSize: () => 30,
+		paddingStart: 2
+	});
+
+	const { isScrolled } = useScrolled(parentRef, 10);
+
+	const isDropdownMenu = useDropdownMenu();
+	const isContextMenu = useContextMenu();
+	const Menu = isDropdownMenu ? DropdownMenu : isContextMenu ? ContextMenu : undefined;
+
+	if (!Menu) return null;
+	return (
+		<>
+			<Menu.Item
+				label="New tag"
+				icon={Plus}
+				iconProps={{ size: 15 }}
+				keybind="⌘N"
+				onClick={() => {
+					dialogManager.create((dp) => <CreateDialog {...dp} assignToObject={props.objectId} />);
+				}}
+			/>
+			<Menu.Separator className={clsx('mx-0 mb-0 transition', isScrolled && 'shadow')} />
+			{tags.data && tags.data.length > 0 ? (
+				<div
+					ref={parentRef}
+					style={{
+						maxHeight: `400px`,
+						height: `100%`,
+						width: `100%`,
+						overflow: 'auto'
+					}}
+				>
+					<div
+						style={{
+							height: `${rowVirtualizer.getTotalSize()}px`,
+							width: '100%',
+							position: 'relative'
+						}}
+					>
+						{rowVirtualizer.getVirtualItems().map((virtualRow) => {
+							const tag = tags.data[virtualRow.index];
+							const active = !!tagsForObject.data?.find((t) => t.id === tag?.id);
+
+							return (
+								tag && (
+									<Menu.Item
+										key={virtualRow.index}
+										style={{
+											position: 'absolute',
+											top: 0,
+											left: 0,
+											width: '100%',
+											height: `${virtualRow.size}px`,
+											transform: `translateY(${virtualRow.start}px)`
+										}}
+										onClick={(e) => {
+											e.preventDefault();
+											assignTag.mutate({
+												tag_id: tag.id,
+												object_id: props.objectId,
+												unassign: active
+											});
+										}}
+									>
+										<div
+											className="mr-0.5 h-[15px] w-[15px] shrink-0 rounded-full border"
+											style={{
+												backgroundColor: active && tag.color ? tag.color : 'transparent',
+												borderColor: tag.color || '#efefef'
+											}}
+										/>
+										<span className="truncate">{tag.name}</span>
+									</Menu.Item>
+								)
+							);
+						})}
+					</div>
+				</div>
+			) : (
+				<div className="text-ink-faint py-1 text-center text-xs">
+					{tags.data ? 'No tags' : 'Failed to load tags'}
+				</div>
+			)}
+		</>
+	);
+};

--- a/interface/app/$libraryId/Explorer/File/ContextMenu.tsx
+++ b/interface/app/$libraryId/Explorer/File/ContextMenu.tsx
@@ -1,3 +1,5 @@
+import { useVirtualizer } from '@tanstack/react-virtual';
+import clsx from 'clsx';
 import {
 	ArrowBendUpRight,
 	Copy,
@@ -12,7 +14,7 @@ import {
 	Trash,
 	TrashSimple
 } from 'phosphor-react';
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, useRef } from 'react';
 import {
 	ExplorerItem,
 	isObject,
@@ -25,7 +27,9 @@ import { ContextMenu, Input, dialogManager } from '@sd/ui';
 import { useExplorerParams } from '~/app/$libraryId/location/$id';
 import { showAlertDialog } from '~/components/AlertDialog';
 import { getExplorerStore, useExplorerStore } from '~/hooks/useExplorerStore';
+import { useScrolled } from '~/hooks/useScrolled';
 import { usePlatform } from '~/util/Platform';
+import CreateDialog from '../../settings/library/tags/CreateDialog';
 import { OpenInNativeExplorer } from '../ContextMenu';
 import DecryptDialog from './DecryptDialog';
 import DeleteDialog from './DeleteDialog';
@@ -158,9 +162,11 @@ export default ({ data, ...props }: Props) => {
 
 				<ContextMenu.Separator />
 
-				<ContextMenu.SubMenu label="Assign tag" icon={TagSimple}>
-					<AssignTagMenuItems objectId={objectData?.id || 0} />
-				</ContextMenu.SubMenu>
+				{objectData && (
+					<ContextMenu.SubMenu label="Assign tag" icon={TagSimple}>
+						<AssignTagMenuItems objectId={objectData.id} />
+					</ContextMenu.SubMenu>
+				)}
 
 				<ContextMenu.SubMenu label="More actions..." icon={Plus}>
 					<ContextMenu.Item
@@ -254,48 +260,96 @@ const AssignTagMenuItems = (props: { objectId: number }) => {
 
 	const tags = useLibraryQuery(['tags.list'], { suspense: true });
 	const tagsForObject = useLibraryQuery(['tags.getForObject', props.objectId], { suspense: true });
+
 	const assignTag = useLibraryMutation('tags.assign', {
 		onSuccess: () => {
 			submitPlausibleEvent({ event: { type: 'tagAssign' } });
 		}
 	});
 
+	const parentRef = useRef<HTMLDivElement>(null);
+	const rowVirtualizer = useVirtualizer({
+		count: tags.data?.length || 0,
+		getScrollElement: () => parentRef.current,
+		estimateSize: () => 30,
+		paddingStart: 2
+	});
+
+	const { isScrolled } = useScrolled(parentRef, 10);
+
 	return (
 		<>
-			{tags.data?.length === 0 && (
-				<div className="m-1 pb-10">
-					<Input autoFocus defaultValue="New tag" />
-				</div>
-			)}
-			{tags.data?.map((tag, index) => {
-				const active = !!tagsForObject.data?.find((t) => t.id === tag.id);
-
-				return (
-					<ContextMenu.Item
-						key={tag.id}
-						keybind={`${index + 1}`}
-						onClick={(e) => {
-							e.preventDefault();
-							if (props.objectId === null) return;
-
-							assignTag.mutate({
-								tag_id: tag.id,
-								object_id: props.objectId,
-								unassign: active
-							});
+			<ContextMenu.Item
+				label="New tag"
+				icon={Plus}
+				iconProps={{ size: 15 }}
+				keybind="⌘N"
+				onClick={() => {
+					dialogManager.create((dp) => <CreateDialog {...dp} assignToObject={props.objectId} />);
+				}}
+			/>
+			<ContextMenu.Separator className={clsx('mx-0 mb-0 transition', isScrolled && 'shadow')} />
+			{tags.data && tags.data.length > 0 ? (
+				<div
+					ref={parentRef}
+					style={{
+						maxHeight: `400px`,
+						height: `100%`,
+						width: `100%`,
+						overflow: 'auto'
+					}}
+				>
+					<div
+						style={{
+							height: `${rowVirtualizer.getTotalSize()}px`,
+							width: '100%',
+							position: 'relative'
 						}}
 					>
-						<div
-							className="mr-0.5 block h-[15px] w-[15px] rounded-full border"
-							style={{
-								backgroundColor: active ? tag.color || '#efefef' : 'transparent' || '#efefef',
-								borderColor: tag.color || '#efefef'
-							}}
-						/>
-						<p>{tag.name}</p>
-					</ContextMenu.Item>
-				);
-			})}
+						{rowVirtualizer.getVirtualItems().map((virtualRow) => {
+							const tag = tags.data[virtualRow.index];
+							const active = !!tagsForObject.data?.find((t) => t.id === tag?.id);
+
+							return (
+								tag && (
+									<ContextMenu.Item
+										key={virtualRow.index}
+										style={{
+											position: 'absolute',
+											top: 0,
+											left: 0,
+											width: '100%',
+											height: `${virtualRow.size}px`,
+											transform: `translateY(${virtualRow.start}px)`
+										}}
+										onClick={(e) => {
+											e.preventDefault();
+											assignTag.mutate({
+												tag_id: tag.id,
+												object_id: props.objectId,
+												unassign: active
+											});
+										}}
+									>
+										<div
+											className="mr-0.5 h-[15px] w-[15px] shrink-0 rounded-full border"
+											style={{
+												backgroundColor: active && tag.color ? tag.color : 'transparent',
+												borderColor: tag.color || '#efefef'
+											}}
+										/>
+										<span className="truncate">{tag.name}</span>
+									</ContextMenu.Item>
+								)
+							);
+						})}
+					</div>
+				</div>
+			) : (
+				<div className="text-ink-faint py-1 text-center text-xs">
+					{tags.data ? 'No tags' : 'Failed to load tags'}
+				</div>
+			)}
 		</>
 	);
 };

--- a/interface/app/$libraryId/Explorer/Inspector/index.tsx
+++ b/interface/app/$libraryId/Explorer/Inspector/index.tsx
@@ -16,7 +16,7 @@ import FileThumb from '../File/Thumb';
 import FavoriteButton from './FavoriteButton';
 import Note from './Note';
 
-export const InfoPill = tw.span`inline border border-transparent px-1 text-[11px] font-medium shadow shadow-app-shade/5 bg-app-selected rounded-md text-ink-dull`;
+export const InfoPill = tw.span`inline border border-transparent px-1 text-[11px] font-medium shadow shadow-app-shade/5 bg-app-selected rounded-md text-ink-dull truncate`;
 export const PlaceholderPill = tw.span`inline border px-1 text-[11px] shadow shadow-app-shade/10 rounded-md bg-transparent border-dashed border-app-active transition hover:text-ink-faint hover:border-ink-faint font-medium text-ink-faint/70`;
 
 export const MetaContainer = tw.div`flex flex-col px-4 py-1.5`;
@@ -110,7 +110,7 @@ export const Inspector = ({ data, context, ...elementProps }: Props) => {
 						)}
 						<Divider />
 						<MetaContainer>
-							<div className="flex flex-wrap gap-1">
+							<div className="flex flex-wrap gap-1 overflow-hidden">
 								<InfoPill>{isDir ? 'Folder' : ObjectKind[objectData?.kind || 0]}</InfoPill>
 								{item?.extension && <InfoPill>{item.extension}</InfoPill>}
 								{tags?.data?.map((tag) => (
@@ -118,6 +118,7 @@ export const Inspector = ({ data, context, ...elementProps }: Props) => {
 										className="!text-white"
 										key={tag.id}
 										style={{ backgroundColor: tag.color + 'CC' }}
+										title={tag.name || ''}
 									>
 										{tag.name}
 									</InfoPill>

--- a/interface/app/$libraryId/Explorer/Inspector/index.tsx
+++ b/interface/app/$libraryId/Explorer/Inspector/index.tsx
@@ -11,7 +11,8 @@ import {
 	isObject,
 	useLibraryQuery
 } from '@sd/client';
-import { Button, Divider, Tooltip, tw } from '@sd/ui';
+import { Button, Divider, DropdownMenu, Tooltip, tw } from '@sd/ui';
+import AssignTagMenuItems from '../AssignTagMenuItems';
 import FileThumb from '../File/Thumb';
 import FavoriteButton from './FavoriteButton';
 import Note from './Note';
@@ -123,7 +124,17 @@ export const Inspector = ({ data, context, ...elementProps }: Props) => {
 										{tag.name}
 									</InfoPill>
 								))}
-								<PlaceholderPill>Add Tag</PlaceholderPill>
+								{objectData?.id && (
+									<DropdownMenu.Root
+										trigger={<PlaceholderPill>Add Tag</PlaceholderPill>}
+										side="left"
+										animate
+										sideOffset={5}
+										alignOffset={-10}
+									>
+										<AssignTagMenuItems objectId={objectData.id} />
+									</DropdownMenu.Root>
+								)}
 							</div>
 						</MetaContainer>
 						<Divider />

--- a/interface/app/$libraryId/Layout/Sidebar/LibrariesDropdown.tsx
+++ b/interface/app/$libraryId/Layout/Sidebar/LibrariesDropdown.tsx
@@ -40,7 +40,7 @@ export default () => {
 					{lib.config.name}
 				</DropdownMenu.Item>
 			))}
-			<DropdownMenu.Separator className="mx-0 my-0.5" />
+			<DropdownMenu.Separator className="mx-0" />
 			<DropdownMenu.Item
 				label="	New Library"
 				icon={Plus}

--- a/interface/app/$libraryId/settings/library/tags/CreateDialog.tsx
+++ b/interface/app/$libraryId/settings/library/tags/CreateDialog.tsx
@@ -1,10 +1,10 @@
-import { useClientContext, useLibraryMutation, usePlausibleEvent } from '@sd/client';
+import { useLibraryMutation, usePlausibleEvent } from '@sd/client';
 import { Dialog, UseDialogProps, useDialog } from '@sd/ui';
 import { Input, useZodForm, z } from '@sd/ui/src/forms';
 import ColorPicker from '~/components/ColorPicker';
 import { usePlatform } from '~/util/Platform';
 
-export default (props: UseDialogProps) => {
+export default (props: UseDialogProps & { assignToObject?: number }) => {
 	const dialog = useDialog(props);
 	const platform = usePlatform();
 	const submitPlausibleEvent = usePlausibleEvent({ platformType: platform.platform });
@@ -20,11 +20,20 @@ export default (props: UseDialogProps) => {
 	});
 
 	const createTag = useLibraryMutation('tags.create', {
-		onSuccess: () => {
+		onSuccess: (tag) => {
 			submitPlausibleEvent({ event: { type: 'tagCreate' } });
+			if (props.assignToObject) {
+				assignTag.mutate({ tag_id: tag.id, object_id: props.assignToObject, unassign: false });
+			}
 		},
 		onError: (e) => {
 			console.error('error', e);
+		}
+	});
+
+	const assignTag = useLibraryMutation('tags.assign', {
+		onSuccess: () => {
+			submitPlausibleEvent({ event: { type: 'tagAssign' } });
 		}
 	});
 

--- a/interface/app/$libraryId/settings/library/tags/index.tsx
+++ b/interface/app/$libraryId/settings/library/tags/index.tsx
@@ -31,18 +31,18 @@ export const Component = () => {
 				}
 			/>
 			<Card className="!px-2">
-				<div className="m-1 flex flex-wrap gap-2">
+				<div className="m-1 flex flex-wrap gap-2 overflow-hidden">
 					{tags.data?.map((tag) => (
 						<div
 							onClick={() => setSelectedTag(tag.id === selectedTag?.id ? null : tag)}
 							key={tag.id}
 							className={clsx(
-								'flex items-center rounded px-1.5 py-0.5',
+								'flex items-center overflow-hidden rounded px-1.5 py-0.5',
 								selectedTag?.id === tag.id && 'ring'
 							)}
 							style={{ backgroundColor: tag.color + 'CC' }}
 						>
-							<span className="text-xs text-white drop-shadow-md">{tag.name}</span>
+							<span className="truncate text-xs text-white drop-shadow-md">{tag.name}</span>
 						</div>
 					))}
 				</div>

--- a/interface/hooks/useScrolled.tsx
+++ b/interface/hooks/useScrolled.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+export const useScrolled = (ref: React.RefObject<HTMLDivElement>, y = 1) => {
+	const [isScrolled, setIsScrolled] = useState(false);
+
+	useEffect(() => {
+		const onScroll = () => {
+			if (ref.current) {
+				if (ref.current.scrollTop >= y) setIsScrolled(true);
+				else setIsScrolled(false);
+			}
+		};
+
+		onScroll();
+		ref.current?.addEventListener('scroll', onScroll);
+		() => ref.current?.removeEventListener('scroll', onScroll);
+	}, [ref.current, y]);
+
+	return { isScrolled };
+};

--- a/packages/ui/src/ContextMenu.tsx
+++ b/packages/ui/src/ContextMenu.tsx
@@ -2,7 +2,7 @@ import * as RadixCM from '@radix-ui/react-context-menu';
 import { VariantProps, cva } from 'class-variance-authority';
 import clsx from 'clsx';
 import { CaretRight, Icon, IconProps } from 'phosphor-react';
-import { PropsWithChildren, Suspense } from 'react';
+import { PropsWithChildren, Suspense, createContext, useContext } from 'react';
 
 interface ContextMenuProps extends RadixCM.MenuContentProps {
 	trigger: React.ReactNode;
@@ -16,13 +16,16 @@ export const contextMenuClassNames = clsx(
 	'cursor-default select-none rounded-md'
 );
 
+const context = createContext<boolean>(false);
+export const useContextMenu = () => useContext(context);
+
 const Root = ({ trigger, children, className, ...props }: ContextMenuProps) => {
 	return (
 		<RadixCM.Root>
 			<RadixCM.Trigger asChild>{trigger}</RadixCM.Trigger>
 			<RadixCM.Portal>
 				<RadixCM.Content className={clsx(contextMenuClassNames, className)} {...props}>
-					{children}
+					<context.Provider value={true}>{children}</context.Provider>
 				</RadixCM.Content>
 			</RadixCM.Portal>
 		</RadixCM.Root>

--- a/packages/ui/src/ContextMenu.tsx
+++ b/packages/ui/src/ContextMenu.tsx
@@ -58,7 +58,7 @@ const SubMenu = ({
 	);
 };
 
-export const contextMenuItemStyles = cva(
+const contextMenuItemStyles = cva(
 	[
 		'flex h-[26px] items-center space-x-2 overflow-hidden rounded px-2',
 		'text-ink text-sm',
@@ -122,13 +122,7 @@ export const ContextMenuDivItem = ({
 	</div>
 );
 
-export const ItemInternals = ({
-	icon,
-	label,
-	rightArrow,
-	keybind,
-	iconProps
-}: ContextMenuItemProps) => {
+const ItemInternals = ({ icon, label, rightArrow, keybind, iconProps }: ContextMenuItemProps) => {
 	const ItemIcon = icon;
 
 	return (

--- a/packages/ui/src/ContextMenu.tsx
+++ b/packages/ui/src/ContextMenu.tsx
@@ -8,21 +8,20 @@ interface ContextMenuProps extends RadixCM.MenuContentProps {
 	trigger: React.ReactNode;
 }
 
-export const contextMenuClasses = clsx(
-	'z-50 flex flex-col',
-	'my-2 min-w-[8rem] px-1 py-0.5',
-	'text-menu-ink text-left text-sm',
+export const contextMenuClassNames = clsx(
+	'z-50 max-h-[calc(100vh-20px)] overflow-y-auto',
+	'my-2 min-w-[12rem] max-w-[16rem] px-1 py-0.5',
 	'bg-menu cool-shadow',
 	'border-menu-line border',
 	'cursor-default select-none rounded-md'
 );
 
-const Root = ({ trigger, children, className, ...props }: PropsWithChildren<ContextMenuProps>) => {
+const Root = ({ trigger, children, className, ...props }: ContextMenuProps) => {
 	return (
 		<RadixCM.Root>
 			<RadixCM.Trigger asChild>{trigger}</RadixCM.Trigger>
 			<RadixCM.Portal>
-				<RadixCM.Content {...props} className={clsx(contextMenuClasses, className)}>
+				<RadixCM.Content className={clsx(contextMenuClassNames, className)} {...props}>
 					{children}
 				</RadixCM.Content>
 			</RadixCM.Portal>
@@ -30,15 +29,11 @@ const Root = ({ trigger, children, className, ...props }: PropsWithChildren<Cont
 	);
 };
 
-export const contextMenuSeparatorClassNames =
-	'border-b-menu-line pointer-events-none mx-2 my-1 border-0 border-b';
+export const contextMenuSeparatorClassNames = 'border-b-menu-line my-0.5 border-b';
 
 const Separator = (props: { className?: string }) => (
 	<RadixCM.Separator className={clsx(contextMenuSeparatorClassNames, props.className)} />
 );
-
-export const contextSubMenuTriggerClassNames =
-	"[&[data-state='open']_div]:bg-accent text-menu-ink py-[3px]  focus:outline-none [&[data-state='open']_div]:text-white";
 
 const SubMenu = ({
 	label,
@@ -48,12 +43,15 @@ const SubMenu = ({
 }: RadixCM.MenuSubContentProps & ContextMenuItemProps) => {
 	return (
 		<RadixCM.Sub>
-			<RadixCM.SubTrigger className={contextSubMenuTriggerClassNames}>
-				<DivItem rightArrow {...{ label, icon }} />
+			<RadixCM.SubTrigger className={contextMenuItemClassNames}>
+				<ContextMenuDivItem rightArrow {...{ label, icon }} />
 			</RadixCM.SubTrigger>
 			<RadixCM.Portal>
 				<Suspense fallback={null}>
-					<RadixCM.SubContent {...props} className={clsx(contextMenuClasses, '-mt-2', className)} />
+					<RadixCM.SubContent
+						className={clsx(contextMenuClassNames, '-mt-2', className)}
+						{...props}
+					/>
 				</Suspense>
 			</RadixCM.Portal>
 		</RadixCM.Sub>
@@ -62,19 +60,21 @@ const SubMenu = ({
 
 export const contextMenuItemStyles = cva(
 	[
-		'flex flex-1 flex-row items-center justify-start overflow-hidden',
-		'space-x-2 px-2 py-[3px]',
-		'cursor-default rounded',
-		'focus:outline-none'
+		'flex h-[26px] items-center space-x-2 overflow-hidden rounded px-2',
+		'text-ink text-sm',
+		'group-radix-highlighted:text-white dark:group-radix-highlighted:text-ink',
+		'group-radix-highlighted:text-white dark:group-radix-highlighted:text-ink',
+		'group-radix-disabled:text-ink/50 group-radix-disabled:pointer-events-none',
+		'group-radix-state-open:bg-accent group-radix-state-open:text-white dark:group-radix-state-open:text-ink'
 	],
 	{
 		variants: {
 			variant: {
-				default: 'hover:bg-accent focus:bg-accent hover:text-white',
+				default: 'group-radix-highlighted:bg-accent',
 				danger: [
 					'text-red-600 dark:text-red-400',
-					'hover:text-white focus:text-white',
-					'hover:bg-red-500 focus:bg-red-500'
+					'group-radix-highlighted:text-white',
+					'group-radix-highlighted:bg-red-500'
 				]
 			}
 		},
@@ -92,6 +92,8 @@ export interface ContextMenuItemProps extends VariantProps<typeof contextMenuIte
 	keybind?: string;
 }
 
+export const contextMenuItemClassNames = 'group py-0.5 outline-none';
+
 const Item = ({
 	icon,
 	label,
@@ -99,20 +101,24 @@ const Item = ({
 	children,
 	keybind,
 	variant,
+	iconProps,
 	...props
 }: ContextMenuItemProps & RadixCM.MenuItemProps) => {
 	return (
-		<RadixCM.Item {...props} className="">
-			<div className={contextMenuItemStyles({ variant })}>
-				{children ? children : <ItemInternals {...{ icon, label, rightArrow, keybind }} />}
-			</div>
+		<RadixCM.Item className={contextMenuItemClassNames} {...props}>
+			<ContextMenuDivItem {...{ icon, iconProps, label, rightArrow, keybind, variant, children }} />
 		</RadixCM.Item>
 	);
 };
 
-const DivItem = ({ variant, ...props }: ContextMenuItemProps) => (
-	<div className={contextMenuItemStyles({ variant })}>
-		<ItemInternals {...props} />
+export const ContextMenuDivItem = ({
+	variant,
+	children,
+	className,
+	...props
+}: PropsWithChildren<ContextMenuItemProps & { className?: string }>) => (
+	<div className={contextMenuItemStyles({ variant, className })}>
+		{children || <ItemInternals {...props} />}
 	</div>
 );
 
@@ -124,21 +130,23 @@ export const ItemInternals = ({
 	iconProps
 }: ContextMenuItemProps) => {
 	const ItemIcon = icon;
+
 	return (
 		<>
 			{ItemIcon && <ItemIcon size={18} {...iconProps} />}
-			{label && <p>{label}</p>}
+			{label && <span className="flex-1 truncate">{label}</span>}
 
 			{keybind && (
-				<span className="flex-end text-menu-faint absolute right-3 text-xs font-medium group-hover:text-white">
+				<span className="text-menu-faint group-radix-highlighted:text-white text-xs font-medium">
 					{keybind}
 				</span>
 			)}
 			{rightArrow && (
-				<>
-					<div className="flex-1" />
-					<CaretRight weight="fill" size={12} alt="" className="text-menu-faint" />
-				</>
+				<CaretRight
+					weight="fill"
+					size={12}
+					className="text-menu-faint group-radix-highlighted:text-white group-radix-state-open:text-white"
+				/>
 			)}
 		</>
 	);

--- a/packages/ui/src/ContextMenu.tsx
+++ b/packages/ui/src/ContextMenu.tsx
@@ -10,7 +10,7 @@ interface ContextMenuProps extends RadixCM.MenuContentProps {
 
 export const contextMenuClassNames = clsx(
 	'z-50 max-h-[calc(100vh-20px)] overflow-y-auto',
-	'my-2 min-w-[12rem] max-w-[16rem] px-1 py-0.5',
+	'my-2 min-w-[12rem] max-w-[16rem] py-0.5',
 	'bg-menu cool-shadow',
 	'border-menu-line border',
 	'cursor-default select-none rounded-md'
@@ -29,7 +29,7 @@ const Root = ({ trigger, children, className, ...props }: ContextMenuProps) => {
 	);
 };
 
-export const contextMenuSeparatorClassNames = 'border-b-menu-line my-0.5 border-b';
+export const contextMenuSeparatorClassNames = 'border-b-menu-line mx-1 my-0.5 border-b';
 
 const Separator = (props: { className?: string }) => (
 	<RadixCM.Separator className={clsx(contextMenuSeparatorClassNames, props.className)} />
@@ -92,7 +92,7 @@ export interface ContextMenuItemProps extends VariantProps<typeof contextMenuIte
 	keybind?: string;
 }
 
-export const contextMenuItemClassNames = 'group py-0.5 outline-none';
+export const contextMenuItemClassNames = 'group py-0.5 outline-none px-1';
 
 const Item = ({
 	icon,

--- a/packages/ui/src/DropdownMenu.tsx
+++ b/packages/ui/src/DropdownMenu.tsx
@@ -5,10 +5,10 @@ import { Link } from 'react-router-dom';
 import {
 	ContextMenuItemProps,
 	ItemInternals,
-	contextMenuClasses,
+	contextMenuClassNames,
+	contextMenuItemClassNames,
 	contextMenuItemStyles,
-	contextMenuSeparatorClassNames,
-	contextSubMenuTriggerClassNames
+	contextMenuSeparatorClassNames
 } from './ContextMenu';
 
 interface DropdownMenuProps
@@ -47,9 +47,10 @@ const Root = ({
 					<div className="fixed inset-0"></div>
 					<RadixDM.Content
 						className={clsx(
-							contextMenuClasses,
+							contextMenuClassNames,
 							animate && 'animate-in fade-in data-[side=bottom]:slide-in-from-top-2',
 							'w-44',
+							width && 'min-w-0',
 							className
 						)}
 						align="start"
@@ -77,7 +78,7 @@ const SubMenu = ({
 }: RadixDM.MenuSubContentProps & ContextMenuItemProps) => {
 	return (
 		<RadixDM.Sub>
-			<RadixDM.SubTrigger className={contextSubMenuTriggerClassNames}>
+			<RadixDM.SubTrigger className={contextMenuItemClassNames}>
 				<div
 					className={contextMenuItemStyles({
 						class: 'group-radix-state-open:bg-trinary/50 group-radix-state-open:text-primary'
@@ -89,7 +90,7 @@ const SubMenu = ({
 			<RadixDM.Portal>
 				<Suspense fallback={null}>
 					<RadixDM.SubContent
-						className={clsx(contextMenuClasses, className)}
+						className={clsx(contextMenuClassNames, className)}
 						collisionPadding={5}
 						{...props}
 					/>

--- a/packages/ui/src/DropdownMenu.tsx
+++ b/packages/ui/src/DropdownMenu.tsx
@@ -3,17 +3,14 @@ import clsx from 'clsx';
 import React, { PropsWithChildren, Suspense, useCallback, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
+	ContextMenuDivItem,
 	ContextMenuItemProps,
-	ItemInternals,
 	contextMenuClassNames,
 	contextMenuItemClassNames,
-	contextMenuItemStyles,
 	contextMenuSeparatorClassNames
 } from './ContextMenu';
 
-interface DropdownMenuProps
-	extends RadixDM.MenuContentProps,
-		Pick<RadixDM.DropdownMenuProps, 'onOpenChange'> {
+interface DropdownMenuProps extends RadixDM.MenuContentProps {
 	trigger: React.ReactNode;
 	triggerClassName?: string;
 	alignToTrigger?: boolean;
@@ -27,7 +24,6 @@ const Root = ({
 	asChild = true,
 	triggerClassName,
 	alignToTrigger,
-	onOpenChange,
 	animate,
 	...props
 }: PropsWithChildren<DropdownMenuProps>) => {
@@ -38,29 +34,24 @@ const Root = ({
 	}, []);
 
 	return (
-		<RadixDM.Root modal={false} onOpenChange={onOpenChange}>
+		<RadixDM.Root>
 			<RadixDM.Trigger ref={measureRef} asChild={asChild} className={triggerClassName}>
 				{trigger}
 			</RadixDM.Trigger>
 			<RadixDM.Portal>
-				<div>
-					<div className="fixed inset-0"></div>
-					<RadixDM.Content
-						className={clsx(
-							contextMenuClassNames,
-							animate && 'animate-in fade-in data-[side=bottom]:slide-in-from-top-2',
-							'w-44',
-							width && 'min-w-0',
-							className
-						)}
-						align="start"
-						collisionPadding={5}
-						style={{ width }}
-						{...props}
-					>
-						{children}
-					</RadixDM.Content>
-				</div>
+				<RadixDM.Content
+					className={clsx(
+						contextMenuClassNames,
+						animate && 'animate-in fade-in data-[side=bottom]:slide-in-from-top-2',
+						width && 'min-w-0',
+						className
+					)}
+					align="start"
+					style={{ width }}
+					{...props}
+				>
+					{children}
+				</RadixDM.Content>
 			</RadixDM.Portal>
 		</RadixDM.Root>
 	);
@@ -79,28 +70,18 @@ const SubMenu = ({
 	return (
 		<RadixDM.Sub>
 			<RadixDM.SubTrigger className={contextMenuItemClassNames}>
-				<div
-					className={contextMenuItemStyles({
-						class: 'group-radix-state-open:bg-trinary/50 group-radix-state-open:text-primary'
-					})}
-				>
-					<ItemInternals rightArrow {...{ label, icon }} />
-				</div>
+				<ContextMenuDivItem rightArrow {...{ label, icon }} />
 			</RadixDM.SubTrigger>
 			<RadixDM.Portal>
 				<Suspense fallback={null}>
-					<RadixDM.SubContent
-						className={clsx(contextMenuClassNames, className)}
-						collisionPadding={5}
-						{...props}
-					/>
+					<RadixDM.SubContent className={clsx(contextMenuClassNames, className)} {...props} />
 				</Suspense>
 			</RadixDM.Portal>
 		</RadixDM.Sub>
 	);
 };
 
-interface DropdownItemProps extends ContextMenuItemProps, RadixDM.MenuItemProps {
+interface DropdownItemProps extends ContextMenuItemProps {
 	to?: string;
 	selected?: boolean;
 }
@@ -117,39 +98,23 @@ const Item = ({
 	selected,
 	to,
 	...props
-}: DropdownItemProps) => {
+}: DropdownItemProps & RadixDM.MenuItemProps) => {
 	const ref = useRef<HTMLDivElement>(null);
 
 	return (
-		<RadixDM.Item
-			className={clsx(
-				'text-menu-ink group cursor-default select-none py-0.5 focus:outline-none active:opacity-80',
-				className
-			)}
-			ref={ref}
-			{...props}
-		>
+		<RadixDM.Item ref={ref} className={clsx(contextMenuItemClassNames, className)} {...props}>
 			{to ? (
-				<Link
-					to={to}
-					className={contextMenuItemStyles({
-						variant,
-						className: clsx(selected && 'bg-accent')
-					})}
-					onClick={() => ref.current?.click()}
-				>
-					{children ? (
-						<span className="truncate">{children}</span>
-					) : (
-						<ItemInternals {...{ icon, iconProps, label, rightArrow, keybind }} />
-					)}
+				<Link to={to} onClick={() => ref.current?.click()}>
+					<ContextMenuDivItem
+						className={clsx(selected && 'bg-accent')}
+						{...{ icon, iconProps, label, rightArrow, keybind, variant, children }}
+					/>
 				</Link>
 			) : (
-				<div
-					className={contextMenuItemStyles({ variant, className: clsx(selected && 'bg-accent') })}
-				>
-					{children || <ItemInternals {...{ icon, iconProps, label, rightArrow, keybind }} />}
-				</div>
+				<ContextMenuDivItem
+					className={clsx(selected && 'bg-accent')}
+					{...{ icon, iconProps, label, rightArrow, keybind, variant, children }}
+				/>
 			)}
 		</RadixDM.Item>
 	);

--- a/packages/ui/src/DropdownMenu.tsx
+++ b/packages/ui/src/DropdownMenu.tsx
@@ -1,6 +1,13 @@
 import * as RadixDM from '@radix-ui/react-dropdown-menu';
 import clsx from 'clsx';
-import React, { PropsWithChildren, Suspense, useCallback, useRef, useState } from 'react';
+import React, {
+	PropsWithChildren,
+	Suspense,
+	useCallback,
+	useContext,
+	useRef,
+	useState
+} from 'react';
 import { Link } from 'react-router-dom';
 import {
 	ContextMenuDivItem,
@@ -16,6 +23,9 @@ interface DropdownMenuProps extends RadixDM.MenuContentProps {
 	alignToTrigger?: boolean;
 	animate?: boolean;
 }
+
+const context = React.createContext<boolean>(false);
+export const useDropdownMenu = () => useContext(context);
 
 const Root = ({
 	trigger,
@@ -50,7 +60,7 @@ const Root = ({
 					style={{ width }}
 					{...props}
 				>
-					{children}
+					<context.Provider value={true}>{children}</context.Provider>
 				</RadixDM.Content>
 			</RadixDM.Portal>
 		</RadixDM.Root>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,8 +1,8 @@
 export { cva, cx } from 'class-variance-authority';
 export * from './Button';
 export * from './CheckBox';
-export { ContextMenu } from './ContextMenu';
-export { DropdownMenu } from './DropdownMenu';
+export { ContextMenu, useContextMenu } from './ContextMenu';
+export { DropdownMenu, useDropdownMenu } from './DropdownMenu';
 export * from './Dialog';
 export * as Dropdown from './Dropdown';
 export * from './Input';

--- a/packages/ui/style/colors.scss
+++ b/packages/ui/style/colors.scss
@@ -81,8 +81,8 @@
 		--color-app-shade: var(--light-hue), 15%, 50%;
 		--color-app-frame: 0, 0%, 100%;
 		// menu
-		--color-menu: var(--light-hue), 16%, 0%;
-		--color-menu-line: var(--light-hue), 5%, 18%;
+		--color-menu: var(--light-hue), 5%, 100%;
+		--color-menu-line: var(--light-hue), 5%, 95%;
 		--color-menu-ink: var(--light-hue), 5%, 100%;
 		--color-menu-faint: var(--light-hue), 5%, 80%;
 		--color-menu-hover: var(--light-hue), 15%, 20%;

--- a/packages/ui/style/colors.scss
+++ b/packages/ui/style/colors.scss
@@ -37,7 +37,7 @@
 	--color-app-frame: var(--dark-hue), 15%, 25%;
 	// menu
 	--color-menu: var(--dark-hue), 25%, 5%;
-	--color-menu-line: var(--dark-hue), 15%, 7%;
+	--color-menu-line: var(--dark-hue), 15%, 10%;
 	--color-menu-ink: var(--dark-hue), 5%, 100%;
 	--color-menu-faint: var(--dark-hue), 5%, 80%;
 	--color-menu-hover: var(--dark-hue), 15%, 30%;


### PR DESCRIPTION
Changes made to dropdown/context menu:
- Fixed light mode colors
- Fixed menu item arrow highlighting
- Truncate long menu items
- Changed the dark theme menu-line color to a slightly lighter one

Changes made to the explorer item context menu:
- Show "Assign tag" sub menu only when objectData is present (temporary)
- Added option to create tags from the "Assign tag" sub menu(upon creation, the tag is assigned to that object)
- Put "Assign tag" sub menu items into a virtual list.
- Moved AssignTagMenuItems component into its own file, as the same component is used in the item inspector

Changes made to the item inspector:
- Show "Add tag" placeholder only when objectData is present (temporary)
- Added a tag assignment dropdown menu to the "Add tag" placeholder(uses the AssignTagMenuItems component)

Changes made to tag settings:
- Truncate long tag names