### PR TITLE
[Desktop, UI] Input, color picker improvements

### DIFF
--- a/apps/landing/src/components/DocsSidebar.tsx
+++ b/apps/landing/src/components/DocsSidebar.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
-import { MagnifyingGlass } from 'phosphor-react';
-import { Input, SearchInput } from '@sd/ui';
+import { SearchInput } from '@sd/ui';
 import { DocsNavigation } from '../pages/docs/api';
 import config from '../pages/docs/docs';
 
@@ -16,9 +15,13 @@ export default function DocsSidebar(props: Props) {
 
 	return (
 		<nav className="mr-8 flex w-full flex-col sm:w-52">
-			<div onClick={() => alert('Search coming soon...')} className="relative mb-5">
-				<SearchInput placeholder="Search..." disabled />
-				<span className="absolute top-2 right-3 text-xs font-semibold text-gray-400">⌘K</span>
+			<div onClick={() => alert('Search coming soon...')} className="mb-5">
+				<SearchInput
+					placeholder="Search..."
+					disabled
+					right={<span className="text-xs font-semibold text-gray-400">⌘K</span>}
+					rightClassName="!px-3"
+				/>
 			</div>
 
 			<div className="mb-6 flex flex-col">

--- a/apps/landing/src/components/HomeCTA.tsx
+++ b/apps/landing/src/components/HomeCTA.tsx
@@ -133,13 +133,12 @@ export function HomeCTA() {
 								<Input
 									{...register('email')}
 									type="email"
+									size="lg"
 									autoFocus
 									autoComplete="off"
 									placeholder="Enter your email"
-									className={clsx({
-										'hidden': waitlistSubmitted,
-										'rounded-r-none': !waitlistSubmitted
-									})}
+									outerClassName={clsx(waitlistSubmitted && 'hidden')}
+									className={clsx(!waitlistSubmitted && 'rounded-r-none')}
 									disabled={waitlistSubmitted}
 								/>
 								{!waitlistSubmitted && (

--- a/interface/app/$libraryId/Explorer/File/DecryptDialog.tsx
+++ b/interface/app/$libraryId/Explorer/File/DecryptDialog.tsx
@@ -134,7 +134,6 @@ export default (props: Props) => {
 					<>
 						<PasswordInput
 							placeholder="Password"
-							size="sm"
 							{...form.register('password', { required: true })}
 						/>
 

--- a/interface/app/$libraryId/Explorer/Inspector/Note.tsx
+++ b/interface/app/$libraryId/Explorer/Inspector/Note.tsx
@@ -42,7 +42,7 @@ export default function Note(props: Props) {
 			<MetaContainer>
 				<MetaTitle>Note</MetaTitle>
 				<TextArea
-					className="mt-2 mb-1 !py-2 text-xs leading-snug"
+					className="mt-2 mb-1 text-xs leading-snug"
 					value={note || ''}
 					onChange={handleNoteUpdate}
 				/>{' '}

--- a/interface/app/$libraryId/Explorer/TopBar.tsx
+++ b/interface/app/$libraryId/Explorer/TopBar.tsx
@@ -5,7 +5,6 @@ import {
 	CaretRight,
 	Columns,
 	Key,
-	List,
 	MonitorPlay,
 	Rows,
 	SidebarSimple,
@@ -88,8 +87,9 @@ export const SearchBar = forwardRef<HTMLInputElement, ComponentProps<'input'>>(
 			}
 		});
 
-		const platform = useOperatingSystem(false);
 		const os = useOperatingSystem(true);
+
+		const cmdKey = os === 'macOS' ? '⌘' : 'CTRL';
 
 		return (
 			<form onSubmit={handleSubmit(() => null)} className="relative flex h-7">
@@ -101,22 +101,17 @@ export const SearchBar = forwardRef<HTMLInputElement, ComponentProps<'input'>>(
 						else if (forwardedRef) forwardedRef.current = el;
 					}}
 					placeholder="Search"
-					className={clsx('w-32 transition-all focus:w-52', props.className)}
+					className={clsx('w-32 transition-all focus-within:w-52', props.className)}
+					size="sm"
+					right={
+						<Shortcut
+							className="border-none !px-2 opacity-70 group-focus-within:hidden"
+							chars={`${cmdKey}F`}
+							aria-label={`Press ${cmdKey}-F to focus search bar`}
+						/>
+					}
 					{...searchField}
 				/>
-				<div
-					className={clsx(
-						'pointer-events-none absolute right-1 flex h-7 items-center space-x-1 opacity-70 peer-focus:invisible'
-					)}
-				>
-					{platform === 'browser' ? (
-						<Shortcut chars="⌘F" aria-label={'Press Command-F to focus search bar'} />
-					) : os === 'macOS' ? (
-						<Shortcut chars="⌘F" aria-label={'Press Command-F to focus search bar'} />
-					) : (
-						<Shortcut chars="CTRL+F" aria-label={'Press CTRL-F to focus search bar'} />
-					)}
-				</div>
 			</form>
 		);
 	}

--- a/interface/app/$libraryId/KeyManager/Mounter.tsx
+++ b/interface/app/$libraryId/KeyManager/Mounter.tsx
@@ -1,7 +1,16 @@
-import { Eye, EyeSlash, Info } from 'phosphor-react';
+import { Info } from 'phosphor-react';
 import { useEffect, useRef, useState } from 'react';
 import { Algorithm, HASHING_ALGOS, HashingAlgoSlug, useLibraryMutation } from '@sd/client';
-import { Button, CategoryHeading, Input, Select, SelectOption, Slider, Switch, tw } from '@sd/ui';
+import {
+	Button,
+	CategoryHeading,
+	PasswordInput,
+	Select,
+	SelectOption,
+	Slider,
+	Switch,
+	tw
+} from '@sd/ui';
 import { Tooltip } from '@sd/ui';
 import { generatePassword } from '~/util';
 
@@ -9,7 +18,6 @@ const KeyHeading = tw(CategoryHeading)`mb-1`;
 
 export default () => {
 	const ref = useRef<HTMLInputElement>(null);
-	const [showKey, setShowKey] = useState(false);
 	const [librarySync, setLibrarySync] = useState(true);
 	const [autoMount, setAutoMount] = useState(false);
 
@@ -20,7 +28,6 @@ export default () => {
 	const [hashingAlgo, setHashingAlgo] = useState<HashingAlgoSlug>('Argon2id-s');
 
 	const createKey = useLibraryMutation('keys.add');
-	const CurrentEyeIcon = showKey ? EyeSlash : Eye;
 
 	// this keeps the input focused when switching tabs
 	// feel free to replace with something cleaner
@@ -33,26 +40,7 @@ export default () => {
 	return (
 		<div className="mb-1 p-3">
 			<KeyHeading>Mount key</KeyHeading>
-			<div className="flex space-x-2">
-				<div className="relative flex grow">
-					<Input
-						ref={ref}
-						value={key}
-						onChange={(e) => setKey(e.target.value)}
-						autoFocus
-						type={showKey ? 'text' : 'password'}
-						className="grow !py-0.5"
-					/>
-					<Button
-						onClick={() => setShowKey(!showKey)}
-						size="icon"
-						className="absolute right-[5px] top-[5px] border-none"
-					>
-						<CurrentEyeIcon className="h-4 w-4" />
-					</Button>
-				</div>
-			</div>
-
+			<PasswordInput ref={ref} value={key} onChange={(e) => setKey(e.target.value)} autoFocus />
 			<div className="flex flex-row space-x-2">
 				<div className="relative mt-2 flex grow">
 					<Slider

--- a/interface/app/$libraryId/KeyManager/NotUnlocked.tsx
+++ b/interface/app/$libraryId/KeyManager/NotUnlocked.tsx
@@ -22,7 +22,6 @@ export default () => {
 	return (
 		<div className="space-y-2 p-2">
 			<PasswordInput
-				size="sm"
 				placeholder="Master Password"
 				value={masterPassword}
 				onChange={(e) => setMasterPassword(e.target.value)}
@@ -31,7 +30,6 @@ export default () => {
 
 			{enterSkManually && (
 				<PasswordInput
-					size="sm"
 					placeholder="Secret Key"
 					value={secretKey}
 					onChange={(e) => setSecretKey(e.target.value)}

--- a/interface/app/$libraryId/Layout/Sidebar/DebugPopover.tsx
+++ b/interface/app/$libraryId/Layout/Sidebar/DebugPopover.tsx
@@ -13,7 +13,6 @@ export default () => {
 	return (
 		<Popover
 			className="p-4 focus:outline-none"
-			transformOrigin="bottom left"
 			trigger={
 				<h1 className="text-ink-faint/50 ml-1 w-full text-[7pt]">
 					v{buildInfo.data?.version || '-.-.-'} - {buildInfo.data?.commit || 'dev'}

--- a/interface/app/$libraryId/settings/client/extensions.tsx
+++ b/interface/app/$libraryId/settings/client/extensions.tsx
@@ -61,7 +61,7 @@ export const Component = () => {
 			<Heading
 				title="Extensions"
 				description="Install extensions to extend the functionality of this client."
-				rightArea={<SearchInput outerClassnames="mt-1.5" placeholder="Search extensions" />}
+				rightArea={<SearchInput outerClassName="mt-1.5" placeholder="Search extensions" />}
 			/>
 
 			<GridLayout>

--- a/interface/app/$libraryId/settings/client/general.tsx
+++ b/interface/app/$libraryId/settings/client/general.tsx
@@ -28,25 +28,24 @@ export const Component = () => {
 
 					<hr className="border-app-line mt-2 mb-4" />
 					<div className="grid grid-cols-3 gap-2">
-						<div className="flex flex-col">
-							<NodeSettingLabel>Node Name</NodeSettingLabel>
-							<Input
-								value={node.data?.name}
-								onChange={() => {
-									/* TODO */
-								}}
-							/>
-						</div>
-						<div className="flex flex-col">
-							<NodeSettingLabel>Node Port</NodeSettingLabel>
-							<Input
-								contentEditable={false}
-								value={node.data?.p2p_port || 5795}
-								onChange={() => {
-									/* TODO */
-								}}
-							/>
-						</div>
+						<Input
+							label="Node Name"
+							labelClassName="text-xs"
+							value={node.data?.name}
+							onChange={() => {
+								/* TODO */
+							}}
+						/>
+
+						<Input
+							label="Node Port"
+							labelClassName="text-xs"
+							contentEditable={false}
+							value={node.data?.p2p_port || 5795}
+							onChange={() => {
+								/* TODO */
+							}}
+						/>
 					</div>
 					<div className="mt-5 flex items-center space-x-3">
 						<Switch size="sm" checked />

--- a/interface/app/$libraryId/settings/library/general.tsx
+++ b/interface/app/$libraryId/settings/library/general.tsx
@@ -29,18 +29,20 @@ export const Component = () => {
 				description="General settings related to the currently active library."
 			/>
 			<div className="flex flex-row space-x-5 pb-3">
-				<div className="flex grow flex-col">
-					<span className="mb-1 text-sm font-medium">Name</span>
-					<Input
-						size="md"
-						{...form.register('name', { required: true })}
-						defaultValue="My Default Library"
-					/>
-				</div>
-				<div className="flex grow flex-col">
-					<span className="mb-1 text-sm font-medium">Description</span>
-					<Input size="md" {...form.register('description')} placeholder="" />
-				</div>
+				<Input
+					label="Name"
+					size="md"
+					outerClassName="grow"
+					{...form.register('name', { required: true })}
+					defaultValue="My Default Library"
+				/>
+
+				<Input
+					label="Description"
+					size="md"
+					outerClassName="grow"
+					{...form.register('description')}
+				/>
 			</div>
 
 			<Setting

--- a/interface/app/$libraryId/settings/library/keys/BackupRestoreDialog.tsx
+++ b/interface/app/$libraryId/settings/library/keys/BackupRestoreDialog.tsx
@@ -1,12 +1,10 @@
-import { Eye, EyeSlash } from 'phosphor-react';
-import { useState } from 'react';
 import { useLibraryMutation } from '@sd/client';
 import { Button, Dialog, UseDialogProps, useDialog } from '@sd/ui';
 import { forms } from '@sd/ui';
 import { showAlertDialog } from '~/components/AlertDialog';
 import { usePlatform } from '~/util/Platform';
 
-const { Input, useZodForm, z } = forms;
+const { PasswordInput, useZodForm, z } = forms;
 
 const schema = z.object({
 	masterPassword: z.string(),
@@ -32,15 +30,7 @@ export default (props: UseDialogProps) => {
 		}
 	});
 
-	const [show, setShow] = useState({
-		masterPassword: false,
-		secretKey: false
-	});
-
 	const dialog = useDialog(props);
-
-	const MPCurrentEyeIcon = show.masterPassword ? EyeSlash : Eye;
-	const SKCurrentEyeIcon = show.secretKey ? EyeSlash : Eye;
 
 	const form = useZodForm({
 		schema
@@ -67,37 +57,18 @@ export default (props: UseDialogProps) => {
 			loading={restoreKeystoreMutation.isLoading}
 			ctaLabel="Restore"
 		>
-			<div className="relative mt-3 mb-2 flex grow">
-				<Input
-					className="grow !py-0.5"
-					placeholder="Master Password"
-					type={show.masterPassword ? 'text' : 'password'}
-					{...form.register('masterPassword', { required: true })}
-				/>
-				<Button
-					onClick={() => setShow((old) => ({ ...old, masterPassword: !old.masterPassword }))}
-					size="icon"
-					className="absolute right-[5px] top-[5px] border-none"
-					type="button"
-				>
-					<MPCurrentEyeIcon className="h-4 w-4" />
-				</Button>
-			</div>
-			<div className="relative mb-3 flex grow">
-				<Input
-					className="grow !py-0.5"
-					placeholder="Secret Key"
-					type={show.secretKey ? 'text' : 'password'}
-					{...form.register('secretKey')}
-				/>
-				<Button
-					onClick={() => setShow((old) => ({ ...old, secretKey: !old.secretKey }))}
-					size="icon"
-					className="absolute right-[5px] top-[5px] border-none"
-				>
-					<SKCurrentEyeIcon className="h-4 w-4" />
-				</Button>
-			</div>
+			<PasswordInput
+				outerClassName="mt-3 mb-2"
+				placeholder="Master Password"
+				{...form.register('masterPassword', { required: true })}
+			/>
+
+			<PasswordInput
+				outerClassName="mb-3"
+				placeholder="Secret Key"
+				{...form.register('secretKey')}
+			/>
+
 			<div className="relative mb-2 flex grow">
 				<Button
 					size="sm"

--- a/interface/app/$libraryId/settings/library/keys/KeyViewerDialog.tsx
+++ b/interface/app/$libraryId/settings/library/keys/KeyViewerDialog.tsx
@@ -106,42 +106,42 @@ export default (props: UseDialogProps) => {
 					</Select>
 				</div>
 			</div>
-			<div className="mt-4 mb-3 grid w-full gap-4">
-				<div className="flex flex-col">
-					<span className="mb-2 text-xs font-bold">Content Salt (hex)</span>
-					<div className="relative flex grow">
-						<Input value={contentSalt} disabled className="grow !py-0.5" />
-						<Button
-							type="button"
-							onClick={() => {
-								navigator.clipboard.writeText(contentSalt);
-							}}
-							size="icon"
-							className="absolute right-[5px] top-[5px] border-none"
-						>
-							<Clipboard className="h-4 w-4" />
-						</Button>
-					</div>
-				</div>
-			</div>
-			<div className="mt-4 mb-3 grid w-full gap-4">
-				<div className="flex flex-col">
-					<span className="mb-2 text-xs font-bold">Key Value</span>
-					<div className="relative flex grow">
-						<Input value={keyValue} disabled className="grow !py-0.5" />
-						<Button
-							type="button"
-							onClick={() => {
-								navigator.clipboard.writeText(keyValue);
-							}}
-							size="icon"
-							className="absolute right-[5px] top-[5px] border-none"
-						>
-							<Clipboard className="h-4 w-4" />
-						</Button>
-					</div>
-				</div>
-			</div>
+
+			<Input
+				label="Content Salt (hex)"
+				value={contentSalt}
+				disabled
+				outerClassName="mt-4 mb-3"
+				right={
+					<Button
+						type="button"
+						onClick={() => {
+							navigator.clipboard.writeText(contentSalt);
+						}}
+						size="icon"
+					>
+						<Clipboard className="h-4 w-4" />
+					</Button>
+				}
+			/>
+
+			<Input
+				label="Key Value"
+				value={keyValue}
+				disabled
+				outerClassName="mt-4 mb-3"
+				right={
+					<Button
+						type="button"
+						onClick={() => {
+							navigator.clipboard.writeText(keyValue);
+						}}
+						size="icon"
+					>
+						<Clipboard className="h-4 w-4" />
+					</Button>
+				}
+			/>
 		</Dialog>
 	);
 };

--- a/interface/app/$libraryId/settings/library/keys/MasterPasswordDialog.tsx
+++ b/interface/app/$libraryId/settings/library/keys/MasterPasswordDialog.tsx
@@ -84,65 +84,64 @@ export default (props: UseDialogProps) => {
 			ctaDanger={true}
 			ctaLabel="Change"
 		>
-			<div className="relative mt-3 mb-2 flex grow">
-				<Input
-					className={`w-max grow !py-0.5`}
-					placeholder="New password"
-					type={show.masterPassword ? 'text' : 'password'}
-					{...form.register('masterPassword', { required: true })}
-				/>
-				<Button
-					onClick={() => {
-						const password = generatePassword(32);
-						form.setValue('masterPassword', password);
-						form.setValue('masterPassword2', password);
-						setShow((old) => ({
-							...old,
-							masterPassword: true,
-							masterPassword2: true
-						}));
-					}}
-					size="icon"
-					className="absolute right-[65px] top-[5px] border-none"
-					type="button"
-				>
-					<ArrowsClockwise className="h-4 w-4" />
-				</Button>
-				<Button
-					type="button"
-					onClick={() => {
-						navigator.clipboard.writeText(form.watch('masterPassword') as string);
-					}}
-					size="icon"
-					className="absolute right-[35px] top-[5px] border-none"
-				>
-					<Clipboard className="h-4 w-4" />
-				</Button>
-				<Button
-					onClick={() => setShow((old) => ({ ...old, masterPassword: !old.masterPassword }))}
-					size="icon"
-					className="absolute right-[5px] top-[5px] border-none"
-					type="button"
-				>
-					<MP1CurrentEyeIcon className="h-4 w-4" />
-				</Button>
-			</div>
-			<div className="relative mb-2 flex grow">
-				<Input
-					className={`!py-0.5} grow`}
-					placeholder="New password (again)"
-					type={show.masterPassword2 ? 'text' : 'password'}
-					{...form.register('masterPassword2', { required: true })}
-				/>
-				<Button
-					onClick={() => setShow((old) => ({ ...old, masterPassword2: !old.masterPassword2 }))}
-					size="icon"
-					className="absolute right-[5px] top-[5px] border-none"
-					type="button"
-				>
-					<MP2CurrentEyeIcon className="h-4 w-4" />
-				</Button>
-			</div>
+			<Input
+				{...form.register('masterPassword', { required: true })}
+				placeholder="New password"
+				type={show.masterPassword ? 'text' : 'password'}
+				outerClassName="mt-3 mb-2"
+				right={
+					<div className="flex">
+						<Button
+							onClick={() => {
+								const password = generatePassword(32);
+								form.setValue('masterPassword', password);
+								form.setValue('masterPassword2', password);
+								setShow((old) => ({
+									...old,
+									masterPassword: true,
+									masterPassword2: true
+								}));
+							}}
+							size="icon"
+							type="button"
+						>
+							<ArrowsClockwise className="h-4 w-4" />
+						</Button>
+						<Button
+							type="button"
+							onClick={() => {
+								navigator.clipboard.writeText(form.watch('masterPassword') as string);
+							}}
+							size="icon"
+						>
+							<Clipboard className="h-4 w-4" />
+						</Button>
+						<Button
+							onClick={() => setShow((old) => ({ ...old, masterPassword: !old.masterPassword }))}
+							size="icon"
+							type="button"
+						>
+							<MP1CurrentEyeIcon className="h-4 w-4" />
+						</Button>
+					</div>
+				}
+			/>
+
+			<Input
+				{...form.register('masterPassword2', { required: true })}
+				placeholder="New password (again)"
+				type={show.masterPassword2 ? 'text' : 'password'}
+				outerClassName="mb-2"
+				right={
+					<Button
+						onClick={() => setShow((old) => ({ ...old, masterPassword2: !old.masterPassword2 }))}
+						size="icon"
+						type="button"
+					>
+						<MP2CurrentEyeIcon className="h-4 w-4" />
+					</Button>
+				}
+			/>
 
 			<PasswordMeter password={form.watch('masterPassword')} />
 

--- a/interface/app/$libraryId/settings/library/keys/index.tsx
+++ b/interface/app/$libraryId/settings/library/keys/index.tsx
@@ -1,11 +1,11 @@
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import clsx from 'clsx';
-import { Eye, EyeSlash, Lock, Plus } from 'phosphor-react';
+import { Lock, Plus } from 'phosphor-react';
 import { PropsWithChildren, ReactNode, useState } from 'react';
 import QRCode from 'react-qr-code';
 import { animated, useTransition } from 'react-spring';
 import { useLibraryMutation, useLibraryQuery } from '@sd/client';
-import { Button, Input, dialogManager } from '@sd/ui';
+import { Button, PasswordInput, dialogManager } from '@sd/ui';
 import { showAlertDialog } from '~/components/AlertDialog';
 import { usePlatform } from '~/util/Platform';
 import KeyList from '../../../KeyManager/List';
@@ -90,56 +90,32 @@ export const Component = () => {
 	const backupKeystore = useLibraryMutation('keys.backupKeystore');
 	const isKeyManagerUnlocking = useLibraryQuery(['keys.isKeyManagerUnlocking']);
 
-	const [showMasterPassword, setShowMasterPassword] = useState(false);
-	const [showSecretKey, setShowSecretKey] = useState(false);
 	const [masterPassword, setMasterPassword] = useState('');
 	const [secretKey, setSecretKey] = useState(''); // for the unlock form
 	const [viewSecretKey, setViewSecretKey] = useState(false); // for the settings page
 
 	const keys = useLibraryQuery(['keys.list']);
 
-	const MPCurrentEyeIcon = showMasterPassword ? EyeSlash : Eye;
-	const SKCurrentEyeIcon = showSecretKey ? EyeSlash : Eye;
-
 	const [enterSkManually, setEnterSkManually] = useState(keyringSk?.data === null);
 
 	if (!isUnlocked?.data) {
 		return (
 			<div className="mx-20 mt-10 p-2">
-				<div className="relative mb-2 flex grow">
-					<Input
-						value={masterPassword}
-						onChange={(e) => setMasterPassword(e.target.value)}
-						autoFocus
-						type={showMasterPassword ? 'text' : 'password'}
-						className="grow !py-0.5"
-						placeholder="Master Password"
-					/>
-					<Button
-						onClick={() => setShowMasterPassword(!showMasterPassword)}
-						size="icon"
-						className="absolute right-[5px] top-[5px] border-none"
-					>
-						<MPCurrentEyeIcon className="h-4 w-4" />
-					</Button>
-				</div>
+				<PasswordInput
+					value={masterPassword}
+					onChange={(e) => setMasterPassword(e.target.value)}
+					autoFocus
+					placeholder="Master Password"
+					outerClassName="mb-2"
+				/>
+
 				{enterSkManually && (
-					<div className="relative mb-2 flex grow">
-						<Input
-							value={secretKey}
-							onChange={(e) => setSecretKey(e.target.value)}
-							type={showSecretKey ? 'text' : 'password'}
-							className="grow !py-0.5"
-							placeholder="Secret Key"
-						/>
-						<Button
-							onClick={() => setShowSecretKey(!showSecretKey)}
-							size="icon"
-							className="absolute right-[5px] top-[5px] border-none"
-						>
-							<SKCurrentEyeIcon className="h-4 w-4" />
-						</Button>
-					</div>
+					<PasswordInput
+						value={secretKey}
+						onChange={(e) => setSecretKey(e.target.value)}
+						placeholder="Secret Key"
+						outerClassName="mb-2"
+					/>
 				)}
 
 				<Button

--- a/interface/app/$libraryId/settings/library/locations/$id.tsx
+++ b/interface/app/$libraryId/settings/library/locations/$id.tsx
@@ -94,16 +94,14 @@ export const Component = () => {
 			>
 				<div className="flex space-x-4">
 					<FlexCol>
-						<Label>Display Name</Label>
-						<Input {...form.register('displayName')} />
+						<Input label="Display Name" {...form.register('displayName')} />
 						<InfoText>
 							The name of this Location, this is what will be displayed in the sidebar. Will not
 							rename the actual folder on disk.
 						</InfoText>
 					</FlexCol>
 					<FlexCol>
-						<Label>Local Path</Label>
-						<Input {...form.register('localPath')} />
+						<Input label="Local Path" {...form.register('localPath')} />
 						<InfoText>
 							The path to this Location, this is where the files will be stored on disk.
 						</InfoText>

--- a/interface/app/$libraryId/settings/library/locations/AddLocationDialog.tsx
+++ b/interface/app/$libraryId/settings/library/locations/AddLocationDialog.tsx
@@ -49,32 +49,31 @@ export const AddLocationDialog = (props: Props) => {
 			})}
 			ctaLabel="Add"
 		>
-			<div className="relative flex flex-col">
-				<p className="mt-2 text-[0.9rem] font-bold">Path:</p>
-				<Input
-					type="text"
-					onClick={async () => {
-						if (!platform.openDirectoryPickerDialog) return;
+			<Input
+				label="Path:"
+				type="text"
+				onClick={async () => {
+					if (!platform.openDirectoryPickerDialog) return;
 
-						const path = await platform.openDirectoryPickerDialog();
-						if (!path) return;
-						if (typeof path !== 'string') {
-							// TODO: Should support for adding multiple locations simultaneously be added?
-							showAlertDialog({
-								title: 'Error',
-								value: "Can't add multiple locations"
-							});
-							return;
-						}
+					const path = await platform.openDirectoryPickerDialog();
+					if (!path) return;
+					if (typeof path !== 'string') {
+						// TODO: Should support for adding multiple locations simultaneously be added?
+						showAlertDialog({
+							title: 'Error',
+							value: "Can't add multiple locations"
+						});
+						return;
+					}
 
-						form.setValue('path', path);
-					}}
-					readOnly={platform.platform !== 'web'}
-					required
-					className="mt-3 w-full grow cursor-pointer"
-					{...form.register('path')}
-				/>
-			</div>
+					form.setValue('path', path);
+				}}
+				readOnly={platform.platform !== 'web'}
+				required
+				className="cursor-pointer"
+				outerClassName="mt-3"
+				{...form.register('path')}
+			/>
 
 			<div className="relative flex flex-col">
 				<p className="mt-6 text-[0.9rem] font-bold">File indexing rules:</p>

--- a/interface/app/$libraryId/settings/library/locations/index.tsx
+++ b/interface/app/$libraryId/settings/library/locations/index.tsx
@@ -14,7 +14,7 @@ export const Component = () => {
 				description="Manage your storage locations."
 				rightArea={
 					<div className="flex flex-row items-center space-x-5">
-						<SearchInput placeholder="Search locations" />
+						<SearchInput placeholder="Search locations" className="h-[33px]" />
 						<AddLocationButton variant="accent" size="md" />
 					</div>
 				}

--- a/interface/app/$libraryId/settings/library/tags/CreateDialog.tsx
+++ b/interface/app/$libraryId/settings/library/tags/CreateDialog.tsx
@@ -1,17 +1,17 @@
-import { useClientContext, useLibraryMutation, usePlausibleEvent } from '@sd/client';
+import { useLibraryMutation, usePlausibleEvent } from '@sd/client';
 import { Dialog, UseDialogProps, useDialog } from '@sd/ui';
 import { Input, useZodForm, z } from '@sd/ui/src/forms';
 import ColorPicker from '~/components/ColorPicker';
 import { usePlatform } from '~/util/Platform';
 
 export default (props: UseDialogProps) => {
-	const dialog = useDialog(props);
+	const dialog = useDialog({ ...props, closeOnSubmit: false });
 	const platform = usePlatform();
 	const submitPlausibleEvent = usePlausibleEvent({ platformType: platform.platform });
 
 	const form = useZodForm({
 		schema: z.object({
-			name: z.string(),
+			name: z.string().min(1, 'Name required'),
 			color: z.string()
 		}),
 		defaultValues: {
@@ -22,6 +22,7 @@ export default (props: UseDialogProps) => {
 	const createTag = useLibraryMutation('tags.create', {
 		onSuccess: () => {
 			submitPlausibleEvent({ event: { type: 'tagCreate' } });
+			dialog.close();
 		},
 		onError: (e) => {
 			console.error('error', e);
@@ -36,14 +37,13 @@ export default (props: UseDialogProps) => {
 			description="Choose a name and color."
 			ctaLabel="Create"
 		>
-			<div className="relative mt-3 ">
-				<ColorPicker className="!absolute left-[9px] top-[-5px]" {...form.register('color')} />
-				<Input
-					{...form.register('name', { required: true })}
-					className="w-full pl-[40px]"
-					placeholder="Name"
-				/>
-			</div>
+			<Input
+				placeholder="Name"
+				icon={<ColorPicker control={form.control} name="color" />}
+				outerClassName="mt-3"
+				error={form.formState.errors.name?.message}
+				{...form.register('name')}
+			/>
 		</Dialog>
 	);
 };

--- a/interface/app/$libraryId/settings/library/tags/EditForm.tsx
+++ b/interface/app/$libraryId/settings/library/tags/EditForm.tsx
@@ -36,17 +36,13 @@ export default ({ tag, onDelete }: Props) => {
 	return (
 		<Form form={form}>
 			<div className="mb-10 flex flex-row space-x-3">
-				<div className="flex flex-col">
-					<span className="mb-1 text-sm font-medium text-gray-700 dark:text-gray-100">Color</span>
-					<div className="relative">
-						<ColorPicker className="!absolute left-[9px] top-[-5px]" {...form.register('color')} />
-						<Input className="w-28 pl-[40px]" {...form.register('color')} />
-					</div>
-				</div>
-				<div className="flex flex-col">
-					<span className="mb-1 text-sm font-medium text-gray-700 dark:text-gray-100">Name</span>
-					<Input {...form.register('name')} />
-				</div>
+				<Input
+					label="Color"
+					className="w-28"
+					icon={<ColorPicker control={form.control} name="color" />}
+					{...form.register('color')}
+				/>
+				<Input label="Name" {...form.register('name')} />
 				<div className="flex grow" />
 				<Button
 					variant="gray"

--- a/interface/app/$libraryId/settings/library/tags/index.tsx
+++ b/interface/app/$libraryId/settings/library/tags/index.tsx
@@ -31,18 +31,18 @@ export const Component = () => {
 				}
 			/>
 			<Card className="!px-2">
-				<div className="m-1 flex flex-wrap gap-2">
+				<div className="m-1 flex flex-wrap gap-2 overflow-hidden">
 					{tags.data?.map((tag) => (
 						<div
 							onClick={() => setSelectedTag(tag.id === selectedTag?.id ? null : tag)}
 							key={tag.id}
 							className={clsx(
-								'flex items-center rounded px-1.5 py-0.5',
+								'flex items-center overflow-hidden rounded px-1.5 py-0.5',
 								selectedTag?.id === tag.id && 'ring'
 							)}
 							style={{ backgroundColor: tag.color + 'CC' }}
 						>
-							<span className="text-xs text-white drop-shadow-md">{tag.name}</span>
+							<span className="truncate text-xs text-white drop-shadow-md">{tag.name}</span>
 						</div>
 					))}
 				</div>

--- a/interface/app/$libraryId/settings/node/libraries/CreateDialog.tsx
+++ b/interface/app/$libraryId/settings/node/libraries/CreateDialog.tsx
@@ -99,14 +99,12 @@ export default (props: UseDialogProps) => {
 			submitDisabled={!form.formState.isValid}
 			ctaLabel="Create"
 		>
-			<div className="relative flex flex-col">
-				<p className="my-2 text-sm font-bold">Library name</p>
-				<Input
-					className="w-full grow"
-					placeholder="My Cool Library"
-					{...form.register('name', { required: true })}
-				/>
-			</div>
+			<Input
+				label="Library Name"
+				placeholder="My Cool Library"
+				outerClassName="my-2"
+				{...form.register('name', { required: true })}
+			/>
 
 			<div className="mt-3 mb-1 flex flex-row items-center">
 				<div className="space-x-2">
@@ -125,100 +123,88 @@ export default (props: UseDialogProps) => {
 			{/* TODO: Proper UI for this. Maybe checkbox for encrypted or not and then reveal these fields. Select encrypted by default. */}
 			{/* <span className="text-sm">Make the secret key field empty to skip key setup.</span> */}
 
-			<div className="relative flex flex-col">
-				<p className="mt-2 mb-1 text-center text-[0.95rem] font-bold">Key Manager</p>
-				<div className="my-1 h-[2px] w-full bg-gray-500" />
+			<div className="relative mt-6 flex flex-col gap-3">
+				<p className="border-app-line border-b pb-1 text-center text-sm font-medium">Key Manager</p>
 
-				<p className="my-2 text-sm font-bold">Master password</p>
-				<div className="relative mb-2 flex grow">
-					<Input
-						className="grow !py-0.5"
-						placeholder="Password"
-						type={showMasterPassword1 ? 'text' : 'password'}
-						{...form.register('password')}
-					/>
-					<Button
-						onClick={() => {
-							const password = generatePassword(32);
+				<Input
+					{...form.register('password')}
+					label="Master password"
+					placeholder="Password"
+					type={showMasterPassword1 ? 'text' : 'password'}
+					right={
+						<div className="flex">
+							<Button
+								onClick={() => {
+									const password = generatePassword(32);
 
-							form.setValue('password', password);
-							form.setValue('password_validate', password);
+									form.setValue('password', password);
+									form.setValue('password_validate', password);
 
-							setShowMasterPassword1(true);
-							setShowMasterPassword2(true);
-						}}
-						size="icon"
-						className="absolute right-[65px] top-[5px] border-none"
-					>
-						<ArrowsClockwise className="h-4 w-4" />
-					</Button>
-					<Button
-						onClick={() => {
-							navigator.clipboard.writeText(form.watch('password') as string);
-						}}
-						size="icon"
-						className="absolute right-[35px] top-[5px] border-none"
-					>
-						<Clipboard className="h-4 w-4" />
-					</Button>
-					<Button
-						onClick={() => setShowMasterPassword1(!showMasterPassword1)}
-						size="icon"
-						className="absolute right-[5px] top-[5px] border-none"
-					>
-						<MP1CurrentEyeIcon className="h-4 w-4" />
-					</Button>
+									setShowMasterPassword1(true);
+									setShowMasterPassword2(true);
+								}}
+								size="icon"
+							>
+								<ArrowsClockwise className="h-4 w-4" />
+							</Button>
+							<Button
+								onClick={() => {
+									navigator.clipboard.writeText(form.watch('password') as string);
+								}}
+								size="icon"
+							>
+								<Clipboard className="h-4 w-4" />
+							</Button>
+							<Button onClick={() => setShowMasterPassword1(!showMasterPassword1)} size="icon">
+								<MP1CurrentEyeIcon className="h-4 w-4" />
+							</Button>
+						</div>
+					}
+				/>
+
+				<Input
+					{...form.register('password_validate')}
+					label="Master password (again)"
+					placeholder="Password"
+					type={showMasterPassword2 ? 'text' : 'password'}
+					right={
+						<Button onClick={() => setShowMasterPassword2(!showMasterPassword2)} size="icon">
+							<MP2CurrentEyeIcon className="h-4 w-4" />
+						</Button>
+					}
+				/>
+
+				<div className="grid w-full grid-cols-2 gap-4">
+					<div className="flex flex-col">
+						<span className="text-sm font-bold">Encryption</span>
+						<Select
+							className="mt-2"
+							value={form.watch('algorithm')}
+							onChange={(e) => form.setValue('algorithm', e)}
+						>
+							<SelectOption value="XChaCha20Poly1305">XChaCha20-Poly1305</SelectOption>
+							<SelectOption value="Aes256Gcm">AES-256-GCM</SelectOption>
+						</Select>
+					</div>
+					<div className="flex flex-col">
+						<span className="text-sm font-bold">Hashing</span>
+						<Select
+							className="mt-2"
+							value={form.watch('hashing_algorithm')}
+							onChange={(e) => form.setValue('hashing_algorithm', e as HashingAlgoSlug)}
+						>
+							<SelectOption value="Argon2id-s">Argon2id (standard)</SelectOption>
+							<SelectOption value="Argon2id-h">Argon2id (hardened)</SelectOption>
+							<SelectOption value="Argon2id-p">Argon2id (paranoid)</SelectOption>
+							<SelectOption value="BalloonBlake3-s">BLAKE3-Balloon (standard)</SelectOption>
+							<SelectOption value="BalloonBlake3-h">BLAKE3-Balloon (hardened)</SelectOption>
+							<SelectOption value="BalloonBlake3-p">BLAKE3-Balloon (paranoid)</SelectOption>
+						</Select>
+					</div>
 				</div>
+
+				<PasswordMeter password={form.watch('password')} />
 			</div>
-			<div className="relative flex flex-col">
-				<p className="my-2 text-sm font-bold">Master password (again)</p>
-				<div className="relative mb-2 flex grow">
-					<Input
-						className="grow !py-0.5"
-						placeholder="Password"
-						type={showMasterPassword2 ? 'text' : 'password'}
-						{...form.register('password_validate')}
-					/>
-					<Button
-						onClick={() => setShowMasterPassword2(!showMasterPassword2)}
-						size="icon"
-						className="absolute right-[5px] top-[5px] border-none"
-					>
-						<MP2CurrentEyeIcon className="h-4 w-4" />
-					</Button>
-				</div>
-			</div>
-
-			<div className="mt-4 mb-3 grid w-full grid-cols-2 gap-4">
-				<div className="flex flex-col">
-					<span className="text-sm font-bold">Encryption</span>
-					<Select
-						className="mt-2"
-						value={form.watch('algorithm')}
-						onChange={(e) => form.setValue('algorithm', e)}
-					>
-						<SelectOption value="XChaCha20Poly1305">XChaCha20-Poly1305</SelectOption>
-						<SelectOption value="Aes256Gcm">AES-256-GCM</SelectOption>
-					</Select>
-				</div>
-				<div className="flex flex-col">
-					<span className="text-sm font-bold">Hashing</span>
-					<Select
-						className="mt-2"
-						value={form.watch('hashing_algorithm')}
-						onChange={(e) => form.setValue('hashing_algorithm', e as HashingAlgoSlug)}
-					>
-						<SelectOption value="Argon2id-s">Argon2id (standard)</SelectOption>
-						<SelectOption value="Argon2id-h">Argon2id (hardened)</SelectOption>
-						<SelectOption value="Argon2id-p">Argon2id (paranoid)</SelectOption>
-						<SelectOption value="BalloonBlake3-s">BLAKE3-Balloon (standard)</SelectOption>
-						<SelectOption value="BalloonBlake3-h">BLAKE3-Balloon (hardened)</SelectOption>
-						<SelectOption value="BalloonBlake3-p">BLAKE3-Balloon (paranoid)</SelectOption>
-					</Select>
-				</div>
-			</div>
-
-			<PasswordMeter password={form.watch('password')} />
 		</Dialog>
 	);
 };

--- a/interface/app/$libraryId/settings/node/p2p.tsx
+++ b/interface/app/$libraryId/settings/node/p2p.tsx
@@ -23,7 +23,7 @@ export const Component = () => {
 				description="Configuration server to aid with establishing peer-to-peer to connections between nodes over the internet. Disabling will result in nodes only being accessible over LAN and direct IP connections."
 			>
 				<div className="mt-1 flex flex-col">
-					<Input className="grow" disabled defaultValue="https://p2p.spacedrive.com" />
+					<Input disabled defaultValue="https://p2p.spacedrive.com" />
 					<div className="mt-1 flex justify-end">
 						<a className="text-accent hover:text-accent p-1 text-sm font-bold">Change</a>
 					</div>

--- a/interface/app/onboarding/master-password.tsx
+++ b/interface/app/onboarding/master-password.tsx
@@ -82,9 +82,7 @@ export default function OnboardingNewLibrary() {
 					<div className="my-2 flex grow">
 						<PasswordInput
 							{...form.register('password')}
-							size="md"
 							autoFocus
-							className="w-full"
 							disabled={form.formState.isSubmitting}
 						/>
 					</div>
@@ -92,10 +90,8 @@ export default function OnboardingNewLibrary() {
 						<div className="mb-2 flex grow">
 							<PasswordInput
 								{...form.register('password_validate')}
-								size="md"
 								placeholder="Confirm password"
 								autoFocus
-								className="w-full"
 								disabled={form.formState.isSubmitting}
 							/>
 						</div>

--- a/interface/app/onboarding/new-library.tsx
+++ b/interface/app/onboarding/new-library.tsx
@@ -66,7 +66,8 @@ export default function OnboardingNewLibrary() {
 							{...form.register('name')}
 							size="md"
 							autoFocus
-							className="mt-6 w-[300px]"
+							className="w-[300px]"
+							outerClassName="mt-6"
 							placeholder={'e.g. "James\' Library"'}
 						/>
 						<div className="flex grow" />

--- a/interface/app/style.scss
+++ b/interface/app/style.scss
@@ -187,3 +187,26 @@ body {
 	border-radius: 9px;
 	box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
 }
+
+.react-colorful__saturation {
+	border-radius: 4px !important;
+}
+
+.react-colorful__saturation-pointer {
+	width: 12px !important;
+	height: 12px !important;
+}
+
+.react-colorful__hue,
+.react-colorful__alpha {
+	margin-top: 12px !important;
+	height: 8px !important;
+	border-radius: 4px !important;
+}
+
+.react-colorful__hue-pointer,
+.react-colorful__alpha-pointer {
+	height: 18px !important;
+	width: 8px !important;
+	border-radius: 3px !important;
+}

--- a/interface/components/AlertDialog.tsx
+++ b/interface/components/AlertDialog.tsx
@@ -23,19 +23,21 @@ const AlertDialog = (props: Props) => {
 			ctaLabel={props.label !== undefined ? props.label : 'Done'}
 		>
 			{props.inputBox && (
-				<div className="relative mt-3 flex grow">
-					<Input value={props.value} disabled className="grow !py-0.5" />
-					<Button
-						type="button"
-						onClick={() => {
-							navigator.clipboard.writeText(props.value);
-						}}
-						size="icon"
-						className="absolute right-[5px] top-[5px] border-none"
-					>
-						<Clipboard className="h-4 w-4" />
-					</Button>
-				</div>
+				<Input
+					value={props.value}
+					disabled
+					right={
+						<Button
+							type="button"
+							onClick={() => {
+								navigator.clipboard.writeText(props.value);
+							}}
+							size="icon"
+						>
+							<Clipboard className="h-4 w-4" />
+						</Button>
+					}
+				/>
 			)}
 
 			{!props.inputBox && <div className="text-sm">{props.value}</div>}

--- a/interface/components/ColorPicker.tsx
+++ b/interface/components/ColorPicker.tsx
@@ -1,39 +1,28 @@
-import clsx from 'clsx';
-import { useCallback, useRef, useState } from 'react';
-import { HexColorPicker } from 'react-colorful';
-import { UseControllerProps, useController } from 'react-hook-form';
-import useClickOutside from '~/hooks/useClickOutside';
+import { HexColorInput, HexColorPicker } from 'react-colorful';
+import { FieldValues, UseControllerProps, useController } from 'react-hook-form';
+import { Popover, inputStyles } from '@sd/ui';
 
-interface Props extends UseControllerProps {
+interface Props<T extends FieldValues> extends UseControllerProps<T> {
 	className?: string;
 }
 
-export default ({ className, ...props }: Props) => {
-	const { field } = useController(props);
-	const popover = useRef<HTMLDivElement | null>(null);
-	const [isOpen, toggle] = useState(false);
-
-	const close = useCallback(() => toggle(false), []);
-	useClickOutside(popover, close);
+export default <T extends FieldValues>({ className, ...props }: Props<T>) => {
+	const { field } = useController({ name: props.name });
 
 	return (
-		<div className={clsx('relative mt-3 flex items-center', className)}>
-			<div
-				className={clsx('h-4 w-4 rounded-full shadow', isOpen && 'dark:border-gray-500')}
-				style={{ backgroundColor: field.value }}
-				onClick={() => toggle(true)}
+		<Popover
+			trigger={
+				<div className="h-4 w-4 rounded-full shadow" style={{ backgroundColor: field.value }} />
+			}
+			className="p-3"
+			sideOffset={5}
+		>
+			<HexColorPicker color={field.value} onChange={field.onChange} />
+			<HexColorInput
+				color={field.value}
+				onChange={field.onChange}
+				className={inputStyles({ size: 'md', className: 'bg-app mt-5 px-3' })}
 			/>
-			{/* <span className="inline ml-2 text-sm text-gray-200">Pick Color</span> */}
-
-			{isOpen && (
-				<div
-					style={{ top: 'calc(100% + 7px)' }}
-					className="absolute left-0 rounded-md shadow"
-					ref={popover}
-				>
-					<HexColorPicker color={field.value} onChange={field.onChange} />
-				</div>
-			)}
-		</div>
+		</Popover>
 	);
 };

--- a/packages/ui/src/Dialog.tsx
+++ b/packages/ui/src/Dialog.tsx
@@ -17,6 +17,7 @@ export type DialogState = ReturnType<typeof createDialogState>;
 
 export interface DialogOptions {
 	onSubmit?(): void;
+	closeOnSubmit?: boolean;
 }
 
 export interface UseDialogProps extends DialogOptions {
@@ -87,7 +88,8 @@ export function useDialog(props: UseDialogProps) {
 
 	return {
 		...props,
-		state
+		state,
+		close: () => (state.open = false)
 	};
 }
 
@@ -164,7 +166,7 @@ export function Dialog<S extends FieldValues>({
 									onSubmit={async (e) => {
 										await onSubmit?.(e);
 										dialog.onSubmit?.();
-										setOpen(false);
+										if (dialog.closeOnSubmit !== false) dialog.close();
 									}}
 									className="bg-app-box border-app-line text-ink shadow-app-shade !pointer-events-auto min-w-[300px] max-w-[400px] rounded-md border"
 								>

--- a/packages/ui/src/Input.tsx
+++ b/packages/ui/src/Input.tsx
@@ -1,61 +1,139 @@
-import { VariantProps, cva } from 'class-variance-authority';
+import { VariantProps, cva, cx } from 'class-variance-authority';
 import clsx from 'clsx';
 import { Eye, EyeSlash, MagnifyingGlass } from 'phosphor-react';
 import { PropsWithChildren, forwardRef, useState } from 'react';
 import { Button } from './Button';
 
-export interface InputBaseProps extends VariantProps<typeof styles> {}
+export interface InputBaseProps extends VariantProps<typeof inputStyles> {
+	label?: string;
+	error?: string | boolean;
+	icon?: React.ReactNode;
+	iconPosition?: 'left' | 'right';
+	right?: React.ReactNode;
+	outerClassName?: string;
+	labelClassName?: string;
+	iconClassName?: string;
+	rightClassName?: string;
+}
 
 export type InputProps = InputBaseProps & Omit<React.ComponentProps<'input'>, 'size'>;
 
 export type TextareaProps = InputBaseProps & React.ComponentProps<'textarea'>;
 
-const styles = cva(
+export const inputStyles = cva(
 	[
 		'w-full',
-		'rounded-md border px-3 text-sm leading-7',
-		'shadow-sm outline-none transition-all focus:ring-2'
+		'rounded-md border text-sm leading-7',
+		'shadow-sm outline-none transition-all focus-within:ring-2'
 	],
 	{
 		variants: {
 			variant: {
 				default: [
-					'bg-app-input focus:bg-app-focus placeholder-ink-faint border-app-line',
-					'focus:ring-app-selected/30 focus:border-app-divider/80'
+					'bg-app-input focus-within:bg-app-focus placeholder-ink-faint border-app-line',
+					'focus-within:ring-app-selected/30 focus-within:border-app-divider/80'
 				]
 			},
 			size: {
-				sm: 'py-0.5 text-sm',
-				md: 'py-1 text-sm'
+				sm: 'h-[30px]',
+				md: 'h-[34px]',
+				lg: 'h-[38px]'
 			}
 		},
 		defaultVariants: {
-			variant: 'default'
+			variant: 'default',
+			size: 'sm'
 		}
 	}
 );
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(
-	({ variant, size, className, ...props }, ref) => (
-		<input {...props} ref={ref} className={styles({ variant, size, className })} />
-	)
-);
+	(
+		{
+			variant,
+			size,
+			label,
+			error,
+			icon,
+			right,
+			className,
+			outerClassName,
+			labelClassName,
+			iconClassName,
+			rightClassName,
+			iconPosition = 'left',
+			required,
+			...props
+		},
+		ref
+	) => (
+		<div className={outerClassName}>
+			{label && (
+				<label htmlFor={props.id} className={clsx('mb-1 flex text-sm font-medium', labelClassName)}>
+					{label}
+					{required && <span className="ml-1 text-red-500">*</span>}
+				</label>
+			)}
 
-export const SearchInput = forwardRef<HTMLInputElement, InputProps & { outerClassnames?: string }>(
-	({ variant, size, className, outerClassnames, ...props }, ref) => (
-		<div className={clsx('relative', outerClassnames)}>
-			<MagnifyingGlass className="text-gray-350 absolute top-[8px] left-[11px] h-auto w-[18px]" />
-			<Input
-				{...props}
-				ref={ref}
-				className={clsx(styles({ variant, size, className }), '!p-0.5 !pl-9')}
-			/>
+			<div
+				className={clsx(
+					'group flex',
+					error && 'border-red-500 focus-within:border-red-500 focus-within:ring-red-400/30',
+					inputStyles({ variant, size: right && !size ? 'md' : size, className })
+				)}
+			>
+				<div
+					className={clsx(
+						'flex h-full flex-1 overflow-hidden',
+						iconPosition === 'right' && 'flex-row-reverse'
+					)}
+				>
+					{icon && (
+						<div
+							className={clsx(
+								'flex h-full items-center',
+								iconPosition === 'left' ? 'pr-2 pl-[10px]' : 'pl-2 pr-[10px]',
+								iconClassName
+							)}
+						>
+							{icon}
+						</div>
+					)}
+
+					<input
+						className={clsx(
+							'placeholder:text-ink-faint flex-1 truncate border-none bg-transparent px-3 text-sm outline-none',
+							(right || (icon && iconPosition === 'right')) && 'pr-0',
+							icon && iconPosition === 'left' && 'pl-0'
+						)}
+						ref={ref}
+						{...props}
+					/>
+				</div>
+
+				{right && (
+					<div className={clsx('flex h-full items-center px-1', rightClassName)}>{right}</div>
+				)}
+			</div>
+
+			{error && typeof error === 'string' && (
+				<span className="whitespace-pre-line text-xs text-red-500">{error}</span>
+			)}
 		</div>
 	)
 );
 
+export const SearchInput = forwardRef<HTMLInputElement, InputProps>((props, ref) => (
+	<Input {...props} ref={ref} icon={<MagnifyingGlass className="text-gray-350" size={18} />} />
+));
+
 export const TextArea = ({ size, variant, ...props }: TextareaProps) => {
-	return <textarea {...props} className={clsx(styles({ size, variant }), props.className)} />;
+	return (
+		<textarea
+			{...props}
+			className={clsx('h-auto px-3 py-2', inputStyles({ size, variant }), props.className)}
+		/>
+	);
 };
 
 export function Label(props: PropsWithChildren<{ slug?: string }>) {
@@ -76,18 +154,19 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>((p
 	const CurrentEyeIcon = showPassword ? EyeSlash : Eye;
 
 	return (
-		<div className="relative grow">
-			<Button
-				onClick={() => setShowPassword(!showPassword)}
-				size="icon"
-				className={clsx(
-					'absolute inset-y-1.5 right-2 m-auto w-[25px] border-none',
-					props.buttonClassnames
-				)}
-			>
-				<CurrentEyeIcon className="h-4 w-4" />
-			</Button>
-			<Input {...props} type={showPassword ? 'text' : 'password'} ref={ref} />
-		</div>
+		<Input
+			{...props}
+			type={showPassword ? 'text' : 'password'}
+			ref={ref}
+			right={
+				<Button
+					onClick={() => setShowPassword(!showPassword)}
+					size="icon"
+					className={clsx(props.buttonClassnames)}
+				>
+					<CurrentEyeIcon className="h-4 w-4" />
+				</Button>
+			}
+		/>
 	);
 });

--- a/packages/ui/src/Input.tsx
+++ b/packages/ui/src/Input.tsx
@@ -1,13 +1,13 @@
 import { VariantProps, cva, cx } from 'class-variance-authority';
 import clsx from 'clsx';
-import { Eye, EyeSlash, MagnifyingGlass } from 'phosphor-react';
-import { PropsWithChildren, forwardRef, useState } from 'react';
+import { Eye, EyeSlash, Icon, IconProps, MagnifyingGlass } from 'phosphor-react';
+import { PropsWithChildren, createElement, forwardRef, isValidElement, useState } from 'react';
 import { Button } from './Button';
 
 export interface InputBaseProps extends VariantProps<typeof inputStyles> {
 	label?: string;
 	error?: string | boolean;
-	icon?: React.ReactNode;
+	icon?: Icon | React.ReactNode;
 	iconPosition?: 'left' | 'right';
 	right?: React.ReactNode;
 	outerClassName?: string;
@@ -96,7 +96,12 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
 								iconClassName
 							)}
 						>
-							{icon}
+							{isValidElement(icon)
+								? icon
+								: createElement<IconProps>(icon as Icon, {
+										size: 18,
+										className: 'text-gray-350'
+								  })}
 						</div>
 					)}
 
@@ -124,7 +129,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
 );
 
 export const SearchInput = forwardRef<HTMLInputElement, InputProps>((props, ref) => (
-	<Input {...props} ref={ref} icon={<MagnifyingGlass className="text-gray-350" size={18} />} />
+	<Input {...props} ref={ref} icon={MagnifyingGlass} />
 ));
 
 export const TextArea = ({ size, variant, ...props }: TextareaProps) => {

--- a/packages/ui/src/Popover.tsx
+++ b/packages/ui/src/Popover.tsx
@@ -1,61 +1,43 @@
 import * as Radix from '@radix-ui/react-popover';
 import clsx from 'clsx';
-import { PropsWithChildren, useState } from 'react';
+import { PropsWithChildren } from 'react';
 
 interface Props extends Radix.PopoverContentProps {
 	trigger: React.ReactNode;
-	transformOrigin?: string;
 	disabled?: boolean;
-	className?: string;
 }
 
 export const Popover = ({
 	trigger,
 	children,
 	disabled,
-	transformOrigin,
 	className,
 	...props
 }: PropsWithChildren<Props>) => {
-	const [open, setOpen] = useState(false);
-
-	// const transitions = useTransition(open, {
-	// 	from: {
-	// 		opacity: 0,
-	// 		transform: `scale(0.5)`,
-	// 		transformOrigin: transformOrigin || 'top'
-	// 	},
-	// 	enter: { opacity: 1, transform: 'scale(1)' },
-	// 	leave: { opacity: -0.5, transform: 'scale(0.95)' },
-	// 	config: { mass: 0.4, tension: 170, friction: 10 }
-	// });
-
 	return (
-		<Radix.Root open={open} onOpenChange={setOpen}>
+		<Radix.Root>
 			<Radix.Trigger disabled={disabled} asChild>
 				{trigger}
 			</Radix.Trigger>
-			{open && (
-				<Radix.Portal forceMount>
-					<Radix.Content forceMount asChild>
-						<div
-							className={clsx(
-								'flex flex-col',
-								'z-50 m-2 min-w-[11rem] space-y-1',
-								'cursor-default select-none rounded-lg',
-								'text-ink text-left text-sm',
-								'bg-app-overlay ',
-								'border-app-line border',
-								'shadow-2xl shadow-black/60 ',
-								className
-							)}
-							// style={styles}
-						>
-							{children}
-						</div>
-					</Radix.Content>
-				</Radix.Portal>
-			)}
+
+			<Radix.Portal>
+				<Radix.Content
+					className={clsx(
+						'flex flex-col',
+						'z-50 m-2 min-w-[11rem]',
+						'cursor-default select-none rounded-lg',
+						'text-ink text-left text-sm',
+						'bg-app-overlay ',
+						'border-app-line border',
+						'shadow-2xl',
+						'animate-in fade-in',
+						className
+					)}
+					{...props}
+				>
+					{children}
+				</Radix.Content>
+			</Radix.Portal>
 		</Radix.Root>
 	);
 };


### PR DESCRIPTION
Changes made to Input:
- label `string` - Shows label above input field
- error `string | boolean`
	- `boolean` -  Applies "error" classes to the field
	- `string` - Applies "error" classes to the field and shows the error below the input
- icon `Icon | ReactNode` - Shows icon
- iconPosition `'left' | 'right'` `default = 'left'` - Determine the position of the icon
- right `ReactNode` - Add extra content on the right side of the input
- outerClassName `string` - Apply styles to the outer(parent) div
- labelClassName `string` - Apply styles to the label
- iconClassName `string` - Apply styles to the icon
- rightClassName `string` - Apply styles to the right content

These changes remove reusable label code and fix input buttons clashing with the input.

![image](https://user-images.githubusercontent.com/43032218/227806487-3547c382-5b9b-44a1-8116-4cd129d21f35.png)
![image](https://user-images.githubusercontent.com/43032218/227806493-d0b2037d-1634-4569-a00c-1b798cc1576a.png)

Changes made to the color picker:
- Changed react-colorful styles
- Added hex input
<img width="245" alt="image" src="https://user-images.githubusercontent.com/43032218/227806816-3c9219c4-e891-4e56-9b96-ef67340cf298.png">

Changes made to useDialog:
- accepts a new `closeOnSubmit: boolean` prop `default = true` - whether to close the dialog after the form has been submitted
- returns a new `close: () => void` prop  - manually close the dialog

Changes made to create tag form:
- Prevent the form from submitting a tag with an empty name

<img width="300" alt="image" src="https://user-images.githubusercontent.com/43032218/227807376-4da59c27-1459-4827-9268-6f069a102fb2.png">


