### PR TITLE
Replace thumbnail server shutdown signal with a channel Receiver

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -3,12 +3,12 @@
 	windows_subsystem = "windows"
 )]
 
-use std::{path::PathBuf, sync::Arc, time::Duration};
+use std::{path::PathBuf, time::Duration};
 
 use sd_core::{custom_uri::create_custom_uri_endpoint, Node, NodeError};
 
 use tauri::{api::path, async_runtime::block_on, plugin::TauriPlugin, Manager, RunEvent, Runtime};
-use tokio::{task::block_in_place, time::sleep};
+use tokio::{sync::mpsc, task::block_in_place, time::sleep};
 use tracing::{debug, error};
 
 #[cfg(target_os = "linux")]
@@ -31,6 +31,9 @@ pub fn tauri_error_plugin<R: Runtime>(err: NodeError) -> TauriPlugin<R> {
 
 #[tokio::main]
 async fn main() -> tauri::Result<()> {
+	#[cfg(target_os = "linux")]
+	let (tx, rx) = mpsc::channel(1);
+
 	let data_dir = path::data_dir()
 		.unwrap_or_else(|| PathBuf::from("./"))
 		.join("spacedrive");
@@ -47,7 +50,7 @@ async fn main() -> tauri::Result<()> {
 			let endpoint = create_custom_uri_endpoint(node.clone());
 
 			#[cfg(target_os = "linux")]
-			let app = app_linux::setup(app, node.clone(), endpoint).await;
+			let app = app_linux::setup(app, rx, endpoint).await;
 
 			#[cfg(not(target_os = "linux"))]
 			let app = app.register_uri_scheme_protocol(
@@ -121,6 +124,10 @@ async fn main() -> tauri::Result<()> {
 			if let Some(node) = &node {
 				block_in_place(|| block_on(node.shutdown()));
 			}
+
+			#[cfg(target_os = "linux")]
+			block_in_place(|| block_on(tx.send(()))).ok();
+
 			app_handler.exit(0);
 		}
 	});


### PR DESCRIPTION
Hi,

After investigating the issue I described in #642, I found that the problem was caused by the `axum_shutdown_signal` call in the `app_linux.rs` setup, which I believe was overriding the signal handler set by Tauri. As a result, when the desktop app was closed with CTRL+C, only the `axum_shutdown_signal` logic was executed, terminating both the backend and the thumbnail server, but leaving the Tauri app still running. 

To fix this issue, I replaced the `axum_shutdown_signal` call with a channel that sends a signal when the `ExitRequested` event occurs. This approach shuts down the thumbnail server along with the Tauri app. I have tested this solution, and it seems to be working correctly. However, as my Rust knowledge is limited, I'm not certain if this is the best solution. Please let me know if it's incorrect, and I will close this PR.

Closes #642 
