### PR TITLE
added title icons for slots

### DIFF
--- a/apps/landing/src/style.scss
+++ b/apps/landing/src/style.scss
@@ -186,6 +186,12 @@ html {
 .slot-block-content {
 	@apply my-1 mx-0 mb-0 text-white;
 }
+.slot-block-title-icon {
+	@apply my-0 h-5 w-5 text-white;
+}
+.slot-block-title-container {
+	@apply flex flex-row items-center gap-x-1;
+}
 
 .doc-sidebar-button:hover,
 .doc-sidebar-button.nav-active {

--- a/apps/landing/src/utils/markdownParse.tsx
+++ b/apps/landing/src/utils/markdownParse.tsx
@@ -1,5 +1,7 @@
 import parseMarkdownMetadata from 'markdown-yaml-metadata-parser';
 import { marked } from 'marked';
+import { Fire, Info } from 'phosphor-react';
+import { renderToString } from 'react-dom/server';
 
 export interface MarkdownPageData {
 	name?: string;
@@ -51,9 +53,19 @@ export function parseMarkdown(markdownRaw: string): MarkdownParsed {
 
 				switch (kind) {
 					case 'slot':
-						return `<div class="slot-block ${name}"><h5 class="slot-block-title">${
-							extra || name
-						}</h5><p class="slot-block-content">${content}</p></div>`;
+						return (
+							// prettier-ignore
+							`<div class="slot-block ${name}">
+                                                                <div class="slot-block-title-container">
+                                                                        ${name === 'warning'
+                                                                                ? renderToString(<Fire className="slot-block-title-icon" />)
+                                                                                : renderToString(<Info className="slot-block-title-icon" />)
+                                                                        }
+                                                                        <h5 class="slot-block-title">${extra || name}</h5>
+                                                                </div>
+                                                                <p class="slot-block-content">${content}</p>
+                                                        </div>`
+						);
 						break;
 
 					default:


### PR DESCRIPTION
**what:**
added the ability to have title icons in slots. the icons I chose are of course not written in stone and can easily be changed.

**how it works:**
as far as I know are there three different slot types (note, info, warning). either a warning icon, or an info icon, is added to the slot title based of the slot type. if the slot type is not note, info or warning (which it probably shouldn't be), an info icon is still added.

**before imgs:**
![bilde](https://user-images.githubusercontent.com/98732287/228888254-3a76ca84-d970-495a-bca3-f3195d2b1087.png)
![bilde](https://user-images.githubusercontent.com/98732287/228886082-db206666-7e6b-4165-8e00-65f4c9d64e74.png)
![bilde](https://user-images.githubusercontent.com/98732287/228886361-3bdf8052-1fd8-4a14-8493-cf18a12f1f54.png)

**after imgs:**
![bilde](https://user-images.githubusercontent.com/98732287/228888576-f5c5895b-cc92-4d8c-a42c-20c49ba0ee45.png)
![bilde](https://user-images.githubusercontent.com/98732287/228889053-91e82335-298d-4ca7-8935-aef56d4e057a.png)
![bilde](https://user-images.githubusercontent.com/98732287/228888858-5f0be5f7-da5b-4790-8139-ec75036c4db8.png)

**closes discussion:** 
https://github.com/spacedriveapp/spacedrive/discussions/654
