### PR TITLE
[ENG-291] Location settings

### DIFF
--- a/interface/app/$libraryId/settings/library/locations/$id.tsx
+++ b/interface/app/$libraryId/settings/library/locations/$id.tsx
@@ -1,52 +1,40 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { Archive, ArrowsClockwise, Info, Trash } from 'phosphor-react';
+import { Controller } from 'react-hook-form';
 import { useParams } from 'react-router';
 import { useLibraryMutation, useLibraryQuery } from '@sd/client';
 import { Button, Divider, forms, tw } from '@sd/ui';
 import { Tooltip } from '@sd/ui';
+import { showAlertDialog } from '~/components/AlertDialog';
 import ModalLayout from '../../ModalLayout';
 import { IndexerRuleEditor } from './IndexerRuleEditor';
 
-const InfoText = tw.p`mt-2 text-xs text-ink-faint`;
 const Label = tw.label`mb-1 text-sm font-medium`;
 const FlexCol = tw.label`flex flex-col flex-1`;
+const InfoText = tw.p`mt-2 text-xs text-ink-faint`;
 const ToggleSection = tw.label`flex flex-row w-full`;
 
 const { Form, Input, Switch, useZodForm, z } = forms;
 
 const schema = z.object({
-	displayName: z.string(),
-	localPath: z.string(),
-	indexer_rules_ids: z.array(z.string()),
-	generatePreviewMedia: z.boolean(),
-	syncPreviewMedia: z.boolean(),
-	hidden: z.boolean()
+	name: z.string(),
+	path: z.string(),
+	hidden: z.boolean(),
+	indexer_rules_ids: z.array(z.number()),
+	sync_preview_media: z.boolean(),
+	generate_preview_media: z.boolean()
 });
 
 export const Component = () => {
-	const queryClient = useQueryClient();
-	const { id } = useParams<{
-		id: string;
-	}>();
-
-	useLibraryQuery(['locations.getById', Number(id)], {
-		onSuccess: (data) => {
-			if (data && !isDirty)
-				form.reset({
-					displayName: data.name,
-					localPath: data.path,
-					indexer_rules_ids: data.indexer_rules.map((i) => i.indexer_rule.id.toString()),
-					generatePreviewMedia: data.generate_preview_media,
-					syncPreviewMedia: data.sync_preview_media,
-					hidden: data.hidden
-				});
+	const form = useZodForm({
+		schema,
+		defaultValues: {
+			indexer_rules_ids: []
 		}
 	});
-
-	const form = useZodForm({
-		schema
-	});
-
+	const params = useParams<{ id: string }>();
+	const fullRescan = useLibraryMutation('locations.fullRescan');
+	const queryClient = useQueryClient();
 	const updateLocation = useLibraryMutation('locations.update', {
 		onError: (e) => console.log({ e }),
 		onSuccess: () => {
@@ -55,20 +43,48 @@ export const Component = () => {
 		}
 	});
 
-	const onSubmit = form.handleSubmit((data) =>
-		updateLocation.mutateAsync({
-			id: Number(id),
-			name: data.displayName,
-			sync_preview_media: data.syncPreviewMedia,
-			generate_preview_media: data.generatePreviewMedia,
-			hidden: data.hidden,
-			indexer_rules_ids: []
-		})
-	);
-
-	const fullRescan = useLibraryMutation('locations.fullRescan');
-
 	const { isDirty } = form.formState;
+	const locationId = Number.parseInt(params.id ?? '');
+	useLibraryQuery(['locations.getById', locationId], {
+		onError: (e) => {
+			showAlertDialog({
+				title: 'Error',
+				value: 'Failed to update location settings'
+			});
+			console.error({ e });
+		},
+		onSuccess: (data) => {
+			if (data && !isDirty)
+				form.reset({
+					path: data.path,
+					name: data.name,
+					hidden: data.hidden,
+					indexer_rules_ids: data.indexer_rules.map((i) => i.indexer_rule.id),
+					sync_preview_media: data.sync_preview_media,
+					generate_preview_media: data.generate_preview_media
+				});
+		}
+	});
+
+	if (Number.isNaN(locationId)) {
+		showAlertDialog({
+			title: 'Error',
+			value: 'Invalid location settings'
+		});
+		return null;
+	}
+
+	const onSubmit = form.handleSubmit(
+		({ name, hidden, sync_preview_media, generate_preview_media, indexer_rules_ids }) =>
+			updateLocation.mutateAsync({
+				id: locationId,
+				name,
+				hidden,
+				indexer_rules_ids,
+				sync_preview_media,
+				generate_preview_media
+			})
+	);
 
 	return (
 		<Form form={form} onSubmit={onSubmit} className="h-full w-full">
@@ -94,14 +110,19 @@ export const Component = () => {
 			>
 				<div className="flex space-x-4">
 					<FlexCol>
-						<Input label="Display Name" {...form.register('displayName')} />
+						<Input label="Display Name" {...form.register('name')} />
 						<InfoText>
 							The name of this Location, this is what will be displayed in the sidebar. Will not
 							rename the actual folder on disk.
 						</InfoText>
 					</FlexCol>
 					<FlexCol>
-						<Input label="Local Path" {...form.register('localPath')} />
+						<Input
+							label="Local Path"
+							readOnly={true}
+							className="text-ink-dull"
+							{...form.register('path')}
+						/>
 						<InfoText>
 							The path to this Location, this is where the files will be stored on disk.
 						</InfoText>
@@ -111,11 +132,11 @@ export const Component = () => {
 				<div className="space-y-2">
 					<ToggleSection>
 						<Label className="grow">Generate preview media for this Location</Label>
-						<Switch {...form.register('generatePreviewMedia')} size="sm" />
+						<Switch {...form.register('generate_preview_media')} size="sm" />
 					</ToggleSection>
 					<ToggleSection>
 						<Label className="grow">Sync preview media for this Location with your devices</Label>
-						<Switch {...form.register('syncPreviewMedia')} size="sm" />
+						<Switch {...form.register('sync_preview_media')} size="sm" />
 					</ToggleSection>
 					<ToggleSection>
 						<Label className="grow">
@@ -128,18 +149,22 @@ export const Component = () => {
 					</ToggleSection>
 				</div>
 				<Divider />
-				<div className="pointer-events-none flex flex-col opacity-30">
+				<div className="flex flex-col">
 					<Label className="grow">Indexer rules</Label>
 					<InfoText className="mt-0 mb-1">
 						Indexer rules allow you to specify paths to ignore using RegEx.
 					</InfoText>
-					<IndexerRuleEditor locationId={id!} />
+					<Controller
+						name="indexer_rules_ids"
+						render={({ field }) => <IndexerRuleEditor field={field} />}
+						control={form.control}
+					/>
 				</div>
 				<Divider />
 				<div className="flex space-x-5">
 					<FlexCol>
 						<div>
-							<Button onClick={() => fullRescan.mutate(Number(id))} size="sm" variant="outline">
+							<Button onClick={() => fullRescan.mutate(locationId)} size="sm" variant="outline">
 								<ArrowsClockwise className="mr-1.5 -mt-0.5 inline h-4 w-4" />
 								Full Reindex
 							</Button>
@@ -164,7 +189,7 @@ export const Component = () => {
 					</FlexCol>
 					<FlexCol>
 						<div>
-							<Button size="sm" variant="colored" className="border-red-500 bg-red-500 ">
+							<Button size="sm" variant="colored" className="border-red-500 bg-red-500">
 								<Trash className="mr-1.5 -mt-0.5 inline h-4 w-4" />
 								Delete
 							</Button>

--- a/interface/app/$libraryId/settings/library/locations/$id.tsx
+++ b/interface/app/$libraryId/settings/library/locations/$id.tsx
@@ -40,7 +40,12 @@ export const Component = () => {
 	const queryClient = useQueryClient();
 	const [isFirstLoad, setIsFirstLoad] = useState<boolean>(true);
 	const updateLocation = useLibraryMutation('locations.update', {
-		onError: (e) => console.log({ e }),
+		onError: () => {
+			showAlertDialog({
+				title: 'Error',
+				value: 'Failed to update location settings'
+			});
+		},
 		onSuccess: () => {
 			form.reset(form.getValues());
 			queryClient.invalidateQueries(['locations.list']);
@@ -51,7 +56,6 @@ export const Component = () => {
 	// Default to first location if no id is provided
 	// fallback to 0 (which should always be an invalid location) when parsing fails
 	const locationId = (params.id ? Number(params.id) : 1) || 0;
-	console.log(locationId);
 	useLibraryQuery(['locations.getById', locationId], {
 		onSettled: (data, error) => {
 			if (isFirstLoad && (!data || error)) {

--- a/interface/app/$libraryId/settings/library/locations/AddLocationDialog.tsx
+++ b/interface/app/$libraryId/settings/library/locations/AddLocationDialog.tsx
@@ -10,7 +10,7 @@ import { showAlertDialog } from '~/components/AlertDialog';
 import { Platform, usePlatform } from '~/util/Platform';
 import { IndexerRuleEditor } from './IndexerRuleEditor';
 
-const schema = z.object({ path: z.string(), indexer_rules_ids: z.array(z.number()) });
+const schema = z.object({ path: z.string(), indexerRulesIds: z.array(z.number()) });
 
 interface Props extends UseDialogProps {
 	path: string;
@@ -54,7 +54,7 @@ export const AddLocationDialog = (props: Props) => {
 		schema,
 		defaultValues: {
 			path: props.path,
-			indexer_rules_ids: []
+			indexerRulesIds: []
 		}
 	});
 
@@ -67,10 +67,10 @@ export const AddLocationDialog = (props: Props) => {
 		return () => subscription.unsubscribe();
 	}, [form]);
 
-	const onLocationSubmit = form.handleSubmit(async ({ path, indexer_rules_ids }) => {
+	const onLocationSubmit = form.handleSubmit(async ({ path, indexerRulesIds }) => {
 		switch (remoteError) {
 			case null:
-				await createLocation.mutateAsync({ path, indexer_rules_ids });
+				await createLocation.mutateAsync({ path, indexer_rules_ids: indexerRulesIds });
 				break;
 			case 'NEED_RELINK':
 				await relinkLocation.mutateAsync(path);
@@ -85,7 +85,7 @@ export const AddLocationDialog = (props: Props) => {
 				// });
 				break;
 			case 'ADD_LIBRARY':
-				await addLocationToLibrary.mutateAsync({ path, indexer_rules_ids });
+				await addLocationToLibrary.mutateAsync({ path, indexer_rules_ids: indexerRulesIds });
 				break;
 			default:
 				throw new Error('Unimplemented custom remote error handling');
@@ -162,7 +162,7 @@ export const AddLocationDialog = (props: Props) => {
 				<p className="my-2 text-sm font-bold">File indexing rules:</p>
 				<div className="w-full text-xs font-medium">
 					<Controller
-						name="indexer_rules_ids"
+						name="indexerRulesIds"
 						render={({ field }) => <IndexerRuleEditor field={field} />}
 						control={form.control}
 					/>

--- a/interface/app/$libraryId/settings/library/locations/AddLocationDialog.tsx
+++ b/interface/app/$libraryId/settings/library/locations/AddLocationDialog.tsx
@@ -3,11 +3,12 @@ import { RSPCError } from '@rspc/client';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { Controller } from 'react-hook-form';
-import { useLibraryMutation, useLibraryQuery } from '@sd/client';
-import { Dialog, RadixCheckbox, UseDialogProps, useDialog } from '@sd/ui';
+import { useLibraryMutation } from '@sd/client';
+import { Dialog, UseDialogProps, useDialog } from '@sd/ui';
 import { Input, useZodForm, z } from '@sd/ui/src/forms';
 import { showAlertDialog } from '~/components/AlertDialog';
 import { Platform, usePlatform } from '~/util/Platform';
+import { IndexerRuleEditor } from './IndexerRuleEditor';
 
 const schema = z.object({ path: z.string(), indexer_rules_ids: z.array(z.number()) });
 
@@ -46,7 +47,6 @@ export const AddLocationDialog = (props: Props) => {
 	const queryClient = useQueryClient();
 	const createLocation = useLibraryMutation('locations.create');
 	const relinkLocation = useLibraryMutation('locations.relink');
-	const indexerRulesList = useLibraryQuery(['locations.indexer_rules.list']);
 	const addLocationToLibrary = useLibraryMutation('locations.addLibrary');
 	const [remoteError, setRemoteError] = useState<null | RemoteErrorFormMessage>(null);
 
@@ -160,28 +160,11 @@ export const AddLocationDialog = (props: Props) => {
 
 			<div className="relative flex flex-col">
 				<p className="my-2 text-sm font-bold">File indexing rules:</p>
-				<div className="grid w-full grid-cols-2 gap-4 text-xs font-medium">
+				<div className="w-full text-xs font-medium">
 					<Controller
 						name="indexer_rules_ids"
+						render={({ field }) => <IndexerRuleEditor field={field} />}
 						control={form.control}
-						render={({ field }) => (
-							<>
-								{indexerRulesList.data?.map((rule) => (
-									<RadixCheckbox
-										key={rule.id}
-										label={rule.name}
-										checked={field.value.includes(rule.id)}
-										onCheckedChange={(checked) =>
-											field.onChange(
-												checked && checked !== 'indeterminate'
-													? [...field.value, rule.id]
-													: field.value.filter((fieldValue) => fieldValue !== rule.id)
-											)
-										}
-									/>
-								))}
-							</>
-						)}
 					/>
 				</div>
 			</div>

--- a/interface/app/$libraryId/settings/library/locations/IndexerRuleEditor.tsx
+++ b/interface/app/$libraryId/settings/library/locations/IndexerRuleEditor.tsx
@@ -1,32 +1,64 @@
+// import { PlusSquare } from '@phosphor-icons/react';
+import clsx from 'clsx';
+import { ControllerRenderProps, FieldPath } from 'react-hook-form';
 import { useLibraryQuery } from '@sd/client';
-import { Card, tw } from '@sd/ui';
+import { Button, Card } from '@sd/ui';
 
-interface Props {
-	locationId: string;
+interface FormFields {
+	indexer_rules_ids: number[];
 }
 
-export const Rule = tw.span`inline border border-transparent px-1 text-[11px] font-medium shadow shadow-app-shade/5 bg-app-selected rounded-md text-ink-dull`;
+type FieldType = ControllerRenderProps<
+	FormFields,
+	Exclude<FieldPath<FormFields>, `indexer_rules_ids.${number}`>
+>;
 
-export function IndexerRuleEditor({ locationId }: Props) {
+export interface IndexerRuleEditorProps<T extends FieldType> {
+	field: T;
+	editable?: boolean;
+}
+
+export function IndexerRuleEditor<T extends FieldType>({
+	field,
+	editable
+}: IndexerRuleEditorProps<T>) {
 	const listIndexerRules = useLibraryQuery(['locations.indexer_rules.list'], {});
-	const currentLocationIndexerRules = useLibraryQuery(
-		['locations.indexer_rules.listForLocation', Number(locationId)],
-		{}
-	);
 
 	return (
-		<div className="flex flex-col">
-			{/* <Input /> */}
-			{/* <Card className="flex flex-wrap mb-2 space-x-1">
-				{currentLocationIndexerRules.data?.map((rule) => (
-					<Rule key={rule.indexer_rule.id}>{rule.indexer_rule.name}</Rule>
-				))}
-			</Card> */}
-			<Card className="mb-2 flex flex-wrap space-x-1">
-				{listIndexerRules.data?.map((rule) => (
-					<Rule key={rule.id}>{rule.name}</Rule>
-				))}
-			</Card>
-		</div>
+		<Card className="mb-2 flex flex-wrap justify-evenly">
+			{listIndexerRules.data
+				? listIndexerRules.data.map((rule) => {
+						const { id, name } = rule;
+						const enabled = field.value.includes(id);
+						return (
+							<Button
+								key={id}
+								size="sm"
+								onClick={() =>
+									field.onChange(
+										enabled
+											? field.value.filter((fieldValue) => fieldValue !== rule.id)
+											: [...field.value, rule.id]
+									)
+								}
+								variant={enabled ? 'colored' : 'outline'}
+								className={clsx('m-1 flex-auto', enabled && 'border-accent bg-accent')}
+							>
+								{name}
+							</Button>
+						);
+				  })
+				: editable || <p>No indexer rules available</p>}
+			{/* {editable && (
+				<Button
+					size="icon"
+					onClick={() => console.log('TODO')}
+					variant="outline"
+					className="m-1 flex-[0_0_99%] text-center leading-none"
+				>
+					<PlusSquare weight="light" size={18} className="inline" />
+				</Button>
+			)} */}
+		</Card>
 	);
 }

--- a/interface/app/$libraryId/settings/library/locations/IndexerRuleEditor.tsx
+++ b/interface/app/$libraryId/settings/library/locations/IndexerRuleEditor.tsx
@@ -5,12 +5,12 @@ import { useLibraryQuery } from '@sd/client';
 import { Button, Card } from '@sd/ui';
 
 interface FormFields {
-	indexer_rules_ids: number[];
+	indexerRulesIds: number[];
 }
 
 type FieldType = ControllerRenderProps<
 	FormFields,
-	Exclude<FieldPath<FormFields>, `indexer_rules_ids.${number}`>
+	Exclude<FieldPath<FormFields>, `indexerRulesIds.${number}`>
 >;
 
 export interface IndexerRuleEditorProps<T extends FieldType> {

--- a/packages/client/src/rspc.ts
+++ b/packages/client/src/rspc.ts
@@ -56,13 +56,13 @@ const libraryHooks = hooks.createHooks<
 					const libraryId = currentLibraryCache.id;
 					if (libraryId === null)
 						throw new Error('Attempted to do library operation with no library set!');
-					return [keyAndInput[0], { library_id: libraryId, arg: keyAndInput[1] || null }];
+					return [keyAndInput[0], { library_id: libraryId, arg: keyAndInput[1] ?? null }];
 				},
 				doMutation: (keyAndInput, next) => {
 					const libraryId = currentLibraryCache.id;
 					if (libraryId === null)
 						throw new Error('Attempted to do library operation with no library set!');
-					return next([keyAndInput[0], { library_id: libraryId, arg: keyAndInput[1] || null }]);
+					return next([keyAndInput[0], { library_id: libraryId, arg: keyAndInput[1] ?? null }]);
 				}
 			};
 		})

--- a/packages/ui/src/forms/Form.tsx
+++ b/packages/ui/src/forms/Form.tsx
@@ -12,11 +12,13 @@ import { z } from 'zod';
 
 export interface FormProps<T extends FieldValues> extends Omit<ComponentProps<'form'>, 'onSubmit'> {
 	form: UseFormReturn<T>;
+	disabled?: boolean;
 	onSubmit?: ReturnType<UseFormHandleSubmit<T>>;
 }
 
 export const Form = <T extends FieldValues>({
 	form,
+	disabled,
 	onSubmit,
 	children,
 	...props
@@ -32,7 +34,7 @@ export const Form = <T extends FieldValues>({
 			>
 				{/* <fieldset> passes the form's 'disabled' state to all of its elements,
             allowing us to handle disabled style variants with just css */}
-				<fieldset disabled={form.formState.isSubmitting}>{children}</fieldset>
+				<fieldset disabled={disabled || form.formState.isSubmitting}>{children}</fieldset>
 			</form>
 		</FormProvider>
 	);


### PR DESCRIPTION
This PR partially implements the `IndexerRuleEditor` component (still lacks the ability to create indexer rules, will be addressed in ENG-384), which allows for editing a location's indexer rules from its settings page. Additionally, I replaced the checkbox list of indexer rules in `AddLocationDialog` with `IndexerRuleEditor` for consistency. I also performed some minor clean-up in the location settings page and improved the error handling for some of its logic.

[indexer_rules.webm](https://user-images.githubusercontent.com/9082460/231084236-3dc40514-5050-437d-a2a5-cfa2fc4aed22.webm)
