### PR TITLE
[ENG-286] Set default indexer rules for location

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -54,3 +54,15 @@ indent_size = 4
 indent_size = 4
 insert_final_newline = false
 trim_trailing_whitespace = true
+
+# SQL
+# https://www.sqlstyle.guide/
+[*.sql]
+indent_size = 4
+indent_style = space
+
+# Prisma
+# https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-schema/data-model#formatting
+[*.prisma]
+indent_size = 4
+indent_style = space

--- a/core/prisma/migrations/20230210031123_init/migration.sql
+++ b/core/prisma/migrations/20230210031123_init/migration.sql
@@ -281,6 +281,7 @@ CREATE TABLE "indexer_rule" (
     "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
     "kind" INTEGER NOT NULL,
     "name" TEXT NOT NULL,
+    "default" BOOLEAN NOT NULL DEFAULT false,
     "parameters" BLOB NOT NULL,
     "date_created" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "date_modified" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
@@ -316,7 +317,12 @@ CREATE UNIQUE INDEX "file_path_integrity_checksum_key" ON "file_path"("integrity
 CREATE INDEX "file_path_location_id_idx" ON "file_path"("location_id");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "file_path_location_id_materialized_path_name_extension_key" ON "file_path"("location_id", "materialized_path", "name", "extension");
+CREATE UNIQUE INDEX "file_path_location_id_materialized_path_name_extension_key" ON "file_path"(
+    "location_id",
+    "materialized_path",
+    "name",
+    "extension"
+);
 
 -- CreateIndex
 CREATE UNIQUE INDEX "file_path_location_id_inode_device_key" ON "file_path"("location_id", "inode", "device");

--- a/core/prisma/migrations/20230210031123_init/migration.sql
+++ b/core/prisma/migrations/20230210031123_init/migration.sql
@@ -281,7 +281,6 @@ CREATE TABLE "indexer_rule" (
     "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
     "kind" INTEGER NOT NULL,
     "name" TEXT NOT NULL,
-    "default" BOOLEAN NOT NULL DEFAULT false,
     "parameters" BLOB NOT NULL,
     "date_created" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "date_modified" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
@@ -317,12 +316,7 @@ CREATE UNIQUE INDEX "file_path_integrity_checksum_key" ON "file_path"("integrity
 CREATE INDEX "file_path_location_id_idx" ON "file_path"("location_id");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "file_path_location_id_materialized_path_name_extension_key" ON "file_path"(
-    "location_id",
-    "materialized_path",
-    "name",
-    "extension"
-);
+CREATE UNIQUE INDEX "file_path_location_id_materialized_path_name_extension_key" ON "file_path"("location_id", "materialized_path", "name", "extension");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "file_path_location_id_inode_device_key" ON "file_path"("location_id", "inode", "device");

--- a/core/prisma/migrations/20230417192552_add_default_param_to_indexerrule/migration.sql
+++ b/core/prisma/migrations/20230417192552_add_default_param_to_indexerrule/migration.sql
@@ -1,0 +1,16 @@
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_indexer_rule" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "kind" INTEGER NOT NULL,
+    "name" TEXT NOT NULL,
+    "default" BOOLEAN NOT NULL DEFAULT false,
+    "parameters" BLOB NOT NULL,
+    "date_created" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "date_modified" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+INSERT INTO "new_indexer_rule" ("date_created", "date_modified", "id", "kind", "name", "parameters") SELECT "date_created", "date_modified", "id", "kind", "name", "parameters" FROM "indexer_rule";
+DROP TABLE "indexer_rule";
+ALTER TABLE "new_indexer_rule" RENAME TO "indexer_rule";
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/core/prisma/schema.prisma
+++ b/core/prisma/schema.prisma
@@ -134,7 +134,7 @@ model FilePath {
     name              String
     extension         String
 
-    size_in_bytes     String   @default("0")
+    size_in_bytes String @default("0")
 
     inode  Bytes // This is actually an unsigned 64 bit integer, but we don't have this type in SQLite
     device Bytes // This is actually an unsigned 64 bit integer, but we don't have this type in SQLite
@@ -167,9 +167,9 @@ model FilePath {
 
 /// @shared(id: pub_id)
 model Object {
-    id                Int      @id @default(autoincrement())
-    pub_id            Bytes    @unique
-    kind              Int      @default(0)
+    id     Int   @id @default(autoincrement())
+    pub_id Bytes @unique
+    kind   Int   @default(0)
 
     key_id            Int?
     // handy ways to mark an object
@@ -417,6 +417,7 @@ model IndexerRule {
     id            Int      @id @default(autoincrement())
     kind          Int
     name          String
+    default       Boolean  @default(false)
     parameters    Bytes
     date_created  DateTime @default(now())
     date_modified DateTime @default(now())

--- a/core/src/location/indexer/rules.rs
+++ b/core/src/location/indexer/rules.rs
@@ -148,9 +148,7 @@ impl IndexerRule {
 						self.kind as i32,
 						self.name,
 						self.parameters.serialize()?,
-						vec![
-							indexer_rule::default::set(self.default),
-						],
+						vec![indexer_rule::default::set(self.default)],
 					),
 					vec![indexer_rule::date_modified::set(Utc::now().into())],
 				)
@@ -163,9 +161,7 @@ impl IndexerRule {
 					self.kind as i32,
 					self.name,
 					self.parameters.serialize()?,
-					vec![
-						indexer_rule::default::set(self.default),
-					],
+					vec![indexer_rule::default::set(self.default)],
 				)
 				.exec()
 				.await?;

--- a/core/src/location/indexer/rules.rs
+++ b/core/src/location/indexer/rules.rs
@@ -304,9 +304,9 @@ mod tests {
 		let rule = IndexerRule::new(
 			RuleKind::RejectFilesByGlob,
 			"ignore build directory".to_string(),
-			ParametersPerKind::RejectFilesByGlob(
-				vec![Glob::new("{**/target/*,**/target}").unwrap()],
-			),
+			ParametersPerKind::RejectFilesByGlob(vec![
+				Glob::new("{**/target/*,**/target}").unwrap()
+			]),
 		);
 
 		assert!(rule.apply(project_file).await.unwrap());

--- a/core/src/location/indexer/walk.rs
+++ b/core/src/location/indexer/walk.rs
@@ -557,7 +557,9 @@ mod tests {
 			vec![IndexerRule::new(
 				RuleKind::AcceptFilesByGlob,
 				"only photos".to_string(),
-				ParametersPerKind::AcceptFilesByGlob(Glob::new("{*.png,*.jpg,*.jpeg}").unwrap()),
+				ParametersPerKind::AcceptFilesByGlob(vec![
+					Glob::new("{*.png,*.jpg,*.jpeg}").unwrap()
+				]),
 			)],
 		)]
 		.into_iter()
@@ -681,16 +683,18 @@ mod tests {
 					IndexerRule::new(
 						RuleKind::RejectFilesByGlob,
 						"reject node_modules".to_string(),
-						ParametersPerKind::RejectFilesByGlob(
-							Glob::new("{**/node_modules/*,**/node_modules}").unwrap(),
-						),
+						ParametersPerKind::RejectFilesByGlob(vec![Glob::new(
+							"{**/node_modules/*,**/node_modules}",
+						)
+						.unwrap()]),
 					),
 					IndexerRule::new(
 						RuleKind::RejectFilesByGlob,
 						"reject rust build dir".to_string(),
-						ParametersPerKind::RejectFilesByGlob(
-							Glob::new("{**/target/*,**/target}").unwrap(),
-						),
+						ParametersPerKind::RejectFilesByGlob(vec![Glob::new(
+							"{**/target/*,**/target}",
+						)
+						.unwrap()]),
 					),
 				],
 			),

--- a/core/src/location/indexer/walk.rs
+++ b/core/src/location/indexer/walk.rs
@@ -557,6 +557,7 @@ mod tests {
 			vec![IndexerRule::new(
 				RuleKind::AcceptFilesByGlob,
 				"only photos".to_string(),
+				false,
 				ParametersPerKind::AcceptFilesByGlob(vec![
 					Glob::new("{*.png,*.jpg,*.jpeg}").unwrap()
 				]),
@@ -617,6 +618,7 @@ mod tests {
 			vec![IndexerRule::new(
 				RuleKind::AcceptIfChildrenDirectoriesArePresent,
 				"git repos".to_string(),
+				false,
 				ParametersPerKind::AcceptIfChildrenDirectoriesArePresent(
 					[".git".to_string()].into_iter().collect(),
 				),
@@ -672,6 +674,7 @@ mod tests {
 				vec![IndexerRule::new(
 					RuleKind::AcceptIfChildrenDirectoriesArePresent,
 					"git repos".to_string(),
+					false,
 					ParametersPerKind::AcceptIfChildrenDirectoriesArePresent(
 						[".git".to_string()].into_iter().collect(),
 					),
@@ -683,6 +686,7 @@ mod tests {
 					IndexerRule::new(
 						RuleKind::RejectFilesByGlob,
 						"reject node_modules".to_string(),
+						false,
 						ParametersPerKind::RejectFilesByGlob(vec![Glob::new(
 							"{**/node_modules/*,**/node_modules}",
 						)
@@ -691,6 +695,7 @@ mod tests {
 					IndexerRule::new(
 						RuleKind::RejectFilesByGlob,
 						"reject rust build dir".to_string(),
+						false,
 						ParametersPerKind::RejectFilesByGlob(vec![Glob::new(
 							"{**/target/*,**/target}",
 						)

--- a/core/src/util/seeder.rs
+++ b/core/src/util/seeder.rs
@@ -93,9 +93,13 @@ pub async fn indexer_rules_seeder(client: &PrismaClient) -> Result<(), SeederErr
 						Glob::new("**/.thumbnails"),
 					],
 					#[cfg(target_family = "unix")]
+					// https://en.wikipedia.org/wiki/Unix_filesystem#Conventional_directory_layout
+					// https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard
 					vec![
 						// Directories containing unix memory/device mapped files/dirs
 						Glob::new("/{dev,sys,proc}"),
+						// Directories containing special files for current running programs
+						Glob::new("/{run,var,boot}"),
 						// ext2-4 recovery directory
 						Glob::new("**/lost+found"),
 					],

--- a/core/src/util/seeder.rs
+++ b/core/src/util/seeder.rs
@@ -56,15 +56,18 @@ pub async fn indexer_rules_seeder(client: &PrismaClient) -> Result<(), SeederErr
 					],
 					// https://github.com/github/gitignore/blob/main/Global/macOS.gitignore
 					// https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html#//apple_ref/doc/uid/TP40010672-CH2-SW14
-					#[cfg(target_os = "macos")]
+					#[cfg(any(target_os = "ios", target_os = "macos"))]
 					vec![
-						Glob::new("/{System,Network,Library,Applications}"),
-						Glob::new("/Users/*/{Library,Applications}"),
 						Glob::new("**/.{DS_Store,AppleDouble,LSOverride}"),
 						// Icon must end with two \r
 						Glob::new("**/Icon\r\r"),
 						// Thumbnails
 						Glob::new("**/._*"),
+					],
+					#[cfg(target_os = "macos")]
+					vec![
+						Glob::new("/{System,Network,Library,Applications}"),
+						Glob::new("/Users/*/{Library,Applications}"),
 						// Files that might appear in the root of a volume
 						Glob::new("**/.{DocumentRevisions-V100,fseventsd,Spotlight-V100,TemporaryItems,Trashes,VolumeIcon.icns,com.apple.timemachine.donotpresent}"),
 						// Directories potentially created on remote AFP share
@@ -83,6 +86,11 @@ pub async fn indexer_rules_seeder(client: &PrismaClient) -> Result<(), SeederErr
 						Glob::new("**/.Trash-*"),
 						// .nfs files are created when an open file is removed but is still being accessed
 						Glob::new("**/.nfs*"),
+					],
+					#[cfg(target_os = "android")]
+					vec![
+						Glob::new("**/.nomedia"),
+						Glob::new("**/.thumbnails"),
 					],
 					#[cfg(target_family = "unix")]
 					vec![

--- a/core/src/util/seeder.rs
+++ b/core/src/util/seeder.rs
@@ -44,30 +44,13 @@ pub async fn indexer_rules_seeder(client: &PrismaClient) -> Result<(), SeederErr
 						// Chkdsk recovery directory
 						Glob::new("**/FOUND.[0-9][0-9][0-9]"),
 						// Need both C:/ and / matches because globset treat them differently
-						Glob::new("C:/$WinREAgent"),
-						Glob::new("/$WinREAgent"),
-						Glob::new("C:/Program Files"),
-						Glob::new("/Program Files"),
-						Glob::new("C:/Program Files (x86)"),
-						Glob::new("/Program Files (x86)"),
-						Glob::new("C:/ProgramData"),
-						Glob::new("/ProgramData"),
-						Glob::new("C:/Recovery"),
-						Glob::new("/Recovery"),
-						Glob::new("C:/PerfLogs"),
-						Glob::new("/PerfLogs"),
-						Glob::new("C:/Windows"),
-						Glob::new("/Windows"),
-						Glob::new("C:/Windows.old"),
-						Glob::new("/Windows.old"),
-						Glob::new("C:/config.sys"),
-						Glob::new("/config.sys"),
-						Glob::new("C:/pagefile.sys"),
-						Glob::new("/pagefile.sys"),
-						Glob::new("C:/hiberfil.sys"),
-						Glob::new("/hiberfil.sys"),
+						Glob::new("C:/{$WinREAgent,Program Files,Program Files (x86),ProgramData,Recovery,PerfLogs,Windows,Windows.old}"),
+						Glob::new("/{$WinREAgent,Program Files,Program Files (x86),ProgramData,Recovery,PerfLogs,Windows,Windows.old}"),
+						// Windows can create a swapfile on any drive
 						Glob::new("[A-Z]:/swapfile.sys"),
-						Glob::new("/swapfile.sys"),
+						Glob::new("C:/{config,pagefile,hiberfil}.sys"),
+						Glob::new("/{config,pagefile,hiberfil,swapfile}.sys"),
+						// NTFS internal files, can exists on any drive
 						Glob::new("[A-Z]:/System Volume Information"),
 						Glob::new("/System Volume Information"),
 					],
@@ -75,12 +58,8 @@ pub async fn indexer_rules_seeder(client: &PrismaClient) -> Result<(), SeederErr
 					// https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html#//apple_ref/doc/uid/TP40010672-CH2-SW14
 					#[cfg(target_os = "macos")]
 					vec![
-						Glob::new("/System"),
-						Glob::new("/Network"),
-						Glob::new("/Library"),
-						Glob::new("/Users/*/Library"),
-						Glob::new("/Applications"),
-						Glob::new("/Users/*/Applications"),
+						Glob::new("/{System,Network,Library,Applications}"),
+						Glob::new("/Users/*/{Library,Applications}"),
 						Glob::new("**/.{DS_Store,AppleDouble,LSOverride}"),
 						// Icon must end with two \r
 						Glob::new("**/Icon\r\r"),
@@ -108,11 +87,9 @@ pub async fn indexer_rules_seeder(client: &PrismaClient) -> Result<(), SeederErr
 					#[cfg(target_family = "unix")]
 					vec![
 						// Directories containing unix memory/device mapped files/dirs
-						Glob::new("/dev"),
-						Glob::new("/sys"),
-						Glob::new("/proc"),
+						Glob::new("/{dev,sys,proc}"),
 						// ext2-4 recovery directory
-						Glob::new("**/lost+found*"),
+						Glob::new("**/lost+found"),
 					],
 				]
 				.into_iter()

--- a/core/src/util/seeder.rs
+++ b/core/src/util/seeder.rs
@@ -17,147 +17,131 @@ pub enum SeederError {
 }
 
 pub async fn indexer_rules_seeder(client: &PrismaClient) -> Result<(), SeederError> {
-	if client.indexer_rule().count(vec![]).exec().await? > 0 {
-		return Ok(());
-	}
-
-	let mut no_os_globs = [
-		vec![
-			"**/.spacedrive",
-		],
-		// https://github.com/github/gitignore/blob/main/Global/Windows.gitignore
-		#[cfg(target_os = "windows")]
-		vec![
-			// Windows thumbnail cache files
-			"**/{Thumbs.db,Thumbs.db:encryptable,ehthumbs.db,ehthumbs_vista.db}",
-			// Dump file
-			"**/*.stackdump",
-			// Folder config file
-			"**/[Dd]esktop.ini",
-			// Recycle Bin used on file shares
-			"**/$RECYCLE.BIN",
-			// Chkdsk recovery directory
-			"**/FOUND.[0-9][0-9][0-9]",
-			// Windows can create a swapfile on any drive
-			"[A-Z]:/swapfile.sys",
-			// NTFS internal files, can exists on any drive
-			"[A-Z]:/System Volume Information",
-		],
-		// https://github.com/github/gitignore/blob/main/Global/macOS.gitignore
-		// https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html#//apple_ref/doc/uid/TP40010672-CH2-SW14
-		#[cfg(any(target_os = "ios", target_os = "macos"))]
-		vec![
-			"**/.{DS_Store,AppleDouble,LSOverride}",
-			// Icon must end with two \r
-			"**/Icon\r\r",
-			// Thumbnails
-			"**/._*",
-		],
-		#[cfg(target_os = "macos")]
-		vec![
-			"/{System,Network,Library,Applications}",
-			"/Users/*/{Library,Applications}",
-			// Files that might appear in the root of a volume
-			"**/.{DocumentRevisions-V100,fseventsd,Spotlight-V100,TemporaryItems,Trashes,VolumeIcon.icns,com.apple.timemachine.donotpresent}",
-			// Directories potentially created on remote AFP share
-			"**/.{AppleDB,AppleDesktop,apdisk}",
-			"**/{Network Trash Folder,Temporary Items}",
-		],
-		// https://github.com/github/gitignore/blob/main/Global/Linux.gitignore
-		#[cfg(target_os = "linux")]
-		vec![
-			"**/*~",
-			// temporary files which can be created if a process still has a handle open of a deleted file
-			"**/.fuse_hidden*",
-			// KDE directory preferences
-			"**/.directory",
-			// Linux trash folder which might appear on any partition or disk
-			"**/.Trash-*",
-			// .nfs files are created when an open file is removed but is still being accessed
-			"**/.nfs*",
-		],
-		#[cfg(target_os = "android")]
-		vec![
-			"**/.nomedia",
-			"**/.thumbnails",
-		],
-		// https://en.wikipedia.org/wiki/Unix_filesystem#Conventional_directory_layout
-		// https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard
-		#[cfg(target_family = "unix")]
-		vec![
-			// Directories containing unix memory/device mapped files/dirs
-			"/{dev,sys,proc}",
-			// Directories containing special files for current running programs
-			"/{run,var,boot}",
-			// ext2-4 recovery directory
-			"**/lost+found",
-		],
-	]
-	.into_iter()
-	.flatten()
-	.map(Glob::new)
-	.collect::<Result<Vec<Glob>, _>>().map_err(IndexerError::GlobBuilderError)?;
-
-	if cfg!(windows) {
-		// https://en.wikipedia.org/wiki/Directory_structure#Windows_10
-		let mut windows_globs = [
-			// User special files
-			"/Users/*/NTUSER.DAT*",
-			"/Users/*/ntuser.dat*",
-			"/Users/*/{ntuser.ini,ntuser.dat,NTUSER.DAT}",
-			// User special folders (most of these the user dont even have permission to access)
-			"/Users/*/{Cookies,AppData,NetHood,Recent,PrintHood,SendTo,Templates,Start Menu,Application Data,Local Settings}",
-			// System special folders
-			"/{$Recycle.Bin,$WinREAgent,Documents and Settings,Program Files,Program Files (x86),ProgramData,Recovery,PerfLogs,Windows,Windows.old}",
-			// System special files
-			"/{config,pagefile,hiberfil,swapfile}.sys",
-			"/DumpStack.log.tmp",
-			// NTFS internal files
-			"/System Volume Information",
-		].into_iter().flat_map(|g| {
-			// Need both C:/ and / matches because globset treat them differently
-			[Glob::new(g), Glob::new(format!("C:{}", g).as_str())]
-		}).collect::<Result<Vec<_>, _>>().map_err(IndexerError::GlobBuilderError)?;
-
-		no_os_globs.append(&mut windows_globs);
-	}
-
-	for rule in [
-		IndexerRule::new(
-			RuleKind::RejectFilesByGlob,
-			// TODO: On windows, beside the listed files, any file with the FILE_ATTRIBUTE_SYSTEM should be considered a system file
-			// https://learn.microsoft.com/en-us/windows/win32/fileio/file-attribute-constants#FILE_ATTRIBUTE_SYSTEM
-			"No OS protected".to_string(),
-			true,
-			ParametersPerKind::RejectFilesByGlob(no_os_globs),
-		),
-		IndexerRule::new(
-			RuleKind::RejectFilesByGlob,
-			"No Hidden".to_string(),
-			true,
-			ParametersPerKind::RejectFilesByGlob(vec![
-				Glob::new("**/.*").map_err(IndexerError::GlobBuilderError)?
-			]),
-		),
-		IndexerRule::new(
-			RuleKind::AcceptIfChildrenDirectoriesArePresent,
-			"Only Git Repositories".into(),
-			false,
-			ParametersPerKind::AcceptIfChildrenDirectoriesArePresent(
-				[".git".to_string()].into_iter().collect(),
+	if client.indexer_rule().count(vec![]).exec().await? == 0 {
+		for rule in [
+			IndexerRule::new(
+				RuleKind::RejectFilesByGlob,
+				// TODO: On windows, beside the listed files, any file with the FILE_ATTRIBUTE_SYSTEM should be considered a system file
+				// https://learn.microsoft.com/en-us/windows/win32/fileio/file-attribute-constants#FILE_ATTRIBUTE_SYSTEM
+				"No OS protected".to_string(),
+				true,
+				ParametersPerKind::RejectFilesByGlob([
+					vec![
+						"**/.spacedrive",
+					],
+					// Globset, even on Windows, requires the use of / as a separator
+					// https://github.com/github/gitignore/blob/main/Global/Windows.gitignore
+					#[cfg(target_os = "windows")]
+					vec![
+						// Windows thumbnail cache files
+						"**/{Thumbs.db,Thumbs.db:encryptable,ehthumbs.db,ehthumbs_vista.db}",
+						// Dump file
+						"**/*.stackdump",
+						// Folder config file
+						"**/[Dd]esktop.ini",
+						// Recycle Bin used on file shares
+						"**/$RECYCLE.BIN",
+						// Chkdsk recovery directory
+						"**/FOUND.[0-9][0-9][0-9]",
+						// User special files
+						"C:/Users/*/NTUSER.DAT*",
+						"C:/Users/*/ntuser.dat*",
+						"C:/Users/*/{ntuser.ini,ntuser.dat,NTUSER.DAT}",
+						// User special folders (most of these the user dont even have permission to access)
+						"C:/Users/*/{Cookies,AppData,NetHood,Recent,PrintHood,SendTo,Templates,Start Menu,Application Data,Local Settings}",
+						// System special folders
+						"C:/{$Recycle.Bin,$WinREAgent,Documents and Settings,Program Files,Program Files (x86),ProgramData,Recovery,PerfLogs,Windows,Windows.old}",
+						// NTFS internal dir, can exists on any drive
+						"[A-Z]:/System Volume Information",
+						// System special files
+						"C:/{config,pagefile,hiberfil}.sys",
+						// Windows can create a swapfile on any drive
+						"[A-Z]:/swapfile.sys",
+						"C:/DumpStack.log.tmp",
+					],
+					// https://github.com/github/gitignore/blob/main/Global/macOS.gitignore
+					// https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html#//apple_ref/doc/uid/TP40010672-CH2-SW14
+					#[cfg(any(target_os = "ios", target_os = "macos"))]
+					vec![
+						"**/.{DS_Store,AppleDouble,LSOverride}",
+						// Icon must end with two \r
+						"**/Icon\r\r",
+						// Thumbnails
+						"**/._*",
+					],
+					#[cfg(target_os = "macos")]
+					vec![
+						"/{System,Network,Library,Applications}",
+						"/Users/*/{Library,Applications}",
+						// Files that might appear in the root of a volume
+						"**/.{DocumentRevisions-V100,fseventsd,Spotlight-V100,TemporaryItems,Trashes,VolumeIcon.icns,com.apple.timemachine.donotpresent}",
+						// Directories potentially created on remote AFP share
+						"**/.{AppleDB,AppleDesktop,apdisk}",
+						"**/{Network Trash Folder,Temporary Items}",
+					],
+					// https://github.com/github/gitignore/blob/main/Global/Linux.gitignore
+					#[cfg(target_os = "linux")]
+					vec![
+						"**/*~",
+						// temporary files which can be created if a process still has a handle open of a deleted file
+						"**/.fuse_hidden*",
+						// KDE directory preferences
+						"**/.directory",
+						// Linux trash folder which might appear on any partition or disk
+						"**/.Trash-*",
+						// .nfs files are created when an open file is removed but is still being accessed
+						"**/.nfs*",
+					],
+					#[cfg(target_os = "android")]
+					vec![
+						"**/.nomedia",
+						"**/.thumbnails",
+					],
+					// https://en.wikipedia.org/wiki/Unix_filesystem#Conventional_directory_layout
+					// https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard
+					#[cfg(target_family = "unix")]
+					vec![
+						// Directories containing unix memory/device mapped files/dirs
+						"/{dev,sys,proc}",
+						// Directories containing special files for current running programs
+						"/{run,var,boot}",
+						// ext2-4 recovery directory
+						"**/lost+found",
+					],
+				]
+				.into_iter()
+				.flatten()
+				.map(Glob::new)
+				.collect::<Result<Vec<Glob>, _>>().map_err(IndexerError::GlobBuilderError)?),
 			),
-		),
-		IndexerRule::new(
-			RuleKind::AcceptFilesByGlob,
-			"Only Images".to_string(),
-			false,
-			ParametersPerKind::AcceptFilesByGlob(vec![Glob::new(
-				"*.{avif,bmp,gif,ico,jpeg,jpg,png,svg,tif,tiff,webp}",
-			)
-			.map_err(IndexerError::GlobBuilderError)?]),
-		),
-	] {
-		rule.save(client).await?;
+			IndexerRule::new(
+				RuleKind::RejectFilesByGlob,
+				"No Hidden".to_string(),
+				true,
+				ParametersPerKind::RejectFilesByGlob(vec![
+					Glob::new("**/.*").map_err(IndexerError::GlobBuilderError)?
+				]),
+			),
+			IndexerRule::new(
+				RuleKind::AcceptIfChildrenDirectoriesArePresent,
+				"Only Git Repositories".into(),
+				false,
+				ParametersPerKind::AcceptIfChildrenDirectoriesArePresent(
+					[".git".to_string()].into_iter().collect(),
+				),
+			),
+			IndexerRule::new(
+				RuleKind::AcceptFilesByGlob,
+				"Only Images".to_string(),
+				false,
+				ParametersPerKind::AcceptFilesByGlob(vec![Glob::new(
+					"*.{avif,bmp,gif,ico,jpeg,jpg,png,svg,tif,tiff,webp}",
+				)
+				.map_err(IndexerError::GlobBuilderError)?]),
+			),
+		] {
+			rule.save(client).await?;
+		}
 	}
 
 	Ok(())

--- a/core/src/util/seeder.rs
+++ b/core/src/util/seeder.rs
@@ -17,131 +17,147 @@ pub enum SeederError {
 }
 
 pub async fn indexer_rules_seeder(client: &PrismaClient) -> Result<(), SeederError> {
-	if client.indexer_rule().count(vec![]).exec().await? == 0 {
-		for rule in [
-			IndexerRule::new(
-				RuleKind::RejectFilesByGlob,
-				// TODO: On windows, beside the listed files, any file with the FILE_ATTRIBUTE_SYSTEM should be considered a system file
-				// https://learn.microsoft.com/en-us/windows/win32/fileio/file-attribute-constants#FILE_ATTRIBUTE_SYSTEM
-				"No OS protected".to_string(),
-				true,
-				ParametersPerKind::RejectFilesByGlob([
-					vec![
-						Glob::new("**/.spacedrive"),
-					],
-					// https://github.com/github/gitignore/blob/main/Global/Windows.gitignore
-					// https://en.wikipedia.org/wiki/Directory_structure#Windows_10
-					#[cfg(target_os = "windows")]
-					vec![
-						// Windows thumbnail cache files
-						Glob::new("**/{Thumbs.db,Thumbs.db:encryptable,ehthumbs.db,ehthumbs_vista.db}"),
-						// Dump file
-						Glob::new("**/*.stackdump"),
-						// Folder config file
-						Glob::new("**/[Dd]esktop.ini"),
-						// Recycle Bin used on file shares
-						Glob::new("**/$RECYCLE.BIN"),
-						// Chkdsk recovery directory
-						Glob::new("**/FOUND.[0-9][0-9][0-9]"),
-						// User special files
-						Glob::new("**/Users/*/NTUSER.DAT*")
-						Glob::new("**/Users/*/ntuser.dat*")
-						Glob::new("**/Users/*/{ntuser.ini,ntuser.dat,NTUSER.DAT}"),
-						// User special folders (most of these the user dont even have permission to access)
-						Glob::new("**/Users/*/{Cookies,AppData,NetHood,Recent,PrintHood,SendTo,Templates,Start Menu,Application Data,Local Settings}"),
-						// Need both C:/ and / matches because globset treat them differently
-						Glob::new("C:/{$WinREAgent,Program Files,Program Files (x86),ProgramData,Recovery,PerfLogs,Windows,Windows.old}"),
-						Glob::new("/{$WinREAgent,Program Files,Program Files (x86),ProgramData,Recovery,PerfLogs,Windows,Windows.old}"),
-						// Windows can create a swapfile on any drive
-						Glob::new("[A-Z]:/swapfile.sys"),
-						Glob::new("C:/{config,pagefile,hiberfil}.sys"),
-						Glob::new("/{config,pagefile,hiberfil,swapfile}.sys"),
-						// NTFS internal files, can exists on any drive
-						Glob::new("[A-Z]:/System Volume Information"),
-						Glob::new("/System Volume Information"),
-					],
-					// https://github.com/github/gitignore/blob/main/Global/macOS.gitignore
-					// https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html#//apple_ref/doc/uid/TP40010672-CH2-SW14
-					#[cfg(any(target_os = "ios", target_os = "macos"))]
-					vec![
-						Glob::new("**/.{DS_Store,AppleDouble,LSOverride}"),
-						// Icon must end with two \r
-						Glob::new("**/Icon\r\r"),
-						// Thumbnails
-						Glob::new("**/._*"),
-					],
-					#[cfg(target_os = "macos")]
-					vec![
-						Glob::new("/{System,Network,Library,Applications}"),
-						Glob::new("/Users/*/{Library,Applications}"),
-						// Files that might appear in the root of a volume
-						Glob::new("**/.{DocumentRevisions-V100,fseventsd,Spotlight-V100,TemporaryItems,Trashes,VolumeIcon.icns,com.apple.timemachine.donotpresent}"),
-						// Directories potentially created on remote AFP share
-						Glob::new("**/.{AppleDB,AppleDesktop,apdisk}"),
-						Glob::new("**/{Network Trash Folder,Temporary Items}"),
-					],
-					// https://github.com/github/gitignore/blob/main/Global/Linux.gitignore
-					#[cfg(target_os = "linux")]
-					vec![
-						Glob::new("**/*~"),
-						// temporary files which can be created if a process still has a handle open of a deleted file
-						Glob::new("**/.fuse_hidden*"),
-						// KDE directory preferences
-						Glob::new("**/.directory"),
-						// Linux trash folder which might appear on any partition or disk
-						Glob::new("**/.Trash-*"),
-						// .nfs files are created when an open file is removed but is still being accessed
-						Glob::new("**/.nfs*"),
-					],
-					#[cfg(target_os = "android")]
-					vec![
-						Glob::new("**/.nomedia"),
-						Glob::new("**/.thumbnails"),
-					],
-					#[cfg(target_family = "unix")]
-					// https://en.wikipedia.org/wiki/Unix_filesystem#Conventional_directory_layout
-					// https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard
-					vec![
-						// Directories containing unix memory/device mapped files/dirs
-						Glob::new("/{dev,sys,proc}"),
-						// Directories containing special files for current running programs
-						Glob::new("/{run,var,boot}"),
-						// ext2-4 recovery directory
-						Glob::new("**/lost+found"),
-					],
-				]
-				.into_iter()
-				.flatten()
-				.collect::<Result<Vec<Glob>, _>>().map_err(IndexerError::GlobBuilderError)?),
+	if client.indexer_rule().count(vec![]).exec().await? > 0 {
+		return Ok(());
+	}
+
+	let mut no_os_globs = [
+		vec![
+			"**/.spacedrive",
+		],
+		// https://github.com/github/gitignore/blob/main/Global/Windows.gitignore
+		#[cfg(target_os = "windows")]
+		vec![
+			// Windows thumbnail cache files
+			"**/{Thumbs.db,Thumbs.db:encryptable,ehthumbs.db,ehthumbs_vista.db}",
+			// Dump file
+			"**/*.stackdump",
+			// Folder config file
+			"**/[Dd]esktop.ini",
+			// Recycle Bin used on file shares
+			"**/$RECYCLE.BIN",
+			// Chkdsk recovery directory
+			"**/FOUND.[0-9][0-9][0-9]",
+			// Windows can create a swapfile on any drive
+			"[A-Z]:/swapfile.sys",
+			// NTFS internal files, can exists on any drive
+			"[A-Z]:/System Volume Information",
+		],
+		// https://github.com/github/gitignore/blob/main/Global/macOS.gitignore
+		// https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html#//apple_ref/doc/uid/TP40010672-CH2-SW14
+		#[cfg(any(target_os = "ios", target_os = "macos"))]
+		vec![
+			"**/.{DS_Store,AppleDouble,LSOverride}",
+			// Icon must end with two \r
+			"**/Icon\r\r",
+			// Thumbnails
+			"**/._*",
+		],
+		#[cfg(target_os = "macos")]
+		vec![
+			"/{System,Network,Library,Applications}",
+			"/Users/*/{Library,Applications}",
+			// Files that might appear in the root of a volume
+			"**/.{DocumentRevisions-V100,fseventsd,Spotlight-V100,TemporaryItems,Trashes,VolumeIcon.icns,com.apple.timemachine.donotpresent}",
+			// Directories potentially created on remote AFP share
+			"**/.{AppleDB,AppleDesktop,apdisk}",
+			"**/{Network Trash Folder,Temporary Items}",
+		],
+		// https://github.com/github/gitignore/blob/main/Global/Linux.gitignore
+		#[cfg(target_os = "linux")]
+		vec![
+			"**/*~",
+			// temporary files which can be created if a process still has a handle open of a deleted file
+			"**/.fuse_hidden*",
+			// KDE directory preferences
+			"**/.directory",
+			// Linux trash folder which might appear on any partition or disk
+			"**/.Trash-*",
+			// .nfs files are created when an open file is removed but is still being accessed
+			"**/.nfs*",
+		],
+		#[cfg(target_os = "android")]
+		vec![
+			"**/.nomedia",
+			"**/.thumbnails",
+		],
+		// https://en.wikipedia.org/wiki/Unix_filesystem#Conventional_directory_layout
+		// https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard
+		#[cfg(target_family = "unix")]
+		vec![
+			// Directories containing unix memory/device mapped files/dirs
+			"/{dev,sys,proc}",
+			// Directories containing special files for current running programs
+			"/{run,var,boot}",
+			// ext2-4 recovery directory
+			"**/lost+found",
+		],
+	]
+	.into_iter()
+	.flatten()
+	.map(Glob::new)
+	.collect::<Result<Vec<Glob>, _>>().map_err(IndexerError::GlobBuilderError)?;
+
+	if cfg!(windows) {
+		// https://en.wikipedia.org/wiki/Directory_structure#Windows_10
+		let mut windows_globs = [
+			// User special files
+			"/Users/*/NTUSER.DAT*",
+			"/Users/*/ntuser.dat*",
+			"/Users/*/{ntuser.ini,ntuser.dat,NTUSER.DAT}",
+			// User special folders (most of these the user dont even have permission to access)
+			"/Users/*/{Cookies,AppData,NetHood,Recent,PrintHood,SendTo,Templates,Start Menu,Application Data,Local Settings}",
+			// System special folders
+			"/{$Recycle.Bin,$WinREAgent,Documents and Settings,Program Files,Program Files (x86),ProgramData,Recovery,PerfLogs,Windows,Windows.old}",
+			// System special files
+			"/{config,pagefile,hiberfil,swapfile}.sys",
+			"/DumpStack.log.tmp",
+			// NTFS internal files
+			"/System Volume Information",
+		].into_iter().flat_map(|g| {
+			// Need both C:/ and / matches because globset treat them differently
+			[Glob::new(g), Glob::new(format!("C:{}", g).as_str())]
+		}).collect::<Result<Vec<_>, _>>().map_err(IndexerError::GlobBuilderError)?;
+
+		no_os_globs.append(&mut windows_globs);
+	}
+
+	for rule in [
+		IndexerRule::new(
+			RuleKind::RejectFilesByGlob,
+			// TODO: On windows, beside the listed files, any file with the FILE_ATTRIBUTE_SYSTEM should be considered a system file
+			// https://learn.microsoft.com/en-us/windows/win32/fileio/file-attribute-constants#FILE_ATTRIBUTE_SYSTEM
+			"No OS protected".to_string(),
+			true,
+			ParametersPerKind::RejectFilesByGlob(no_os_globs),
+		),
+		IndexerRule::new(
+			RuleKind::RejectFilesByGlob,
+			"No Hidden".to_string(),
+			true,
+			ParametersPerKind::RejectFilesByGlob(vec![
+				Glob::new("**/.*").map_err(IndexerError::GlobBuilderError)?
+			]),
+		),
+		IndexerRule::new(
+			RuleKind::AcceptIfChildrenDirectoriesArePresent,
+			"Only Git Repositories".into(),
+			false,
+			ParametersPerKind::AcceptIfChildrenDirectoriesArePresent(
+				[".git".to_string()].into_iter().collect(),
 			),
-			IndexerRule::new(
-				RuleKind::RejectFilesByGlob,
-				"No Hidden".to_string(),
-				true,
-				ParametersPerKind::RejectFilesByGlob(
-					vec![Glob::new("**/.*").map_err(IndexerError::GlobBuilderError)?],
-				),
-			),
-			IndexerRule::new(
-				RuleKind::AcceptIfChildrenDirectoriesArePresent,
-				"Only Git Repositories".into(),
-				false,
-				ParametersPerKind::AcceptIfChildrenDirectoriesArePresent(
-					[".git".to_string()].into_iter().collect(),
-				),
-			),
-			IndexerRule::new(
-				RuleKind::AcceptFilesByGlob,
-				"Only Images".to_string(),
-				false,
-				ParametersPerKind::AcceptFilesByGlob(vec![
-					Glob::new("*.{avif,bmp,gif,ico,jpeg,jpg,png,svg,tif,tiff,webp}")
-					.map_err(IndexerError::GlobBuilderError)?
-				]),
-			),
-		] {
-			rule.save(client).await?;
-		}
+		),
+		IndexerRule::new(
+			RuleKind::AcceptFilesByGlob,
+			"Only Images".to_string(),
+			false,
+			ParametersPerKind::AcceptFilesByGlob(vec![Glob::new(
+				"*.{avif,bmp,gif,ico,jpeg,jpg,png,svg,tif,tiff,webp}",
+			)
+			.map_err(IndexerError::GlobBuilderError)?]),
+		),
+	] {
+		rule.save(client).await?;
 	}
 
 	Ok(())

--- a/core/src/util/seeder.rs
+++ b/core/src/util/seeder.rs
@@ -19,12 +19,12 @@ pub enum SeederError {
 pub async fn indexer_rules_seeder(client: &PrismaClient) -> Result<(), SeederError> {
 	if client.indexer_rule().count(vec![]).exec().await? == 0 {
 		for rule in [
-			// `No OS protected` must be first indexer rule, because the first indexer rule is enabled by default in the UI
 			IndexerRule::new(
 				RuleKind::RejectFilesByGlob,
 				// TODO: On windows, beside the listed files, any file with the FILE_ATTRIBUTE_SYSTEM should be considered a system file
 				// https://learn.microsoft.com/en-us/windows/win32/fileio/file-attribute-constants#FILE_ATTRIBUTE_SYSTEM
 				"No OS protected".to_string(),
+				true,
 				ParametersPerKind::RejectFilesByGlob([
 					vec![
 						Glob::new("**/.spacedrive"),
@@ -111,6 +111,7 @@ pub async fn indexer_rules_seeder(client: &PrismaClient) -> Result<(), SeederErr
 			IndexerRule::new(
 				RuleKind::RejectFilesByGlob,
 				"No Hidden".to_string(),
+				true,
 				ParametersPerKind::RejectFilesByGlob(
 					vec![Glob::new("**/.*").map_err(IndexerError::GlobBuilderError)?],
 				),
@@ -118,6 +119,7 @@ pub async fn indexer_rules_seeder(client: &PrismaClient) -> Result<(), SeederErr
 			IndexerRule::new(
 				RuleKind::AcceptIfChildrenDirectoriesArePresent,
 				"Only Git Repositories".into(),
+				false,
 				ParametersPerKind::AcceptIfChildrenDirectoriesArePresent(
 					[".git".to_string()].into_iter().collect(),
 				),
@@ -125,6 +127,7 @@ pub async fn indexer_rules_seeder(client: &PrismaClient) -> Result<(), SeederErr
 			IndexerRule::new(
 				RuleKind::AcceptFilesByGlob,
 				"Only Images".to_string(),
+				false,
 				ParametersPerKind::AcceptFilesByGlob(vec![
 					Glob::new("*.{avif,bmp,gif,ico,jpeg,jpg,png,svg,tif,tiff,webp}")
 					.map_err(IndexerError::GlobBuilderError)?

--- a/core/src/util/seeder.rs
+++ b/core/src/util/seeder.rs
@@ -43,6 +43,12 @@ pub async fn indexer_rules_seeder(client: &PrismaClient) -> Result<(), SeederErr
 						Glob::new("**/$RECYCLE.BIN"),
 						// Chkdsk recovery directory
 						Glob::new("**/FOUND.[0-9][0-9][0-9]"),
+						// User special files
+						Glob::new("**/Users/*/NTUSER.DAT*")
+						Glob::new("**/Users/*/ntuser.dat*")
+						Glob::new("**/Users/*/{ntuser.ini,ntuser.dat,NTUSER.DAT}"),
+						// User special folders (most of these the user dont even have permission to access)
+						Glob::new("**/Users/*/{Cookies,AppData,NetHood,Recent,PrintHood,SendTo,Templates,Start Menu,Application Data,Local Settings}"),
 						// Need both C:/ and / matches because globset treat them differently
 						Glob::new("C:/{$WinREAgent,Program Files,Program Files (x86),ProgramData,Recovery,PerfLogs,Windows,Windows.old}"),
 						Glob::new("/{$WinREAgent,Program Files,Program Files (x86),ProgramData,Recovery,PerfLogs,Windows,Windows.old}"),

--- a/interface/app/$libraryId/settings/library/locations/AddLocationDialog.tsx
+++ b/interface/app/$libraryId/settings/library/locations/AddLocationDialog.tsx
@@ -52,25 +52,17 @@ export const AddLocationDialog = ({ path, ...dialogProps }: Props) => {
 	const [remoteError, setRemoteError] = useState<null | RemoteErrorFormMessage>(null);
 
 	// This is required because indexRules is undefined on first render
-	const indexerRules = listIndexerRules.data;
-	const defaultValue = useMemo(
-		() => ({
-			path: path,
-			indexerRulesIds:
-				indexerRules?.filter((rule) => rule.default).map((rule) => rule.id) ?? []
-		}),
-		[indexerRules, path]
+	const indexerRulesIds = useMemo(
+		() => listIndexerRules.data?.filter((rule) => rule.default).map((rule) => rule.id) ?? [],
+		[listIndexerRules.data]
 	);
 
-	const form = useZodForm({
-		schema,
-		defaultValues: defaultValue
-	});
+	const form = useZodForm({ schema, defaultValues: { path, indexerRulesIds } });
 
 	useEffect(() => {
 		// Update form values when default value changes and the user hasn't made any changes
-		if (!form.formState.isDirty) form.reset(defaultValue);
-	}, [form, defaultValue]);
+		if (!form.formState.isDirty) form.reset({ path, indexerRulesIds });
+	}, [form, path, indexerRulesIds]);
 
 	useEffect(() => {
 		// TODO: Instead of clearing the error on every change, we should just validate with backend again

--- a/interface/app/$libraryId/settings/library/locations/AddLocationDialog.tsx
+++ b/interface/app/$libraryId/settings/library/locations/AddLocationDialog.tsx
@@ -47,22 +47,24 @@ export const AddLocationDialog = ({ path, ...dialogProps }: Props) => {
 	const queryClient = useQueryClient();
 	const createLocation = useLibraryMutation('locations.create');
 	const relinkLocation = useLibraryMutation('locations.relink');
-	const { data: indexRules } = useLibraryQuery(['locations.indexer_rules.list'], {});
+	const listIndexerRules = useLibraryQuery(['locations.indexer_rules.list']);
 	const addLocationToLibrary = useLibraryMutation('locations.addLibrary');
 	const [remoteError, setRemoteError] = useState<null | RemoteErrorFormMessage>(null);
 
 	// This is required because indexRules is undefined on first render
+	const indexerRules = listIndexerRules.data;
 	const defaultValue = useMemo(
 		() => ({
 			path: path,
-			indexerRulesIds: indexRules?.filter((rule) => rule.default).map((rule) => rule.id) ?? []
+			indexerRulesIds:
+				indexerRules?.filter((rule) => rule.default).map((rule) => rule.id) ?? []
 		}),
-		[indexRules, path]
+		[indexerRules, path]
 	);
 
 	const form = useZodForm({
 		schema,
-		defaultValues: useMemo(() => defaultValue, [defaultValue])
+		defaultValues: defaultValue
 	});
 
 	useEffect(() => {

--- a/interface/app/$libraryId/settings/library/locations/AddLocationDialog.tsx
+++ b/interface/app/$libraryId/settings/library/locations/AddLocationDialog.tsx
@@ -54,7 +54,8 @@ export const AddLocationDialog = (props: Props) => {
 		schema,
 		defaultValues: {
 			path: props.path,
-			indexerRulesIds: []
+			// First indexer rule is `No OS protected` and should be checked by default
+			indexerRulesIds: [1]
 		}
 	});
 

--- a/interface/app/$libraryId/settings/library/locations/IndexerRuleEditor.tsx
+++ b/interface/app/$libraryId/settings/library/locations/IndexerRuleEditor.tsx
@@ -22,38 +22,39 @@ export function IndexerRuleEditor<T extends FieldType>({
 	field,
 	editable
 }: IndexerRuleEditorProps<T>) {
-	const { data: indexRules } = useLibraryQuery(['locations.indexer_rules.list'], {});
-
+	const listIndexerRules = useLibraryQuery(['locations.indexer_rules.list']);
+	const indexRules = listIndexerRules.data;
 	return (
 		<Card className="mb-2 flex flex-wrap justify-evenly">
-			{indexRules
-				? indexRules.map((rule) => {
-						const { id, name } = rule;
-						const enabled = field.value.includes(id);
-						return (
-							<Button
-								key={id}
-								size="sm"
-								onClick={() =>
-									field.onChange(
-										enabled
-											? field.value.filter(
-													(fieldValue) => fieldValue !== rule.id
-											  )
-											: Array.from(new Set([...field.value, rule.id]))
-									)
-								}
-								variant={enabled ? 'colored' : 'outline'}
-								className={clsx(
-									'm-1 flex-auto',
-									enabled && 'border-accent bg-accent'
-								)}
-							>
-								{name}
-							</Button>
-						);
-				  })
-				: editable || <p>No indexer rules available</p>}
+			{indexRules ? (
+				indexRules.map((rule) => {
+					const { id, name } = rule;
+					const enabled = field.value.includes(id);
+					return (
+						<Button
+							key={id}
+							size="sm"
+							onClick={() =>
+								field.onChange(
+									enabled
+										? field.value.filter((fieldValue) => fieldValue !== rule.id)
+										: Array.from(new Set([...field.value, rule.id]))
+								)
+							}
+							variant={enabled ? 'colored' : 'outline'}
+							className={clsx('m-1 flex-auto', enabled && 'border-accent bg-accent')}
+						>
+							{name}
+						</Button>
+					);
+				})
+			) : (
+				<p className={clsx(listIndexerRules.isError && 'text-red-500')}>
+					{listIndexerRules.isError
+						? 'Error while retriving indexer rules'
+						: 'No indexer rules available'}
+				</p>
+			)}
 			{/* {editable && (
 				<Button
 					size="icon"

--- a/interface/app/$libraryId/settings/library/locations/IndexerRuleEditor.tsx
+++ b/interface/app/$libraryId/settings/library/locations/IndexerRuleEditor.tsx
@@ -22,12 +22,12 @@ export function IndexerRuleEditor<T extends FieldType>({
 	field,
 	editable
 }: IndexerRuleEditorProps<T>) {
-	const listIndexerRules = useLibraryQuery(['locations.indexer_rules.list'], {});
+	const { data: indexRules } = useLibraryQuery(['locations.indexer_rules.list'], {});
 
 	return (
 		<Card className="mb-2 flex flex-wrap justify-evenly">
-			{listIndexerRules.data
-				? listIndexerRules.data.map((rule) => {
+			{indexRules
+				? indexRules.map((rule) => {
 						const { id, name } = rule;
 						const enabled = field.value.includes(id);
 						return (
@@ -40,7 +40,7 @@ export function IndexerRuleEditor<T extends FieldType>({
 											? field.value.filter(
 													(fieldValue) => fieldValue !== rule.id
 											  )
-											: [...field.value, rule.id]
+											: Array.from(new Set([...field.value, rule.id]))
 									)
 								}
 								variant={enabled ? 'colored' : 'outline'}

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -148,7 +148,7 @@ export type HashingAlgorithm = { name: "Argon2id", params: Params } | { name: "B
 
 export type IdentifyUniqueFilesArgs = { id: number, path: string }
 
-export type IndexerRule = { id: number, kind: number, name: string, parameters: number[], date_created: string, date_modified: string }
+export type IndexerRule = { id: number, kind: number, name: string, default: boolean, parameters: number[], date_created: string, date_modified: string }
 
 /**
  *  `IndexerRuleCreateArgs` is the argument received from the client using rspc to create a new indexer rule.


### PR DESCRIPTION
This PR adds a new default indexer rule called `No OS protected`, which is intended to prevent the indexing of OS-protected files. To implement this rule, I had to modify the logic of the `AcceptFilesByGlob` and `RejectFilesByGlob` rules types to accept multiple globs and use a `GlobSet` for matching. The only potential issue with these changes is the `globset_from_globs` function, which creates a new GlobSet for each indexer rule during each directory/file check. While my testing didn't show any noticeable performance impact, the best approach would be to memoize it to execute only once for each indexer rule. However, I couldn't find a simple way to do this in Rust. If anyone has a solution, it would be greatly appreciated. Otherwise, I'll create a low-priority issue to address this later.

TODO: Still needs to test on macOS ~and Windows~