### PR TITLE
ENG-460 Location creation fails for some writable directories

### DIFF
--- a/core/src/location/error.rs
+++ b/core/src/location/error.rs
@@ -44,8 +44,6 @@ pub enum LocationError {
 	LocationMetadataError(#[from] LocationMetadataError),
 	#[error("Failed to read location path metadata info (path: {1:?}); (error: {0:?})")]
 	LocationPathFilesystemMetadataAccess(io::Error, PathBuf),
-	#[error("Location is read only (at path: {0:?})")]
-	ReadonlyLocationFailure(PathBuf),
 	#[error("Missing metadata file for location (path: {0:?})")]
 	MissingMetadataFile(PathBuf),
 	#[error("Failed to open file from local os (error: {0:?})")]


### PR DESCRIPTION
This PR removes the check that verifies if a location's path is read-only during creation. This check caused false positives in cases where the users actually has write permissions to the path (I experienced it on both Windows and Linux). Instead, the creation of the `.spacedrive` metadata file can act as a better indicator of write access. Additionally, I implemented a rollback mechanism for location creation when either the `.spacedrive` file fails to be written or the location cannot be added to the library location manager.