### PR TITLE
update to ffmpeg 6.0.0

### DIFF
--- a/.github/scripts/setup-system.sh
+++ b/.github/scripts/setup-system.sh
@@ -184,10 +184,17 @@ elif [[ $OSTYPE == "darwin"* ]]; then
 
 	echo "Installing Homebrew dependencies..."
 
-	BREW_DEPS="ffmpeg"
 	BREW_LIBP2P_DEPS="protobuf"
 
-	brew install -q $BREW_DEPS $BREW_LIBP2P_DEPS
+	brew install -q $BREW_LIBP2P_DEPS
+
+	if ! brew tap homebrew-ffmpeg/ffmpeg; then
+		log_err "We were unable to add the homebrew-ffmpeg tap. Please ensure that you have ran `brew uninstall ffmpeg` and try again."
+	fi
+
+	if ! brew install homebrew-ffmpeg/ffmpeg/ffmpeg; then
+		log_err "We were unable to install the homebrew-ffmpeg/ffmpeg package. Please ensure that you have ran `brew uninstall ffmpeg` and try again."
+	fi
 else
 	log_err "Your OS ($OSTYPE) is not supported by this script. We would welcome a PR or some help adding your OS to this script. https://github.com/spacedriveapp/spacedrive/issues"
 	exit 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.59.2"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
+checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -600,6 +600,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
+ "syn",
 ]
 
 [[package]]
@@ -2172,9 +2173,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-next"
-version = "5.1.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a80971eee67be0079a1c8890bde68226fe9bd0441740fd6ddd0cee131486b321"
+checksum = "8af03c47ad26832ab3aabc4cdbf210af3d3b878783edd5a7ba044ba33aab7a60"
 dependencies = [
  "bitflags",
  "ffmpeg-sys-next",
@@ -2183,9 +2184,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-sys-next"
-version = "5.1.1"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d780b36e092254367e2f1f21191992735c8e23f31a5a5a8678db3a79f775021f"
+checksum = "cf650f461ccf130f4eef4927affed703cc387b183bfc4a7dfee86a076c131127"
 dependencies = [
  "bindgen",
  "cc",
@@ -4732,11 +4733,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -72,7 +72,7 @@ http-range = "0.1.5"
 mini-moka = "0.10.0"
 serde_with = "2.2.0"
 dashmap = { version = "5.4.0", features = ["serde"] }
-ffmpeg-next = { version = "5.1.1", optional = true, features = [] }
+ffmpeg-next = { version = "6.0.0", optional = true, features = [] }
 notify = { version = "5.0.0", default-features = false, features = [
   "macos_fsevent",
 ], optional = true }

--- a/crates/ffmpeg/Cargo.toml
+++ b/crates/ffmpeg/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ffmpeg-sys-next = "5.1.1"
+ffmpeg-sys-next = "6.0.0"
 
 thiserror = "1.0.37"
 webp = "0.2.2"


### PR DESCRIPTION
This PR upgrades Spacedrive to use `ffmpeg 6.0.0` via an external brew tap.

I believe this means users will be compiling `ffmpeg`, so that will take a while (and CI will likely take longer). This is hopefully only a temporary solution until `brew` add official support for `ffmpeg` 6.

NOTE: `ffmpeg` will have to be uninstalled if the official package is installed. Additionally, developers on MacOS will either have to install this ffmpeg version manually, or re-run the setup script. Manual installation can be accomplished with these commands:

```
brew tap homebrew-ffmpeg/ffmpeg
brew install homebrew-ffmpeg/ffmpeg/ffmpeg
```