### PR TITLE
ENG-462 Object size is `0` when it shouldn't be

### DIFF
--- a/core/src/location/file_path_helper.rs
+++ b/core/src/location/file_path_helper.rs
@@ -406,7 +406,7 @@ impl LastFilePathIdManager {
 						file_path::is_dir::set(is_dir),
 						file_path::size_in_bytes::set(metadata.size_in_bytes.to_string()),
 						file_path::date_created::set(metadata.created_at.into()),
-						file_path::date_modified::set(metadata.modified_at.into())
+						file_path::date_modified::set(metadata.modified_at.into()),
 					],
 				),
 			)

--- a/core/src/location/file_path_helper.rs
+++ b/core/src/location/file_path_helper.rs
@@ -8,6 +8,7 @@ use std::{
 	path::{Path, PathBuf, MAIN_SEPARATOR, MAIN_SEPARATOR_STR},
 };
 
+use chrono::{DateTime, Utc};
 use dashmap::{mapref::entry::Entry, DashMap};
 use futures::future::try_join_all;
 use prisma_client_rust::{Direction, QueryError};
@@ -46,6 +47,15 @@ file_path::select!(file_path_just_materialized_path_cas_id {
 
 // File Path includes!
 file_path::include!(file_path_with_object { object });
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub struct FilePathMetadata {
+	pub inode: u64,
+	pub device: u64,
+	pub size_in_bytes: u64,
+	pub created_at: DateTime<Utc>,
+	pub modified_at: DateTime<Utc>,
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct MaterializedPath<'a> {
@@ -318,8 +328,7 @@ impl LastFilePathIdManager {
 		}: MaterializedPath<'_>,
 		parent_id: Option<i32>,
 		cas_id: Option<String>,
-		inode: u64,
-		device: u64,
+		metadata: FilePathMetadata,
 	) -> Result<file_path::Data, FilePathError> {
 		// Keeping a reference in that map for the entire duration of the function, so we keep it locked
 
@@ -348,9 +357,12 @@ impl LastFilePathIdManager {
 			("materialized_path", json!(materialized_path)),
 			("name", json!(name)),
 			("extension", json!(extension)),
-			("inode", json!(inode.to_le_bytes())),
-			("device", json!(device.to_le_bytes())),
+			("size_in_bytes", json!(metadata.size_in_bytes.to_string())),
+			("inode", json!(metadata.inode.to_le_bytes())),
+			("device", json!(metadata.device.to_le_bytes())),
 			("is_dir", json!(is_dir)),
+			("date_created", json!(metadata.created_at)),
+			("date_modified", json!(metadata.modified_at)),
 		]
 		.into_iter()
 		.map(Some)
@@ -386,12 +398,15 @@ impl LastFilePathIdManager {
 					materialized_path.into_owned(),
 					name.into_owned(),
 					extension.into_owned(),
-					inode.to_le_bytes().into(),
-					device.to_le_bytes().into(),
+					metadata.inode.to_le_bytes().into(),
+					metadata.device.to_le_bytes().into(),
 					vec![
 						file_path::cas_id::set(cas_id),
 						file_path::parent_id::set(parent_id),
 						file_path::is_dir::set(is_dir),
+						file_path::size_in_bytes::set(metadata.size_in_bytes.to_string()),
+						file_path::date_created::set(metadata.created_at.into()),
+						file_path::date_modified::set(metadata.modified_at.into())
 					],
 				),
 			)

--- a/core/src/location/indexer/indexer_job.rs
+++ b/core/src/location/indexer/indexer_job.rs
@@ -181,7 +181,6 @@ impl StatefulJob for IndexerJob {
 						(!dirs_ids.contains_key(&entry.path)).then(|| {
 							IndexerJobStepEntry {
 								materialized_path,
-								created_at: entry.created_at,
 								file_id: 0, // To be set later
 								parent_id: entry.path.parent().and_then(|parent_dir| {
 									/***************************************************************
@@ -191,8 +190,7 @@ impl StatefulJob for IndexerJob {
 									dirs_ids.get(parent_dir).copied()
 								}),
 								full_path: entry.path,
-								inode: entry.inode,
-								device: entry.device,
+								metadata: entry.metadata,
 							}
 						})
 					},

--- a/core/src/location/indexer/mod.rs
+++ b/core/src/location/indexer/mod.rs
@@ -24,7 +24,7 @@ use tokio::io;
 use tracing::info;
 
 use super::{
-	file_path_helper::{FilePathError, MaterializedPath},
+	file_path_helper::{FilePathError, MaterializedPath, FilePathMetadata},
 	location_with_indexer_rules,
 };
 
@@ -72,11 +72,9 @@ pub type IndexerJobStep = Vec<IndexerJobStepEntry>;
 pub struct IndexerJobStepEntry {
 	full_path: PathBuf,
 	materialized_path: MaterializedPath<'static>,
-	created_at: DateTime<Utc>,
 	file_id: i32,
 	parent_id: Option<i32>,
-	inode: u64,
-	device: u64,
+	metadata: FilePathMetadata,
 }
 
 impl IndexerJobData {
@@ -178,10 +176,12 @@ async fn execute_indexer_step(
 						("name", json!(name.clone())),
 						("is_dir", json!(is_dir)),
 						("extension", json!(extension.clone())),
-						("inode", json!(entry.inode.to_le_bytes())),
-						("device", json!(entry.device.to_le_bytes())),
+						("size_in_bytes", json!(entry.metadata.size_in_bytes.to_string())),
+						("inode", json!(entry.metadata.inode.to_le_bytes())),
+						("device", json!(entry.metadata.device.to_le_bytes())),
 						("parent_id", json!(entry.parent_id)),
-						("date_created", json!(entry.created_at)),
+						("date_created", json!(entry.metadata.created_at)),
+						("date_modified", json!(entry.metadata.modified_at)),
 					],
 				),
 				file_path::create_unchecked(
@@ -190,12 +190,14 @@ async fn execute_indexer_step(
 					materialized_path.into_owned(),
 					name.into_owned(),
 					extension.into_owned(),
-					entry.inode.to_le_bytes().into(),
-					entry.device.to_le_bytes().into(),
+					entry.metadata.inode.to_le_bytes().into(),
+					entry.metadata.device.to_le_bytes().into(),
 					vec![
 						is_dir::set(is_dir),
+						size_in_bytes::set(entry.metadata.size_in_bytes.to_string()),
 						parent_id::set(entry.parent_id),
-						date_created::set(entry.created_at.into()),
+						date_created::set(entry.metadata.created_at.into()),
+						date_modified::set(entry.metadata.modified_at.into()),
 					],
 				),
 			)

--- a/core/src/location/indexer/mod.rs
+++ b/core/src/location/indexer/mod.rs
@@ -24,7 +24,7 @@ use tokio::io;
 use tracing::info;
 
 use super::{
-	file_path_helper::{FilePathError, MaterializedPath, FilePathMetadata},
+	file_path_helper::{FilePathError, FilePathMetadata, MaterializedPath},
 	location_with_indexer_rules,
 };
 
@@ -176,7 +176,10 @@ async fn execute_indexer_step(
 						("name", json!(name.clone())),
 						("is_dir", json!(is_dir)),
 						("extension", json!(extension.clone())),
-						("size_in_bytes", json!(entry.metadata.size_in_bytes.to_string())),
+						(
+							"size_in_bytes",
+							json!(entry.metadata.size_in_bytes.to_string()),
+						),
 						("inode", json!(entry.metadata.inode.to_le_bytes())),
 						("device", json!(entry.metadata.device.to_le_bytes())),
 						("parent_id", json!(entry.parent_id)),

--- a/core/src/location/indexer/shallow_indexer_job.rs
+++ b/core/src/location/indexer/shallow_indexer_job.rs
@@ -193,11 +193,9 @@ impl StatefulJob for ShallowIndexerJob {
 							.then_some(IndexerJobStepEntry {
 								full_path: entry.path,
 								materialized_path,
-								created_at: entry.created_at,
 								file_id: 0, // To be set later
 								parent_id: Some(parent_id),
-								inode: entry.inode,
-								device: entry.device,
+								metadata: entry.metadata,
 							})
 						},
 					)

--- a/core/src/location/indexer/walk.rs
+++ b/core/src/location/indexer/walk.rs
@@ -1,3 +1,5 @@
+use crate::location::file_path_helper::FilePathMetadata;
+
 #[cfg(target_family = "unix")]
 use crate::location::file_path_helper::get_inode_and_device;
 
@@ -11,7 +13,6 @@ use std::{
 	path::{Path, PathBuf},
 };
 
-use chrono::{DateTime, Utc};
 use tokio::fs;
 use tracing::{error, trace};
 
@@ -26,9 +27,7 @@ use super::{
 pub(super) struct WalkEntry {
 	pub(super) path: PathBuf,
 	pub(super) is_dir: bool,
-	pub(super) created_at: DateTime<Utc>,
-	pub(super) inode: u64,
-	pub(super) device: u64,
+	pub(super) metadata: FilePathMetadata,
 }
 
 impl PartialEq for WalkEntry {
@@ -288,9 +287,13 @@ async fn inner_walk_single_dir(
 				WalkEntry {
 					path: current_path.clone(),
 					is_dir,
-					created_at: metadata.created()?.into(),
-					inode,
-					device,
+					metadata: FilePathMetadata {
+						inode,
+						device,
+						size_in_bytes: metadata.len(),
+						created_at: metadata.created()?.into(),
+						modified_at: metadata.modified()?.into(),
+					},
 				},
 			);
 
@@ -320,9 +323,13 @@ async fn inner_walk_single_dir(
 						WalkEntry {
 							path: ancestor.to_path_buf(),
 							is_dir: true,
-							created_at: metadata.created()?.into(),
-							inode,
-							device,
+							metadata: FilePathMetadata {
+								inode,
+								device,
+								size_in_bytes: metadata.len(),
+								created_at: metadata.created()?.into(),
+								modified_at: metadata.modified()?.into(),
+							},
 						},
 					);
 				} else {
@@ -361,9 +368,13 @@ async fn prepared_indexed_paths(
 		indexed_paths.push(WalkEntry {
 			path: root,
 			is_dir: true,
-			created_at: metadata.created()?.into(),
-			inode,
-			device,
+			metadata: FilePathMetadata {
+				inode,
+				device,
+				size_in_bytes: metadata.len(),
+				created_at: metadata.created()?.into(),
+				modified_at: metadata.modified()?.into(),
+			},
 		});
 	}
 
@@ -470,35 +481,39 @@ mod tests {
 		let root = prepare_location().await;
 		let root_path = root.path();
 
-		let created_at = Utc::now();
-		let inode = 0;
-		let device = 0;
+		let metadata = FilePathMetadata {
+			inode: 0,
+			device: 0,
+			size_in_bytes: 0,
+			created_at: Utc::now(),
+			modified_at: Utc::now(),
+		};
 
 		#[rustfmt::skip]
 		let expected = [
-			WalkEntry { path: root_path.to_path_buf(), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("rust_project"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("rust_project/.git"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("rust_project/Cargo.toml"), is_dir: false, created_at, inode, device },
-			WalkEntry { path: root_path.join("rust_project/src"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("rust_project/src/main.rs"), is_dir: false, created_at, inode, device },
-			WalkEntry { path: root_path.join("rust_project/target"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("rust_project/target/debug"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("rust_project/target/debug/main"), is_dir: false, created_at, inode, device },
-			WalkEntry { path: root_path.join("inner"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("inner/node_project"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("inner/node_project/.git"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("inner/node_project/package.json"), is_dir: false, created_at, inode, device },
-			WalkEntry { path: root_path.join("inner/node_project/src"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("inner/node_project/src/App.tsx"), is_dir: false, created_at, inode, device },
-			WalkEntry { path: root_path.join("inner/node_project/node_modules"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("inner/node_project/node_modules/react"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("inner/node_project/node_modules/react/package.json"), is_dir: false, created_at, inode, device },
-			WalkEntry { path: root_path.join("photos"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("photos/photo1.png"), is_dir: false, created_at, inode, device },
-			WalkEntry { path: root_path.join("photos/photo2.jpg"), is_dir: false, created_at, inode, device },
-			WalkEntry { path: root_path.join("photos/photo3.jpeg"), is_dir: false, created_at, inode, device },
-			WalkEntry { path: root_path.join("photos/text.txt"), is_dir: false, created_at, inode, device },
+			WalkEntry { path: root_path.to_path_buf(), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("rust_project"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("rust_project/.git"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("rust_project/Cargo.toml"), is_dir: false, metadata },
+			WalkEntry { path: root_path.join("rust_project/src"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("rust_project/src/main.rs"), is_dir: false, metadata },
+			WalkEntry { path: root_path.join("rust_project/target"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("rust_project/target/debug"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("rust_project/target/debug/main"), is_dir: false, metadata },
+			WalkEntry { path: root_path.join("inner"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("inner/node_project"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("inner/node_project/.git"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("inner/node_project/package.json"), is_dir: false, metadata },
+			WalkEntry { path: root_path.join("inner/node_project/src"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("inner/node_project/src/App.tsx"), is_dir: false, metadata },
+			WalkEntry { path: root_path.join("inner/node_project/node_modules"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("inner/node_project/node_modules/react"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("inner/node_project/node_modules/react/package.json"), is_dir: false, metadata },
+			WalkEntry { path: root_path.join("photos"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("photos/photo1.png"), is_dir: false, metadata },
+			WalkEntry { path: root_path.join("photos/photo2.jpg"), is_dir: false, metadata },
+			WalkEntry { path: root_path.join("photos/photo3.jpeg"), is_dir: false, metadata },
+			WalkEntry { path: root_path.join("photos/text.txt"), is_dir: false, metadata },
 		]
 		.into_iter()
 		.collect::<BTreeSet<_>>();
@@ -518,17 +533,21 @@ mod tests {
 		let root = prepare_location().await;
 		let root_path = root.path();
 
-		let created_at = Utc::now();
-		let inode = 0;
-		let device = 0;
+		let metadata = FilePathMetadata {
+			inode: 0,
+			device: 0,
+			size_in_bytes: 0,
+			created_at: Utc::now(),
+			modified_at: Utc::now(),
+		};
 
 		#[rustfmt::skip]
 		let expected = [
-			WalkEntry { path: root_path.to_path_buf(), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("photos"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("photos/photo1.png"), is_dir: false, created_at, inode, device },
-			WalkEntry { path: root_path.join("photos/photo2.jpg"), is_dir: false, created_at, inode, device },
-			WalkEntry { path: root_path.join("photos/photo3.jpeg"), is_dir: false, created_at, inode, device },
+			WalkEntry { path: root_path.to_path_buf(), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("photos"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("photos/photo1.png"), is_dir: false, metadata },
+			WalkEntry { path: root_path.join("photos/photo2.jpg"), is_dir: false, metadata },
+			WalkEntry { path: root_path.join("photos/photo3.jpeg"), is_dir: false, metadata },
 		]
 		.into_iter()
 		.collect::<BTreeSet<_>>();
@@ -559,30 +578,34 @@ mod tests {
 		let root = prepare_location().await;
 		let root_path = root.path();
 
-		let created_at = Utc::now();
-		let inode = 0;
-		let device = 0;
+		let metadata = FilePathMetadata {
+			inode: 0,
+			device: 0,
+			size_in_bytes: 0,
+			created_at: Utc::now(),
+			modified_at: Utc::now(),
+		};
 
 		#[rustfmt::skip]
 		let expected = [
-			WalkEntry { path: root_path.to_path_buf(), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("rust_project"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("rust_project/.git"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("rust_project/Cargo.toml"), is_dir: false, created_at, inode, device },
-			WalkEntry { path: root_path.join("rust_project/src"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("rust_project/src/main.rs"), is_dir: false, created_at, inode, device },
-			WalkEntry { path: root_path.join("rust_project/target"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("rust_project/target/debug"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("rust_project/target/debug/main"), is_dir: false, created_at, inode, device },
-			WalkEntry { path: root_path.join("inner"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("inner/node_project"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("inner/node_project/.git"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("inner/node_project/package.json"), is_dir: false, created_at, inode, device },
-			WalkEntry { path: root_path.join("inner/node_project/src"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("inner/node_project/src/App.tsx"), is_dir: false, created_at, inode, device },
-			WalkEntry { path: root_path.join("inner/node_project/node_modules"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("inner/node_project/node_modules/react"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("inner/node_project/node_modules/react/package.json"), is_dir: false, created_at, inode, device },
+			WalkEntry { path: root_path.to_path_buf(), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("rust_project"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("rust_project/.git"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("rust_project/Cargo.toml"), is_dir: false, metadata },
+			WalkEntry { path: root_path.join("rust_project/src"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("rust_project/src/main.rs"), is_dir: false, metadata },
+			WalkEntry { path: root_path.join("rust_project/target"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("rust_project/target/debug"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("rust_project/target/debug/main"), is_dir: false, metadata },
+			WalkEntry { path: root_path.join("inner"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("inner/node_project"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("inner/node_project/.git"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("inner/node_project/package.json"), is_dir: false, metadata },
+			WalkEntry { path: root_path.join("inner/node_project/src"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("inner/node_project/src/App.tsx"), is_dir: false, metadata },
+			WalkEntry { path: root_path.join("inner/node_project/node_modules"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("inner/node_project/node_modules/react"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("inner/node_project/node_modules/react/package.json"), is_dir: false, metadata },
 		]
 		.into_iter()
 		.collect::<BTreeSet<_>>();
@@ -615,24 +638,28 @@ mod tests {
 		let root = prepare_location().await;
 		let root_path = root.path();
 
-		let created_at = Utc::now();
-		let inode = 0;
-		let device = 0;
+		let metadata = FilePathMetadata {
+			inode: 0,
+			device: 0,
+			size_in_bytes: 0,
+			created_at: Utc::now(),
+			modified_at: Utc::now(),
+		};
 
 		#[rustfmt::skip]
 		let expected = [
-			WalkEntry { path: root_path.to_path_buf(), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("rust_project"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("rust_project/.git"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("rust_project/Cargo.toml"), is_dir: false, created_at, inode, device },
-			WalkEntry { path: root_path.join("rust_project/src"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("rust_project/src/main.rs"), is_dir: false, created_at, inode, device },
-			WalkEntry { path: root_path.join("inner"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("inner/node_project"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("inner/node_project/.git"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("inner/node_project/package.json"), is_dir: false, created_at, inode, device },
-			WalkEntry { path: root_path.join("inner/node_project/src"), is_dir: true, created_at, inode, device },
-			WalkEntry { path: root_path.join("inner/node_project/src/App.tsx"), is_dir: false, created_at, inode, device },
+			WalkEntry { path: root_path.to_path_buf(), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("rust_project"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("rust_project/.git"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("rust_project/Cargo.toml"), is_dir: false, metadata },
+			WalkEntry { path: root_path.join("rust_project/src"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("rust_project/src/main.rs"), is_dir: false, metadata },
+			WalkEntry { path: root_path.join("inner"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("inner/node_project"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("inner/node_project/.git"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("inner/node_project/package.json"), is_dir: false, metadata },
+			WalkEntry { path: root_path.join("inner/node_project/src"), is_dir: true, metadata },
+			WalkEntry { path: root_path.join("inner/node_project/src/App.tsx"), is_dir: false, metadata },
 		]
 		.into_iter()
 		.collect::<BTreeSet<_>>();


### PR DESCRIPTION
Migrating `size_in_bytes` to `file_path` table from `object` table had some problems before, so we messed up to pass this data on `file_path` creation.