### PR TITLE
[ENG-458] - Top Bar Responsiveness

### DIFF
--- a/interface/app/$libraryId/Explorer/SearchBar.tsx
+++ b/interface/app/$libraryId/Explorer/SearchBar.tsx
@@ -32,11 +32,7 @@ export default forwardRef<HTMLInputElement, Props>((props, forwardedRef) => {
 	}, [forwardedRef]);
 
 	return (
-		<form
-			data-tauri-drag-region
-			onSubmit={() => {}}
-			className={`relative flex h-7 ${props.formClassName}`}
-		>
+		<form data-tauri-drag-region className={`relative flex h-7 ${props.formClassName}`}>
 			<Input
 				ref={(el) => {
 					if (typeof forwardedRef === 'function') forwardedRef(el);

--- a/interface/app/$libraryId/Explorer/SearchBar.tsx
+++ b/interface/app/$libraryId/Explorer/SearchBar.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import { ComponentPropsWithRef, forwardRef, useEffect } from 'react';
-import { useForm } from 'react-hook-form';
+import { useState } from 'react';
 import { Input, Shortcut } from '@sd/ui';
 import { useOperatingSystem } from '~/hooks/useOperatingSystem';
 
@@ -9,20 +9,7 @@ interface Props extends ComponentPropsWithRef<'input'> {
 }
 
 export default forwardRef<HTMLInputElement, Props>((props, forwardedRef) => {
-	const {
-		register,
-		handleSubmit,
-		reset,
-		formState: { dirtyFields }
-	} = useForm();
-
-	const { ref, ...searchField } = register('searchField', {
-		onBlur: () => {
-			// if there's no text in the search bar, don't mark it as dirty so the key hint shows
-			if (!dirtyFields.searchField) reset();
-		}
-	});
-
+	const [searchValue, setSearchValue] = useState('');
 	const platform = useOperatingSystem(false);
 	const os = useOperatingSystem(true);
 
@@ -34,7 +21,7 @@ export default forwardRef<HTMLInputElement, Props>((props, forwardedRef) => {
 					forwardedRef?.current?.focus();
 				} else if (forwardedRef?.current === document.activeElement && event.key === 'Escape') {
 					forwardedRef.current?.blur();
-					reset();
+					setSearchValue('');
 				}
 			}
 		};
@@ -42,24 +29,25 @@ export default forwardRef<HTMLInputElement, Props>((props, forwardedRef) => {
 		return () => {
 			document.removeEventListener('keydown', keyboardSearchFocus);
 		};
-	}, [forwardedRef, reset]);
+	}, [forwardedRef]);
 
 	return (
 		<form
 			data-tauri-drag-region
-			onSubmit={handleSubmit(() => null)}
+			onSubmit={() => {}}
 			className={`relative flex h-7 ${props.formClassName}`}
 		>
 			<Input
 				ref={(el) => {
-					ref(el);
 					if (typeof forwardedRef === 'function') forwardedRef(el);
 					else if (forwardedRef) forwardedRef.current = el;
 				}}
 				placeholder="Search"
 				className={clsx('w-52 transition-all duration-200 focus-within:w-60', props.className)}
 				size="sm"
-				{...searchField}
+				onChange={(e) => setSearchValue(e.target.value)}
+				onBlur={() => setSearchValue('')}
+				value={searchValue}
 				right={
 					<div
 						className={clsx(

--- a/interface/app/$libraryId/Explorer/TopBar.tsx
+++ b/interface/app/$libraryId/Explorer/TopBar.tsx
@@ -1,26 +1,56 @@
 import clsx from 'clsx';
 import { CaretLeft, CaretRight } from 'phosphor-react';
 import { useRef } from 'react';
+import { useLayoutEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Popover, Tooltip } from '@sd/ui';
 import { RoutePaths, groupKeys, useToolBarRouteOptions } from '~/hooks/useToolBarOptions';
 import SearchBar from './SearchBar';
 import TopBarButton from './TopBarButton';
+import TopBarMobile from './TopBarMobile';
 
 export const TOP_BAR_HEIGHT = 46;
 
 export default () => {
 	const TOP_BAR_ICON_STYLE = 'm-0.5 w-5 h-5 text-ink-dull';
 	const navigate = useNavigate();
-
+	const topBarRef = useRef<HTMLDivElement>(null);
 	const searchRef = useRef<HTMLInputElement>(null);
 	const { pathname } = useLocation();
 	const getPageName = pathname.split('/')[2] as RoutePaths;
 	const { toolBarRouteOptions } = useToolBarRouteOptions();
+	const [topBarWidth, setTopBarWidth] = useState(0);
+	const countToolOptions = toolBarRouteOptions[getPageName].options.reduce(
+		(totalOptionsCount, option) => {
+			const allTools = ([].concat as any)(...Object.values(option));
+			return totalOptionsCount + allTools.length;
+		},
+		0
+	);
+
+	useLayoutEffect(() => {
+		const topBar = topBarRef.current;
+		const searchBar = searchRef.current;
+		const getTopBarWidth = () => {
+			if (topBar && searchBar) {
+				const { width } = topBar.getBoundingClientRect();
+				setTopBarWidth(width);
+			}
+		};
+		getTopBarWidth();
+		window.addEventListener('resize', getTopBarWidth);
+		return () => {
+			window.removeEventListener('resize', getTopBarWidth);
+		};
+	}, [topBarRef]);
+
+	const topBarCondition =
+		(topBarWidth < 1000 && countToolOptions >= 8) || (topBarWidth < 600 && countToolOptions >= 6);
 
 	return (
 		<div
 			data-tauri-drag-region
+			ref={topBarRef}
 			className={clsx(
 				'duration-250 absolute top-0 z-20 flex grid h-[46px] w-full shrink-0 grid-cols-3 items-center justify-center overflow-hidden border-b border-sidebar-divider bg-app px-5 transition-[background-color] transition-[border-color] ease-out'
 			)}
@@ -41,21 +71,29 @@ export default () => {
 			<SearchBar formClassName="justify-center" ref={searchRef} />
 
 			<div data-tauri-drag-region className="flex flex-row justify-end w-full">
-				<div data-tauri-drag-region className="flex gap-0">
+				<div data-tauri-drag-region className={`gap-0 ${topBarCondition ? 'hidden' : 'flex'}`}>
 					{toolBarRouteOptions[getPageName].options.map((group) => {
 						return (Object.keys(group) as groupKeys[]).map((groupKey) => {
 							return group[groupKey]?.map(
-								({ icon, onClick, popOverComponent, toolTipLabel, topBarActive }, index) => {
+								(
+									{ icon, onClick, popOverComponent, toolTipLabel, topBarActive, individual },
+									index
+								) => {
 									const groupCount = Object.keys(group).length;
 									const groupIndex = Object.keys(group).indexOf(groupKey);
-									const roundingCondition =
-										index === 0
-											? 'left'
-											: index === (group[groupKey]?.length as number) - 1
-											? 'right'
-											: 'none';
+									const roundingCondition = individual
+										? 'both'
+										: index === 0
+										? 'left'
+										: index === (group[groupKey]?.length as number) - 1
+										? 'right'
+										: 'none';
 									return (
-										<div data-tauri-drag-region key={toolTipLabel} className="flex items-center">
+										<div
+											data-tauri-drag-region
+											key={toolTipLabel}
+											className={`flex items-center ${individual && 'mx-1'}`}
+										>
 											<Tooltip label={toolTipLabel}>
 												{popOverComponent ? (
 													<Popover
@@ -96,6 +134,7 @@ export default () => {
 						});
 					})}
 				</div>
+				<TopBarMobile className={`${topBarCondition ? 'flex' : 'hidden'}`} />
 			</div>
 		</div>
 	);

--- a/interface/app/$libraryId/Explorer/TopBar.tsx
+++ b/interface/app/$libraryId/Explorer/TopBar.tsx
@@ -52,7 +52,7 @@ export default () => {
 			data-tauri-drag-region
 			ref={topBarRef}
 			className={clsx(
-				'duration-250 absolute top-0 z-20 flex grid h-[46px] w-full shrink-0 grid-cols-3 items-center justify-center overflow-hidden border-b border-sidebar-divider bg-app px-5 transition-[background-color] transition-[border-color] ease-out'
+				'duration-250 top-bar-blur absolute top-0 z-20  grid h-[46px] w-full shrink-0 grid-cols-3 items-center justify-center overflow-hidden border-b border-sidebar-divider bg-app/90 px-5 transition-[background-color,border-color] ease-out'
 			)}
 		>
 			<div data-tauri-drag-region className="flex ">

--- a/interface/app/$libraryId/Explorer/TopBarButton.tsx
+++ b/interface/app/$libraryId/Explorer/TopBarButton.tsx
@@ -1,4 +1,5 @@
 import { cva } from 'class-variance-authority';
+import { Check } from 'phosphor-react';
 import { forwardRef } from 'react';
 import { Button } from '@sd/ui';
 
@@ -8,10 +9,11 @@ export interface TopBarButtonProps {
 	active?: boolean;
 	className?: string;
 	onClick?: () => void;
+	checkIcon?: React.ReactNode;
 }
 
 const topBarButtonStyle = cva(
-	'text-ink hover:text-ink text-md hover:bg-app-selected radix-state-open:bg-app-selected mr-[1px] flex border-none !p-0.5 font-medium outline-none transition-colors duration-100',
+	'text-ink hover:text-ink text-md relative hover:bg-app-selected radix-state-open:bg-app-selected mr-[1px] flex border-none !p-0.5 font-medium outline-none transition-colors duration-100',
 	{
 		variants: {
 			active: {
@@ -37,6 +39,9 @@ export default forwardRef<HTMLButtonElement, TopBarButtonProps>(
 		return (
 			<Button {...props} ref={ref} className={topBarButtonStyle({ active, rounding, className })}>
 				{props.children}
+				{props.checkIcon && active && (
+					<Check className="absolute right-2 m-0.5 h-5 w-5 text-ink-dull" />
+				)}
 			</Button>
 		);
 	}

--- a/interface/app/$libraryId/Explorer/TopBarMobile.tsx
+++ b/interface/app/$libraryId/Explorer/TopBarMobile.tsx
@@ -1,0 +1,81 @@
+import { Check, DotsThreeCircle } from 'phosphor-react';
+import { HTMLAttributes } from 'react';
+import { useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { Popover } from '@sd/ui';
+import { TOP_BAR_ICON_STYLE } from '~/hooks/useToolBarOptions';
+import { RoutePaths, groupKeys, useToolBarRouteOptions } from '~/hooks/useToolBarOptions';
+import TopBarButton from './TopBarButton';
+
+interface Props extends HTMLAttributes<HTMLDivElement> {}
+
+export default ({ className = '' }: Props) => {
+	const { pathname } = useLocation();
+	const getPageName = pathname.split('/')[2] as RoutePaths;
+	const { toolBarRouteOptions } = useToolBarRouteOptions();
+
+	return (
+		<div className={className}>
+			<Popover
+				trigger={
+					<TopBarButton>
+						<DotsThreeCircle className={TOP_BAR_ICON_STYLE} />
+					</TopBarButton>
+				}
+			>
+				<div className="flex flex-col p-2 overflow-hidden">
+					{toolBarRouteOptions[getPageName].options.map((group) => {
+						return (Object.keys(group) as groupKeys[]).map((groupKey) => {
+							return group[groupKey]?.map(
+								({ icon, onClick, popOverComponent, toolTipLabel, topBarActive }, index) => {
+									const groupCount = Object.keys(group).length;
+									const groupIndex = Object.keys(group).indexOf(groupKey);
+									return (
+										<div key={toolTipLabel}>
+											{popOverComponent ? (
+												<Popover
+													className="focus:outline-none"
+													trigger={
+														<TopBarButton
+															className="mb-1 flex !w-full gap-1"
+															active={topBarActive}
+															onClick={onClick}
+															checkIcon={true}
+														>
+															<div className="flex items-center justify-between w-full">
+																<div className="flex items-center gap-1">
+																	{icon}
+																	{toolTipLabel}
+																</div>
+															</div>
+														</TopBarButton>
+													}
+												>
+													<div className="block w-[250px] ">{popOverComponent}</div>
+												</Popover>
+											) : (
+												<TopBarButton
+													className="mb-1 flex !w-full gap-1"
+													active={topBarActive}
+													onClick={onClick ?? undefined}
+													checkIcon={true}
+												>
+													{icon}
+													{toolTipLabel}
+												</TopBarButton>
+											)}
+											{index === (group[groupKey]?.length as number) - 1 &&
+												groupCount !== groupIndex + 1 && (
+													<div className="my-2 w-[100%] border-b border-app-line" />
+												)}
+										</div>
+									);
+								}
+							);
+						});
+					})}
+				</div>
+			</Popover>
+		</div>
+	);
+};

--- a/interface/hooks/useToolBarOptions.tsx
+++ b/interface/hooks/useToolBarOptions.tsx
@@ -33,6 +33,7 @@ export interface ToolOptions {
 		[key in groupKeys]?: {
 			icon: JSX.Element;
 			onClick?: () => void;
+			individual?: boolean;
 			toolTipLabel: string;
 			topBarActive?: boolean;
 			popOverComponent?: JSX.Element;
@@ -40,7 +41,7 @@ export interface ToolOptions {
 	}[];
 }
 
-const TOP_BAR_ICON_STYLE = 'm-0.5 w-5 h-5 text-ink-dull';
+export const TOP_BAR_ICON_STYLE = 'm-0.5 w-5 h-5 text-ink-dull';
 
 export const useToolBarRouteOptions = () => {
 	const store = useExplorerStore();
@@ -81,7 +82,8 @@ export const useToolBarRouteOptions = () => {
 						{
 							toolTipLabel: 'Key Manager',
 							icon: <Key className={TOP_BAR_ICON_STYLE} />,
-							popOverComponent: <KeyManager />
+							popOverComponent: <KeyManager />,
+							individual: true
 						},
 						{
 							toolTipLabel: 'Tag Assign Mode',
@@ -92,18 +94,21 @@ export const useToolBarRouteOptions = () => {
 								/>
 							),
 							onClick: () => (getExplorerStore().tagAssignMode = !store.tagAssignMode),
-							topBarActive: store.tagAssignMode
+							topBarActive: store.tagAssignMode,
+							individual: true
 						},
 						{
 							toolTipLabel: 'Regenerate thumbs (temp)',
-							icon: <ArrowClockwise className={TOP_BAR_ICON_STYLE} />
+							icon: <ArrowClockwise className={TOP_BAR_ICON_STYLE} />,
+							individual: true
 						}
 					],
 					groupThree: [
 						{
 							toolTipLabel: 'Explorer display',
 							icon: <SlidersHorizontal className={TOP_BAR_ICON_STYLE} />,
-							popOverComponent: <OptionsPanel />
+							popOverComponent: <OptionsPanel />,
+							individual: true
 						},
 						{
 							toolTipLabel: 'Show Inspector',
@@ -113,7 +118,8 @@ export const useToolBarRouteOptions = () => {
 									weight={store.showInspector ? 'fill' : 'regular'}
 									className={clsx(TOP_BAR_ICON_STYLE, 'scale-x-[-1]')}
 								/>
-							)
+							),
+							individual: true
 						}
 					]
 				}

--- a/packages/ui/src/Popover.tsx
+++ b/packages/ui/src/Popover.tsx
@@ -15,6 +15,8 @@ export const Popover = ({ trigger, children, disabled, className, ...props }: Pr
 
 			<Radix.Portal>
 				<Radix.Content
+					onOpenAutoFocus={(event) => event.preventDefault()}
+					onCloseAutoFocus={(event) => event.preventDefault()}
 					className={clsx(
 						'flex flex-col',
 						'z-50 m-2 min-w-[11rem]',


### PR DESCRIPTION
This PR makes the top bar responsive.

**Notes**:

- Used side effects to get the width of the topbar for the sake of collapsing at the right time, rather than using media queries from tailwind for a better user experience.
- There's only 2 cases when it needs to collapse, when the tool count is >= 8 or  6 and at certain widths. No need to go further because thats the maximum amount you can resize the window to.
- Added check icon as an optional prop to top button component, that is the best way to apply this.
- Used the Popover component, rather than DropDown because it's styling is completely off and different, don't want to make un-necessary edits.

**Other notes**:

- Individual buttons are now supported for the Top bar, this allows them to have their own spacing and are away from each other + are rounded from both sides.

**Keep in mind another iteration within the code will take place in the next PR for API improvement.**

**Whats next**:

- Fix the popover component from going to the left corner when you resize the window, decided to do that in another PR so I don't go too far away from the focus of this change.


**Video below**:

https://user-images.githubusercontent.com/33054370/231892378-da10a143-d919-46f3-9fea-7140ca624d52.mp4

