### PR TITLE
[ENG-461] Location creation fails for '/' (root) and 'C:' ([A-Z] drives)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4609,6 +4609,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "normpath"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec60c60a693226186f5d6edf073232bfb6464ed97eb22cf3b01c1e8198fd97f5"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "notify"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6644,6 +6653,7 @@ dependencies = [
  "int-enum",
  "itertools",
  "mini-moka",
+ "normpath",
  "notify",
  "once_cell",
  "prisma-client-rust",
@@ -9364,12 +9374,12 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
+ "windows_aarch64_gnullvm 0.42.1",
  "windows_aarch64_msvc 0.42.1",
  "windows_i686_gnu 0.42.1",
  "windows_i686_msvc 0.42.1",
  "windows_x86_64_gnu 0.42.1",
- "windows_x86_64_gnullvm",
+ "windows_x86_64_gnullvm 0.42.1",
  "windows_x86_64_msvc 0.42.1",
 ]
 
@@ -9379,7 +9389,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -9388,13 +9407,28 @@ version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
- "windows_aarch64_gnullvm",
+ "windows_aarch64_gnullvm 0.42.1",
  "windows_aarch64_msvc 0.42.1",
  "windows_i686_gnu 0.42.1",
  "windows_i686_msvc 0.42.1",
  "windows_x86_64_gnu 0.42.1",
- "windows_x86_64_gnullvm",
+ "windows_x86_64_gnullvm 0.42.1",
  "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -9408,6 +9442,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -9446,6 +9486,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9480,6 +9526,12 @@ name = "windows_i686_gnu"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -9518,6 +9570,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9554,10 +9612,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -9594,6 +9664,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winreg"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,9 +18,9 @@ sync-messages = []
 [dependencies]
 sd-ffmpeg = { path = "../crates/ffmpeg", optional = true }
 sd-crypto = { path = "../crates/crypto", features = [
-  "rspc",
-  "serde",
-  "keymanager",
+	"rspc",
+	"serde",
+	"keymanager",
 ] }
 sd-file-ext = { path = "../crates/file-ext" }
 sd-sync = { path = "../crates/sync" }
@@ -31,11 +31,11 @@ httpz = { workspace = true }
 prisma-client-rust = { workspace = true }
 specta = { workspace = true }
 tokio = { workspace = true, features = [
-  "sync",
-  "rt-multi-thread",
-  "io-util",
-  "macros",
-  "time",
+	"sync",
+	"rt-multi-thread",
+	"io-util",
+	"macros",
+	"time",
 ] }
 
 base64 = "0.21.0"
@@ -70,10 +70,11 @@ serde_with = "2.2.0"
 dashmap = { version = "5.4.0", features = ["serde"] }
 ffmpeg-next = { version = "6.0.0", optional = true, features = [] }
 notify = { version = "5.0.0", default-features = false, features = [
-  "macos_fsevent",
+	"macos_fsevent",
 ], optional = true }
 static_assertions = "1.1.0"
 serde-hashkey = "0.4.5"
+normpath = { version = "1.1.1", features = ["localization"] }
 
 [target.'cfg(windows)'.dependencies.winapi-util]
 version = "0.1.5"

--- a/core/src/location/file_path_helper.rs
+++ b/core/src/location/file_path_helper.rs
@@ -5,6 +5,7 @@ use std::{
 	fmt::{Display, Formatter},
 	fs::Metadata,
 	path::{Path, PathBuf, MAIN_SEPARATOR, MAIN_SEPARATOR_STR},
+	time::SystemTime,
 };
 
 use chrono::{DateTime, Utc};
@@ -722,5 +723,21 @@ pub async fn get_inode_and_device_from_path(
 		let info = information(&Handle::from_path_any(path.as_ref())?)?;
 
 		Ok((info.file_index(), info.volume_serial_number()))
+	}
+}
+
+pub trait MetadataExt {
+	fn created_or_now(&self) -> SystemTime;
+
+	fn modified_or_now(&self) -> SystemTime;
+}
+
+impl MetadataExt for Metadata {
+	fn created_or_now(&self) -> SystemTime {
+		self.created().unwrap_or_else(|_| SystemTime::now())
+	}
+
+	fn modified_or_now(&self) -> SystemTime {
+		self.modified().unwrap_or_else(|_| SystemTime::now())
 	}
 }

--- a/core/src/location/indexer/walk.rs
+++ b/core/src/location/indexer/walk.rs
@@ -1,4 +1,4 @@
-use crate::location::file_path_helper::FilePathMetadata;
+use crate::location::file_path_helper::{FilePathMetadata, MetadataExt};
 
 #[cfg(target_family = "unix")]
 use crate::location::file_path_helper::get_inode_and_device;
@@ -291,8 +291,8 @@ async fn inner_walk_single_dir(
 						inode,
 						device,
 						size_in_bytes: metadata.len(),
-						created_at: metadata.created()?.into(),
-						modified_at: metadata.modified()?.into(),
+						created_at: metadata.created_or_now().into(),
+						modified_at: metadata.modified_or_now().into(),
 					},
 				},
 			);
@@ -327,8 +327,8 @@ async fn inner_walk_single_dir(
 								inode,
 								device,
 								size_in_bytes: metadata.len(),
-								created_at: metadata.created()?.into(),
-								modified_at: metadata.modified()?.into(),
+								created_at: metadata.created_or_now().into(),
+								modified_at: metadata.modified_or_now().into(),
 							},
 						},
 					);
@@ -372,8 +372,8 @@ async fn prepared_indexed_paths(
 				inode,
 				device,
 				size_in_bytes: metadata.len(),
-				created_at: metadata.created()?.into(),
-				modified_at: metadata.modified()?.into(),
+				created_at: metadata.created_or_now().into(),
+				modified_at: metadata.modified_or_now().into(),
 			},
 		});
 	}

--- a/core/src/location/manager/watcher/utils.rs
+++ b/core/src/location/manager/watcher/utils.rs
@@ -6,7 +6,7 @@ use crate::{
 		file_path_helper::{
 			extract_materialized_path, file_path_with_object, filter_existing_file_path_params,
 			get_parent_dir, get_parent_dir_id, loose_find_existing_file_path_params, FilePathError,
-			FilePathMetadata, MaterializedPath,
+			FilePathMetadata, MaterializedPath, MetadataExt,
 		},
 		find_location, location_with_indexer_rules,
 		manager::LocationManagerError,
@@ -117,8 +117,8 @@ pub(super) async fn create_dir(
 				inode,
 				device,
 				size_in_bytes: metadata.len(),
-				created_at: metadata.created()?.into(),
-				modified_at: metadata.modified()?.into(),
+				created_at: metadata.created_or_now().into(),
+				modified_at: metadata.modified_or_now().into(),
 			},
 		)
 		.await?;
@@ -191,8 +191,8 @@ pub(super) async fn create_file(
 				inode,
 				device,
 				size_in_bytes: metadata.len(),
-				created_at: metadata.created()?.into(),
-				modified_at: metadata.modified()?.into(),
+				created_at: metadata.created_or_now().into(),
+				modified_at: metadata.modified_or_now().into(),
 			},
 		)
 		.await?;
@@ -217,7 +217,7 @@ pub(super) async fn create_file(
 				Uuid::new_v4().as_bytes().to_vec(),
 				vec![
 					object::date_created::set(
-						DateTime::<Local>::from(fs_metadata.created().unwrap()).into(),
+						DateTime::<Local>::from(fs_metadata.created_or_now()).into(),
 					),
 					object::kind::set(kind.int_value()),
 				],
@@ -373,7 +373,7 @@ async fn inner_update_file(
 					file_path::size_in_bytes::set(fs_metadata.len().to_string()),
 				),
 				{
-					let date = DateTime::<Local>::from(fs_metadata.modified()?).into();
+					let date = DateTime::<Local>::from(fs_metadata.modified_or_now()).into();
 
 					(
 						("date_modified", json!(date)),

--- a/core/src/location/mod.rs
+++ b/core/src/location/mod.rs
@@ -454,19 +454,15 @@ async fn create_location(
 
 	let location_path = location_path.as_ref();
 
-	let name = location_path.normalize().map_or_else(
+	// Use `to_string_lossy` because a partially corrupted but identifiable name is better than `Unknown`
+	let mut name = location_path.normalize().map_or_else(
 		|_| {
 			location_path
 				.components()
 				.next()
 				.and_then(|component| match component {
 					Component::Prefix(component) => {
-						let prefix = component.as_os_str().to_string_lossy().to_string();
-						Some(if prefix == "/" {
-							"Root".to_string()
-						} else {
-							prefix
-						})
+						Some(component.as_os_str().to_string_lossy().to_string())
 					}
 					_ => None,
 				})
@@ -475,6 +471,10 @@ async fn create_location(
 		},
 		|p| p.localize_name().to_string_lossy().to_string(),
 	);
+
+	if name == "/" {
+		name = "Root".to_string()
+	}
 
 	let path = location_path
 		.to_str()


### PR DESCRIPTION
This PR fixes a possible error when adding a location that could occur when the core fails to extract a name from its accompanying path. Additionally, I improved the location's name extraction logic by using [`localize_name`](https://docs.rs/normpath/1.1.1/normpath/trait.PathExt.html#tymethod.localize_name) and added an `Unknown` value as the default when all else fails. Besides this, I fixed a possible panic that could occur when the Indexer job fails to retrieve the created/modified date of a path. To solve this, I implemented a `MetadataExt` trait with `created_or_now`/`modified_or_now` that returns the current time when the path time isn't available.
