### PR TITLE
[ENG-468]: Toggle Popover off on window resize

### DIFF
--- a/packages/ui/src/Popover.tsx
+++ b/packages/ui/src/Popover.tsx
@@ -31,7 +31,7 @@ export const Popover = ({ trigger, children, disabled, className, ...props }: Pr
 			window.removeEventListener('click', handleClickOutside);
 			window.removeEventListener('touchstart', handleClickOutside);
 		};
-	}, [open]);
+	}, []);
 	return (
 		<Radix.Root open={open}>
 			<Radix.Trigger

--- a/packages/ui/src/Popover.tsx
+++ b/packages/ui/src/Popover.tsx
@@ -1,5 +1,6 @@
 import * as Radix from '@radix-ui/react-popover';
 import clsx from 'clsx';
+import React, { useEffect, useRef, useState } from 'react';
 
 interface Props extends Radix.PopoverContentProps {
 	trigger: React.ReactNode;
@@ -7,14 +8,44 @@ interface Props extends Radix.PopoverContentProps {
 }
 
 export const Popover = ({ trigger, children, disabled, className, ...props }: Props) => {
+	const [open, setOpen] = useState(false);
+	const popOverRef = useRef<HTMLDivElement>(null);
+	const triggerRef = useRef<HTMLButtonElement>(null);
+	const handleClickOutside = (event: MouseEvent | TouchEvent) => {
+		if (popOverRef.current && triggerRef.current) {
+			if (
+				!popOverRef.current.contains(event.target as Node) &&
+				!triggerRef.current.contains(event.target as Node)
+			) {
+				setOpen(false);
+			}
+		}
+	};
+	useEffect(() => {
+		const windowResizeListener = () => setOpen(false);
+		window.addEventListener('resize', windowResizeListener);
+		window.addEventListener('click', handleClickOutside);
+		window.addEventListener('touchstart', handleClickOutside);
+		return () => {
+			window.removeEventListener('resize', windowResizeListener);
+			window.removeEventListener('click', handleClickOutside);
+			window.removeEventListener('touchstart', handleClickOutside);
+		};
+	}, [open]);
 	return (
-		<Radix.Root>
-			<Radix.Trigger disabled={disabled} asChild>
+		<Radix.Root open={open}>
+			<Radix.Trigger
+				ref={triggerRef}
+				onClick={() => setOpen(!open)}
+				disabled={disabled}
+				asChild
+			>
 				{trigger}
 			</Radix.Trigger>
 
 			<Radix.Portal>
 				<Radix.Content
+					ref={popOverRef}
 					onOpenAutoFocus={(event) => event.preventDefault()}
 					onCloseAutoFocus={(event) => event.preventDefault()}
 					className={clsx(


### PR DESCRIPTION
**This PR toggles the Popover off when the user resizes window, this should be the normal behaviour from a UI point of view.** 

- Also fixes a bug where the popover would be moving to left the corner, because it's parent element would be hidden for different screen sizes.
- Used 2 refs, for the button itself and the popover to guarantee the functionality of this expected behaviour.