### PR TITLE
Checking if new location is nested or already exists

### DIFF
--- a/core/src/location/error.rs
+++ b/core/src/location/error.rs
@@ -36,8 +36,10 @@ pub enum LocationError {
 	AddLibraryToMetadata(PathBuf),
 	#[error("Location metadata file not found: (path: {0:?})")]
 	MetadataNotFound(PathBuf),
-	#[error("Location already exists (path: {0:?})")]
+	#[error("Location already exists in database (path: {0:?})")]
 	LocationAlreadyExists(PathBuf),
+	#[error("Nested location currently not supported (path: {0:?})")]
+	NestedLocation(PathBuf),
 
 	// Internal Errors
 	#[error("Location metadata error (error: {0:?})")]
@@ -71,8 +73,9 @@ impl From<LocationError> for rspc::Error {
 			}
 
 			// User's fault errors
-			// | LocationError::MissingLocalPath(_)
-			LocationError::NotDirectory(_) => {
+			LocationError::NotDirectory(_)
+			| LocationError::NestedLocation(_)
+			| LocationError::LocationAlreadyExists(_) => {
 				rspc::Error::with_cause(ErrorCode::BadRequest, err.to_string(), err)
 			}
 

--- a/core/src/location/metadata.rs
+++ b/core/src/location/metadata.rs
@@ -182,15 +182,11 @@ impl SpacedriveLocationMetadataFile {
 		self.metadata.libraries.contains_key(&library_id)
 	}
 
-	pub(super) fn location_path(
-		&self,
-		library_id: LibraryId,
-	) -> Result<&Path, LocationMetadataError> {
+	pub(super) fn location_path(&self, library_id: LibraryId) -> Option<&Path> {
 		self.metadata
 			.libraries
 			.get(&library_id)
 			.map(|l| l.path.as_path())
-			.ok_or(LocationMetadataError::LibraryNotFound(library_id))
 	}
 
 	pub(super) async fn remove_library(

--- a/core/src/location/mod.rs
+++ b/core/src/location/mod.rs
@@ -472,13 +472,10 @@ async fn create_location(
 
 			Ok((
 				// TODO: Maybe save the path bytes instead of the string representation to avoid depending on UTF-8
-				path
-					.to_str()
-					.map(str::to_string)
-					.ok_or(io::Error::new(
-						io::ErrorKind::InvalidInput,
-						"Found non-UTF-8 path",
-					))?,
+				path.to_str().map(str::to_string).ok_or(io::Error::new(
+					io::ErrorKind::InvalidInput,
+					"Found non-UTF-8 path",
+				))?,
 				normalized_path,
 			))
 		})


### PR DESCRIPTION
Currently, we're not planning to support nested locations, so this PR introduce checks to validate that the location path passed to create function isn't a descendant of any location path previously in the database. Also introducing a fix when tried to add a location path already in database that was giving a relink error instead of conflicting with a location path already on database, this happens because before checking DB, we check the `.spacedrive` file. This part is double checked, as someone could just delete `.spacedrive` file and try to add an existing location, so on location create function we check the database.