### PR TITLE
Automatic job progress

### DIFF
--- a/core/prisma/migrations/20230418040228_job_date_completed/migration.sql
+++ b/core/prisma/migrations/20230418040228_job_date_completed/migration.sql
@@ -1,0 +1,31 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `date_modified` on the `job` table. All the data in the column will be lost.
+  - You are about to drop the column `seconds_elapsed` on the `job` table. All the data in the column will be lost.
+
+*/
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_job" (
+    "id" BLOB NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "node_id" INTEGER NOT NULL,
+    "action" INTEGER NOT NULL,
+    "status" INTEGER NOT NULL DEFAULT 0,
+    "data" BLOB,
+    "metadata" BLOB,
+    "parent_id" BLOB,
+    "task_count" INTEGER NOT NULL DEFAULT 1,
+    "completed_task_count" INTEGER NOT NULL DEFAULT 0,
+    "date_created" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "date_started" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    "date_completed" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "job_node_id_fkey" FOREIGN KEY ("node_id") REFERENCES "node" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "job_parent_id_fkey" FOREIGN KEY ("parent_id") REFERENCES "job" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_job" ("action", "completed_task_count", "data", "date_created", "id", "metadata", "name", "node_id", "parent_id", "status", "task_count") SELECT "action", "completed_task_count", "data", "date_created", "id", "metadata", "name", "node_id", "parent_id", "status", "task_count" FROM "job";
+DROP TABLE "job";
+ALTER TABLE "new_job" RENAME TO "job";
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/core/prisma/schema.prisma
+++ b/core/prisma/schema.prisma
@@ -367,8 +367,8 @@ model Job {
     task_count           Int      @default(1)
     completed_task_count Int      @default(0)
     date_created         DateTime @default(now())
-    date_modified        DateTime @default(now())
-    seconds_elapsed      Int      @default(0)
+		date_started 			   DateTime? @default(now()) // Started execution
+		date_completed 		   DateTime? @default(now()) // Finished execution
 
     nodes Node @relation(fields: [node_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
 

--- a/core/src/job/worker.rs
+++ b/core/src/job/worker.rs
@@ -1,6 +1,7 @@
 use crate::invalidate_query;
 use crate::job::{DynJob, JobError, JobManager, JobReportUpdate, JobStatus};
 use crate::library::Library;
+use chrono::Utc;
 use std::{sync::Arc, time::Duration};
 use tokio::sync::oneshot;
 use tokio::{
@@ -9,19 +10,18 @@ use tokio::{
 		mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
 		Mutex,
 	},
-	time::{interval_at, Instant},
+	time::Instant,
 };
 use tracing::{error, info, warn};
 
 use super::{JobMetadata, JobReport};
 
+const JOB_REPORT_UPDATE_INTERVAL: Duration = Duration::from_millis(1000 / 60);
+
 // used to update the worker state from inside the worker thread
 #[derive(Debug)]
 pub enum WorkerEvent {
-	Progressed {
-		updates: Vec<JobReportUpdate>,
-		debounce: bool,
-	},
+	Progressed(Vec<JobReportUpdate>),
 	Completed(oneshot::Sender<()>, JobMetadata),
 	Failed(oneshot::Sender<()>),
 	Paused(Vec<u8>, oneshot::Sender<()>),
@@ -32,24 +32,26 @@ pub struct WorkerContext {
 	pub library: Library,
 	events_tx: UnboundedSender<WorkerEvent>,
 	shutdown_tx: Arc<broadcast::Sender<()>>,
+	// Used for debouncing
+	last_event: Instant,
 }
 
 impl WorkerContext {
 	pub fn progress(&self, updates: Vec<JobReportUpdate>) {
 		self.events_tx
-			.send(WorkerEvent::Progressed {
-				updates,
-				debounce: false,
-			})
+			.send(WorkerEvent::Progressed(updates))
 			.expect("critical error: failed to send worker worker progress event updates");
 	}
-	pub fn progress_debounced(&self, updates: Vec<JobReportUpdate>) {
-		self.events_tx
-			.send(WorkerEvent::Progressed {
-				updates,
-				debounce: true,
-			})
-			.expect("critical error: failed to send worker worker progress event updates");
+
+	pub fn progress_debounced(&mut self, updates: Vec<JobReportUpdate>) {
+		let now = Instant::now();
+		if self.last_event.duration_since(now) > JOB_REPORT_UPDATE_INTERVAL {
+			self.last_event = now;
+
+			self.events_tx
+				.send(WorkerEvent::Progressed(updates))
+				.expect("critical error: failed to send worker worker progress event updates");
+		}
 	}
 
 	pub fn shutdown_rx(&self) -> broadcast::Receiver<()> {
@@ -104,6 +106,9 @@ impl Worker {
 		let job_id = worker.report.id;
 
 		worker.report.status = JobStatus::Running;
+		if worker.report.started_at.is_none() {
+			worker.report.started_at = Some(Utc::now());
+		}
 
 		// If the report doesn't have a created_at date, it's a new report
 		if worker.report.created_at.is_none() {
@@ -131,28 +136,9 @@ impl Worker {
 				library: library.clone(),
 				events_tx: worker_events_tx,
 				shutdown_tx: job_manager.shutdown_tx(),
+				last_event: (Instant::now()
+					- (JOB_REPORT_UPDATE_INTERVAL + Duration::from_secs(1))), // So we don't miss the first event
 			};
-
-			// track time
-			let events_tx = worker_ctx.events_tx.clone();
-			tokio::spawn(async move {
-				let mut interval = interval_at(
-					Instant::now() + Duration::from_millis(1000),
-					Duration::from_millis(1000),
-				);
-				loop {
-					interval.tick().await;
-					if events_tx
-						.send(WorkerEvent::Progressed {
-							updates: vec![JobReportUpdate::SecondsElapsed(1)],
-							debounce: false,
-						})
-						.is_err() && events_tx.is_closed()
-					{
-						break;
-					}
-				}
-			});
 
 			let (done_tx, done_rx) = oneshot::channel();
 
@@ -202,21 +188,11 @@ impl Worker {
 		mut worker_events_rx: UnboundedReceiver<WorkerEvent>,
 		library: Library,
 	) {
-		let mut last = Instant::now();
-
 		while let Some(command) = worker_events_rx.recv().await {
 			let mut worker = worker.lock().await;
 
 			match command {
-				WorkerEvent::Progressed { updates, debounce } => {
-					if debounce {
-						let current = Instant::now();
-						if current.duration_since(last) > Duration::from_millis(1000 / 60) {
-							last = current
-						} else {
-							continue;
-						}
-					}
+				WorkerEvent::Progressed(updates) => {
 					// protect against updates if job is not running
 					if worker.report.status != JobStatus::Running {
 						continue;
@@ -232,9 +208,6 @@ impl Worker {
 							JobReportUpdate::Message(message) => {
 								worker.report.message = message;
 							}
-							JobReportUpdate::SecondsElapsed(seconds) => {
-								worker.report.seconds_elapsed += seconds as i32;
-							}
 						}
 					}
 
@@ -244,6 +217,7 @@ impl Worker {
 					worker.report.status = JobStatus::Completed;
 					worker.report.data = None;
 					worker.report.metadata = metadata;
+					worker.report.completed_at = Some(Utc::now());
 					if let Err(e) = worker.report.update(&library).await {
 						error!("failed to update job report: {:#?}", e);
 					}

--- a/core/src/location/indexer/mod.rs
+++ b/core/src/location/indexer/mod.rs
@@ -78,7 +78,7 @@ pub struct IndexerJobStepEntry {
 }
 
 impl IndexerJobData {
-	fn on_scan_progress(ctx: &WorkerContext, progress: Vec<ScanProgress>) {
+	fn on_scan_progress(ctx: &mut WorkerContext, progress: Vec<ScanProgress>) {
 		ctx.progress_debounced(
 			progress
 				.iter()

--- a/core/src/location/indexer/shallow_indexer_job.rs
+++ b/core/src/location/indexer/shallow_indexer_job.rs
@@ -1,6 +1,5 @@
 use crate::{
 	job::{JobError, JobInitData, JobResult, JobState, StatefulJob, WorkerContext},
-	library::Library,
 	location::file_path_helper::{
 		ensure_sub_path_is_directory, ensure_sub_path_is_in_location,
 		file_path_just_id_materialized_path, filter_existing_file_path_params,
@@ -70,13 +69,11 @@ impl StatefulJob for ShallowIndexerJob {
 	}
 
 	/// Creates a vector of valid path buffers from a directory, chunked into batches of `BATCH_SIZE`.
-	async fn init(&self, ctx: WorkerContext, state: &mut JobState<Self>) -> Result<(), JobError> {
-		let Library {
-			last_file_path_id_manager,
-			db,
-			..
-		} = &ctx.library;
-
+	async fn init(
+		&self,
+		mut ctx: WorkerContext,
+		state: &mut JobState<Self>,
+	) -> Result<(), JobError> {
 		let location_id = state.init.location.id;
 		let location_path = Path::new(&state.init.location.path);
 
@@ -105,7 +102,9 @@ impl StatefulJob for ShallowIndexerJob {
 
 			(
 				full_path,
-				db.file_path()
+				ctx.library
+					.db
+					.file_path()
 					.find_first(filter_existing_file_path_params(&materialized_path))
 					.select(file_path_just_id_materialized_path::select())
 					.exec()
@@ -116,7 +115,9 @@ impl StatefulJob for ShallowIndexerJob {
 		} else {
 			(
 				location_path.to_path_buf(),
-				db.file_path()
+				ctx.library
+					.db
+					.file_path()
 					.find_first(filter_existing_file_path_params(
 						&MaterializedPath::new(location_id, location_path, location_path, true)
 							.map_err(IndexerError::from)?,
@@ -130,22 +131,27 @@ impl StatefulJob for ShallowIndexerJob {
 		};
 
 		let scan_start = Instant::now();
-		let found_paths = walk_single_dir(
-			to_walk_path,
-			&indexer_rules_by_kind,
-			|path, total_entries| {
-				IndexerJobData::on_scan_progress(
-					&ctx,
-					vec![
-						ScanProgress::Message(format!("Scanning {}", path.display())),
-						ScanProgress::ChunkCount(total_entries / BATCH_SIZE),
-					],
-				);
-			},
-		)
-		.await?;
+		let found_paths = {
+			let ctx = &mut ctx; // Borrow outside of closure so it's not moved
+			walk_single_dir(
+				to_walk_path,
+				&indexer_rules_by_kind,
+				|path, total_entries| {
+					IndexerJobData::on_scan_progress(
+						ctx,
+						vec![
+							ScanProgress::Message(format!("Scanning {}", path.display())),
+							ScanProgress::ChunkCount(total_entries / BATCH_SIZE),
+						],
+					);
+				},
+			)
+			.await?
+		};
 
-		let (already_existing_file_paths, mut to_retain) = db
+		let (already_existing_file_paths, mut to_retain) = ctx
+			.library
+			.db
 			.file_path()
 			.find_many(
 				filter_file_paths_by_many_full_path_params(
@@ -171,14 +177,19 @@ impl StatefulJob for ShallowIndexerJob {
 		to_retain.push(parent_id);
 
 		// Removing all other file paths that are not in the filesystem anymore
-		let removed_paths =
-			retain_file_paths_in_location(location_id, to_retain, Some(parent_file_path), db)
-				.await
-				.map_err(IndexerError::from)?;
+		let removed_paths = retain_file_paths_in_location(
+			location_id,
+			to_retain,
+			Some(parent_file_path),
+			&ctx.library.db,
+		)
+		.await
+		.map_err(IndexerError::from)?;
 
 		// Syncing the last file path id manager, as we potentially just removed a bunch of ids
-		last_file_path_id_manager
-			.sync(location_id, db)
+		ctx.library
+			.last_file_path_id_manager
+			.sync(location_id, &ctx.library.db)
 			.await
 			.map_err(IndexerError::from)?;
 
@@ -212,8 +223,10 @@ impl StatefulJob for ShallowIndexerJob {
 		let total_paths = new_paths.len();
 
 		// grab the next id so we can increment in memory for batch inserting
-		let first_file_id = last_file_path_id_manager
-			.increment(location_id, total_paths as i32, db)
+		let first_file_id = ctx
+			.library
+			.last_file_path_id_manager
+			.increment(location_id, total_paths as i32, &ctx.library.db)
 			.await
 			.map_err(IndexerError::from)?;
 
@@ -242,7 +255,7 @@ impl StatefulJob for ShallowIndexerJob {
 			.map(|(i, chunk)| {
 				let chunk_steps = chunk.collect::<Vec<_>>();
 				IndexerJobData::on_scan_progress(
-					&ctx,
+					&mut ctx,
 					vec![
 						ScanProgress::SavedChunks(i),
 						ScanProgress::Message(format!(

--- a/core/src/location/indexer/walk.rs
+++ b/core/src/location/indexer/walk.rs
@@ -64,7 +64,7 @@ type ToWalkEntry = (PathBuf, Option<bool>);
 pub(super) async fn walk(
 	root: impl AsRef<Path>,
 	rules_per_kind: &HashMap<RuleKind, Vec<IndexerRule>>,
-	update_notifier: impl Fn(&Path, usize),
+	mut update_notifier: impl FnMut(&Path, usize) + '_,
 	include_root: bool,
 ) -> Result<Vec<WalkEntry>, IndexerError> {
 	let root = root.as_ref().to_path_buf();
@@ -91,7 +91,7 @@ pub(super) async fn walk(
 			(current_path, parent_dir_accepted_by_its_children),
 			&mut read_dir,
 			rules_per_kind,
-			&update_notifier,
+			&mut update_notifier,
 			&mut indexed_paths,
 			Some(&mut to_walk),
 		)
@@ -106,7 +106,7 @@ async fn inner_walk_single_dir(
 	(current_path, parent_dir_accepted_by_its_children): ToWalkEntry,
 	read_dir: &mut fs::ReadDir,
 	rules_per_kind: &HashMap<RuleKind, Vec<IndexerRule>>,
-	update_notifier: &impl Fn(&Path, usize),
+	update_notifier: &mut impl FnMut(&Path, usize),
 	indexed_paths: &mut HashMap<PathBuf, WalkEntry>,
 	mut maybe_to_walk: Option<&mut VecDeque<(PathBuf, Option<bool>)>>,
 ) -> Result<(), IndexerError> {
@@ -387,7 +387,7 @@ async fn prepared_indexed_paths(
 pub(super) async fn walk_single_dir(
 	root: impl AsRef<Path>,
 	rules_per_kind: &HashMap<RuleKind, Vec<IndexerRule>>,
-	update_notifier: impl Fn(&Path, usize),
+	mut update_notifier: impl FnMut(&Path, usize) + '_,
 ) -> Result<Vec<WalkEntry>, IndexerError> {
 	let root = root.as_ref().to_path_buf();
 
@@ -399,7 +399,7 @@ pub(super) async fn walk_single_dir(
 		(root.clone(), None),
 		&mut read_dir,
 		rules_per_kind,
-		&update_notifier,
+		&mut update_notifier,
 		&mut indexed_paths,
 		None,
 	)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"client": "pnpm --filter @sd/client -- ",
 		"prisma": "cd core && cargo prisma",
 		"codegen": "cargo test -p sd-core api::tests::test_and_export_rspc_bindings -- --exact",
-		"typecheck": "turbo run typecheck",
+		"typecheck": "pnpm -r typecheck",
 		"lint": "turbo run lint",
 		"lint:fix": "turbo run lint -- --fix",
 		"clean": "rimraf -g \"node_modules/\" \"**/node_modules/\" \"target/\" \"**/.build/\" \"**/.next/\" \"**/dist/!(.gitignore)**\""

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -163,7 +163,7 @@ export type IndexerRuleCreateArgs = { kind: RuleKind, name: string, parameters: 
 
 export type InvalidateOperationEvent = { key: string, arg: any, result: any | null }
 
-export type JobReport = { id: string, name: string, data: number[] | null, metadata: any | null, created_at: string | null, updated_at: string | null, parent_id: string | null, status: JobStatus, task_count: number, completed_task_count: number, message: string, seconds_elapsed: number }
+export type JobReport = { id: string, name: string, data: number[] | null, metadata: any | null, created_at: string | null, started_at: string | null, completed_at: string | null, parent_id: string | null, status: JobStatus, task_count: number, completed_task_count: number, message: string }
 
 export type JobStatus = "Queued" | "Running" | "Completed" | "Canceled" | "Failed" | "Paused"
 


### PR DESCRIPTION
Previously for every job, every second we would send an event to the frontend to tell it the job had progressed by one second. This is kinda wasteful of IPC bandwidth which can be very limited when indexing a large location.

Changes:
 - Don’t send time updates from the backend
 - Store finished time as a timestamp instead of seconds elapsed
 - Debounce events before sending them on `WorkerContext {}.events_tx`. Debouncing at the sender in much nicer, imo.
 - Disabled Turbo as the runner for `pnpm typecheck` because it's caching when it shouldn't and this could allow bugs to make it though.

Breaking changes:
 - I removed the `seconds_elapsed` column so I think a DB reset will be required as all previous jobs will not show up correctly in the UI.