### PR TITLE
remove `int-enum`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3294,27 +3294,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "int-enum"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff87d3cc4b79b4559e3c75068d64247284aceb6a038bd4bb38387f3f164476d"
-dependencies = [
- "int-enum-impl",
-]
-
-[[package]]
-name = "int-enum-impl"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1f2f068675add1a3fc77f5f5ab2e29290c841ee34d151abc007bce902e5d34"
-dependencies = [
- "proc-macro-crate 1.2.1",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "interceptor"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6650,7 +6629,6 @@ dependencies = [
  "httpz 0.0.3 (git+https://github.com/oscartbeaumont/httpz?rev=a5185f2ed2fdefeb2f582dce38a692a1bf76d1d6)",
  "image",
  "include_dir",
- "int-enum",
  "itertools",
  "mini-moka",
  "normpath",
@@ -6732,7 +6710,6 @@ dependencies = [
 name = "sd-file-ext"
 version = "0.0.0"
 dependencies = [
- "int-enum",
  "serde",
  "serde_json",
  "strum 0.24.1",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,8 +10,12 @@ rust-version = "1.68.1"
 
 [features]
 default = []
-mobile = [] # This feature allows features to be disabled when the Core is running on mobile.
-ffmpeg = ["dep:ffmpeg-next", "dep:sd-ffmpeg"] # This feature controls whether the Spacedrive Core contains functionality which requires FFmpeg.
+mobile = [
+] # This feature allows features to be disabled when the Core is running on mobile.
+ffmpeg = [
+	"dep:ffmpeg-next",
+	"dep:sd-ffmpeg",
+] # This feature controls whether the Spacedrive Core contains functionality which requires FFmpeg.
 location-watcher = ["dep:notify"]
 sync-messages = []
 
@@ -43,7 +47,6 @@ serde = { version = "1.0", features = ["derive"] }
 chrono = { version = "0.4.22", features = ["serde"] }
 serde_json = "1.0"
 futures = "0.3"
-int-enum = "0.5.0"
 rmp = "^0.8.11"
 rmp-serde = "^1.1.1"
 blake3 = "1.3.1"

--- a/core/src/job/mod.rs
+++ b/core/src/job/mod.rs
@@ -51,6 +51,8 @@ pub enum JobError {
 	OsStr,
 	#[error("error converting/handling paths")]
 	Path,
+	#[error("invalid job status integer")]
+	InvalidJobStatusInt(i32),
 
 	// Specific job errors
 	#[error("Indexer error: {0}")]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -222,4 +222,6 @@ pub enum NodeError {
 	FailedToInitializeLibraryManager(#[from] library::LibraryManagerError),
 	#[error("Location manager error: {0}")]
 	LocationManager(#[from] LocationManagerError),
+	#[error("invalid platform integer")]
+	InvalidPlatformInt(i32),
 }

--- a/core/src/location/indexer/mod.rs
+++ b/core/src/location/indexer/mod.rs
@@ -13,10 +13,8 @@ use std::{
 };
 
 use chrono::{DateTime, Utc};
-use int_enum::IntEnumError;
 use rmp_serde::{decode, encode};
 use rspc::ErrorCode;
-use rules::RuleKind;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::json;
 use thiserror::Error;
@@ -108,7 +106,7 @@ pub enum IndexerError {
 
 	// User errors
 	#[error("Invalid indexer rule kind integer: {0}")]
-	InvalidRuleKindInt(#[from] IntEnumError<RuleKind>),
+	InvalidRuleKindInt(i32),
 	#[error("Glob builder error: {0}")]
 	GlobBuilderError(#[from] globset::Error),
 

--- a/core/src/location/manager/watcher/utils.rs
+++ b/core/src/location/manager/watcher/utils.rs
@@ -40,7 +40,6 @@ use std::{
 use sd_file_ext::extensions::ImageExtension;
 
 use chrono::{DateTime, Local};
-use int_enum::IntEnum;
 use notify::{Event, EventKind};
 use prisma_client_rust::{raw, PrismaValue};
 use serde_json::json;
@@ -219,7 +218,7 @@ pub(super) async fn create_file(
 					object::date_created::set(
 						DateTime::<Local>::from(fs_metadata.created_or_now()).into(),
 					),
-					object::kind::set(kind.int_value()),
+					object::kind::set(kind as i32),
 				],
 			)
 			.select(object_just_id_has_thumbnail::select())
@@ -431,7 +430,7 @@ async fn inner_update_file(
 					generate_thumbnail(&file_path.extension, &cas_id, full_path, library).await;
 				}
 
-				let int_kind = kind.int_value();
+				let int_kind = kind as i32;
 
 				if object.kind != int_kind {
 					sync.write_op(

--- a/core/src/node/mod.rs
+++ b/core/src/node/mod.rs
@@ -1,7 +1,6 @@
-use crate::prisma::node;
+use crate::{prisma::node, NodeError};
 
 use chrono::{DateTime, Utc};
-use int_enum::IntEnum;
 use rspc::Type;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -24,7 +23,7 @@ impl From<node::Data> for LibraryNode {
 		Self {
 			uuid: Uuid::from_slice(&data.pub_id).unwrap(),
 			name: data.name,
-			platform: IntEnum::from_int(data.platform).unwrap(),
+			platform: Platform::try_from(data.platform).unwrap(),
 			last_seen: data.last_seen.into(),
 		}
 	}
@@ -38,7 +37,7 @@ impl From<Box<node::Data>> for LibraryNode {
 
 #[allow(clippy::upper_case_acronyms)]
 #[repr(i32)]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, Eq, PartialEq, IntEnum)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, Eq, PartialEq)]
 pub enum Platform {
 	Unknown = 0,
 	Windows = 1,
@@ -46,4 +45,22 @@ pub enum Platform {
 	Linux = 3,
 	IOS = 4,
 	Android = 5,
+}
+
+impl TryFrom<i32> for Platform {
+	type Error = NodeError;
+
+	fn try_from(value: i32) -> Result<Self, Self::Error> {
+		let s = match value {
+			0 => Self::Unknown,
+			1 => Self::Windows,
+			2 => Self::MacOS,
+			3 => Self::Linux,
+			4 => Self::IOS,
+			5 => Self::Android,
+			_ => return Err(NodeError::InvalidPlatformInt(value)),
+		};
+
+		Ok(s)
+	}
 }

--- a/core/src/object/file_identifier/mod.rs
+++ b/core/src/object/file_identifier/mod.rs
@@ -13,7 +13,6 @@ use sd_file_ext::{extensions::Extension, kind::ObjectKind};
 use sd_sync::CRDTOperation;
 
 use futures::future::join_all;
-use int_enum::IntEnum;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{
@@ -240,7 +239,7 @@ async fn identifier_job_step(
 					};
 
 					let size = meta.fs_metadata.len().to_string();
-					let kind = meta.kind.int_value();
+					let kind = meta.kind as i32;
 
 					let object_creation_args = (
 						[sync.shared_create(sync_id())]

--- a/crates/file-ext/Cargo.toml
+++ b/crates/file-ext/Cargo.toml
@@ -9,7 +9,6 @@ authors = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-int-enum = "0.5.0"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.85"
 strum = { version = "0.24", features = ["derive"] }

--- a/crates/file-ext/src/kind.rs
+++ b/crates/file-ext/src/kind.rs
@@ -1,53 +1,50 @@
-/// Object Kind
-///
-use int_enum::IntEnum;
 use serde::{Deserialize, Serialize};
 
 #[repr(i32)]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq, IntEnum)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq)]
 pub enum ObjectKind {
-	// A file that can not be identified by the indexer
+	/// A file that can not be identified by the indexer
 	Unknown = 0,
-	// A known filetype, but without specific support
+	/// A known filetype, but without specific support
 	Document = 1,
-	// A virtual filesystem directory
+	/// A virtual filesystem directory
 	Folder = 2,
-	// A file that contains human-readable text
+	/// A file that contains human-readable text
 	Text = 3,
-	// A virtual directory int
+	/// A virtual directory int
 	Package = 4,
-	// An image file
+	/// An image file
 	Image = 5,
-	// An audio file
+	/// An audio file
 	Audio = 6,
-	// A video file
+	/// A video file
 	Video = 7,
-	// A compressed archive of data
+	/// A compressed archive of data
 	Archive = 8,
-	// An executable, program or application
+	/// An executable, program or application
 	Executable = 9,
-	// A link to another object
+	/// A link to another object
 	Alias = 10,
-	// Raw bytes encrypted by Spacedrive with self contained metadata
+	/// Raw bytes encrypted by Spacedrive with self contained metadata
 	Encrypted = 11,
-	// A link can open web pages, apps or Spaces
+	/// A link can open web pages, apps or Spaces
 	Key = 12,
-	// A link can open web pages, apps or Spaces
+	/// A link can open web pages, apps or Spaces
 	Link = 13,
-	// A special filetype that represents a preserved webpage
+	/// A special filetype that represents a preserved webpage
 	WebPageArchive = 14,
-	// A widget is a mini app that can be placed in a Space at various sizes, associated Widget struct required
+	/// A widget is a mini app that can be placed in a Space at various sizes, associated Widget struct required
 	Widget = 15,
-	// Albums can only have one level of children, and are associated with the Album struct
+	/// Albums can only have one level of children, and are associated with the Album struct
 	Album = 16,
-	// Its like a folder, but appears like a stack of files, designed for burst photos / associated groups of files
+	/// Its like a folder, but appears like a stack of files, designed for burst photos / associated groups of files
 	Collection = 17,
-	// You know, text init
+	/// You know, text init
 	Font = 18,
-	// 3D Object
+	/// 3D Object
 	Mesh = 19,
-	// Editable source code file
+	/// Editable source code file
 	Code = 20,
-	// Database file
+	/// Database file
 	Database = 21,
 }


### PR DESCRIPTION
This PR removes the `int-enum` crate as it's essentially useless. We use `repr(i32)`, and provide associated `i32` values - all the crate did was generating the `match` statements but it's simple enough to do ourselves.