### PR TITLE
[Eng 493] Job manager status showing incorrect

### DIFF
--- a/core/src/location/indexer/indexer_job.rs
+++ b/core/src/location/indexer/indexer_job.rs
@@ -108,7 +108,7 @@ impl StatefulJob for IndexerJob {
 		let found_paths = {
 			let ctx = &mut ctx; // Borrow outside of closure so it's not moved
 			walk(
-				to_walk_path,
+				&to_walk_path,
 				&indexer_rules_by_kind,
 				|path, total_entries| {
 					IndexerJobData::on_scan_progress(
@@ -237,6 +237,7 @@ impl StatefulJob for IndexerJob {
 			});
 
 		state.data = Some(IndexerJobData {
+			indexed_path: to_walk_path,
 			db_write_start: Utc::now(),
 			scan_read_time: scan_start.elapsed(),
 			total_paths,

--- a/core/src/location/indexer/mod.rs
+++ b/core/src/location/indexer/mod.rs
@@ -55,6 +55,7 @@ impl Hash for IndexerJobInit {
 /// contains some metadata for logging purposes.
 #[derive(Serialize, Deserialize)]
 pub struct IndexerJobData {
+	indexed_path: PathBuf,
 	db_write_start: DateTime<Utc>,
 	scan_read_time: Duration,
 	total_paths: usize,

--- a/core/src/location/indexer/shallow_indexer_job.rs
+++ b/core/src/location/indexer/shallow_indexer_job.rs
@@ -134,7 +134,7 @@ impl StatefulJob for ShallowIndexerJob {
 		let found_paths = {
 			let ctx = &mut ctx; // Borrow outside of closure so it's not moved
 			walk_single_dir(
-				to_walk_path,
+				&to_walk_path,
 				&indexer_rules_by_kind,
 				|path, total_entries| {
 					IndexerJobData::on_scan_progress(
@@ -240,6 +240,7 @@ impl StatefulJob for ShallowIndexerJob {
 		let total_paths = new_paths.len();
 
 		state.data = Some(IndexerJobData {
+			indexed_path: to_walk_path,
 			db_write_start: Utc::now(),
 			scan_read_time: scan_start.elapsed(),
 			total_paths,

--- a/core/src/util/migrator.rs
+++ b/core/src/util/migrator.rs
@@ -165,14 +165,14 @@ mod test {
 	}
 
 	fn file_as_str(path: &Path) -> String {
-		let mut file = File::open(&path).unwrap();
+		let mut file = File::open(path).unwrap();
 		let mut contents = String::new();
 		file.read_to_string(&mut contents).unwrap();
 		contents
 	}
 
 	fn write_to_file(path: &Path, contents: &str) {
-		let mut file = File::create(&path).unwrap();
+		let mut file = File::create(path).unwrap();
 		file.write_all(contents.as_bytes()).unwrap();
 	}
 
@@ -187,9 +187,9 @@ mod test {
 		let p = path("test_migrator_happy_path.config");
 
 		// Check config is created when it's missing
-		assert_eq!(p.exists(), false, "config file should start out deleted");
+		assert!(!p.exists(), "config file should start out deleted");
 		let default_cfg = migrator.load(&p).unwrap();
-		assert_eq!(p.exists(), true, "config file was not initialised");
+		assert!(p.exists(), "config file was not initialised");
 		assert_eq!(file_as_str(&p), r#"{"version":0,"a":0}"#);
 
 		// Check config can be loaded back into the system correctly
@@ -197,7 +197,7 @@ mod test {
 		assert_eq!(default_cfg, config, "Config has got mangled somewhere");
 
 		// Update the config and check it saved correctly
-		let mut new_config = config.clone();
+		let mut new_config = config;
 		new_config.a = 1;
 		migrator.save(&p, new_config.clone()).unwrap();
 		assert_eq!(file_as_str(&p), r#"{"version":0,"a":1}"#);
@@ -221,9 +221,9 @@ mod test {
 		assert_eq!(file_as_str(&p), r#"{"version":1,"a":1,"b":2}"#);
 
 		// Check editing works
-		let mut new_config = config.clone();
+		let mut new_config = config;
 		new_config.a = 2;
-		migrator.save(&p, new_config.clone()).unwrap();
+		migrator.save(&p, new_config).unwrap();
 		assert_eq!(file_as_str(&p), r#"{"version":1,"a":2,"b":2}"#);
 
 		// Test upgrading to a new version which adds a field asynchronously

--- a/interface/app/$libraryId/Layout/Sidebar/JobManager.tsx
+++ b/interface/app/$libraryId/Layout/Sidebar/JobManager.tsx
@@ -28,7 +28,7 @@ interface JobNiceData {
 const getNiceData = (job: JobReport): Record<string, JobNiceData> => ({
 	indexer: {
 		name: `Indexed ${numberWithCommas(job.metadata?.data?.total_paths || 0)} paths at "${
-			job.metadata?.data?.location_path || '?'
+			job.metadata?.data?.indexed_path || '?'
 		}"`,
 		icon: Folder
 	},


### PR DESCRIPTION
Fixing the Job Manager message regarding the path being indexed in the front-end. Also fixing some smaller non-related warning on some tests, just to keep Clippy clean.