### PR TITLE
[ENG-489] FileThumb has incorrect dimensions for some thumbnails

### DIFF
--- a/interface/app/$libraryId/Explorer/File/Thumb.tsx
+++ b/interface/app/$libraryId/Explorer/File/Thumb.tsx
@@ -1,111 +1,146 @@
 import * as icons from '@sd/assets/icons';
 import clsx from 'clsx';
-import { CSSProperties, useEffect, useState } from 'react';
-import { ExplorerItem, useLibraryContext } from '@sd/client';
+import { useRef, useState } from 'react';
+import { ExplorerItem, isKeyOf, useLibraryContext } from '@sd/client';
 import { useExplorerStore } from '~/hooks/useExplorerStore';
 import { useIsDark, usePlatform } from '~/util/Platform';
 import { getExplorerItemData } from '../util';
 import classes from './Thumb.module.scss';
 
+export const getIcon = (
+	isDir: boolean,
+	isDark: boolean,
+	kind: string,
+	extension?: string | null
+) => {
+	if (isDir) return icons[isDark ? 'Folder' : 'Folder_Light'];
+
+	let document: Extract<keyof typeof icons, 'Document' | 'Document_Light'> = 'Document';
+	if (extension) extension = `${kind}_${extension.toLowerCase()}`;
+	if (!isDark) {
+		kind = kind + '_Light';
+		document = 'Document_Light';
+		if (extension) extension = extension + '_Light';
+	}
+
+	return icons[
+		extension && isKeyOf(icons, extension) ? extension : isKeyOf(icons, kind) ? kind : document
+	];
+};
+
 interface Props {
 	data: ExplorerItem;
-	size: number;
-	loadOriginal?: boolean;
+	size: null | number;
 	className?: string;
+	loadOriginal?: boolean;
 	forceShowExtension?: boolean;
-	extensionClassName?: string;
 }
 
 export default function Thumb(props: Props) {
-	const { cas_id, isDir, kind, hasThumbnail, extension } = getExplorerItemData(props.data);
-	const store = useExplorerStore();
+	const isDark = useIsDark();
+	const thumbRef = useRef<HTMLImageElement>(null);
 	const platform = usePlatform();
 	const { library } = useLibraryContext();
-	const isDark = useIsDark();
+	const { locationId } = useExplorerStore();
+	const [thumbSize, setThumbSize] = useState<null | { width: number; height: number }>(null);
+	const { cas_id, isDir, kind, hasThumbnail, extension } = getExplorerItemData(props.data);
 
-	const [fullPreviewUrl, setFullPreviewUrl] = useState<string | null>(null);
+	// Only Videos and Images can show the original file
+	if (props.loadOriginal && kind !== 'Video' && kind !== 'Image') props.loadOriginal = false;
 
-	useEffect(() => {
-		if (props.loadOriginal && hasThumbnail) {
-			const url = platform.getFileUrl(library.uuid, store.locationId!, props.data.item.id);
-			if (url) setFullPreviewUrl(url);
-		}
-	}, [
-		props.data.item.id,
-		hasThumbnail,
-		library.uuid,
-		props.loadOriginal,
-		platform,
-		store.locationId
-	]);
+	const src = hasThumbnail
+		? props.loadOriginal && locationId
+			? platform.getFileUrl(library.uuid, locationId, props.data.item.id)
+			: cas_id && platform.getThumbnailUrlById(cas_id)
+		: null;
 
-	const videoBarsHeight = Math.floor(props.size / 10);
-	const videoHeight = Math.floor((props.size * 9) / 16) + videoBarsHeight * 2;
-
-	const imgStyle: CSSProperties =
-		kind === 'Video'
-			? {
-					borderTopWidth: videoBarsHeight,
-					borderBottomWidth: videoBarsHeight,
-					width: props.size,
-					height: videoHeight
-			  }
-			: {};
-
-	let icon = icons['Document'];
-	if (isDir) {
-		icon = icons['Folder'];
-	} else if (
-		kind &&
-		extension &&
-		icons[`${kind}_${extension.toLowerCase()}` as keyof typeof icons]
-	) {
-		icon = icons[`${kind}_${extension.toLowerCase()}` as keyof typeof icons];
-	} else if (kind !== 'Unknown' && kind && icons[kind as keyof typeof icons]) {
-		icon = icons[kind as keyof typeof icons];
+	let style = {};
+	if (props.size && kind === 'Video') {
+		const videoBarsHeight = Math.floor(props.size / 10);
+		style = {
+			borderTopWidth: videoBarsHeight,
+			borderBottomWidth: videoBarsHeight
+		};
 	}
 
-	if (!hasThumbnail || !cas_id) {
-		if (!isDark) {
-			icon = icon?.substring(0, icon.length - 4) + '_Light' + '.png';
-		}
-		return <img src={icon} className={clsx('h-full overflow-hidden')} />;
-	}
+	const childClassName = clsx(
+		'z-90 pointer-events-none h-auto max-h-full w-auto max-w-full object-cover'
+	);
 
 	return (
 		<div
+			style={props.size ? { width: props.size, height: props.size } : {}}
 			className={clsx(
-				'relative flex h-full shrink-0 items-center justify-center border-2 border-transparent',
+				props.size && 'shrink-0',
+				'relative flex items-center justify-center justify-items-center border-2 border-transparent p-1',
 				props.className
 			)}
 		>
-			<img
-				style={{ ...imgStyle, maxWidth: props.size, width: props.size - 10 }}
-				decoding="async"
-				className={clsx(
-					'z-90 pointer-events-none',
-					hasThumbnail &&
-						'max-h-full w-auto max-w-full rounded-sm object-cover shadow shadow-black/30',
-					kind === 'Image' && classes.checkers,
-					kind === 'Image' && props.size > 60 && 'border-2 border-app-line',
-					kind === 'Video' && 'rounded border-x-0 !border-black',
-					props.className
-				)}
-				src={fullPreviewUrl || platform.getThumbnailUrlById(cas_id)}
-			/>
-			{extension &&
-				kind === 'Video' &&
-				hasThumbnail &&
-				(props.size > 80 || props.forceShowExtension) && (
-					<div
+			{src ? (
+				kind === 'Video' && props.loadOriginal ? (
+					<video
+						src={src}
+						onCanPlay={(e) => {
+							const video = e.target as HTMLVideoElement;
+							// Why not use the element attribute? Because React...
+							// https://github.com/facebook/react/issues/10389
+							video.loop = true;
+							video.muted = true;
+						}}
+						style={style}
+						autoPlay
 						className={clsx(
-							'absolute bottom-[13%] right-[5%] rounded bg-black/60 py-0.5 px-1 text-[9px] font-semibold uppercase opacity-70',
-							props.extensionClassName
+							childClassName,
+							kind === 'Video' && 'rounded border-x-0 !border-black'
 						)}
-					>
-						{extension}
-					</div>
-				)}
+						playsInline
+					/>
+				) : (
+					<>
+						<img
+							src={src}
+							ref={thumbRef}
+							style={style}
+							onLoad={(e) => {
+								const { width, height } = e.target as HTMLImageElement;
+								setThumbSize(
+									width === 0 || height === 0 ? null : { width, height }
+								);
+							}}
+							className={clsx(
+								childClassName,
+								'rounded-sm shadow shadow-black/30',
+								kind === 'Image' && classes.checkers,
+								kind === 'Image' &&
+									props.size &&
+									props.size > 60 &&
+									'border-2 border-app-line',
+								kind === 'Video' && 'rounded border-x-0 !border-black'
+							)}
+						/>
+						{kind === 'Video' &&
+							thumbSize &&
+							props.size &&
+							(props.size > 80 || props.forceShowExtension) && (
+								<div
+									style={{
+										marginTop: Math.floor(thumbSize.height / 2) - 2,
+										marginLeft: Math.floor(thumbSize.width / 2) - 2
+									}}
+									className="absolute left-1/2 top-1/2 -translate-x-full -translate-y-full rounded bg-black/60 py-0.5 px-1 text-[9px] font-semibold uppercase opacity-70"
+								>
+									{extension}
+								</div>
+							)}
+					</>
+				)
+			) : (
+				<img
+					src={getIcon(isDir, isDark, kind, extension)}
+					decoding="async"
+					className={childClassName}
+				/>
+			)}
 		</div>
 	);
 }

--- a/interface/app/$libraryId/Explorer/File/Thumb.tsx
+++ b/interface/app/$libraryId/Explorer/File/Thumb.tsx
@@ -94,8 +94,8 @@ export default function Thumb({ size, ...props }: Props) {
 				'relative flex shrink-0 items-center justify-center',
 				src &&
 					kind !== 'Video' && [classes.checkers, size && 'border-2 border-transparent'],
-				props.className,
-				size || ['h-full', props.cover ? 'w-full overflow-hidden' : 'w-[90%]']
+				size || ['h-full', props.cover ? 'w-full overflow-hidden' : 'w-[90%]'],
+				props.className
 			)}
 		>
 			{src ? (
@@ -111,7 +111,11 @@ export default function Thumb({ size, ...props }: Props) {
 						}}
 						style={style}
 						autoPlay
-						className={clsx(childClassName, size && 'rounded border-x-0 border-black')}
+						className={clsx(
+							childClassName,
+							size && 'rounded border-x-0 border-black',
+							props.className
+						)}
 						playsInline
 					/>
 				) : (
@@ -133,7 +137,8 @@ export default function Thumb({ size, ...props }: Props) {
 								size &&
 									(kind === 'Video'
 										? 'border-x-0 border-black'
-										: size > 60 && 'border-2 border-app-line')
+										: size > 60 && 'border-2 border-app-line'),
+								props.className
 							)}
 						/>
 						{kind === 'Video' && (!size || size > 80) && (
@@ -163,7 +168,7 @@ export default function Thumb({ size, ...props }: Props) {
 				<img
 					src={getIcon(isDir, isDark, kind, extension)}
 					decoding="async"
-					className={childClassName}
+					className={clsx(childClassName, props.className)}
 				/>
 			)}
 		</div>

--- a/interface/app/$libraryId/Explorer/File/Thumb.tsx
+++ b/interface/app/$libraryId/Explorer/File/Thumb.tsx
@@ -1,6 +1,6 @@
 import * as icons from '@sd/assets/icons';
 import clsx from 'clsx';
-import { useRef, useState } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 import { ExplorerItem, isKeyOf, useLibraryContext } from '@sd/client';
 import { useExplorerStore } from '~/hooks/useExplorerStore';
 import { useIsDark, usePlatform } from '~/util/Platform';
@@ -31,107 +31,132 @@ export const getIcon = (
 interface Props {
 	data: ExplorerItem;
 	size: null | number;
+	cover?: boolean;
 	className?: string;
 	loadOriginal?: boolean;
-	forceShowExtension?: boolean;
 }
 
-export default function Thumb(props: Props) {
+export default function Thumb({ size, ...props }: Props) {
 	const isDark = useIsDark();
-	const thumbRef = useRef<HTMLImageElement>(null);
 	const platform = usePlatform();
 	const { library } = useLibraryContext();
 	const { locationId } = useExplorerStore();
+	const [image, setImage] = useState<HTMLImageElement>();
 	const [thumbSize, setThumbSize] = useState<null | { width: number; height: number }>(null);
 	const { cas_id, isDir, kind, hasThumbnail, extension } = getExplorerItemData(props.data);
 
-	// Only Videos and Images can show the original file
-	if (props.loadOriginal && kind !== 'Video' && kind !== 'Image') props.loadOriginal = false;
+	useLayoutEffect(() => {
+		if (!image) return;
 
+		// This is needed because the image might not be loaded yet
+		// https://stackoverflow.com/q/61864491#61864635
+		let counter = 0;
+		const waitImageRender = () => {
+			const { width, height } = image;
+			if (width && height) {
+				setThumbSize({ width, height });
+			} else if (++counter < 3) {
+				requestAnimationFrame(waitImageRender);
+			} else {
+				setThumbSize(null);
+			}
+		};
+
+		waitImageRender();
+
+		return () => {
+			counter = 3;
+		};
+	}, [image]);
+
+	// Only Videos and Images can show the original file
+	const loadOriginal = (kind === 'Video' || kind === 'Image') && props.loadOriginal;
 	const src = hasThumbnail
-		? props.loadOriginal && locationId
+		? loadOriginal && locationId
 			? platform.getFileUrl(library.uuid, locationId, props.data.item.id)
 			: cas_id && platform.getThumbnailUrlById(cas_id)
 		: null;
 
 	let style = {};
-	if (props.size && kind === 'Video') {
-		const videoBarsHeight = Math.floor(props.size / 10);
+	if (size && kind === 'Video') {
+		const videoBarsHeight = Math.floor(size / 10);
 		style = {
 			borderTopWidth: videoBarsHeight,
 			borderBottomWidth: videoBarsHeight
 		};
 	}
 
-	const childClassName = clsx(
-		'z-90 pointer-events-none h-auto max-h-full w-auto max-w-full object-cover'
-	);
-
+	const childClassName = 'max-h-full max-w-full object-contain';
 	return (
 		<div
-			style={props.size ? { width: props.size, height: props.size } : {}}
+			style={size ? { maxWidth: size, width: size - 10, height: size } : {}}
 			className={clsx(
-				props.size && 'shrink-0',
-				'relative flex items-center justify-center justify-items-center border-2 border-transparent p-1',
-				props.className
+				'relative flex shrink-0 items-center justify-center',
+				src &&
+					kind !== 'Video' && [classes.checkers, size && 'border-2 border-transparent'],
+				props.className,
+				size || ['h-full', props.cover ? 'w-full overflow-hidden' : 'w-[90%]']
 			)}
 		>
 			{src ? (
-				kind === 'Video' && props.loadOriginal ? (
+				kind === 'Video' && loadOriginal ? (
 					<video
 						src={src}
 						onCanPlay={(e) => {
 							const video = e.target as HTMLVideoElement;
-							// Why not use the element attribute? Because React...
+							// Why not use the element's attribute? Because React...
 							// https://github.com/facebook/react/issues/10389
 							video.loop = true;
 							video.muted = true;
 						}}
 						style={style}
 						autoPlay
-						className={clsx(
-							childClassName,
-							kind === 'Video' && 'rounded border-x-0 !border-black'
-						)}
+						className={clsx(childClassName, size && 'rounded border-x-0 border-black')}
 						playsInline
 					/>
 				) : (
 					<>
 						<img
 							src={src}
-							ref={thumbRef}
 							style={style}
 							onLoad={(e) => {
-								const { width, height } = e.target as HTMLImageElement;
-								setThumbSize(
-									width === 0 || height === 0 ? null : { width, height }
-								);
+								if (kind === 'Video' && !props.cover)
+									setImage(e.target as HTMLImageElement);
 							}}
+							decoding="async"
 							className={clsx(
-								childClassName,
-								'rounded-sm shadow shadow-black/30',
-								kind === 'Image' && classes.checkers,
-								kind === 'Image' &&
-									props.size &&
-									props.size > 60 &&
-									'border-2 border-app-line',
-								kind === 'Video' && 'rounded border-x-0 !border-black'
+								props.cover
+									? 'min-h-full min-w-full object-cover object-center'
+									: childClassName,
+								'shadow shadow-black/30',
+								kind === 'Video' ? 'rounded' : 'rounded-sm',
+								size &&
+									(kind === 'Video'
+										? 'border-x-0 border-black'
+										: size > 60 && 'border-2 border-app-line')
 							)}
 						/>
-						{kind === 'Video' &&
-							thumbSize &&
-							props.size &&
-							(props.size > 80 || props.forceShowExtension) && (
-								<div
-									style={{
-										marginTop: Math.floor(thumbSize.height / 2) - 2,
-										marginLeft: Math.floor(thumbSize.width / 2) - 2
-									}}
-									className="absolute left-1/2 top-1/2 -translate-x-full -translate-y-full rounded bg-black/60 py-0.5 px-1 text-[9px] font-semibold uppercase opacity-70"
-								>
-									{extension}
-								</div>
-							)}
+						{kind === 'Video' && (!size || size > 80) && (
+							<div
+								style={
+									props.cover || thumbSize == null
+										? {}
+										: {
+												marginTop: Math.floor(thumbSize.height / 2) - 2,
+												marginLeft: Math.floor(thumbSize.width / 2) - 2
+										  }
+								}
+								className={clsx(
+									props.cover
+										? 'right-1 bottom-1'
+										: 'left-1/2 top-1/2 -translate-x-full -translate-y-full',
+									'absolute rounded',
+									'bg-black/60 py-0.5 px-1 text-[9px] font-semibold uppercase opacity-70'
+								)}
+							>
+								{extension}
+							</div>
+						)}
 					</>
 				)
 			) : (

--- a/interface/app/$libraryId/Explorer/File/Thumb.tsx
+++ b/interface/app/$libraryId/Explorer/File/Thumb.tsx
@@ -1,6 +1,6 @@
 import * as icons from '@sd/assets/icons';
 import clsx from 'clsx';
-import { useLayoutEffect, useRef, useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
 import { ExplorerItem, isKeyOf, useLibraryContext } from '@sd/client';
 import { useExplorerStore } from '~/hooks/useExplorerStore';
 import { useIsDark, usePlatform } from '~/util/Platform';

--- a/interface/app/$libraryId/Explorer/File/Thumb.tsx
+++ b/interface/app/$libraryId/Explorer/File/Thumb.tsx
@@ -45,10 +45,10 @@ function Thumb({ size, cover, ...props }: ThumbProps) {
 	const isDark = useIsDark();
 	const platform = usePlatform();
 	const thumbImg = useRef<HTMLImageElement>(null);
+	const [thumbSize, setThumbSize] = useState<null | VideoThumbSize>(null);
 	const { library } = useLibraryContext();
+	const [thumbLoaded, setThumbLoaded] = useState<boolean>(false);
 	const { locationId } = useExplorerStore();
-	const [videoThumbSize, setVideoThumbSize] = useState<null | VideoThumbSize>(null);
-	const [videoThumbLoaded, setVideoThumbLoaded] = useState<boolean>(false);
 	const { cas_id, isDir, kind, hasThumbnail, extension } = getExplorerItemData(props.data);
 
 	// Allows disabling thumbnails when they fail to load
@@ -56,16 +56,16 @@ function Thumb({ size, cover, ...props }: ThumbProps) {
 
 	useLayoutEffect(() => {
 		const img = thumbImg.current;
-		if (cover || kind !== 'Video' || !img || !videoThumbLoaded) return;
+		if (cover || kind !== 'Video' || !img || !thumbLoaded) return;
 
 		const resizeObserver = new ResizeObserver(() => {
 			const { width, height } = img;
-			setVideoThumbSize(width && height ? { width, height } : null);
+			setThumbSize(width && height ? { width, height } : null);
 		});
 
 		resizeObserver.observe(img);
 		return () => resizeObserver.disconnect();
-	}, [kind, cover, thumbImg, videoThumbLoaded]);
+	}, [kind, cover, thumbImg, thumbLoaded]);
 
 	// Only Videos and Images can show the original file
 	const loadOriginal = (kind === 'Video' || kind === 'Image') && props.loadOriginal;
@@ -124,12 +124,12 @@ function Thumb({ size, cover, ...props }: ThumbProps) {
 							style={style}
 							onLoad={() => {
 								setUseThumb(true);
-								setVideoThumbLoaded(true);
+								setThumbLoaded(true);
 							}}
 							onError={() => {
 								setUseThumb(false);
-								setVideoThumbSize(null);
-								setVideoThumbLoaded(false);
+								setThumbSize(null);
+								setThumbLoaded(false);
 							}}
 							decoding="async"
 							className={clsx(
@@ -150,11 +150,10 @@ function Thumb({ size, cover, ...props }: ThumbProps) {
 								style={
 									cover
 										? {}
-										: videoThumbSize
+										: thumbSize
 										? {
-												marginTop:
-													Math.floor(videoThumbSize.height / 2) - 2,
-												marginLeft: Math.floor(videoThumbSize.width / 2) - 2
+												marginTop: Math.floor(thumbSize.height / 2) - 2,
+												marginLeft: Math.floor(thumbSize.width / 2) - 2
 										  }
 										: { display: 'none' }
 								}

--- a/interface/app/$libraryId/Explorer/GridView.tsx
+++ b/interface/app/$libraryId/Explorer/GridView.tsx
@@ -33,7 +33,7 @@ const GridViewItem = memo(({ data, selected, index, ...props }: GridViewItemProp
 					height: explorerStore.gridItemSize
 				}}
 				className={clsx(
-					'mb-1 rounded-lg border-2 border-transparent text-center active:translate-y-[1px]',
+					'mb-1 flex items-center justify-center justify-items-center rounded-lg border-2 border-transparent text-center active:translate-y-[1px]',
 					{
 						'bg-app-selected/20': selected
 					}

--- a/interface/app/$libraryId/Explorer/Inspector/index.tsx
+++ b/interface/app/$libraryId/Explorer/Inspector/index.tsx
@@ -79,7 +79,7 @@ export const Inspector = ({ data, context, ...elementProps }: Props) => {
 					{explorerStore.layoutMode !== 'media' && (
 						<div
 							className={clsx(
-								'mb-[10px] flex h-52 w-full items-center justify-center overflow-hidden'
+								'mb-[10px] flex h-[240] w-full items-center justify-center overflow-hidden'
 							)}
 						>
 							<FileThumb loadOriginal size={240} data={data} />

--- a/interface/app/$libraryId/Explorer/MediaView.tsx
+++ b/interface/app/$libraryId/Explorer/MediaView.tsx
@@ -44,11 +44,6 @@ const MediaViewItem = memo(({ data, index }: MediaViewItemProps) => {
 							: '!h-auto max-h-full !w-[90%]'
 					)}
 					forceShowExtension
-					extensionClassName={clsx(
-						explorerStore.mediaAspectSquare
-							? '!bottom-2 !right-2'
-							: '!bottom-[8%] !right-[8%]'
-					)}
 				/>
 
 				<Button

--- a/interface/app/$libraryId/Explorer/MediaView.tsx
+++ b/interface/app/$libraryId/Explorer/MediaView.tsx
@@ -34,17 +34,7 @@ const MediaViewItem = memo(({ data, index }: MediaViewItemProps) => {
 					selected && 'bg-app-selected/20'
 				)}
 			>
-				<Thumb
-					data={data}
-					size={0}
-					className={clsx(
-						'!max-w-none !rounded-none !border-0',
-						explorerStore.mediaAspectSquare
-							? '!h-full !w-full'
-							: '!h-auto max-h-full !w-[90%]'
-					)}
-					forceShowExtension
-				/>
+				<Thumb data={data} size={0} cover={explorerStore.mediaAspectSquare} className="!rounded-none" />
 
 				<Button
 					variant="gray"

--- a/interface/app/$libraryId/Explorer/MediaView.tsx
+++ b/interface/app/$libraryId/Explorer/MediaView.tsx
@@ -34,7 +34,12 @@ const MediaViewItem = memo(({ data, index }: MediaViewItemProps) => {
 					selected && 'bg-app-selected/20'
 				)}
 			>
-				<Thumb data={data} size={0} cover={explorerStore.mediaAspectSquare} className="!rounded-none" />
+				<Thumb
+					size={0}
+					data={data}
+					cover={explorerStore.mediaAspectSquare}
+					className="!rounded-none"
+				/>
 
 				<Button
 					variant="gray"

--- a/interface/app/$libraryId/Explorer/QuickPreview.tsx
+++ b/interface/app/$libraryId/Explorer/QuickPreview.tsx
@@ -53,7 +53,7 @@ const pdfViewerEnabled = () => {
 
 function FilePreview({ explorerItem, kind, src, onError }: FilePreviewProps) {
 	const className = clsx('relative inset-y-2/4 max-h-full max-w-full translate-y-[-50%]');
-	const fileThumb = <FileThumb size={0} data={explorerItem} cover={true} className={className} />;
+	const fileThumb = <FileThumb size={0} data={explorerItem} cover className={className} />;
 	switch (kind) {
 		case 'PDF':
 			return <object data={src} type="application/pdf" className="h-full w-full border-0" />;

--- a/interface/app/$libraryId/Explorer/QuickPreview.tsx
+++ b/interface/app/$libraryId/Explorer/QuickPreview.tsx
@@ -53,7 +53,7 @@ const pdfViewerEnabled = () => {
 
 function FilePreview({ explorerItem, kind, src, onError }: FilePreviewProps) {
 	const className = clsx('relative inset-y-2/4 max-h-full max-w-full translate-y-[-50%]');
-	const fileThumb = <FileThumb size={1} data={explorerItem} className={className} />;
+	const fileThumb = <FileThumb size={0} data={explorerItem} cover={true} className={className} />;
 	switch (kind) {
 		case 'PDF':
 			return <object data={src} type="application/pdf" className="h-full w-full border-0" />;

--- a/interface/app/$libraryId/Explorer/util.ts
+++ b/interface/app/$libraryId/Explorer/util.ts
@@ -1,4 +1,4 @@
-import { ExplorerItem, ObjectKind, ObjectKinds, isObject, isPath } from '@sd/client';
+import { ExplorerItem, ObjectKind, ObjectKindKey, isObject, isPath } from '@sd/client';
 
 export function getExplorerItemData(data: ExplorerItem) {
 	const objectData = getItemObject(data);
@@ -7,7 +7,7 @@ export function getExplorerItemData(data: ExplorerItem) {
 	return {
 		cas_id: filePath?.cas_id || null,
 		isDir: isPath(data) && data.item.is_dir,
-		kind: (ObjectKind[objectData?.kind ?? 0] as ObjectKinds) || null,
+		kind: (ObjectKind[objectData?.kind ?? 0] as ObjectKindKey) || null,
 		hasThumbnail: data.has_thumbnail,
 		extension: filePath?.extension || null
 	};

--- a/interface/app/$libraryId/Explorer/util.ts
+++ b/interface/app/$libraryId/Explorer/util.ts
@@ -1,4 +1,4 @@
-import { ExplorerItem, ObjectKind, isObject, isPath } from '@sd/client';
+import { ExplorerItem, ObjectKind, ObjectKinds, isObject, isPath } from '@sd/client';
 
 export function getExplorerItemData(data: ExplorerItem) {
 	const objectData = getItemObject(data);
@@ -7,7 +7,7 @@ export function getExplorerItemData(data: ExplorerItem) {
 	return {
 		cas_id: filePath?.cas_id || null,
 		isDir: isPath(data) && data.item.is_dir,
-		kind: ObjectKind[objectData?.kind || 0] || null,
+		kind: (ObjectKind[objectData?.kind ?? 0] as ObjectKinds) || null,
 		hasThumbnail: data.has_thumbnail,
 		extension: filePath?.extension || null
 	};

--- a/interface/app/$libraryId/settings/library/locations/IndexerRuleEditor.tsx
+++ b/interface/app/$libraryId/settings/library/locations/IndexerRuleEditor.tsx
@@ -445,7 +445,7 @@ export function IndexerRuleEditor<T extends IndexerRuleIdFieldType>({
 											<Tabs.Root
 												value={currentTab}
 												onValueChange={(tab) =>
-													isKeyOf(tab, RuleTabsInput) &&
+													isKeyOf(RuleTabsInput, tab) &&
 													setCurrentTab(tab)
 												}
 											>

--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -19,3 +19,7 @@ export function arraysEqual<T>(a: T[], b: T[]) {
 
 	return a.every((n, i) => b[i] === n);
 }
+
+export function isKeyOf<T extends object>(obj: T, key: PropertyKey): key is keyof T {
+	return key in obj;
+}

--- a/packages/client/src/utils/objectKind.ts
+++ b/packages/client/src/utils/objectKind.ts
@@ -25,4 +25,4 @@ export enum ObjectKind {
 	Database
 }
 
-export type ObjectKinds = keyof typeof ObjectKind;
+export type ObjectKindKey = keyof typeof ObjectKind;

--- a/packages/client/src/utils/objectKind.ts
+++ b/packages/client/src/utils/objectKind.ts
@@ -1,26 +1,28 @@
 // An array of Object kinds.
 // Note: The order of this enum should never change, and always be kept in sync with `crates/file_ext/src/kind.rs`
-export const ObjectKind = [
-	'Unknown',
-	'Document',
-	'Folder',
-	'Text',
-	'Package',
-	'Image',
-	'Audio',
-	'Video',
-	'Archive',
-	'Executable',
-	'Alias',
-	'Encrypted',
-	'Key',
-	'Link',
-	'WebPageArchive',
-	'Widget',
-	'Album',
-	'Collection',
-	'Font',
-	'Mesh',
-	'Code',
-	'Database'
-];
+export enum ObjectKind {
+	Unknown,
+	Document,
+	Folder,
+	Text,
+	Package,
+	Image,
+	Audio,
+	Video,
+	Archive,
+	Executable,
+	Alias,
+	Encrypted,
+	Key,
+	Link,
+	WebPageArchive,
+	Widget,
+	Album,
+	Collection,
+	Font,
+	Mesh,
+	Code,
+	Database
+}
+
+export type ObjectKinds = keyof typeof ObjectKind;


### PR DESCRIPTION
This PR is a rework of the `FileThumb` component, with multiple bug fixes:

 - Fixed tall and long images being displayed with incorrect dimensions (zoomed)
 - Fixed application crashes when selecting any non-image file while the inspector was open (at least on Linux)
 - Implemented video rendering when requiring a `FileThumb` with `loadOriginal`
 - Fixed the inspector's container cropping the `FileThumb` when selecting tall images
 - Correctly implemented `size=0` and allowed for `size=null` in `FileThumb`
 - Fixed the video extension pill's incorrect position with portrait video (now it will be correctly positioned regardless of the video's aspect ratio)
 - Internalized the `mediaAspectSquare` style introduced by `MediaView` (can be enabled with `cover=true`)
 - Changed `ObjectKind` to an enum for improved type checking.