### PR TITLE
[ENG-492] Onboarding "set password" feels kinda clunky

### DIFF
--- a/interface/app/onboarding/new-library.tsx
+++ b/interface/app/onboarding/new-library.tsx
@@ -74,10 +74,10 @@ export default function OnboardingNewLibrary() {
 							<Button type="submit" variant="accent" size="sm">
 								New library
 							</Button>
-							<span className="px-2 text-xs font-bold text-ink-faint">OR</span>
+							{/* <span className="px-2 text-xs font-bold text-ink-faint">OR</span>
 							<Button onClick={() => setImportMode(true)} variant="outline" size="sm">
 								Import library
-							</Button>
+							</Button> */}
 						</div>
 					</>
 				)}

--- a/interface/components/PasswordMeter.tsx
+++ b/interface/components/PasswordMeter.tsx
@@ -30,7 +30,7 @@ export const PasswordMeter = (props: PasswordMeterProps) => {
 							width: `${score !== 0 ? score * 25 : 12.5}%`
 						}}
 						className={clsx(
-							'h-2 rounded-full',
+							'h-2 rounded-full transition-all',
 							score === 0 && 'bg-red-500',
 							score === 1 && 'bg-red-500',
 							score === 2 && 'bg-amber-400',

--- a/interface/index.tsx
+++ b/interface/index.tsx
@@ -37,6 +37,7 @@ const Devtools = () => {
 			position="bottom-right"
 			context={defaultContext}
 			toggleButtonProps={{
+				tabIndex: -1,
 				className: debugState.reactQueryDevtools === 'invisible' ? 'opacity-0' : ''
 			}}
 		/>

--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -1,4 +1,5 @@
 import { VariantProps, cva, cx } from 'class-variance-authority';
+import clsx from 'clsx';
 import { forwardRef } from 'react';
 import { Link, LinkProps } from 'react-router-dom';
 
@@ -54,7 +55,7 @@ const styles = cva(
 					'border-app-line hover:border-app-line active:border-app-active'
 				],
 				accent: [
-					'border-accent-deep bg-accent text-white shadow-md shadow-app-shade/10 hover:border-accent hover:bg-accent-faint active:border-accent-deep active:bg-accent'
+					'border-accent-deep bg-accent text-white shadow-md shadow-app-shade/10 hover:border-accent hover:bg-accent-faint focus:outline-none focus:ring focus:ring-accent active:border-accent-deep active:bg-accent'
 				],
 				colored: ['text-white shadow-sm hover:bg-opacity-90 active:bg-opacity-100'],
 				bare: ''

--- a/packages/ui/src/Input.tsx
+++ b/packages/ui/src/Input.tsx
@@ -139,6 +139,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>((p
 			ref={ref}
 			right={
 				<Button
+					tabIndex={0}
 					onClick={() => setShowPassword(!showPassword)}
 					size="icon"
 					className={clsx(props.buttonClassnames)}

--- a/packages/ui/src/forms/FormField.tsx
+++ b/packages/ui/src/forms/FormField.tsx
@@ -34,7 +34,7 @@ export const FormField = (props: FormFieldProps) => {
 				</label>
 			)}
 			{props.children}
-			{props.error && <span className="mt-1 text-xs text-red-500">{props.error}</span>}
+			{props.error && <span className="mt-1 w-full text-xs text-red-500">{props.error}</span>}
 		</div>
 	);
 };


### PR DESCRIPTION
Minor improvements to some onboarding screens

 - Add transitions to the password form
 - Fix tab order in the Password form
 - Remove unimplemented `import Library` button
 - Some minor style changes to button focus and form validation error messages