### PR TITLE
[ENG-516] Prevent copies/cuts to the same source/dest

### DIFF
--- a/core/src/api/mod.rs
+++ b/core/src/api/mod.rs
@@ -1,7 +1,6 @@
 use chrono::{DateTime, Utc};
 use prisma_client_rust::{operator::or, Direction};
 use rspc::{Config, Type};
-use sd_file_ext::kind::ObjectKind;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -84,7 +83,7 @@ pub(crate) fn mount() -> Arc<Router> {
 			})
 		})
 		.library_query("search", |t| {
-			#[derive(Deserialize, Type, Debug)]
+			#[derive(Deserialize, Type, Debug, Clone, Copy)]
 			#[serde(rename_all = "camelCase")]
 			#[specta(inline)]
 			enum Ordering {
@@ -145,7 +144,7 @@ pub(crate) fn mount() -> Arc<Router> {
 					.search
 					.map(|search| {
 						search
-							.split(" ")
+							.split(' ')
 							.map(str::to_string)
 							.map(file_path::materialized_path::contains)
 							.map(Some)
@@ -158,7 +157,7 @@ pub(crate) fn mount() -> Arc<Router> {
 						args.kind
 							.map(|kind| file_path::object::is(vec![object::kind::equals(kind)])),
 						args.extension.map(file_path::extension::equals),
-						(args.tags.len() > 0).then(|| {
+						(!args.tags.is_empty()).then(|| {
 							file_path::object::is(vec![object::tags::some(vec![
 								tag_on_object::tag::is(vec![or(args
 									.tags

--- a/core/src/job/mod.rs
+++ b/core/src/job/mod.rs
@@ -63,8 +63,10 @@ pub enum JobError {
 	IdentifierError(#[from] FileIdentifierJobError),
 	#[error("Crypto error: {0}")]
 	CryptoError(#[from] CryptoError),
-	#[error("source and destination path are the same")]
+	#[error("source and destination path are the same: {0}")]
 	MatchingSrcDest(String),
+	#[error("action would overwrite another file: {0}")]
+	WouldOverwrite(String),
 
 	// Not errors
 	#[error("Job had a early finish: <name='{name}', reason='{reason}'>")]

--- a/core/src/job/mod.rs
+++ b/core/src/job/mod.rs
@@ -63,6 +63,8 @@ pub enum JobError {
 	IdentifierError(#[from] FileIdentifierJobError),
 	#[error("Crypto error: {0}")]
 	CryptoError(#[from] CryptoError),
+	#[error("source and destination path are the same")]
+	MatchingSrcDest(String),
 
 	// Not errors
 	#[error("Job had a early finish: <name='{name}', reason='{reason}'>")]

--- a/core/src/job/mod.rs
+++ b/core/src/job/mod.rs
@@ -8,6 +8,7 @@ use std::{
 	collections::{hash_map::DefaultHasher, VecDeque},
 	fmt::Debug,
 	hash::{Hash, Hasher},
+	path::PathBuf,
 	sync::Arc,
 };
 
@@ -63,10 +64,10 @@ pub enum JobError {
 	IdentifierError(#[from] FileIdentifierJobError),
 	#[error("Crypto error: {0}")]
 	CryptoError(#[from] CryptoError),
-	#[error("source and destination path are the same: {0}")]
-	MatchingSrcDest(String),
-	#[error("action would overwrite another file: {0}")]
-	WouldOverwrite(String),
+	#[error("source and destination path are the same: {}", .0.display())]
+	MatchingSrcDest(PathBuf),
+	#[error("action would overwrite another file: {}", .0.display())]
+	WouldOverwrite(PathBuf),
 
 	// Not errors
 	#[error("Job had a early finish: <name='{name}', reason='{reason}'>")]

--- a/core/src/object/fs/copy.rs
+++ b/core/src/object/fs/copy.rs
@@ -138,7 +138,14 @@ impl StatefulJob for FileCopierJob {
 					);
 				}
 
-				if path.canonicalize()? == target_path.canonicalize()? {
+				if path
+					.parent()
+					.map_or(Err(JobError::Path), Ok)?
+					.canonicalize()? == target_path
+					.parent()
+					.map_or(Err(JobError::Path), Ok)?
+					.canonicalize()?
+				{
 					return Err(JobError::MatchingSrcDest(
 						path.to_str().map_or(String::new(), str::to_string),
 					));

--- a/core/src/object/fs/copy.rs
+++ b/core/src/object/fs/copy.rs
@@ -138,6 +138,12 @@ impl StatefulJob for FileCopierJob {
 					);
 				}
 
+				if path.canonicalize()? == target_path.canonicalize()? {
+					return Err(JobError::MatchingSrcDest(
+						path.to_str().map_or(String::new(), str::to_string),
+					));
+				}
+
 				trace!("Copying from {:?} to {:?}", path, target_path);
 
 				tokio::fs::copy(&path, &target_path).await?;

--- a/core/src/object/fs/cut.rs
+++ b/core/src/object/fs/cut.rs
@@ -9,7 +9,7 @@ use std::{hash::Hash, path::PathBuf};
 
 use serde::{Deserialize, Serialize};
 use specta::Type;
-use tracing::trace;
+use tracing::{log::trace, warn};
 
 use super::{context_menu_fs_info, get_path_from_location_id, FsInfo};
 
@@ -97,6 +97,17 @@ impl StatefulJob for FileCutterJob {
 			return Err(JobError::MatchingSrcDest(
 				source_info
 					.fs_path
+					.to_str()
+					.map_or(String::new(), str::to_string),
+			));
+		}
+
+		if full_output.exists() {
+			warn!("Skipping {:?} as it would be overwritten", &full_output);
+
+			return Err(JobError::WouldOverwrite(
+				full_output
+					.clone()
 					.to_str()
 					.map_or(String::new(), str::to_string),
 			));

--- a/core/src/object/fs/cut.rs
+++ b/core/src/object/fs/cut.rs
@@ -84,7 +84,16 @@ impl StatefulJob for FileCutterJob {
 			.target_directory
 			.join(source_info.fs_path.file_name().ok_or(JobError::OsStr)?);
 
-		if source_info.fs_path.canonicalize()? == full_output.canonicalize()? {
+		if source_info
+			.fs_path
+			.parent()
+			.map_or(Err(JobError::Path), Ok)?
+			.canonicalize()?
+			== full_output
+				.parent()
+				.map_or(Err(JobError::Path), Ok)?
+				.canonicalize()?
+		{
 			return Err(JobError::MatchingSrcDest(
 				source_info
 					.fs_path

--- a/core/src/object/fs/cut.rs
+++ b/core/src/object/fs/cut.rs
@@ -9,7 +9,8 @@ use std::{hash::Hash, path::PathBuf};
 
 use serde::{Deserialize, Serialize};
 use specta::Type;
-use tracing::{log::trace, warn};
+use tokio::fs;
+use tracing::{trace, warn};
 
 use super::{context_menu_fs_info, get_path_from_location_id, FsInfo};
 
@@ -84,38 +85,34 @@ impl StatefulJob for FileCutterJob {
 			.target_directory
 			.join(source_info.fs_path.file_name().ok_or(JobError::OsStr)?);
 
-		if source_info
-			.fs_path
-			.parent()
-			.map_or(Err(JobError::Path), Ok)?
-			.canonicalize()?
-			== full_output
+		if fs::canonicalize(
+			source_info
+				.fs_path
 				.parent()
-				.map_or(Err(JobError::Path), Ok)?
-				.canonicalize()?
+				.map_or(Err(JobError::Path), Ok)?,
+		)
+		.await? == fs::canonicalize(full_output.parent().map_or(Err(JobError::Path), Ok)?)
+			.await?
 		{
-			return Err(JobError::MatchingSrcDest(
-				source_info
-					.fs_path
-					.to_str()
-					.map_or(String::new(), str::to_string),
-			));
+			return Err(JobError::MatchingSrcDest(source_info.fs_path.clone()));
 		}
 
-		if full_output.exists() {
-			warn!("Skipping {:?} as it would be overwritten", &full_output);
+		if fs::metadata(&full_output).await.is_ok() {
+			warn!(
+				"Skipping {} as it would be overwritten",
+				full_output.display()
+			);
 
-			return Err(JobError::WouldOverwrite(
-				full_output
-					.clone()
-					.to_str()
-					.map_or(String::new(), str::to_string),
-			));
+			return Err(JobError::WouldOverwrite(full_output));
 		}
 
-		trace!("Cutting {:?} to {:?}", source_info.fs_path, full_output);
+		trace!(
+			"Cutting {} to {}",
+			source_info.fs_path.display(),
+			full_output.display()
+		);
 
-		tokio::fs::rename(&source_info.fs_path, &full_output).await?;
+		fs::rename(&source_info.fs_path, &full_output).await?;
 
 		ctx.progress(vec![JobReportUpdate::CompletedTaskCount(
 			state.step_number + 1,

--- a/core/src/object/fs/cut.rs
+++ b/core/src/object/fs/cut.rs
@@ -84,6 +84,15 @@ impl StatefulJob for FileCutterJob {
 			.target_directory
 			.join(source_info.fs_path.file_name().ok_or(JobError::OsStr)?);
 
+		if source_info.fs_path.canonicalize()? == full_output.canonicalize()? {
+			return Err(JobError::MatchingSrcDest(
+				source_info
+					.fs_path
+					.to_str()
+					.map_or(String::new(), str::to_string),
+			));
+		}
+
 		trace!("Cutting {:?} to {:?}", source_info.fs_path, full_output);
 
 		tokio::fs::rename(&source_info.fs_path, &full_output).await?;

--- a/crates/file-ext/src/kind.rs
+++ b/crates/file-ext/src/kind.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use specta::Type;
 
 #[repr(i32)]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq)]

--- a/interface/app/$libraryId/Explorer/ContextMenu.tsx
+++ b/interface/app/$libraryId/Explorer/ContextMenu.tsx
@@ -46,6 +46,13 @@ export default (props: PropsWithChildren) => {
 	const copyFiles = useLibraryMutation('files.copyFiles');
 	const cutFiles = useLibraryMutation('files.cutFiles');
 
+	const isPastable =
+		store.cutCopyState.sourceLocationId !== store.locationId
+			? true
+			: store.cutCopyState.sourcePath !== params.path
+			? true
+			: false;
+
 	return (
 		<CM.Root trigger={props.children}>
 			<OpenInNativeExplorer />
@@ -74,7 +81,7 @@ export default (props: PropsWithChildren) => {
 				icon={Repeat}
 			/>
 
-			{store.cutCopyState.sourcePath !== params.path && (
+			{isPastable && (
 				<CM.Item
 					label="Paste"
 					keybind="⌘V"

--- a/interface/app/$libraryId/Explorer/ContextMenu.tsx
+++ b/interface/app/$libraryId/Explorer/ContextMenu.tsx
@@ -74,32 +74,34 @@ export default (props: PropsWithChildren) => {
 				icon={Repeat}
 			/>
 
-			<CM.Item
-				label="Paste"
-				keybind="⌘V"
-				hidden={!store.cutCopyState.active}
-				onClick={() => {
-					if (store.cutCopyState.actionType == 'Copy') {
-						store.locationId &&
-							copyFiles.mutate({
-								source_location_id: store.cutCopyState.sourceLocationId,
-								source_path_id: store.cutCopyState.sourcePathId,
-								target_location_id: store.locationId,
-								target_path: params.path,
-								target_file_name_suffix: null
-							});
-					} else {
-						store.locationId &&
-							cutFiles.mutate({
-								source_location_id: store.cutCopyState.sourceLocationId,
-								source_path_id: store.cutCopyState.sourcePathId,
-								target_location_id: store.locationId,
-								target_path: params.path
-							});
-					}
-				}}
-				icon={Clipboard}
-			/>
+			{store.cutCopyState.sourcePath !== params.path && (
+				<CM.Item
+					label="Paste"
+					keybind="⌘V"
+					hidden={!store.cutCopyState.active}
+					onClick={() => {
+						if (store.cutCopyState.actionType == 'Copy') {
+							store.locationId &&
+								copyFiles.mutate({
+									source_location_id: store.cutCopyState.sourceLocationId,
+									source_path_id: store.cutCopyState.sourcePathId,
+									target_location_id: store.locationId,
+									target_path: params.path,
+									target_file_name_suffix: null
+								});
+						} else {
+							store.locationId &&
+								cutFiles.mutate({
+									source_location_id: store.cutCopyState.sourceLocationId,
+									source_path_id: store.cutCopyState.sourcePathId,
+									target_location_id: store.locationId,
+									target_path: params.path
+								});
+						}
+					}}
+					icon={Clipboard}
+				/>
+			)}
 
 			<CM.Item
 				label="Deselect"

--- a/interface/app/$libraryId/Explorer/File/ContextMenu.tsx
+++ b/interface/app/$libraryId/Explorer/File/ContextMenu.tsx
@@ -80,6 +80,7 @@ export default ({ data, className, ...props }: Props) => {
 					keybind="⌘X"
 					onClick={() => {
 						getExplorerStore().cutCopyState = {
+							sourcePath: params.path,
 							sourceLocationId: store.locationId!,
 							sourcePathId: data.item.id,
 							actionType: 'Cut',
@@ -94,6 +95,7 @@ export default ({ data, className, ...props }: Props) => {
 					keybind="⌘C"
 					onClick={() => {
 						getExplorerStore().cutCopyState = {
+							sourcePath: params.path,
 							sourceLocationId: store.locationId!,
 							sourcePathId: data.item.id,
 							actionType: 'Copy',

--- a/interface/hooks/useExplorerStore.tsx
+++ b/interface/hooks/useExplorerStore.tsx
@@ -26,6 +26,7 @@ const state = {
 	contextMenuActiveObject: null as object | null,
 	newThumbnails: {} as Record<string, boolean>,
 	cutCopyState: {
+		sourcePath: '', // this is used solely for preventing copy/cutting to the same path (as that will truncate the file)
 		sourceLocationId: 0,
 		sourcePathId: 0,
 		actionType: 'Cut',


### PR DESCRIPTION
This prevents some gnarly file truncation issues when files are copied and moved to the same source and destination.

The paste button is hidden in the UI entirely, and then rest validates that the paths do not canonicalize to the same path on the filesystem.

If a file will be overwritten by a copy action, the file will be skipped. During cuts, an error will be returned if the destination file/directory will be overwritten (in any capacity).