### PR TITLE
rspc 0.1.3 prep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2387,9 +2387,11 @@ dependencies = [
 [[package]]
 name = "futures-locks"
 version = "0.7.1"
-source = "git+https://github.com/oscartbeaumont/futures-locks?rev=a2e880337e6bfb3140a261932667149607e3ada9#a2e880337e6bfb3140a261932667149607e3ada9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45ec6fe3675af967e67c5536c0b9d44e34e6c52f86bedc4ea49c5317b8e94d06"
 dependencies = [
  "futures-channel",
+ "futures-task",
  "tokio",
 ]
 
@@ -6409,7 +6411,7 @@ dependencies = [
 [[package]]
 name = "rspc"
 version = "0.1.4"
-source = "git+https://github.com/oscartbeaumont/rspc?rev=d9a39c8cb08d4c805035e9aa609e107c736c62d2#d9a39c8cb08d4c805035e9aa609e107c736c62d2"
+source = "git+https://github.com/oscartbeaumont/rspc?rev=9cb64def32aef5a987f9f06f727b4160c321b5f8#9cb64def32aef5a987f9f06f727b4160c321b5f8"
 dependencies = [
  "futures",
  "futures-channel",
@@ -6816,6 +6818,8 @@ name = "sd-mobile-core"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "futures-channel",
+ "futures-locks",
  "once_cell",
  "openssl",
  "openssl-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,7 +259,7 @@ checksum = "db8b7511298d5b7784b40b092d9e9dcd3a627a5707e4b5e507931ab0d44eeebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "synstructure",
 ]
 
@@ -271,7 +271,7 @@ checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "synstructure",
 ]
 
@@ -283,7 +283,7 @@ checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -330,7 +330,7 @@ checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -341,7 +341,7 @@ checksum = "eff18d764974428cf3a9328e23fc5c986f5fbed46e6cd4cdf42544df5d297ec1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -600,7 +600,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -727,7 +727,7 @@ dependencies = [
 [[package]]
 name = "builtin-psl-connectors"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "connection-string",
  "either",
@@ -1057,7 +1057,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1424,7 +1424,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "smallvec",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1434,7 +1434,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfae75de57f2b2e85e8768c3ea840fd159c8f33e2b6522c7835b7abac81be16e"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1444,7 +1444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdffe87e1d521a10f9696f833fe502293ea446d7f256c06128293a4119bdf4cb"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1543,7 +1543,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1560,7 +1560,7 @@ checksum = "747b608fecf06b0d72d440f27acc99288207324b793be2c17991839f3d4995ea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1594,7 +1594,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1608,7 +1608,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1619,7 +1619,7 @@ checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core 0.13.4",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1630,7 +1630,7 @@ checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
  "darling_core 0.14.2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1670,13 +1670,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5bbed42daaa95e780b60a50546aa345b8413a1e46f9a40a12907d3598f038db"
 dependencies = [
  "data-encoding",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "datamodel-renderer"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "base64 0.13.1",
  "once_cell",
@@ -1754,7 +1754,7 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1775,7 +1775,7 @@ dependencies = [
  "darling 0.14.2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1785,7 +1785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
 dependencies = [
  "derive_builder_core",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1798,13 +1798,13 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.0",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "diagnostics"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "colored",
  "indoc",
@@ -1886,13 +1886,13 @@ checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "dml"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "chrono",
  "cuid",
@@ -1910,7 +1910,7 @@ dependencies = [
 [[package]]
 name = "dmmf"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "bigdecimal",
  "indexmap",
@@ -1930,6 +1930,12 @@ checksum = "e493c573fce17f00dcab13b6ac057994f3ce17d1af4dc39bfd482b83c6eb6157"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "dtoa"
@@ -2051,7 +2057,7 @@ dependencies = [
  "heck 0.4.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2081,7 +2087,7 @@ checksum = "946ee94e3dbf58fdd324f9ce245c7b238d46a66f00e86a020b71996349e46cce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2092,7 +2098,7 @@ checksum = "f58dc3c5e468259f19f2d46304a6b28f1c3d034442e14b322d2b850e36f6d5ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2316,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2331,9 +2337,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2341,15 +2347,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2359,9 +2365,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-lite"
@@ -2379,14 +2385,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-locks"
+version = "0.7.1"
+source = "git+https://github.com/oscartbeaumont/futures-locks?rev=a2e880337e6bfb3140a261932667149607e3ada9#a2e880337e6bfb3140a261932667149607e3ada9"
+dependencies = [
+ "futures-channel",
+ "tokio",
+]
+
+[[package]]
 name = "futures-macro"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -2402,15 +2417,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-timer"
@@ -2420,9 +2435,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2662,7 +2677,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2779,7 +2794,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2967,7 +2982,7 @@ dependencies = [
  "markup5ever",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3019,7 +3034,24 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 [[package]]
 name = "httpz"
 version = "0.0.3"
-source = "git+https://github.com/oscartbeaumont/httpz.git?rev=a5020adecb15b55d84a8330b4680eba82fa6b820#a5020adecb15b55d84a8330b4680eba82fa6b820"
+source = "git+https://github.com/oscartbeaumont/httpz?rev=a5185f2ed2fdefeb2f582dce38a692a1bf76d1d6#a5185f2ed2fdefeb2f582dce38a692a1bf76d1d6"
+dependencies = [
+ "axum",
+ "form_urlencoded",
+ "futures",
+ "http",
+ "hyper",
+ "percent-encoding",
+ "tauri",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "httpz"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6769d2cb10425c442c41a787d1a3719744770a188cfa7885cd4d8126fa13f37a"
 dependencies = [
  "async-tungstenite",
  "axum",
@@ -3030,22 +3062,6 @@ dependencies = [
  "http",
  "hyper",
  "sha1",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "httpz"
-version = "0.0.3"
-source = "git+https://github.com/oscartbeaumont/httpz?rev=a5185f2ed2fdefeb2f582dce38a692a1bf76d1d6#a5185f2ed2fdefeb2f582dce38a692a1bf76d1d6"
-dependencies = [
- "axum",
- "form_urlencoded",
- "futures",
- "http",
- "hyper",
- "percent-encoding",
- "tauri",
  "thiserror",
  "tokio",
 ]
@@ -3315,7 +3331,7 @@ dependencies = [
 [[package]]
 name = "introspection-connector"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3502,7 @@ dependencies = [
 [[package]]
 name = "json-rpc-api-build"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "backtrace",
  "heck 0.3.3",
@@ -3561,9 +3577,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.135"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "libdbus-sys"
@@ -4025,6 +4041,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf0c9b980bf4f3a37fd7b1c066941dd1b1d0152ce6ee6e8fe8c49b9f6810d862"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58093314a45e00c77d5c508f76e77c3396afbbc0d01506e7fae47b018bac2b1d"
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4156,7 +4188,7 @@ checksum = "49e30813093f757be5cf21e50389a24dc7dbb22c49f23b7e8f51d69b508a5ffa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -4200,7 +4232,7 @@ dependencies = [
 [[package]]
 name = "migration-connector"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "chrono",
  "enumflags2 0.7.5",
@@ -4215,7 +4247,7 @@ dependencies = [
 [[package]]
 name = "migration-core"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4370,7 +4402,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "synstructure",
 ]
 
@@ -4631,6 +4663,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "nougat"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97b57b9ced431322f054fc673f1d3c7fa52d80efd9df74ad2fc759f044742510"
+dependencies = [
+ "macro_rules_attribute",
+ "nougat-proc_macros",
+]
+
+[[package]]
+name = "nougat-proc_macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c84f77a45e99a2f9b492695d99e1c23844619caa5f3e57647cffacad773ca257"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4753,7 +4806,7 @@ dependencies = [
  "proc-macro-crate 1.2.1",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -4876,7 +4929,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -5089,7 +5142,7 @@ dependencies = [
 [[package]]
 name = "parser-database"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "diagnostics",
  "either",
@@ -5181,7 +5234,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -5278,7 +5331,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -5292,7 +5345,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -5330,7 +5383,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -5472,7 +5525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebcd279d20a4a0a2404a33056388e950504d891c855c7975b9a8fef75f3bf04"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -5485,21 +5538,22 @@ dependencies = [
 
 [[package]]
 name = "prisma-client-rust"
-version = "0.6.4"
-source = "git+https://github.com/Brendonovich/prisma-client-rust?branch=spacedrive#c965b89f1a07a6931d90f4b5556421f7ffcda03b"
+version = "0.6.8"
+source = "git+https://github.com/Brendonovich/prisma-client-rust?tag=0.6.8#51f0473b642b16bb78fe0f5f3235aeb56f89300d"
 dependencies = [
  "base64 0.13.1",
  "bigdecimal",
  "chrono",
- "convert_case 0.6.0",
  "diagnostics",
  "dml",
  "dmmf",
+ "dotenv",
  "futures",
  "include_dir",
  "indexmap",
  "migration-core",
  "paste",
+ "prisma-client-rust-macros",
  "prisma-models",
  "psl",
  "query-connector",
@@ -5509,6 +5563,7 @@ dependencies = [
  "serde",
  "serde-value",
  "serde_json",
+ "specta",
  "tempdir",
  "thiserror",
  "tokio",
@@ -5519,8 +5574,8 @@ dependencies = [
 
 [[package]]
 name = "prisma-client-rust-cli"
-version = "0.6.4"
-source = "git+https://github.com/Brendonovich/prisma-client-rust?branch=spacedrive#c965b89f1a07a6931d90f4b5556421f7ffcda03b"
+version = "0.6.8"
+source = "git+https://github.com/Brendonovich/prisma-client-rust?tag=0.6.8#51f0473b642b16bb78fe0f5f3235aeb56f89300d"
 dependencies = [
  "directories",
  "flate2",
@@ -5533,14 +5588,26 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "syn",
+ "syn 1.0.107",
  "thiserror",
 ]
 
 [[package]]
+name = "prisma-client-rust-macros"
+version = "0.6.8"
+source = "git+https://github.com/Brendonovich/prisma-client-rust?tag=0.6.8#51f0473b642b16bb78fe0f5f3235aeb56f89300d"
+dependencies = [
+ "convert_case 0.6.0",
+ "proc-macro2",
+ "quote",
+ "specta",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "prisma-client-rust-sdk"
-version = "0.6.4"
-source = "git+https://github.com/Brendonovich/prisma-client-rust?branch=spacedrive#c965b89f1a07a6931d90f4b5556421f7ffcda03b"
+version = "0.6.8"
+source = "git+https://github.com/Brendonovich/prisma-client-rust?tag=0.6.8#51f0473b642b16bb78fe0f5f3235aeb56f89300d"
 dependencies = [
  "convert_case 0.5.0",
  "dml",
@@ -5554,14 +5621,14 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "syn",
+ "syn 1.0.107",
  "thiserror",
 ]
 
 [[package]]
 name = "prisma-models"
 version = "0.0.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -5577,7 +5644,7 @@ dependencies = [
 [[package]]
 name = "prisma-value"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "base64 0.12.3",
  "bigdecimal",
@@ -5618,7 +5685,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "version_check",
 ]
 
@@ -5641,9 +5708,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -5668,7 +5735,7 @@ checksum = "72b6a5217beb0ad503ee7fa752d451c905113d70721b937126158f3106a48cc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -5698,7 +5765,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 1.0.107",
  "tempfile",
  "which",
 ]
@@ -5726,7 +5793,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -5741,7 +5808,7 @@ dependencies = [
 [[package]]
 name = "psl"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "builtin-psl-connectors",
  "dml",
@@ -5751,7 +5818,7 @@ dependencies = [
 [[package]]
 name = "psl-core"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -5784,7 +5851,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint?rev=6df49f14efe99696e577ffb9902c83b09bec8de2#6df49f14efe99696e577ffb9902c83b09bec8de2"
+source = "git+https://github.com/Brendonovich/quaint?tag=0.6.5#2bf0c3620f76d83982c17e567b71da6fc9d65d14"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -5828,7 +5895,7 @@ dependencies = [
 [[package]]
 name = "query-connector"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5848,7 +5915,7 @@ dependencies = [
 [[package]]
 name = "query-core"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -5892,7 +5959,7 @@ dependencies = [
 [[package]]
 name = "query-engine-metrics"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "metrics 0.18.1",
  "metrics-exporter-prometheus",
@@ -5941,9 +6008,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -6201,7 +6268,7 @@ dependencies = [
 [[package]]
 name = "request-handlers"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "bigdecimal",
  "connection-string",
@@ -6341,12 +6408,15 @@ dependencies = [
 
 [[package]]
 name = "rspc"
-version = "0.1.2"
-source = "git+https://github.com/oscartbeaumont/rspc?rev=c03872c0ba29d2429e9c059dfb235cdd03e15e8c#c03872c0ba29d2429e9c059dfb235cdd03e15e8c"
+version = "0.1.4"
+source = "git+https://github.com/oscartbeaumont/rspc?rev=56e98472af11171d142498ff31fc29d4ff6bbc94#56e98472af11171d142498ff31fc29d4ff6bbc94"
 dependencies = [
- "async-stream",
  "futures",
- "httpz 0.0.3 (git+https://github.com/oscartbeaumont/httpz.git?rev=a5020adecb15b55d84a8330b4680eba82fa6b820)",
+ "futures-channel",
+ "futures-locks",
+ "httpz 0.0.4",
+ "nougat",
+ "pin-project",
  "serde",
  "serde_json",
  "specta",
@@ -6541,7 +6611,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "once_cell",
  "prisma-models",
@@ -6551,7 +6621,7 @@ dependencies = [
 [[package]]
 name = "schema-ast"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "diagnostics",
  "pest",
@@ -6561,7 +6631,7 @@ dependencies = [
 [[package]]
 name = "schema-builder"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "itertools",
  "lazy_static",
@@ -6632,7 +6702,7 @@ dependencies = [
  "globset",
  "hostname",
  "http-range",
- "httpz 0.0.3 (git+https://github.com/oscartbeaumont/httpz?rev=a5185f2ed2fdefeb2f582dce38a692a1bf76d1d6)",
+ "httpz 0.0.3",
  "image",
  "include_dir",
  "itertools",
@@ -6688,6 +6758,7 @@ dependencies = [
  "serde",
  "serde-big-array 0.5.1",
  "serde_json",
+ "specta",
  "thiserror",
  "tokio",
  "uuid 1.2.1",
@@ -6789,10 +6860,10 @@ version = "0.1.0"
 dependencies = [
  "prisma-client-rust",
  "rand 0.8.5",
- "rspc",
  "serde",
  "serde-value",
  "serde_json",
+ "specta",
  "uhlc",
  "uuid 1.2.1",
 ]
@@ -6928,9 +6999,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
 dependencies = [
  "serde_derive",
 ]
@@ -6974,20 +7045,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "indexmap",
  "itoa 1.0.4",
@@ -7012,7 +7083,7 @@ checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -7062,7 +7133,7 @@ dependencies = [
  "darling 0.13.4",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -7074,7 +7145,7 @@ dependencies = [
  "darling 0.14.2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -7096,7 +7167,7 @@ checksum = "74064874e9f6a15f04c1f3cb627902d0e6b410abbf36668afa873c61889f1763"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -7106,7 +7177,7 @@ dependencies = [
  "axum",
  "ctrlc",
  "http",
- "httpz 0.0.3 (git+https://github.com/oscartbeaumont/httpz?rev=a5185f2ed2fdefeb2f582dce38a692a1bf76d1d6)",
+ "httpz 0.0.3",
  "hyper",
  "rspc",
  "sd-core",
@@ -7277,9 +7348,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
@@ -7319,7 +7390,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "http",
- "httpz 0.0.3 (git+https://github.com/oscartbeaumont/httpz?rev=a5185f2ed2fdefeb2f582dce38a692a1bf76d1d6)",
+ "httpz 0.0.3",
  "percent-encoding",
  "rand 0.8.5",
  "rspc",
@@ -7335,8 +7406,9 @@ dependencies = [
 
 [[package]]
 name = "specta"
-version = "0.0.6"
-source = "git+https://github.com/oscartbeaumont/rspc?rev=c03872c0ba29d2429e9c059dfb235cdd03e15e8c#c03872c0ba29d2429e9c059dfb235cdd03e15e8c"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95aa33f3135e656964f468db8369ac8e0b77ac957fe8cf335960202d68966d3b"
 dependencies = [
  "chrono",
  "document-features",
@@ -7348,20 +7420,22 @@ dependencies = [
  "serde_json",
  "specta-macros",
  "thiserror",
+ "tokio",
  "uhlc",
  "uuid 1.2.1",
 ]
 
 [[package]]
 name = "specta-macros"
-version = "0.0.6"
-source = "git+https://github.com/oscartbeaumont/rspc?rev=c03872c0ba29d2429e9c059dfb235cdd03e15e8c#c03872c0ba29d2429e9c059dfb235cdd03e15e8c"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f66517b551b511fa78fa94bc553c7baf4a8d81c68a90e7458ea74f3de70acf6c"
 dependencies = [
  "Inflector",
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "termcolor",
 ]
 
@@ -7393,12 +7467,12 @@ dependencies = [
 [[package]]
 name = "sql-ddl"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 
 [[package]]
 name = "sql-introspection-connector"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7422,7 +7496,7 @@ dependencies = [
 [[package]]
 name = "sql-migration-connector"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "chrono",
  "connection-string",
@@ -7449,7 +7523,7 @@ dependencies = [
 [[package]]
 name = "sql-query-connector"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7480,7 +7554,7 @@ dependencies = [
 [[package]]
 name = "sql-schema-describer"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "async-trait",
  "bigdecimal",
@@ -7588,7 +7662,7 @@ dependencies = [
  "heck 0.3.3",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -7601,7 +7675,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -7661,6 +7735,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7674,7 +7759,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "unicode-xid",
 ]
 
@@ -7911,7 +7996,7 @@ dependencies = [
  "heck 0.4.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "tauri-codegen",
  "tauri-utils",
 ]
@@ -8047,22 +8132,22 @@ checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
 
 [[package]]
 name = "thiserror"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -8151,14 +8236,13 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.26.0"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
+checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "parking_lot 0.12.1",
@@ -8171,13 +8255,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -8282,7 +8366,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -8378,7 +8462,7 @@ checksum = "744324b12d69a9fc1edea4b38b7b1311295b662d161ad5deac17bb1358224a08"
 dependencies = [
  "lazy_static",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -8638,17 +8722,17 @@ dependencies = [
 [[package]]
 name = "user-facing-error-macros"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "user-facing-errors"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=6bad339fc5b8bbc77e028eeae2038cf2ade2e6be#6bad339fc5b8bbc77e028eeae2038cf2ade2e6be"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "backtrace",
  "indoc",
@@ -8792,7 +8876,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-shared",
 ]
 
@@ -8826,7 +8910,7 @@ checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -9171,7 +9255,7 @@ checksum = "eaebe196c01691db62e9e4ca52c5ef1e4fd837dcae27dae3ada599b5a8fd05ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -9333,7 +9417,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba01f98f509cb5dc05f4e5fc95e535f78260f15fea8fe1a8abdd08f774f1cee7"
 dependencies = [
- "syn",
+ "syn 1.0.107",
  "windows-tokens",
 ]
 
@@ -9851,7 +9935,7 @@ dependencies = [
  "proc-macro-crate 0.1.5",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -9871,7 +9955,7 @@ checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "synstructure",
 ]
 
@@ -9909,5 +9993,5 @@ dependencies = [
  "proc-macro-crate 1.2.1",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6409,7 +6409,7 @@ dependencies = [
 [[package]]
 name = "rspc"
 version = "0.1.4"
-source = "git+https://github.com/oscartbeaumont/rspc?rev=56e98472af11171d142498ff31fc29d4ff6bbc94#56e98472af11171d142498ff31fc29d4ff6bbc94"
+source = "git+https://github.com/oscartbeaumont/rspc?rev=d9a39c8cb08d4c805035e9aa609e107c736c62d2#d9a39c8cb08d4c805035e9aa609e107c736c62d2"
 dependencies = [
  "futures",
  "futures-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,24 +13,24 @@ members = [
 ]
 
 [workspace.dependencies]
-prisma-client-rust =  { git = "https://github.com/Brendonovich/prisma-client-rust", branch = "spacedrive", features = [
+prisma-client-rust =  { git = "https://github.com/Brendonovich/prisma-client-rust", tag = "0.6.8", features = [
   "rspc",
   "sqlite-create-many",
   "migrations",
   "sqlite",
 ], default-features = false }
-prisma-client-rust-cli = { git = "https://github.com/Brendonovich/prisma-client-rust", branch = "spacedrive", features = [
+prisma-client-rust-cli = { git = "https://github.com/Brendonovich/prisma-client-rust", tag = "0.6.8", features = [
   "rspc",
   "sqlite-create-many",
   "migrations",
   "sqlite",
 ], default-features = false }
-prisma-client-rust-sdk = { git = "https://github.com/Brendonovich/prisma-client-rust", branch = "spacedrive", features = [
+prisma-client-rust-sdk = { git = "https://github.com/Brendonovich/prisma-client-rust", tag = "0.6.8", features = [
   "sqlite",
 ], default-features = false }
 
-rspc = { version = "0.1.2" }
-specta = { version = "0.0.6" }
+rspc = { version = "0.1.4" }
+specta = { version = "1.0.3" }
 httpz = { version = "0.0.3" }
 
 swift-rs = { version = "1.0.1" }
@@ -45,6 +45,6 @@ if-watch = { git = "https://github.com/oscartbeaumont/if-watch", rev = "410e8e1d
 
 mdns-sd = { git = "https://github.com/oscartbeaumont/mdns-sd", rev = "45515a98e9e408c102871abaa5a9bff3bee0cbe8" } # TODO: Do upstream PR
 
-rspc = { git = "https://github.com/oscartbeaumont/rspc", rev = "c03872c0ba29d2429e9c059dfb235cdd03e15e8c" }   # TODO: Move back to crates.io when new jsonrpc executor + `tokio::spawn` in the Tauri IPC plugin + upgraded Tauri version is released
-specta = { git = "https://github.com/oscartbeaumont/rspc", rev = "c03872c0ba29d2429e9c059dfb235cdd03e15e8c" }
+rspc = { git = "https://github.com/oscartbeaumont/rspc", rev = "56e98472af11171d142498ff31fc29d4ff6bbc94" }
+# rspc = { path = "../rspc" }
 httpz = { git = "https://github.com/oscartbeaumont/httpz", rev = "a5185f2ed2fdefeb2f582dce38a692a1bf76d1d6" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,5 @@ if-watch = { git = "https://github.com/oscartbeaumont/if-watch", rev = "410e8e1d
 
 mdns-sd = { git = "https://github.com/oscartbeaumont/mdns-sd", rev = "45515a98e9e408c102871abaa5a9bff3bee0cbe8" } # TODO: Do upstream PR
 
-rspc = { git = "https://github.com/oscartbeaumont/rspc", rev = "56e98472af11171d142498ff31fc29d4ff6bbc94" }
-# rspc = { path = "../rspc" }
+rspc = { git = "https://github.com/oscartbeaumont/rspc", rev = "d9a39c8cb08d4c805035e9aa609e107c736c62d2" }
 httpz = { git = "https://github.com/oscartbeaumont/httpz", rev = "a5185f2ed2fdefeb2f582dce38a692a1bf76d1d6" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,5 +45,5 @@ if-watch = { git = "https://github.com/oscartbeaumont/if-watch", rev = "410e8e1d
 
 mdns-sd = { git = "https://github.com/oscartbeaumont/mdns-sd", rev = "45515a98e9e408c102871abaa5a9bff3bee0cbe8" } # TODO: Do upstream PR
 
-rspc = { git = "https://github.com/oscartbeaumont/rspc", rev = "d9a39c8cb08d4c805035e9aa609e107c736c62d2" }
+rspc = { git = "https://github.com/oscartbeaumont/rspc", rev = "9cb64def32aef5a987f9f06f727b4160c321b5f8" }
 httpz = { git = "https://github.com/oscartbeaumont/httpz", rev = "a5185f2ed2fdefeb2f582dce38a692a1bf76d1d6" }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="#">
-    
+
   </a>
   <p align="center">
    <img width="150" height="150" src="https://github.com/spacedriveapp/spacedrive/blob/main/packages/assets/images/AppLogo.png" alt="Logo">
@@ -28,7 +28,7 @@
     <i>~ Links will be added once a release is available. ~</i>
   </p>
 </p>
-Spacedrive is an open source cross-platform file manager, powered by a virtual distributed filesystem (<a href="#what-is-a-vdfs">VDFS</a>) written in Rust. 
+Spacedrive is an open source cross-platform file manager, powered by a virtual distributed filesystem (<a href="#what-is-a-vdfs">VDFS</a>) written in Rust.
 <br/>
 <br/>
 
@@ -83,7 +83,7 @@ This project is using what I'm calling the **"PRRTT"** stack (Prisma, Rust, Reac
 
 - Prisma on the front-end? 🤯 Made possible thanks to [prisma-client-rust](https://github.com/brendonovich/prisma-client-rust), developed by [Brendonovich](https://github.com/brendonovich). Gives us access to the powerful migration CLI in development, along with the Prisma syntax for our schema. The application bundles with the Prisma query engine and codegen for a beautiful Rust API. Our lightweight migration runner is custom built for a desktop app context.
 - Tauri allows us to create a pure Rust native OS webview, without the overhead of your average Electron app. This brings the bundle size and average memory usage down dramatically. It also contributes to a more native feel, especially on macOS due to Safari's close integration with the OS.
-- We also use [rspc](https://rspc.otbeaumont.me) which allows us to define functions in Rust and call them on the Typescript frontend in a completely typesafe manner, so no unnecessary bugs make it into production!
+- We also use [rspc](https://rspc.dev) which allows us to define functions in Rust and call them on the Typescript frontend in a completely typesafe manner, so no unnecessary bugs make it into production!
 - The core (`sdcore`) is written in pure Rust.
 
 ## Monorepo structure:

--- a/apps/mobile/crates/core/Cargo.toml
+++ b/apps/mobile/crates/core/Cargo.toml
@@ -20,3 +20,5 @@ openssl-sys = { version = "0.9.76", features = [
 ] } # Override features of transitive dependencies to support IOS Simulator on M1
 futures = "0.3.24"
 tracing = "0.1.37"
+futures-channel = "0.3.28"
+futures-locks = "0.7.1"

--- a/apps/mobile/crates/core/src/lib.rs
+++ b/apps/mobile/crates/core/src/lib.rs
@@ -23,6 +23,7 @@ pub type NodeType = Lazy<Mutex<Option<(Arc<Node>, Arc<Router>)>>>;
 
 pub static NODE: NodeType = Lazy::new(|| Mutex::new(None));
 
+#[allow(clippy::type_complexity)]
 pub static SUBSCRIPTIONS: Lazy<Arc<futures_locks::Mutex<HashMap<RequestId, oneshot::Sender<()>>>>> =
 	Lazy::new(Default::default);
 

--- a/apps/mobile/crates/core/src/lib.rs
+++ b/apps/mobile/crates/core/src/lib.rs
@@ -1,15 +1,19 @@
-use futures::future::join_all;
+use futures::{future::join_all, StreamExt};
+use futures_channel::mpsc;
 use once_cell::sync::{Lazy, OnceCell};
-use rspc::internal::jsonrpc::*;
+use rspc::internal::jsonrpc::{self, *};
 use sd_core::{api::Router, Node};
 use serde_json::{from_str, from_value, to_string, Value};
-use std::{collections::HashMap, marker::Send, sync::Arc};
+use std::{
+	borrow::Cow,
+	collections::HashMap,
+	future::{ready, Ready},
+	marker::Send,
+	sync::Arc,
+};
 use tokio::{
 	runtime::Runtime,
-	sync::{
-		mpsc::{unbounded_channel, UnboundedSender},
-		oneshot, Mutex,
-	},
+	sync::{oneshot, Mutex},
 };
 use tracing::error;
 
@@ -19,10 +23,37 @@ pub type NodeType = Lazy<Mutex<Option<(Arc<Node>, Arc<Router>)>>>;
 
 pub static NODE: NodeType = Lazy::new(|| Mutex::new(None));
 
-pub static SUBSCRIPTIONS: Lazy<Mutex<HashMap<RequestId, oneshot::Sender<()>>>> =
+pub static SUBSCRIPTIONS: Lazy<Arc<futures_locks::Mutex<HashMap<RequestId, oneshot::Sender<()>>>>> =
 	Lazy::new(Default::default);
 
-pub static EVENT_SENDER: OnceCell<UnboundedSender<Response>> = OnceCell::new();
+pub static EVENT_SENDER: OnceCell<mpsc::Sender<Response>> = OnceCell::new();
+
+pub struct MobileSender<'a> {
+	resp: &'a mut Option<Response>,
+}
+
+impl<'a> Sender<'a> for MobileSender<'a> {
+	type SendFut = Ready<()>;
+	type SubscriptionMap = Arc<futures_locks::Mutex<HashMap<RequestId, oneshot::Sender<()>>>>;
+	type OwnedSender = OwnedMpscSender;
+
+	fn subscription(self) -> SubscriptionUpgrade<'a, Self> {
+		SubscriptionUpgrade::Supported(
+			OwnedMpscSender::new(
+				EVENT_SENDER
+					.get()
+					.expect("Core was not started before making a request!")
+					.clone(),
+			),
+			SUBSCRIPTIONS.clone(),
+		)
+	}
+
+	fn send(self, resp: jsonrpc::Response) -> Self::SendFut {
+		*self.resp = Some(resp);
+		ready(())
+	}
+}
 
 pub fn handle_core_msg(
 	query: String,
@@ -59,22 +90,15 @@ pub fn handle_core_msg(
 			let node = node.clone();
 			let router = router.clone();
 			async move {
-				let mut channel = EVENT_SENDER.get().unwrap().clone();
-				let mut resp = Sender::ResponseAndChannel(None, &mut channel);
-
+				let mut resp = Option::<Response>::None;
 				handle_json_rpc(
 					node.clone(),
 					request,
-					&router,
-					&mut resp,
-					&mut SubscriptionMap::Mutex(&SUBSCRIPTIONS),
+					Cow::Borrowed(&router),
+					MobileSender { resp: &mut resp },
 				)
 				.await;
-
-				match resp {
-					Sender::ResponseAndChannel(resp, _) => resp,
-					_ => unreachable!(),
-				}
+				resp
 			}
 		}))
 		.await;
@@ -87,11 +111,11 @@ pub fn handle_core_msg(
 }
 
 pub fn spawn_core_event_listener(callback: impl Fn(String) + Send + 'static) {
-	let (tx, mut rx) = unbounded_channel();
+	let (tx, mut rx) = mpsc::channel(100);
 	let _ = EVENT_SENDER.set(tx);
 
 	RUNTIME.spawn(async move {
-		while let Some(event) = rx.recv().await {
+		while let Some(event) = rx.next().await {
 			let data = match to_string(&event) {
 				Ok(json) => json,
 				Err(err) => {

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -23,6 +23,7 @@ sync-messages = []
 sd-ffmpeg = { path = "../crates/ffmpeg", optional = true }
 sd-crypto = { path = "../crates/crypto", features = [
 	"rspc",
+	"specta",
 	"serde",
 	"keymanager",
 ] }
@@ -30,7 +31,7 @@ sd-file-ext = { path = "../crates/file-ext" }
 sd-sync = { path = "../crates/sync" }
 sd-p2p = { path = "../crates/p2p", features = ["specta", "serde"] }
 
-rspc = { workspace = true, features = ["uuid", "chrono", "tracing"] }
+rspc = { workspace = true, features = ["uuid", "chrono", "tracing", "unstable"] }
 httpz = { workspace = true }
 prisma-client-rust = { workspace = true }
 specta = { workspace = true }

--- a/core/src/api/files.rs
+++ b/core/src/api/files.rs
@@ -9,8 +9,9 @@ use crate::{
 	prisma::{location, object},
 };
 
-use rspc::{ErrorCode, Type};
+use rspc::ErrorCode;
 use serde::Deserialize;
+use specta::Type;
 use std::path::Path;
 use tokio::fs;
 

--- a/core/src/api/jobs.rs
+++ b/core/src/api/jobs.rs
@@ -8,8 +8,8 @@ use crate::{
 	},
 };
 
-use rspc::Type;
 use serde::Deserialize;
+use specta::Type;
 use std::path::PathBuf;
 use uuid::Uuid;
 

--- a/core/src/api/libraries.rs
+++ b/core/src/api/libraries.rs
@@ -6,8 +6,8 @@ use crate::{
 };
 
 use chrono::Utc;
-use rspc::Type;
 use serde::Deserialize;
+use specta::Type;
 use tracing::debug;
 use uuid::Uuid;
 

--- a/core/src/api/locations.rs
+++ b/core/src/api/locations.rs
@@ -13,8 +13,9 @@ use std::{
 	path::{PathBuf, MAIN_SEPARATOR, MAIN_SEPARATOR_STR},
 };
 
-use rspc::{self, ErrorCode, RouterBuilderLike, Type};
+use rspc::{self, ErrorCode, RouterBuilderLike};
 use serde::{Deserialize, Serialize};
+use specta::Type;
 
 use super::{utils::LibraryRequest, Ctx, RouterBuilder};
 
@@ -49,7 +50,7 @@ pub struct ExplorerData {
 file_path::include!(file_path_with_object { object });
 object::include!(object_with_file_paths { file_paths });
 
-pub(crate) fn mount() -> impl RouterBuilderLike<Ctx> {
+pub(crate) fn mount() -> impl RouterBuilderLike<Ctx, Meta = ()> {
 	<RouterBuilder>::new()
 		.library_query("list", |t| {
 			t(|_, _: (), library| async move {

--- a/core/src/api/mod.rs
+++ b/core/src/api/mod.rs
@@ -1,7 +1,8 @@
 use chrono::{DateTime, Utc};
 use prisma_client_rust::{operator::or, Direction};
-use rspc::{Config, Type};
+use rspc::Config;
 use serde::{Deserialize, Serialize};
+use specta::Type;
 use std::sync::Arc;
 
 use crate::{
@@ -215,16 +216,16 @@ pub(crate) fn mount() -> Arc<Router> {
 				Ok(items)
 			})
 		})
-		.yolo_merge("library.", libraries::mount())
-		.yolo_merge("volumes.", volumes::mount())
-		.yolo_merge("tags.", tags::mount())
-		.yolo_merge("keys.", keys::mount())
-		.yolo_merge("locations.", locations::mount())
-		.yolo_merge("files.", files::mount())
-		.yolo_merge("jobs.", jobs::mount())
-		.yolo_merge("p2p.", p2p::mount())
-		.yolo_merge("sync.", sync::mount())
-		.yolo_merge("invalidation.", utils::mount_invalidate())
+		.merge("library.", libraries::mount())
+		.merge("volumes.", volumes::mount())
+		.merge("tags.", tags::mount())
+		.merge("keys.", keys::mount())
+		.merge("locations.", locations::mount())
+		.merge("files.", files::mount())
+		.merge("jobs.", jobs::mount())
+		.merge("p2p.", p2p::mount())
+		.merge("sync.", sync::mount())
+		.merge("invalidation.", utils::mount_invalidate())
 		.build()
 		.arced();
 	InvalidRequests::validate(r.clone()); // This validates all invalidation calls.

--- a/core/src/api/p2p.rs
+++ b/core/src/api/p2p.rs
@@ -1,6 +1,6 @@
-use rspc::Type;
 use sd_p2p::PeerId;
 use serde::Deserialize;
+use specta::Type;
 use std::path::PathBuf;
 
 use crate::p2p::P2PEvent;

--- a/core/src/api/sync.rs
+++ b/core/src/api/sync.rs
@@ -5,12 +5,9 @@ use super::{utils::LibraryRequest, RouterBuilder};
 pub fn mount() -> RouterBuilder {
 	RouterBuilder::new()
 		.library_subscription("newMessage", |t| {
-			t(|ctx, _: (), library| {
+			t(|_, _: (), library| {
 				async_stream::stream! {
-					let Some(lib) = ctx.library_manager.get_ctx(library.id).await else {
-						return
-					};
-					let mut rx = lib.sync.tx.subscribe();
+					let mut rx = library.sync.tx.subscribe();
 					while let Ok(msg) = rx.recv().await {
 						let op = match msg {
 							SyncMessage::Ingested(op) => op,

--- a/core/src/api/sync.rs
+++ b/core/src/api/sync.rs
@@ -5,9 +5,9 @@ use super::{utils::LibraryRequest, RouterBuilder};
 pub fn mount() -> RouterBuilder {
 	RouterBuilder::new()
 		.library_subscription("newMessage", |t| {
-			t(|ctx, _: (), library_id| {
+			t(|ctx, _: (), library| {
 				async_stream::stream! {
-					let Some(lib) = ctx.library_manager.get_ctx(library_id).await else {
+					let Some(lib) = ctx.library_manager.get_ctx(library.id).await else {
 						return
 					};
 					let mut rx = lib.sync.tx.subscribe();

--- a/core/src/api/tags.rs
+++ b/core/src/api/tags.rs
@@ -1,5 +1,6 @@
-use rspc::{ErrorCode, Type};
+use rspc::ErrorCode;
 use serde::Deserialize;
+use specta::Type;
 
 use serde_json::json;
 use tracing::info;

--- a/core/src/api/utils/invalidate.rs
+++ b/core/src/api/utils/invalidate.rs
@@ -1,10 +1,10 @@
 use crate::api::{CoreEvent, Router, RouterBuilder};
 
 use async_stream::stream;
-use rspc::{internal::specta::DataType, Type};
 use serde::Serialize;
 use serde_hashkey::to_key;
 use serde_json::Value;
+use specta::{DataType, Type};
 use std::{
 	collections::HashMap,
 	sync::{

--- a/core/src/api/utils/library.rs
+++ b/core/src/api/utils/library.rs
@@ -1,14 +1,14 @@
-use std::sync::Arc;
+use std::{borrow::Cow, marker::PhantomData, panic::Location, process, sync::Arc};
 
-use futures::Stream;
 use rspc::{
 	internal::{
-		specta, BuiltProcedureBuilder, MiddlewareBuilderLike, RequestResult,
+		BuiltProcedureBuilder, LayerResult, MiddlewareBuilderLike, ResolverLayer,
 		UnbuiltProcedureBuilder,
 	},
-	ErrorCode, Type,
+	is_invalid_procedure_name, typedef, ErrorCode, ExecError, RequestLayer, StreamRequestLayer,
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use specta::Type;
 use uuid::Uuid;
 
 use crate::{api::Ctx, library::Library};
@@ -22,77 +22,81 @@ pub(crate) struct LibraryArgs<T> {
 
 // WARNING: This is system is using internal API's which means it will break between rspc release. I would avoid copying it unless you understand the cost of maintaining it!
 pub trait LibraryRequest {
-	fn library_query<TUnbuiltResolver, TUnbuiltResult, TUnbuiltResultMarker, TBuiltResolver, TArg>(
+	fn library_query<TResolver, TArg, TResult, TResultMarker>(
 		self,
 		key: &'static str,
 		builder: impl FnOnce(
-			UnbuiltProcedureBuilder<Ctx, TUnbuiltResolver>,
-		) -> BuiltProcedureBuilder<TBuiltResolver>,
+			UnbuiltProcedureBuilder<Ctx, TResolver>,
+		) -> BuiltProcedureBuilder<TResolver>,
 	) -> Self
 	where
-		TUnbuiltResolver: Fn(Ctx, TArg, Library) -> TUnbuiltResult + Send,
-		TBuiltResolver: Fn(Ctx, TArg, Library) -> TUnbuiltResult + Send + Sync + 'static,
-		TUnbuiltResult: RequestResult<TUnbuiltResultMarker> + Send,
-		TArg: DeserializeOwned + specta::Type + Send + 'static;
+		TArg: DeserializeOwned + Type + Send + 'static,
+		TResult: RequestLayer<TResultMarker> + Send,
+		TResolver: Fn(Ctx, TArg, Library) -> TResult + Send + Sync + 'static;
 
-	fn library_mutation<
-		TUnbuiltResolver,
-		TUnbuiltResult,
-		TUnbuiltResultMarker,
-		TBuiltResolver,
-		TArg,
-	>(
+	fn library_mutation<TResolver, TArg, TResult, TResultMarker>(
 		self,
 		key: &'static str,
 		builder: impl FnOnce(
-			UnbuiltProcedureBuilder<Ctx, TUnbuiltResolver>,
-		) -> BuiltProcedureBuilder<TBuiltResolver>,
+			UnbuiltProcedureBuilder<Ctx, TResolver>,
+		) -> BuiltProcedureBuilder<TResolver>,
 	) -> Self
 	where
-		TUnbuiltResolver: Fn(Ctx, TArg, Library) -> TUnbuiltResult + Send,
-		TBuiltResolver: Fn(Ctx, TArg, Library) -> TUnbuiltResult + Send + Sync + 'static,
-		TUnbuiltResult: RequestResult<TUnbuiltResultMarker> + Send,
-		TArg: DeserializeOwned + specta::Type + Send + 'static;
+		TArg: DeserializeOwned + Type + Send + 'static,
+		TResult: RequestLayer<TResultMarker> + Send,
+		TResolver: Fn(Ctx, TArg, Library) -> TResult + Send + Sync + 'static;
 
-	fn library_subscription<TResolver, TArg, TStream, TResult>(
+	fn library_subscription<F, TArg, TResult, TResultMarker>(
 		self,
 		key: &'static str,
-		builder: impl Fn(UnbuiltProcedureBuilder<Ctx, TResolver>) -> BuiltProcedureBuilder<TResolver>,
+		builder: impl FnOnce(UnbuiltProcedureBuilder<Ctx, F>) -> BuiltProcedureBuilder<F>,
 	) -> Self
 	where
-		TArg: DeserializeOwned + specta::Type + 'static,
-		TStream: Stream<Item = TResult> + Send + Sync + 'static,
-		TResult: Serialize + specta::Type,
-		TResolver: Fn(Ctx, TArg, Uuid) -> TStream + Send + Sync + 'static;
+		F: Fn(Ctx, TArg, Library) -> TResult + Send + Sync + 'static,
+		TArg: DeserializeOwned + Type + Send + 'static,
+		TResult: StreamRequestLayer<TResultMarker> + Send;
 }
 
 // Note: This will break with middleware context switching but that's fine for now
-impl<TMiddleware> LibraryRequest for rspc::RouterBuilder<Ctx, TMiddleware>
+impl<TMiddleware> LibraryRequest for rspc::RouterBuilder<Ctx, (), TMiddleware>
 where
 	TMiddleware: MiddlewareBuilderLike<Ctx, LayerContext = Ctx> + Send + 'static,
 {
-	fn library_query<TUnbuiltResolver, TUnbuiltResult, TUnbuiltResultMarker, TBuiltResolver, TArg>(
-		self,
+	fn library_query<TResolver, TArg, TResult, TResultMarker>(
+		mut self,
 		key: &'static str,
 		builder: impl FnOnce(
-			UnbuiltProcedureBuilder<Ctx, TUnbuiltResolver>,
-		) -> BuiltProcedureBuilder<TBuiltResolver>,
+			UnbuiltProcedureBuilder<Ctx, TResolver>,
+		) -> BuiltProcedureBuilder<TResolver>,
 	) -> Self
 	where
-		TUnbuiltResolver: Fn(Ctx, TArg, Library) -> TUnbuiltResult + Send,
-		TBuiltResolver: Fn(Ctx, TArg, Library) -> TUnbuiltResult + Send + Sync + 'static,
-		TUnbuiltResult: RequestResult<TUnbuiltResultMarker> + Send,
-		TArg: DeserializeOwned + specta::Type + Send + 'static,
+		TArg: DeserializeOwned + Type + Send + 'static,
+		TResult: RequestLayer<TResultMarker> + Send,
+		TResolver: Fn(Ctx, TArg, Library) -> TResult + Send + Sync + 'static,
 	{
-		self.query(key, move |t| {
-			let resolver = Arc::new(builder(UnbuiltProcedureBuilder::from_builder(&t)).resolver);
+		if is_invalid_procedure_name(key) {
+			eprintln!(
+                "{}: rspc error: attempted to attach a query with the key '{}', however this name is not allowed. ",
+                Location::caller(),
+                key
+            );
+			process::exit(1);
+		}
 
-			t(move |ctx, arg: LibraryArgs<TArg>| {
+		let resolver = Arc::new(builder(UnbuiltProcedureBuilder::default()).resolver);
+		let ty =
+			typedef::<LibraryArgs<TArg>, TResult::Result>(Cow::Borrowed(key), self.typ_store())
+				.unwrap();
+		let layer = self.prev_middleware().build(ResolverLayer {
+			func: move |ctx: Ctx, input, _| {
 				let resolver = resolver.clone();
-				async move {
+				Ok(LayerResult::FutureValueOrStream(Box::pin(async move {
+					let args: LibraryArgs<TArg> =
+						serde_json::from_value(input).map_err(ExecError::DeserializingArgErr)?;
+
 					let library = ctx
 						.library_manager
-						.get_ctx(arg.library_id)
+						.get_ctx(args.library_id)
 						.await
 						.ok_or_else(|| {
 							rspc::Error::new(
@@ -102,43 +106,53 @@ where
 							)
 						})?;
 
-					Ok(resolver(ctx, arg.arg, library)
-						.into_request_future()?
-						.exec()
+					Ok(resolver(ctx, args.arg, library)
+						.into_layer_result()?
+						.into_value_or_stream()
 						.await?)
-				}
-			})
-		})
+				})))
+			},
+			phantom: PhantomData,
+		});
+		self.queries().append(key.into(), layer, ty);
+		self
 	}
 
-	fn library_mutation<
-		TUnbuiltResolver,
-		TUnbuiltResult,
-		TUnbuiltResultMarker,
-		TBuiltResolver,
-		TArg,
-	>(
-		self,
+	fn library_mutation<TResolver, TArg, TResult, TResultMarker>(
+		mut self,
 		key: &'static str,
 		builder: impl FnOnce(
-			UnbuiltProcedureBuilder<Ctx, TUnbuiltResolver>,
-		) -> BuiltProcedureBuilder<TBuiltResolver>,
+			UnbuiltProcedureBuilder<Ctx, TResolver>,
+		) -> BuiltProcedureBuilder<TResolver>,
 	) -> Self
 	where
-		TUnbuiltResolver: Fn(Ctx, TArg, Library) -> TUnbuiltResult + Send,
-		TBuiltResolver: Fn(Ctx, TArg, Library) -> TUnbuiltResult + Send + Sync + 'static,
-		TUnbuiltResult: RequestResult<TUnbuiltResultMarker> + Send,
-		TArg: DeserializeOwned + specta::Type + Send + 'static,
+		TArg: DeserializeOwned + Type + Send + 'static,
+		TResult: RequestLayer<TResultMarker> + Send,
+		TResolver: Fn(Ctx, TArg, Library) -> TResult + Send + Sync + 'static,
 	{
-		self.mutation(key, move |t| {
-			let resolver = Arc::new(builder(UnbuiltProcedureBuilder::from_builder(&t)).resolver);
+		if is_invalid_procedure_name(key) {
+			eprintln!(
+                "{}: rspc error: attempted to attach a mutation with the key '{}', however this name is not allowed. ",
+                Location::caller(),
+                key
+            );
+			process::exit(1);
+		}
 
-			t(move |ctx, arg: LibraryArgs<TArg>| {
+		let resolver = Arc::new(builder(UnbuiltProcedureBuilder::default()).resolver);
+		let ty =
+			typedef::<LibraryArgs<TArg>, TResult::Result>(Cow::Borrowed(key), self.typ_store())
+				.unwrap();
+		let layer = self.prev_middleware().build(ResolverLayer {
+			func: move |ctx: Ctx, input, _| {
 				let resolver = resolver.clone();
-				async move {
+				Ok(LayerResult::FutureValueOrStream(Box::pin(async move {
+					let args: LibraryArgs<TArg> =
+						serde_json::from_value(input).map_err(ExecError::DeserializingArgErr)?;
+
 					let library = ctx
 						.library_manager
-						.get_ctx(arg.library_id)
+						.get_ctx(args.library_id)
 						.await
 						.ok_or_else(|| {
 							rspc::Error::new(
@@ -148,44 +162,69 @@ where
 							)
 						})?;
 
-					Ok(resolver(ctx, arg.arg, library)
-						.into_request_future()?
-						.exec()
+					Ok(resolver(ctx, args.arg, library)
+						.into_layer_result()?
+						.into_value_or_stream()
 						.await?)
-				}
-			})
-		})
+				})))
+			},
+			phantom: PhantomData,
+		});
+		self.mutations().append(key.into(), layer, ty);
+		self
 	}
 
-	fn library_subscription<TResolver, TArg, TStream, TResult>(
-		self,
+	fn library_subscription<F, TArg, TResult, TResultMarker>(
+		mut self,
 		key: &'static str,
-		builder: impl Fn(UnbuiltProcedureBuilder<Ctx, TResolver>) -> BuiltProcedureBuilder<TResolver>,
+		builder: impl FnOnce(UnbuiltProcedureBuilder<Ctx, F>) -> BuiltProcedureBuilder<F>,
 	) -> Self
 	where
-		TArg: DeserializeOwned + specta::Type + 'static,
-		TStream: Stream<Item = TResult> + Send + Sync + 'static,
-		TResult: Serialize + specta::Type,
-		TResolver: Fn(Ctx, TArg, Uuid) -> TStream + Send + Sync + 'static,
+		F: Fn(Ctx, TArg, Library) -> TResult + Send + Sync + 'static,
+		TArg: DeserializeOwned + Type + Send + 'static,
+		TResult: StreamRequestLayer<TResultMarker> + Send,
 	{
-		self.subscription(key, |t| {
-			let resolver = Arc::new(builder(UnbuiltProcedureBuilder::from_builder(&t)).resolver);
+		if is_invalid_procedure_name(key) {
+			eprintln!(
+                "{}: rspc error: attempted to attach a subscription with the key '{}', however this name is not allowed. ",
+                Location::caller(),
+                key
+            );
+			process::exit(1);
+		}
 
-			t(move |ctx, arg: LibraryArgs<TArg>| {
-				// TODO(@Oscar): Upstream rspc work to allow this to work
-				// let library = ctx
-				// 	.library_manager
-				// 	.get_ctx(arg.library_id)
-				// 	.await
-				// 	.ok_or_else(|| {
-				// 		rspc::Error::new(
-				// 			ErrorCode::BadRequest,
-				// 			"You must specify a valid library to use this operation.".to_string(),
-				// 		)
-				// 	})?;
+		let resolver = Arc::new(builder(UnbuiltProcedureBuilder::default()).resolver);
+		let ty =
+			typedef::<LibraryArgs<TArg>, TResult::Result>(Cow::Borrowed(key), self.typ_store())
+				.unwrap();
+		let layer = self.prev_middleware().build(ResolverLayer {
+			func: move |ctx: Ctx, input, _| {
+				let resolver = resolver.clone();
+				Ok(LayerResult::FutureValueOrStream(Box::pin(async move {
+					let args: LibraryArgs<TArg> =
+						serde_json::from_value(input).map_err(ExecError::DeserializingArgErr)?;
 
-				resolver(ctx, arg.arg, arg.library_id)
-			})
-		})
+					let library = ctx
+						.library_manager
+						.get_ctx(args.library_id)
+						.await
+						.ok_or_else(|| {
+							rspc::Error::new(
+								ErrorCode::BadRequest,
+								"You must specify a valid library to use this operation."
+									.to_string(),
+							)
+						})?;
+
+					Ok(resolver(ctx, args.arg, library)
+						.into_layer_result()?
+						.into_value_or_stream()
+						.await?)
+				})))
+			},
+			phantom: PhantomData,
+		});
+		self.subscriptions().append(key.into(), layer, ty);
+		self
 	}
 }

--- a/core/src/api/utils/library.rs
+++ b/core/src/api/utils/library.rs
@@ -106,10 +106,10 @@ where
 							)
 						})?;
 
-					Ok(resolver(ctx, args.arg, library)
+					resolver(ctx, args.arg, library)
 						.into_layer_result()?
 						.into_value_or_stream()
-						.await?)
+						.await
 				})))
 			},
 			phantom: PhantomData,
@@ -162,10 +162,10 @@ where
 							)
 						})?;
 
-					Ok(resolver(ctx, args.arg, library)
+					resolver(ctx, args.arg, library)
 						.into_layer_result()?
 						.into_value_or_stream()
-						.await?)
+						.await
 				})))
 			},
 			phantom: PhantomData,
@@ -216,10 +216,10 @@ where
 							)
 						})?;
 
-					Ok(resolver(ctx, args.arg, library)
+					resolver(ctx, args.arg, library)
 						.into_layer_result()?
 						.into_value_or_stream()
-						.await?)
+						.await
 				})))
 			},
 			phantom: PhantomData,

--- a/core/src/job/job_manager.rs
+++ b/core/src/job/job_manager.rs
@@ -31,8 +31,8 @@ use std::{
 
 use chrono::{DateTime, Utc};
 use prisma_client_rust::Direction;
-use rspc::Type;
 use serde::{Deserialize, Serialize};
+use specta::Type;
 use thiserror::Error;
 use tokio::{
 	sync::{broadcast, mpsc, Mutex, RwLock},

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -26,6 +26,7 @@ pub(crate) mod sync;
 pub(crate) mod util;
 pub(crate) mod volume;
 
+#[allow(warnings, unused)]
 pub(crate) mod prisma;
 pub(crate) mod prisma_sync;
 

--- a/core/src/library/config.rs
+++ b/core/src/library/config.rs
@@ -1,7 +1,7 @@
 use std::{marker::PhantomData, path::PathBuf};
 
-use rspc::Type;
 use serde::{Deserialize, Serialize};
+use specta::Type;
 use uuid::Uuid;
 
 use crate::{migrations, util::migrator::FileMigrator};

--- a/core/src/location/indexer/rules.rs
+++ b/core/src/location/indexer/rules.rs
@@ -7,8 +7,8 @@ use crate::{
 use chrono::{DateTime, Utc};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use rmp_serde;
-use rspc::Type;
 use serde::{Deserialize, Serialize};
+use specta::Type;
 use std::{collections::HashSet, path::Path};
 use tokio::fs;
 

--- a/core/src/location/mod.rs
+++ b/core/src/location/mod.rs
@@ -23,9 +23,9 @@ use std::{
 use futures::future::TryFutureExt;
 use normpath::PathExt;
 use prisma_client_rust::QueryError;
-use rspc::Type;
 use serde::Deserialize;
 use serde_json::json;
+use specta::Type;
 use tokio::{fs, io};
 use tracing::{debug, info};
 use uuid::Uuid;

--- a/core/src/node/config.rs
+++ b/core/src/node/config.rs
@@ -1,6 +1,6 @@
-use rspc::Type;
 use sd_p2p::Keypair;
 use serde::{Deserialize, Serialize};
+use specta::Type;
 use std::{
 	marker::PhantomData,
 	path::{Path, PathBuf},

--- a/core/src/node/mod.rs
+++ b/core/src/node/mod.rs
@@ -1,8 +1,8 @@
 use crate::{prisma::node, NodeError};
 
 use chrono::{DateTime, Utc};
-use rspc::Type;
 use serde::{Deserialize, Serialize};
+use specta::Type;
 use uuid::Uuid;
 
 mod config;

--- a/core/src/node/peer_request.rs
+++ b/core/src/node/peer_request.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, unused_variables)] // TODO: Reenable once this is working
 
-use rspc::Type;
 use serde::{Deserialize, Serialize};
+use specta::Type;
 use tokio::sync::{mpsc, oneshot};
 
 pub enum PeerRequest {

--- a/core/src/object/mod.rs
+++ b/core/src/object/mod.rs
@@ -1,7 +1,7 @@
 use crate::prisma::{file_path, object};
 
-use rspc::Type;
 use serde::{Deserialize, Serialize};
+use specta::Type;
 
 pub mod cas;
 pub mod file_identifier;

--- a/core/src/object/tag.rs
+++ b/core/src/object/tag.rs
@@ -1,6 +1,6 @@
 use prisma_client_rust::QueryError;
-use rspc::Type;
 use serde::Deserialize;
+use specta::Type;
 
 use uuid::Uuid;
 

--- a/core/src/p2p/p2p_manager.rs
+++ b/core/src/p2p/p2p_manager.rs
@@ -1,12 +1,12 @@
 use std::{path::PathBuf, sync::Arc, time::Instant};
 
-use rspc::Type;
 use sd_p2p::{
 	spaceblock::{BlockSize, TransferRequest},
 	Event, Manager, MetadataManager, PeerId,
 };
 use sd_sync::CRDTOperation;
 use serde::Serialize;
+use specta::Type;
 use tokio::{
 	fs::File,
 	io::{AsyncReadExt, AsyncWriteExt, BufReader},

--- a/core/src/p2p/peer_metadata.rs
+++ b/core/src/p2p/peer_metadata.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap, env, str::FromStr};
 
-use rspc::Type;
 use sd_p2p::Metadata;
 use serde::{Deserialize, Serialize};
+use specta::Type;
 
 #[derive(Debug, Clone, Type, Serialize, Deserialize)]
 pub struct PeerMetadata {

--- a/core/src/volume.rs
+++ b/core/src/volume.rs
@@ -1,8 +1,8 @@
 use crate::{library::Library, prisma::volume::*};
 
-use rspc::Type;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
+use specta::Type;
 use std::process::Command;
 use sysinfo::{DiskExt, System, SystemExt};
 use thiserror::Error;

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -8,7 +8,8 @@ edition = "2021"
 rust-version = "1.67.0"
 
 [features]
-rspc = ["dep:rspc"]
+rspc = ["dep:rspc", "dep:specta"]
+specta = ["dep:specta"]
 serde = ["dep:serde", "dep:serde_json", "dep:serde-big-array", "uuid/serde"]
 keymanager = ["dep:dashmap", "os-keyrings"]
 os-keyrings = ["dep:secret-service", "dep:security-framework"]
@@ -46,7 +47,8 @@ uuid = { version = "1.1.2", features = ["v4"] }
 dashmap = { version = "5.4.0", optional = true }
 
 # optional, for support with rspc
-rspc = { workspace = true, features = ["uuid"], optional = true }
+rspc = { workspace = true, features = [], optional = true }
+specta = { workspace = true, features = ["uuid"], optional = true }
 
 # for asynchronous crypto
 tokio = { workspace = true, features = ["io-util", "rt-multi-thread", "sync"] }

--- a/crates/crypto/src/keys/keymanager.rs
+++ b/crates/crypto/src/keys/keymanager.rs
@@ -62,7 +62,7 @@ use super::keyring::{Identifier, KeyringInterface};
 /// It contains no sensitive information that is not encrypted.
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "rspc", derive(rspc::Type))]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct StoredKey {
 	pub uuid: Uuid, // uuid for identification. shared with mounted keys
 	pub version: StoredKeyVersion,
@@ -82,7 +82,7 @@ pub struct StoredKey {
 /// This denotes the type of key. `Root` keys can be used to unlock the key manager, and `User` keys are ordinary keys.
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "rspc", derive(rspc::Type))]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
 pub enum StoredKeyType {
 	User,
 	Root,
@@ -91,7 +91,7 @@ pub enum StoredKeyType {
 /// This denotes the `StoredKey` version.
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "rspc", derive(rspc::Type))]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
 pub enum StoredKeyVersion {
 	V1,
 }

--- a/crates/crypto/src/protected.rs
+++ b/crates/crypto/src/protected.rs
@@ -34,41 +34,36 @@ use zeroize::Zeroize;
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(any(feature = "specta", feature = "serde"), serde(transparent))]
-pub struct Protected<T>
+pub struct Protected<T>(T)
 where
-	T: Zeroize,
-{
-	data: T,
-}
+	T: Zeroize;
 
 impl<T> Protected<T>
 where
 	T: Zeroize,
 {
 	pub const fn new(value: T) -> Self {
-		Self { data: value }
+		Self(value)
 	}
 
 	pub const fn expose(&self) -> &T {
-		&self.data
+		&self.0
 	}
 
 	pub fn zeroize(mut self) {
-		self.data.zeroize();
+		self.0.zeroize();
 	}
 }
 
 impl From<Vec<u8>> for Protected<Vec<u8>> {
 	fn from(value: Vec<u8>) -> Self {
-		Self { data: value }
+		Self(value)
 	}
 }
 
 impl From<Protected<String>> for Protected<Vec<u8>> {
 	fn from(value: Protected<String>) -> Self {
-		Self {
-			data: value.expose().as_bytes().to_vec(),
-		}
+		Self(value.expose().as_bytes().to_vec())
 	}
 }
 
@@ -78,7 +73,7 @@ where
 {
 	pub fn into_inner(mut self) -> T {
 		let mut out = Default::default();
-		swap(&mut self.data, &mut out);
+		swap(&mut self.0, &mut out);
 		out
 	}
 }
@@ -88,7 +83,7 @@ where
 	T: Zeroize,
 {
 	fn drop(&mut self) {
-		self.data.zeroize();
+		self.0.zeroize();
 	}
 }
 

--- a/crates/crypto/src/protected.rs
+++ b/crates/crypto/src/protected.rs
@@ -31,6 +31,9 @@
 use std::{fmt::Debug, mem::swap};
 use zeroize::Zeroize;
 #[derive(Clone)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[cfg_attr(any(feature = "specta", feature = "serde"), serde(transparent))]
 pub struct Protected<T>
 where
 	T: Zeroize,
@@ -95,43 +98,5 @@ where
 {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.write_str("[REDACTED]")
-	}
-}
-
-#[cfg(feature = "serde")]
-impl<'de, T> serde::Deserialize<'de> for Protected<T>
-where
-	T: serde::Deserialize<'de> + Zeroize,
-{
-	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-	where
-		D: serde::Deserializer<'de>,
-	{
-		Ok(Self::new(T::deserialize(deserializer)?))
-	}
-}
-
-#[cfg(feature = "rspc")]
-use rspc::internal::specta;
-
-#[cfg(feature = "rspc")]
-impl<T> specta::Type for Protected<T>
-where
-	T: specta::Type + Zeroize,
-{
-	const NAME: &'static str = T::NAME;
-	const SID: specta::TypeSid = specta::sid!();
-	const IMPL_LOCATION: specta::ImplLocation = specta::impl_location!();
-
-	fn inline(opts: specta::DefOpts, generics: &[specta::DataType]) -> specta::DataType {
-		T::inline(opts, generics)
-	}
-
-	fn reference(opts: specta::DefOpts, generics: &[specta::DataType]) -> specta::DataType {
-		T::reference(opts, generics)
-	}
-
-	fn definition(opts: specta::DefOpts) -> specta::DataTypeExt {
-		T::definition(opts)
 	}
 }

--- a/crates/crypto/src/types.rs
+++ b/crates/crypto/src/types.rs
@@ -17,7 +17,7 @@ use serde_big_array::BigArray;
 /// You may also generate a nonce for a given algorithm with `Nonce::generate()`
 #[derive(Clone, Copy, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "rspc", derive(rspc::Type))]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
 pub enum Nonce {
 	XChaCha20Poly1305([u8; 20]),
 	Aes256Gcm([u8; 8]),
@@ -32,7 +32,7 @@ pub enum Nonce {
 	derive(serde::Serialize),
 	derive(serde::Deserialize)
 )]
-#[cfg_attr(feature = "rspc", derive(rspc::Type))]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
 pub enum Params {
 	Standard,
 	Hardened,
@@ -47,7 +47,7 @@ pub enum Params {
 	derive(serde::Deserialize),
 	serde(tag = "name", content = "params")
 )]
-#[cfg_attr(feature = "rspc", derive(rspc::Type))]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
 pub enum HashingAlgorithm {
 	Argon2id(Params),
 	BalloonBlake3(Params),
@@ -127,7 +127,7 @@ impl Deref for Nonce {
 	derive(serde::Serialize),
 	derive(serde::Deserialize)
 )]
-#[cfg_attr(feature = "rspc", derive(rspc::Type))]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
 pub enum Algorithm {
 	XChaCha20Poly1305,
 	Aes256Gcm,
@@ -300,7 +300,7 @@ impl From<SecretKeyString> for SecretKey {
 /// This is always `ENCRYPTED_KEY_LEN` (which is `KEY_LEM` + `AEAD_TAG_LEN`)
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "rspc", derive(rspc::Type))]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct EncryptedKey(
 	#[cfg_attr(feature = "serde", serde(with = "BigArray"))] // salt used for file data
 	pub  [u8; ENCRYPTED_KEY_LEN],
@@ -327,7 +327,7 @@ impl TryFrom<Vec<u8>> for EncryptedKey {
 /// You may also generate a salt with `Salt::generate()`
 #[derive(Clone, PartialEq, Eq, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "rspc", derive(rspc::Type))]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct Salt(pub [u8; SALT_LEN]);
 
 impl Salt {
@@ -357,7 +357,7 @@ impl TryFrom<Vec<u8>> for Salt {
 
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
-#[cfg_attr(feature = "rspc", derive(rspc::Type))]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct OnboardingConfig {
 	pub password: Protected<String>,
 	pub algorithm: Algorithm,

--- a/crates/p2p/src/utils/peer_id.rs
+++ b/crates/p2p/src/utils/peer_id.rs
@@ -1,9 +1,10 @@
 use std::{fmt::Display, str::FromStr};
 
 #[derive(Debug, Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(transparent))]
-pub struct PeerId(pub(crate) libp2p::PeerId);
+#[cfg_attr(any(feature = "specta", feature = "serde"), serde(transparent))]
+pub struct PeerId(#[specta(type = String)] pub(crate) libp2p::PeerId);
 
 impl FromStr for PeerId {
 	type Err = libp2p::core::ParseError;
@@ -16,27 +17,5 @@ impl FromStr for PeerId {
 impl Display for PeerId {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		write!(f, "{}", self.0)
-	}
-}
-
-// TODO: Replace this with transparent when the new Specta release is merged
-// TODO: 	#[cfg_attr(feature = "specta", derive(specta::Type))]
-// TODO: 	pub struct PeerId(#[cfg_attr(feature = "specta", specta(type = String))] pub(crate) libp2p::PeerId);
-#[cfg(feature = "specta")]
-impl specta::Type for PeerId {
-	const NAME: &'static str = "PeerId";
-	const SID: specta::TypeSid = specta::sid!();
-	const IMPL_LOCATION: specta::ImplLocation = specta::impl_location!();
-
-	fn inline(opts: specta::DefOpts, generics: &[specta::DataType]) -> specta::DataType {
-		<String as specta::Type>::inline(opts, generics)
-	}
-
-	fn reference(opts: specta::DefOpts, generics: &[specta::DataType]) -> specta::DataType {
-		<String as specta::Type>::reference(opts, generics)
-	}
-
-	fn definition(opts: specta::DefOpts) -> specta::DataTypeExt {
-		<String as specta::Type>::definition(opts)
 	}
 }

--- a/crates/sync-generator/src/lib.rs
+++ b/crates/sync-generator/src/lib.rs
@@ -114,11 +114,11 @@ impl PrismaGenerator for SDSyncGenerator {
 
                         let typ = match field {
                             dml::Field::ScalarField(_) => {
-                                field.type_tokens(quote!(self))
+                                field.type_tokens(&quote!(self))
                             },
                             dml::Field::RelationField(relation)=> {
                                 let relation_model_name_snake = snake_ident(&relation.relation_info.referenced_model);
-                                quote!(super::#relation_model_name_snake::SyncId)
+                                Some(quote!(super::#relation_model_name_snake::SyncId))
                             },
                             _ => return None
                         };

--- a/crates/sync/Cargo.toml
+++ b/crates/sync/Cargo.toml
@@ -2,11 +2,10 @@
 name = "sd-sync"
 version = "0.1.0"
 edition = "2021"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 rand = "0.8.5"
-rspc = { workspace = true, features = ["uuid", "uhlc"] }
+specta = { workspace = true, features = ["uuid", "uhlc"] }
 serde = "1.0.145"
 serde_json = "1.0.85"
 uhlc = "0.5.1"

--- a/crates/sync/src/crdt.rs
+++ b/crates/sync/src/crdt.rs
@@ -1,8 +1,8 @@
 use std::{collections::BTreeMap, fmt::Debug};
 
-use rspc::Type;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
+use specta::Type;
 use uhlc::NTP64;
 use uuid::Uuid;
 

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -292,7 +292,7 @@ export type UnlockKeyManagerArgs = { password: Protected<string>; secret_key: Pr
 
 export type FileDecryptorJobInit = { location_id: number; path_id: number; mount_associated_key: boolean; output_path: string | null; password: string | null; save_to_library: boolean | null }
 
-export type Protected<T> = { data: T }
+export type Protected<T> = T
 
 /**
  * `IndexerRuleCreateArgs` is the argument received from the client using rspc to create a new indexer rule.

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -4,7 +4,7 @@
 export type Procedures = {
     queries: 
         { key: "buildInfo", input: never, result: BuildInfo } | 
-        { key: "files.get", input: LibraryArgs<GetArgs>, result: { id: number, pub_id: number[], kind: number, key_id: number | null, hidden: boolean, favorite: boolean, important: boolean, has_thumbnail: boolean, has_thumbstrip: boolean, has_video_preview: boolean, ipfs_id: string | null, note: string | null, date_created: string, file_paths: FilePath[], media_data: MediaData | null } | null } | 
+        { key: "files.get", input: LibraryArgs<GetArgs>, result: { id: number; pub_id: number[]; kind: number; key_id: number | null; hidden: boolean; favorite: boolean; important: boolean; has_thumbnail: boolean; has_thumbstrip: boolean; has_video_preview: boolean; ipfs_id: string | null; note: string | null; date_created: string; file_paths: FilePath[]; media_data: MediaData | null } | null } | 
         { key: "jobs.getHistory", input: LibraryArgs<null>, result: JobReport[] } | 
         { key: "jobs.getRunning", input: LibraryArgs<null>, result: JobReport[] } | 
         { key: "keys.getDefault", input: LibraryArgs<null>, result: string | null } | 
@@ -17,14 +17,14 @@ export type Procedures = {
         { key: "keys.listMounted", input: LibraryArgs<null>, result: string[] } | 
         { key: "library.getStatistics", input: LibraryArgs<null>, result: Statistics } | 
         { key: "library.list", input: never, result: LibraryConfigWrapped[] } | 
-        { key: "locations.getById", input: LibraryArgs<number>, result: location_with_indexer_rules | null } | 
+        { key: "locations.getById", input: LibraryArgs<number>, result: LocationWithIndexerRules | null } | 
         { key: "locations.getExplorerData", input: LibraryArgs<LocationExplorerArgs>, result: ExplorerData } | 
         { key: "locations.indexer_rules.get", input: LibraryArgs<number>, result: IndexerRule } | 
         { key: "locations.indexer_rules.list", input: LibraryArgs<null>, result: IndexerRule[] } | 
         { key: "locations.indexer_rules.listForLocation", input: LibraryArgs<number>, result: IndexerRule[] } | 
-        { key: "locations.list", input: LibraryArgs<null>, result: { id: number, pub_id: number[], node_id: number, name: string, path: string, total_capacity: number | null, available_capacity: number | null, is_archived: boolean, generate_preview_media: boolean, sync_preview_media: boolean, hidden: boolean, date_created: string, node: Node }[] } | 
+        { key: "locations.list", input: LibraryArgs<null>, result: ({ id: number; pub_id: number[]; node_id: number; name: string; path: string; total_capacity: number | null; available_capacity: number | null; is_archived: boolean; generate_preview_media: boolean; sync_preview_media: boolean; hidden: boolean; date_created: string; node: Node })[] } | 
         { key: "nodeState", input: never, result: NodeState } | 
-        { key: "search", input: LibraryArgs<{ locationId?: number, afterFileId?: [number, number], take?: number, order?: Ordering, search?: string, extension?: string, kind?: number, tags?: number[], createdAtFrom?: string, createdAtTo?: string, path?: string }>, result: ExplorerItem[] } | 
+        { key: "search", input: LibraryArgs<{ locationId?: number | null; afterFileId?: [number, number] | null; take?: number | null; order?: Ordering | null; search?: string | null; extension?: string | null; kind?: number | null; tags?: number[] | null; createdAtFrom?: string | null; createdAtTo?: string | null; path?: string | null }>, result: ExplorerItem[] } | 
         { key: "sync.messages", input: LibraryArgs<null>, result: CRDTOperation[] } | 
         { key: "tags.get", input: LibraryArgs<number>, result: Tag | null } | 
         { key: "tags.getExplorerData", input: LibraryArgs<number>, result: ExplorerData } | 
@@ -87,234 +87,238 @@ export type Procedures = {
         { key: "sync.newMessage", input: LibraryArgs<null>, result: CRDTOperation }
 };
 
-/**
- *  These are all possible algorithms that can be used for encryption and decryption
- */
-export type Algorithm = "XChaCha20Poly1305" | "Aes256Gcm"
-
-export type AutomountUpdateArgs = { uuid: string, status: boolean }
-
-export type BuildInfo = { version: string, commit: string }
-
-export type CRDTOperation = { node: string, timestamp: number, id: string, typ: CRDTOperationType }
-
-export type CRDTOperationType = SharedOperation | RelationOperation | OwnedOperation
-
-export type CreateLibraryArgs = { name: string }
-
-export type EditLibraryArgs = { id: string, name: string | null, description: string | null }
-
-/**
- *  This should be used for passing an encrypted key around.
- * 
- *  This is always `ENCRYPTED_KEY_LEN` (which is `KEY_LEM` + `AEAD_TAG_LEN`)
- */
-export type EncryptedKey = number[]
-
-export type ExplorerContext = ({ type:  "Location" } & Location) | ({ type:  "Tag" } & Tag)
-
-export type ExplorerData = { context: ExplorerContext, items: ExplorerItem[] }
-
-export type ExplorerItem = { type: "Path", has_thumbnail: boolean, item: file_path_with_object } | { type: "Object", has_thumbnail: boolean, item: object_with_file_paths }
-
-export type FileCopierJobInit = { source_location_id: number, source_path_id: number, target_location_id: number, target_path: string, target_file_name_suffix: string | null }
-
-export type FileCutterJobInit = { source_location_id: number, source_path_id: number, target_location_id: number, target_path: string }
-
-export type FileDecryptorJobInit = { location_id: number, path_id: number, mount_associated_key: boolean, output_path: string | null, password: string | null, save_to_library: boolean | null }
-
-export type FileDeleterJobInit = { location_id: number, path_id: number }
-
-export type FileEncryptorJobInit = { location_id: number, path_id: number, key_uuid: string, algorithm: Algorithm, metadata: boolean, preview_media: boolean, output_path: string | null }
-
-export type FileEraserJobInit = { location_id: number, path_id: number, passes: string }
-
-export type FilePath = { id: number, is_dir: boolean, cas_id: string | null, integrity_checksum: string | null, location_id: number, materialized_path: string, name: string, extension: string, size_in_bytes: string, inode: number[], device: number[], object_id: number | null, parent_id: number | null, key_id: number | null, date_created: string, date_modified: string, date_indexed: string }
-
-export type GenerateThumbsForLocationArgs = { id: number, path: string }
-
-export type GetArgs = { id: number }
-
-/**
- *  This defines all available password hashing algorithms.
- */
-export type HashingAlgorithm = { name: "Argon2id", params: Params } | { name: "BalloonBlake3", params: Params }
-
-export type IdentifyUniqueFilesArgs = { id: number, path: string }
-
-export type IndexerRule = { id: number, kind: number, name: string, default: boolean, parameters: number[], date_created: string, date_modified: string }
-
-/**
- *  `IndexerRuleCreateArgs` is the argument received from the client using rspc to create a new indexer rule.
- *  Note that `parameters` field **MUST** be a JSON object serialized to bytes.
- * 
- *  In case of  `RuleKind::AcceptFilesByGlob` or `RuleKind::RejectFilesByGlob`, it will be a
- *  single string containing a glob pattern.
- * 
- *  In case of `RuleKind::AcceptIfChildrenDirectoriesArePresent` or `RuleKind::RejectIfChildrenDirectoriesArePresent` the
- *  `parameters` field must be a vector of strings containing the names of the directories.
- */
-export type IndexerRuleCreateArgs = { kind: RuleKind, name: string, parameters: string[] }
-
-export type InvalidateOperationEvent = { key: string, arg: any, result: any | null }
-
-export type JobReport = { id: string, name: string, action: string | null, data: number[] | null, metadata: any | null, is_background: boolean, created_at: string | null, started_at: string | null, completed_at: string | null, parent_id: string | null, status: JobStatus, task_count: number, completed_task_count: number, message: string }
-
-export type JobStatus = "Queued" | "Running" | "Completed" | "Canceled" | "Failed" | "Paused"
-
-export type KeyAddArgs = { algorithm: Algorithm, hashing_algorithm: HashingAlgorithm, key: string, library_sync: boolean, automount: boolean }
-
-/**
- *  Can wrap a query argument to require it to contain a `library_id` and provide helpers for working with libraries.
- */
-export type LibraryArgs<T> = { library_id: string, arg: T }
-
-/**
- *  LibraryConfig holds the configuration for a specific library. This is stored as a '{uuid}.sdlibrary' file.
- */
-export type LibraryConfig = { name: string, description: string }
-
-export type LibraryConfigWrapped = { uuid: string, config: LibraryConfig }
-
-export type LightScanArgs = { location_id: number, sub_path: string }
-
-export type Location = { id: number, pub_id: number[], node_id: number, name: string, path: string, total_capacity: number | null, available_capacity: number | null, is_archived: boolean, generate_preview_media: boolean, sync_preview_media: boolean, hidden: boolean, date_created: string }
-
-/**
- *  `LocationCreateArgs` is the argument received from the client using `rspc` to create a new location.
- *  It has the actual path and a vector of indexer rules ids, to create many-to-many relationships
- *  between the location and indexer rules.
- */
-export type LocationCreateArgs = { path: string, indexer_rules_ids: number[] }
-
-export type LocationExplorerArgs = { location_id: number, path: string | null, limit: number, cursor: string | null, kind: number[] | null }
-
-/**
- *  `LocationUpdateArgs` is the argument received from the client using `rspc` to update a location.
- *  It contains the id of the location to be updated, possible a name to change the current location's name
- *  and a vector of indexer rules ids to add or remove from the location.
- * 
- *  It is important to note that only the indexer rule ids in this vector will be used from now on.
- *  Old rules that aren't in this vector will be purged.
- */
-export type LocationUpdateArgs = { id: number, name: string | null, generate_preview_media: boolean | null, sync_preview_media: boolean | null, hidden: boolean | null, indexer_rules_ids: number[] }
-
-export type MasterPasswordChangeArgs = { password: string, algorithm: Algorithm, hashing_algorithm: HashingAlgorithm }
-
-export type MediaData = { id: number, pixel_width: number | null, pixel_height: number | null, longitude: number | null, latitude: number | null, fps: number | null, capture_device_make: string | null, capture_device_model: string | null, capture_device_software: string | null, duration_seconds: number | null, codecs: string | null, streams: number | null }
-
-export type Node = { id: number, pub_id: number[], name: string, platform: number, version: string | null, last_seen: string, timezone: string | null, date_created: string }
-
-/**
- *  NodeConfig is the configuration for a node. This is shared between all libraries and is stored in a JSON file on disk.
- */
-export type NodeConfig = { id: string, name: string, p2p_port: number | null, p2p_email: string | null, p2p_img_url: string | null }
-
-export type NodeState = ({ id: string, name: string, p2p_port: number | null, p2p_email: string | null, p2p_img_url: string | null }) & { data_path: string }
-
-/**
- *  This should be used for providing a nonce to encrypt/decrypt functions.
- * 
- *  You may also generate a nonce for a given algorithm with `Nonce::generate()`
- */
-export type Nonce = { XChaCha20Poly1305: number[] } | { Aes256Gcm: number[] }
-
-export type Object = { id: number, pub_id: number[], kind: number, key_id: number | null, hidden: boolean, favorite: boolean, important: boolean, has_thumbnail: boolean, has_thumbstrip: boolean, has_video_preview: boolean, ipfs_id: string | null, note: string | null, date_created: string }
-
-export type ObjectValidatorArgs = { id: number, path: string }
-
-export type OnboardingConfig = { password: string, algorithm: Algorithm, hashing_algorithm: HashingAlgorithm }
-
-/**
- *  Represents the operating system which the remote peer is running.
- *  This is not used internally and predominantly is designed to be used for display purposes by the embedding application.
- */
-export type OperatingSystem = "Windows" | "Linux" | "MacOS" | "Ios" | "Android" | { Other: string }
-
-export type Ordering = { name: boolean }
-
-export type OwnedOperation = { model: string, items: OwnedOperationItem[] }
-
-export type OwnedOperationData = { Create: { [key: string]: any } } | { CreateMany: { values: [any, { [key: string]: any }][], skip_duplicates: boolean } } | { Update: { [key: string]: any } } | "Delete"
-
-export type OwnedOperationItem = { id: any, data: OwnedOperationData }
-
-/**
- *  TODO: P2P event for the frontend
- */
-export type P2PEvent = { type: "DiscoveredPeer", peer_id: string, metadata: PeerMetadata } | { type: "SyncOperation", library_id: string, operations: CRDTOperation[] }
-
-/**
- *  These parameters define the password-hashing level.
- * 
- *  The greater the parameter, the longer the password will take to hash.
- */
-export type Params = "Standard" | "Hardened" | "Paranoid"
-
-export type PeerMetadata = { name: string, operating_system: OperatingSystem | null, version: string | null, email: string | null, img_url: string | null }
-
-export type RelationOperation = { relation_item: string, relation_group: string, relation: string, data: RelationOperationData }
-
-export type RelationOperationData = "Create" | { Update: { field: string, value: any } } | "Delete"
-
-export type RenameFileArgs = { location_id: number, file_name: string, new_file_name: string }
-
-export type RestoreBackupArgs = { password: string, secret_key: string, path: string }
+export type EditLibraryArgs = { id: string; name: string | null; description: string | null }
 
 export type RuleKind = "AcceptFilesByGlob" | "RejectFilesByGlob" | "AcceptIfChildrenDirectoriesArePresent" | "RejectIfChildrenDirectoriesArePresent"
 
+export type PeerMetadata = { name: string; operating_system: OperatingSystem | null; version: string | null; email: string | null; img_url: string | null }
+
 /**
- *  This should be used for passing a salt around.
+ * `LocationUpdateArgs` is the argument received from the client using `rspc` to update a location.
+ * It contains the id of the location to be updated, possible a name to change the current location's name
+ * and a vector of indexer rules ids to add or remove from the location.
  * 
- *  You may also generate a salt with `Salt::generate()`
+ * It is important to note that only the indexer rule ids in this vector will be used from now on.
+ * Old rules that aren't in this vector will be purged.
  */
-export type Salt = number[]
-
-export type SetFavoriteArgs = { id: number, favorite: boolean }
-
-export type SetNoteArgs = { id: number, note: string | null }
-
-export type SharedOperation = { record_id: any, model: string, data: SharedOperationData }
-
-export type SharedOperationCreateData = { u: { [key: string]: any } } | "a"
-
-export type SharedOperationData = SharedOperationCreateData | { field: string, value: any } | null
-
-export type SpacedropArgs = { peer_id: string, file_path: string }
-
-export type Statistics = { id: number, date_captured: string, total_object_count: number, library_db_size: string, total_bytes_used: string, total_bytes_capacity: string, total_unique_bytes: string, total_bytes_free: string, preview_media_bytes: string }
+export type LocationUpdateArgs = { id: number; name: string | null; generate_preview_media: boolean | null; sync_preview_media: boolean | null; hidden: boolean | null; indexer_rules_ids: number[] }
 
 /**
- *  This is a stored key, and can be freely written to the database.
- * 
- *  It contains no sensitive information that is not encrypted.
+ * NodeConfig is the configuration for a node. This is shared between all libraries and is stored in a JSON file on disk.
  */
-export type StoredKey = { uuid: string, version: StoredKeyVersion, key_type: StoredKeyType, algorithm: Algorithm, hashing_algorithm: HashingAlgorithm, content_salt: Salt, master_key: EncryptedKey, master_key_nonce: Nonce, key_nonce: Nonce, key: number[], salt: Salt, memory_only: boolean, automount: boolean }
+export type NodeConfig = { id: string; name: string; p2p_port: number | null; p2p_email: string | null; p2p_img_url: string | null }
 
 /**
- *  This denotes the type of key. `Root` keys can be used to unlock the key manager, and `User` keys are ordinary keys.
- */
-export type StoredKeyType = "User" | "Root"
-
-/**
- *  This denotes the `StoredKey` version.
+ * This denotes the `StoredKey` version.
  */
 export type StoredKeyVersion = "V1"
 
-export type Tag = { id: number, pub_id: number[], name: string | null, color: string | null, total_objects: number | null, redundancy_goal: number | null, date_created: string, date_modified: string }
+/**
+ * This should be used for passing an encrypted key around.
+ * 
+ * This is always `ENCRYPTED_KEY_LEN` (which is `KEY_LEM` + `AEAD_TAG_LEN`)
+ */
+export type EncryptedKey = number[]
 
-export type TagAssignArgs = { object_id: number, tag_id: number, unassign: boolean }
+export type PeerId = string
 
-export type TagCreateArgs = { name: string, color: string }
+export type Object = { id: number; pub_id: number[]; kind: number; key_id: number | null; hidden: boolean; favorite: boolean; important: boolean; has_thumbnail: boolean; has_thumbstrip: boolean; has_video_preview: boolean; ipfs_id: string | null; note: string | null; date_created: string }
 
-export type TagUpdateArgs = { id: number, name: string | null, color: string | null }
+export type LibraryConfigWrapped = { uuid: string; config: LibraryConfig }
 
-export type UnlockKeyManagerArgs = { password: string, secret_key: string }
+/**
+ * These parameters define the password-hashing level.
+ * 
+ * The greater the parameter, the longer the password will take to hash.
+ */
+export type Params = "Standard" | "Hardened" | "Paranoid"
 
-export type Volume = { name: string, mount_point: string, total_capacity: string, available_capacity: string, is_removable: boolean, disk_type: string | null, file_system: string | null, is_root_filesystem: boolean }
+export type ExplorerData = { context: ExplorerContext; items: ExplorerItem[] }
 
-export type file_path_with_object = { id: number, is_dir: boolean, cas_id: string | null, integrity_checksum: string | null, location_id: number, materialized_path: string, name: string, extension: string, size_in_bytes: string, inode: number[], device: number[], object_id: number | null, parent_id: number | null, key_id: number | null, date_created: string, date_modified: string, date_indexed: string, object: Object | null }
+/**
+ * Represents the operating system which the remote peer is running.
+ * This is not used internally and predominantly is designed to be used for display purposes by the embedding application.
+ */
+export type OperatingSystem = "Windows" | "Linux" | "MacOS" | "Ios" | "Android" | { Other: string }
 
-export type location_with_indexer_rules = { id: number, pub_id: number[], node_id: number, name: string, path: string, total_capacity: number | null, available_capacity: number | null, is_archived: boolean, generate_preview_media: boolean, sync_preview_media: boolean, hidden: boolean, date_created: string, indexer_rules: { indexer_rule: IndexerRule }[] }
+export type MediaData = { id: number; pixel_width: number | null; pixel_height: number | null; longitude: number | null; latitude: number | null; fps: number | null; capture_device_make: string | null; capture_device_model: string | null; capture_device_software: string | null; duration_seconds: number | null; codecs: string | null; streams: number | null }
 
-export type object_with_file_paths = { id: number, pub_id: number[], kind: number, key_id: number | null, hidden: boolean, favorite: boolean, important: boolean, has_thumbnail: boolean, has_thumbstrip: boolean, has_video_preview: boolean, ipfs_id: string | null, note: string | null, date_created: string, file_paths: FilePath[] }
+export type IdentifyUniqueFilesArgs = { id: number; path: string }
+
+/**
+ * This is a stored key, and can be freely written to the database.
+ * 
+ * It contains no sensitive information that is not encrypted.
+ */
+export type StoredKey = { uuid: string; version: StoredKeyVersion; key_type: StoredKeyType; algorithm: Algorithm; hashing_algorithm: HashingAlgorithm; content_salt: Salt; master_key: EncryptedKey; master_key_nonce: Nonce; key_nonce: Nonce; key: number[]; salt: Salt; memory_only: boolean; automount: boolean }
+
+export type OnboardingConfig = { password: Protected<string>; algorithm: Algorithm; hashing_algorithm: HashingAlgorithm }
+
+/**
+ * This should be used for providing a nonce to encrypt/decrypt functions.
+ * 
+ * You may also generate a nonce for a given algorithm with `Nonce::generate()`
+ */
+export type Nonce = { XChaCha20Poly1305: number[] } | { Aes256Gcm: number[] }
+
+export type FilePathWithObject = { id: number; is_dir: boolean; cas_id: string | null; integrity_checksum: string | null; location_id: number; materialized_path: string; name: string; extension: string; size_in_bytes: string; inode: number[]; device: number[]; object_id: number | null; parent_id: number | null; key_id: number | null; date_created: string; date_modified: string; date_indexed: string; object: Object | null }
+
+export type SpacedropArgs = { peer_id: PeerId; file_path: string }
+
+export type CRDTOperation = { node: string; timestamp: number; id: string; typ: CRDTOperationType }
+
+export type ObjectWithFilePaths = { id: number; pub_id: number[]; kind: number; key_id: number | null; hidden: boolean; favorite: boolean; important: boolean; has_thumbnail: boolean; has_thumbstrip: boolean; has_video_preview: boolean; ipfs_id: string | null; note: string | null; date_created: string; file_paths: FilePath[] }
+
+/**
+ * This should be used for passing a salt around.
+ * 
+ * You may also generate a salt with `Salt::generate()`
+ */
+export type Salt = number[]
+
+export type GetArgs = { id: number }
+
+export type FileCutterJobInit = { source_location_id: number; source_path_id: number; target_location_id: number; target_path: string }
+
+export type FilePath = { id: number; is_dir: boolean; cas_id: string | null; integrity_checksum: string | null; location_id: number; materialized_path: string; name: string; extension: string; size_in_bytes: string; inode: number[]; device: number[]; object_id: number | null; parent_id: number | null; key_id: number | null; date_created: string; date_modified: string; date_indexed: string }
+
+export type JobStatus = "Queued" | "Running" | "Completed" | "Canceled" | "Failed" | "Paused"
+
+export type FileEraserJobInit = { location_id: number; path_id: number; passes: string }
+
+export type TagCreateArgs = { name: string; color: string }
+
+/**
+ * Can wrap a query argument to require it to contain a `library_id` and provide helpers for working with libraries.
+ */
+export type LibraryArgs<T> = { library_id: string; arg: T }
+
+/**
+ * TODO: P2P event for the frontend
+ */
+export type P2PEvent = { type: "DiscoveredPeer"; peer_id: PeerId; metadata: PeerMetadata } | { type: "SyncOperation"; library_id: string; operations: CRDTOperation[] }
+
+export type SetFavoriteArgs = { id: number; favorite: boolean }
+
+export type RenameFileArgs = { location_id: number; file_name: string; new_file_name: string }
+
+export type Volume = { name: string; mount_point: string; total_capacity: string; available_capacity: string; is_removable: boolean; disk_type: string | null; file_system: string | null; is_root_filesystem: boolean }
+
+export type FileDeleterJobInit = { location_id: number; path_id: number }
+
+/**
+ * These are all possible algorithms that can be used for encryption and decryption
+ */
+export type Algorithm = "XChaCha20Poly1305" | "Aes256Gcm"
+
+export type CreateLibraryArgs = { name: string }
+
+export type ExplorerItem = { type: "Path"; has_thumbnail: boolean; item: FilePathWithObject } | { type: "Object"; has_thumbnail: boolean; item: ObjectWithFilePaths }
+
+export type IndexerRule = { id: number; kind: number; name: string; default: boolean; parameters: number[]; date_created: string; date_modified: string }
+
+export type JobReport = { id: string; name: string; action: string | null; data: number[] | null; metadata: any | null; is_background: boolean; created_at: string | null; started_at: string | null; completed_at: string | null; parent_id: string | null; status: JobStatus; task_count: number; completed_task_count: number; message: string }
+
+export type OwnedOperationItem = { id: any; data: OwnedOperationData }
+
+export type CRDTOperationType = SharedOperation | RelationOperation | OwnedOperation
+
+export type Statistics = { id: number; date_captured: string; total_object_count: number; library_db_size: string; total_bytes_used: string; total_bytes_capacity: string; total_unique_bytes: string; total_bytes_free: string; preview_media_bytes: string }
+
+export type GenerateThumbsForLocationArgs = { id: number; path: string }
+
+export type TagAssignArgs = { object_id: number; tag_id: number; unassign: boolean }
+
+export type OwnedOperation = { model: string; items: OwnedOperationItem[] }
+
+export type SharedOperation = { record_id: any; model: string; data: SharedOperationData }
+
+export type MasterPasswordChangeArgs = { password: Protected<string>; algorithm: Algorithm; hashing_algorithm: HashingAlgorithm }
+
+export type RelationOperationData = "Create" | { Update: { field: string; value: any } } | "Delete"
+
+export type InvalidateOperationEvent = { key: string; arg: any; result: any | null }
+
+export type FileEncryptorJobInit = { location_id: number; path_id: number; key_uuid: string; algorithm: Algorithm; metadata: boolean; preview_media: boolean; output_path: string | null }
+
+export type SharedOperationCreateData = { u: { [key: string]: any } } | "a"
+
+export type BuildInfo = { version: string; commit: string }
+
+export type Location = { id: number; pub_id: number[]; node_id: number; name: string; path: string; total_capacity: number | null; available_capacity: number | null; is_archived: boolean; generate_preview_media: boolean; sync_preview_media: boolean; hidden: boolean; date_created: string }
+
+/**
+ * `LocationCreateArgs` is the argument received from the client using `rspc` to create a new location.
+ * It has the actual path and a vector of indexer rules ids, to create many-to-many relationships
+ * between the location and indexer rules.
+ */
+export type LocationCreateArgs = { path: string; indexer_rules_ids: number[] }
+
+export type KeyAddArgs = { algorithm: Algorithm; hashing_algorithm: HashingAlgorithm; key: Protected<string>; library_sync: boolean; automount: boolean }
+
+export type Node = { id: number; pub_id: number[]; name: string; platform: number; version: string | null; last_seen: string; timezone: string | null; date_created: string }
+
+export type NodeState = ({ id: string; name: string; p2p_port: number | null; p2p_email: string | null; p2p_img_url: string | null }) & { data_path: string }
+
+export type OwnedOperationData = { Create: { [key: string]: any } } | { CreateMany: { values: ([any, { [key: string]: any }])[]; skip_duplicates: boolean } } | { Update: { [key: string]: any } } | "Delete"
+
+export type SharedOperationData = SharedOperationCreateData | { field: string; value: any } | null
+
+export type LocationExplorerArgs = { location_id: number; path: string | null; limit: number; cursor: string | null; kind: number[] | null }
+
+export type FileCopierJobInit = { source_location_id: number; source_path_id: number; target_location_id: number; target_path: string; target_file_name_suffix: string | null }
+
+export type LightScanArgs = { location_id: number; sub_path: string }
+
+/**
+ * This defines all available password hashing algorithms.
+ */
+export type HashingAlgorithm = { name: "Argon2id"; params: Params } | { name: "BalloonBlake3"; params: Params }
+
+export type AutomountUpdateArgs = { uuid: string; status: boolean }
+
+export type ExplorerContext = ({ type: "Location" } & Location) | ({ type: "Tag" } & Tag)
+
+export type LocationWithIndexerRules = { id: number; pub_id: number[]; node_id: number; name: string; path: string; total_capacity: number | null; available_capacity: number | null; is_archived: boolean; generate_preview_media: boolean; sync_preview_media: boolean; hidden: boolean; date_created: string; indexer_rules: ({ indexer_rule: IndexerRule })[] }
+
+/**
+ * LibraryConfig holds the configuration for a specific library. This is stored as a '{uuid}.sdlibrary' file.
+ */
+export type LibraryConfig = { name: string; description: string }
+
+export type Ordering = { name: boolean }
+
+export type UnlockKeyManagerArgs = { password: Protected<string>; secret_key: Protected<string> }
+
+export type FileDecryptorJobInit = { location_id: number; path_id: number; mount_associated_key: boolean; output_path: string | null; password: string | null; save_to_library: boolean | null }
+
+export type Protected<T> = { data: T }
+
+/**
+ * `IndexerRuleCreateArgs` is the argument received from the client using rspc to create a new indexer rule.
+ * Note that `parameters` field **MUST** be a JSON object serialized to bytes.
+ * 
+ * In case of  `RuleKind::AcceptFilesByGlob` or `RuleKind::RejectFilesByGlob`, it will be a
+ * single string containing a glob pattern.
+ * 
+ * In case of `RuleKind::AcceptIfChildrenDirectoriesArePresent` or `RuleKind::RejectIfChildrenDirectoriesArePresent` the
+ * `parameters` field must be a vector of strings containing the names of the directories.
+ */
+export type IndexerRuleCreateArgs = { kind: RuleKind; name: string; parameters: string[] }
+
+export type SetNoteArgs = { id: number; note: string | null }
+
+export type TagUpdateArgs = { id: number; name: string | null; color: string | null }
+
+export type ObjectValidatorArgs = { id: number; path: string }
+
+export type RestoreBackupArgs = { password: Protected<string>; secret_key: Protected<string>; path: string }
+
+export type Tag = { id: number; pub_id: number[]; name: string | null; color: string | null; total_objects: number | null; redundancy_goal: number | null; date_created: string; date_modified: string }
+
+export type RelationOperation = { relation_item: string; relation_group: string; relation: string; data: RelationOperationData }
+
+/**
+ * This denotes the type of key. `Root` keys can be used to unlock the key manager, and `User` keys are ordinary keys.
+ */
+export type StoredKeyType = "User" | "Root"


### PR DESCRIPTION
Changes:
 - Change `rspc::Type` to `specta::Type` ready for the upstream change over
 - Upgrade rspc
 - Upgrade Specta
 - Upgrade PCR
 - Library subscriptions that don't suck finally!!!!!
 - Also removed all custom `impl Type`'s which is gonna be nice for easy Specta upgrades even over breaking changes.
 - The library query system's ease of maintenance has regressed in this PR but it's gonna be redone soon anyway.