### PR TITLE
[ENG-527] - Bundle gstreamer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
       - main
   workflow_dispatch:
 
+# NOTE: For Linux builds, we can only build with Ubuntu. It should be the oldest base system we intend to support. See PR-759 & https://tauri.app/v1/guides/building/linux for reference.
+
 jobs:
   desktop-main:
     name: Desktop - Main (${{ matrix.platform }})

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -12,6 +12,9 @@
 	"tauri": {
 		"macOSPrivateApi": true,
 		"bundle": {
+			"appimage": {
+				"bundleMediaFramework": true
+			},
 			"active": true,
 			"targets": "all",
 			"identifier": "com.spacedrive.desktop",


### PR DESCRIPTION
`Includes additional gstreamer dependencies needed for audio and video playback. This increases the bundle size by ~15-35MB depending on your build system.`


**This flag is currently only supported on Ubuntu build systems.**
