### PR TITLE
Fix Windows CI + format

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -66,3 +66,8 @@ indent_style = space
 [*.prisma]
 indent_size = 4
 indent_style = space
+
+# YAML
+# http://yaml.org/spec/1.2/2009-07-21/spec.html#id2576668
+[*.{yaml,yml}]
+indent_style = space

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+.prettierignore

--- a/.github/actions/cache-rust-deps/action.yaml
+++ b/.github/actions/cache-rust-deps/action.yaml
@@ -4,7 +4,7 @@ inputs:
   save-cache:
     description: Whether to save the Rust cache
     required: false
-    default: "false"
+    default: 'false'
 runs:
   using: 'composite'
   steps:

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,10 +1,14 @@
 name: Setup
 description: Sets up runner, Rust and pnpm
 inputs:
+  token:
+    description: Github token
+    required: false
+    default: ''
   save-cache:
     description: Whether to save the Rust cache
     required: false
-    default: "false"
+    default: 'false'
 runs:
   using: 'composite'
   steps:
@@ -18,6 +22,22 @@ runs:
       uses: pnpm/action-setup@v2.2.2
       with:
         version: 7.x.x
+        run_install: false
+
+    - name: Cache LLVM and Clang
+      if: runner.os == 'Windows'
+      id: cache-llvm
+      uses: actions/cache@v3
+      with:
+        path: C:/Program Files/LLVM
+        key: llvm-15
+
+    - name: Install LLVM and Clang
+      if: runner.os == 'Windows'
+      uses: KyleMayes/install-llvm-action@v1
+      with:
+        version: '15'
+        cached: ${{ steps.cache-llvm.outputs.cache-hit }}
 
     - name: Cache Rust deps
       uses: ./.github/actions/cache-rust-deps
@@ -33,6 +53,8 @@ runs:
       shell: powershell
       if: runner.os == 'Windows'
       run: ./.github/scripts/setup-system.ps1
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
 
     - name: Generate Prisma client
       uses: ./.github/actions/generate-prisma-client

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,14 +12,15 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Install Rust stable
-      uses: actions-rs/toolchain@v1
+    - name: Install Rust
+      id: toolchain
+      uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
-        profile: minimal
+        components: clippy, rustfmt
 
     - name: Install pnpm
-      uses: pnpm/action-setup@v2.2.2
+      uses: pnpm/action-setup@v2
       with:
         version: 7.x.x
         run_install: false

--- a/.github/scripts/setup-system.ps1
+++ b/.github/scripts/setup-system.ps1
@@ -175,7 +175,10 @@ https://learn.microsoft.com/windows/package-manager/winget/
 
 Write-Host
 Write-Host 'Checking for pnpm...' -ForegroundColor Yellow
-if ((Get-Command pnpm -ea 0) -and (pnpm --version | Select-Object -First 1) -match "^$pnpm_major\." ) {
+if ($env:CI) {
+	# The CI has pnpm installed already
+	Write-Host 'Running with CI, skipping pnpm install.' -ForegroundColor Green
+}if ((Get-Command pnpm -ea 0) -and (pnpm --version | Select-Object -First 1) -match "^$pnpm_major\." ) {
    Write-Host "pnpm $pnpm_major is installed." -ForegroundColor Green
 } else {
    # Check for pnpm installed with standalone installer
@@ -211,8 +214,8 @@ https://pnpm.io/uninstall
 Write-Host
 Write-Host 'Checking for LLVM...' -ForegroundColor Yellow
 if ($env:CI) {
-   # The CI has LLVM installed already, so we instead just set the env variables.
-   Write-Host 'Running with Ci, skipping LLVM install.' -ForegroundColor Green
+   # The CI has LLVM installed already
+   Write-Host 'Running with CI, skipping LLVM install.' -ForegroundColor Green
 } elseif (
    (Get-Command clang -ea 0) -and (
       (clang --version | Select-String -Pattern 'version\s+(\d+)' | ForEach-Object { $_.Matches.Groups[1].Value }) -eq "$llvm_major"

--- a/.github/workflows/cache-factory.yaml
+++ b/.github/workflows/cache-factory.yaml
@@ -25,10 +25,10 @@ jobs:
 
       - uses: ./.github/actions/setup
         with:
-          save-cache: "true"
+          save-cache: 'true'
 
       - name: Compile (debug)
         run: cargo test --workspace --all-features --no-run
-      
+
       - name: Compile (release)
         run: cargo test --workspace --all-features --no-run --release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,8 @@ jobs:
 
       - name: Setup
         uses: ./.github/actions/setup
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Clippy
         uses: actions-rs/clippy-check@v1

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ packages/*/node_modules
 packages/*/data
 apps/*/data
 apps/*/stats.html
+apps/releases/.vscode
 docs/public/*.st
 docs/public/*.toml
 dev.db

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -63,5 +63,19 @@
 		"packages/ui"
 	],
 	"eslint.packageManager": "pnpm",
-	"eslint.lintTask.enable": true
+	"eslint.lintTask.enable": true,
+	"explorer.fileNesting.enabled": true,
+	"explorer.fileNesting.patterns": {
+		"*.ts": "${capture}.js",
+		"*.js": "${capture}.js.map, ${capture}.min.js, ${capture}.d.ts",
+		"*.jsx": "${capture}.js",
+		"*.tsx": "${capture}.ts",
+		".npmrc": ".nvmrc, .yarnrc.yml",
+		".gitignore": ".eslintignore, .prettierignore",
+		"README.md": "CONTRIBUTING.md, CODE_OF_CONDUCT.md",
+		"Cargo.toml": "Cargo.lock",
+		".eslintrc.js": ".eslintcache",
+		"package.json": "package-lock.json, yarn.lock, pnpm-lock.yaml, pnpm-workspace.yaml, .pnp.cjs, .pnp.loader.mjs",
+		"tsconfig.json": "tsconfig.*.json"
+	}
 }

--- a/apps/releases/next.config.js
+++ b/apps/releases/next.config.js
@@ -1,8 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    appDir: true,
-  },
-}
+	experimental: {
+		appDir: true
+	}
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/apps/releases/package.json
+++ b/apps/releases/package.json
@@ -1,24 +1,24 @@
 {
-  "name": "releases",
-  "version": "0.1.0",
-  "private": true,
-  "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
-    "lint": "next lint"
-  },
-  "dependencies": {
-    "@types/node": "18.15.11",
-    "@types/react": "18.0.35",
-    "@types/react-dom": "18.0.11",
-    "@vercel/edge-config": "^0.1.7",
-    "eslint": "^8.38.0",
-    "eslint-config-next": "13.3.0",
-    "next": "13.3.0",
-    "octokit": "^2.0.14",
-    "react": "18.2.0",
-    "react-dom": "^18.2.0",
-    "typescript": "5.0.4"
-  }
+	"name": "releases",
+	"version": "0.1.0",
+	"private": true,
+	"scripts": {
+		"dev": "next dev",
+		"build": "next build",
+		"start": "next start",
+		"lint": "next lint --strict"
+	},
+	"dependencies": {
+		"@types/node": "18.15.11",
+		"@types/react": "18.0.35",
+		"@types/react-dom": "18.0.11",
+		"@vercel/edge-config": "^0.1.7",
+		"eslint": "^8.38.0",
+		"eslint-config-next": "13.3.0",
+		"next": "13.3.0",
+		"octokit": "^2.0.14",
+		"react": "18.2.0",
+		"react-dom": "^18.2.0",
+		"typescript": "5.0.4"
+	}
 }

--- a/apps/releases/tsconfig.json
+++ b/apps/releases/tsconfig.json
@@ -1,28 +1,28 @@
 {
-  "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "preserve",
-    "incremental": true,
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ],
-    "paths": {
-      "~/*": ["./*"]
-    }
-  },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+	"compilerOptions": {
+		"target": "es5",
+		"lib": ["dom", "dom.iterable", "esnext"],
+		"allowJs": true,
+		"skipLibCheck": true,
+		"strict": true,
+		"forceConsistentCasingInFileNames": true,
+		"noEmit": true,
+		"esModuleInterop": true,
+		"module": "esnext",
+		"moduleResolution": "node",
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"jsx": "preserve",
+		"incremental": true,
+		"plugins": [
+			{
+				"name": "next"
+			}
+		],
+		"paths": {
+			"~/*": ["./*"]
+		}
+	},
+	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+	"exclude": ["node_modules"]
 }

--- a/interface/app/$libraryId/Explorer/DismissibleNotice.tsx
+++ b/interface/app/$libraryId/Explorer/DismissibleNotice.tsx
@@ -6,14 +6,14 @@ import { dismissibleNoticeStore } from '~/hooks/useDismissibleNoticeStore';
 import { ExplorerLayoutMode, useExplorerStore } from '~/hooks/useExplorerStore';
 
 const MediaViewIcon = () => (
-	<div className="relative mr-10 ml-3 h-14 w-14 flex-shrink-0">
+	<div className="relative mr-10 ml-3 h-14 w-14 shrink-0">
 		<img src={Image} className="absolute left-6 -top-1 h-14 w-14 rotate-6 overflow-hidden" />
 		<img src={Video} className="absolute top-2 z-10 h-14 w-14 -rotate-6 overflow-hidden" />
 	</div>
 );
 
 const CollectionIcon = () => (
-	<div className="mr-4 ml-3 h-14 w-14 flex-shrink-0">
+	<div className="mr-4 ml-3 h-14 w-14 shrink-0">
 		<img src={Collection} />
 	</div>
 );

--- a/package.json
+++ b/package.json
@@ -52,5 +52,7 @@
 		"yarn": "pnpm",
 		"node": ">=18.0.0"
 	},
-	"eslintConfig": {}
+	"eslintConfig": {
+		"root": true
+	}
 }

--- a/packages/config/eslint/base.js
+++ b/packages/config/eslint/base.js
@@ -1,6 +1,5 @@
 const path = require('node:path');
 module.exports = {
-	root: true,
 	parser: '@typescript-eslint/parser',
 	parserOptions: {
 		ecmaFeatures: {


### PR DESCRIPTION
- Ensure version 15 of LLVM is installed in Windows CI (due to` ffmpeg-sys-next`)
- Use `GITHUB_TOKEN` in setup-system.ps1 to avoid rate-limiting by github api in Windows CI
- Add `yaml` settings to `.editorconfig`
- Create a symbolic link from `.prettierignore` to `.eslintignore`
- Move `eslint` root to package root config
- Enable `fileNesting` to reduce dotfile clutter in vscode
- Pass `--strict` to apps/releases `lint` command to avoid making interactive queries and hanging `pnpm lint`
- Format with `prettier` and `eslint`
- Remove empty interface/hooks/useMediaQuery.ts
- Replace unmaintained `actions-rs/toolchain` with `dtolnay/rust-toolchain`
- Change setup-system.ps1 to avoid installing pnpm in CI
- Change `pnpm/action-setup` to lock only o major versions of the action
