### PR TITLE
revert back to official ffmpeg package (fast ci)

### DIFF
--- a/.github/scripts/setup-system.sh
+++ b/.github/scripts/setup-system.sh
@@ -184,17 +184,10 @@ elif [[ $OSTYPE == "darwin"* ]]; then
 
 	echo "Installing Homebrew dependencies..."
 
+	BREW_FFMPEG_DEPS="ffmpeg"
 	BREW_LIBP2P_DEPS="protobuf"
 
-	brew install -q $BREW_LIBP2P_DEPS
-
-	if ! brew tap homebrew-ffmpeg/ffmpeg; then
-		log_err "We were unable to add the homebrew-ffmpeg tap. Please ensure that you have ran `brew uninstall ffmpeg` and try again."
-	fi
-
-	if ! brew install homebrew-ffmpeg/ffmpeg/ffmpeg; then
-		log_err "We were unable to install the homebrew-ffmpeg/ffmpeg package. Please ensure that you have ran `brew uninstall ffmpeg` and try again."
-	fi
+	brew install -q $BREW_FFMPEG_DEPS $BREW_LIBP2P_DEPS
 else
 	log_err "Your OS ($OSTYPE) is not supported by this script. We would welcome a PR or some help adding your OS to this script. https://github.com/spacedriveapp/spacedrive/issues"
 	exit 1


### PR DESCRIPTION
this reverts the setup script back to the official ffmpeg package, now that brew offer support for ffmpeg 6.

update guide for devs:
`brew uninstall --force ffmpeg` (`force` removes other versions, too)
`brew untap homebrew-ffmpeg/ffmpeg` (if this errors, run `brew uninstall x` on the package specified in the error. if you get a "tap not found" or similar error, all is well and you can continue)
`brew install ffmpeg`

for good measure, devs should also run `brew tap`. if `spacedriveapp/deps` is present, run `brew untap spacedriveapp/deps` - if this fails, run `brew uninstall ffmpeg@5.0.1` (or the version specified by the error) and re-run `brew untap spacedriveapp/deps`.

the aforementioned custom tap was around when we were manually compiling ffmpeg 5.0.1, but this is no longer required but may still remain on your system.