### PR TITLE
[Fix] Nav button alignment

### DIFF
--- a/interface/app/$libraryId/Layout/Sidebar/index.tsx
+++ b/interface/app/$libraryId/Layout/Sidebar/index.tsx
@@ -20,7 +20,7 @@ export default () => {
 		>
 			{showControls && <MacTrafficLights className="absolute left-[13px] top-[13px] z-50" />}
 			{(os !== 'browser' || showControls) && (
-				<div className="flex justify-end">
+				<div className="flex justify-end -mt-[4px]">
 					<NavigationButtons />
 				</div>
 			)}


### PR DESCRIPTION
The nav button now visually aligns with the traffic icons on macOS, not tested for Windows/Linux/Web

Before:
<img width="264" alt="Screenshot 2023-05-04 at 8 53 23 AM" src="https://user-images.githubusercontent.com/32987599/236263789-06424246-52db-465d-8bbc-6bfc5a58a628.png">
After:
<img width="229" alt="Screenshot 2023-05-04 at 9 11 39 AM" src="https://user-images.githubusercontent.com/32987599/236263802-ac33a995-4efd-4127-bc71-54e6e7e71316.png">
