### PR TITLE
source `has_thumbnail` correctly for the recent file query

### DIFF
--- a/core/prisma/migrations/old20230504181124_remove_has_thumbnail/migration.sql
+++ b/core/prisma/migrations/old20230504181124_remove_has_thumbnail/migration.sql
@@ -1,0 +1,30 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `has_thumbnail` on the `object` table. All the data in the column will be lost.
+
+*/
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_object" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "pub_id" BLOB NOT NULL,
+    "kind" INTEGER NOT NULL DEFAULT 0,
+    "key_id" INTEGER,
+    "hidden" BOOLEAN NOT NULL DEFAULT false,
+    "favorite" BOOLEAN NOT NULL DEFAULT false,
+    "important" BOOLEAN NOT NULL DEFAULT false,
+    "has_thumbstrip" BOOLEAN NOT NULL DEFAULT false,
+    "has_video_preview" BOOLEAN NOT NULL DEFAULT false,
+    "ipfs_id" TEXT,
+    "note" TEXT,
+    "date_created" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "date_accessed" DATETIME,
+    CONSTRAINT "object_key_id_fkey" FOREIGN KEY ("key_id") REFERENCES "key" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_object" ("date_accessed", "date_created", "favorite", "has_thumbstrip", "has_video_preview", "hidden", "id", "important", "ipfs_id", "key_id", "kind", "note", "pub_id") SELECT "date_accessed", "date_created", "favorite", "has_thumbstrip", "has_video_preview", "hidden", "id", "important", "ipfs_id", "key_id", "kind", "note", "pub_id" FROM "object";
+DROP TABLE "object";
+ALTER TABLE "new_object" RENAME TO "object";
+CREATE UNIQUE INDEX "object_pub_id_key" ON "object"("pub_id");
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/core/prisma/schema.prisma
+++ b/core/prisma/schema.prisma
@@ -183,7 +183,6 @@ model Object {
     favorite          Boolean   @default(false)
     important         Boolean   @default(false)
     // if we have generated preview media for this object on at least one Node
-    has_thumbnail     Boolean   @default(false)
     has_thumbstrip    Boolean   @default(false)
     has_video_preview Boolean   @default(false)
     // TODO: change above to:

--- a/core/src/object/mod.rs
+++ b/core/src/object/mod.rs
@@ -15,7 +15,7 @@ pub mod validation;
 // Objects are what can be added to Spaces
 
 // Object selectables!
-object::select!(object_just_id_has_thumbnail { id has_thumbnail });
+object::select!(object_just_id { id });
 object::select!(object_for_file_identifier {
 	pub_id
 	file_paths: select { pub_id cas_id }

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -4,7 +4,7 @@
 export type Procedures = {
     queries: 
         { key: "buildInfo", input: never, result: BuildInfo } | 
-        { key: "files.get", input: LibraryArgs<GetArgs>, result: { id: number; pub_id: number[]; kind: number; key_id: number | null; hidden: boolean; favorite: boolean; important: boolean; has_thumbnail: boolean; has_thumbstrip: boolean; has_video_preview: boolean; ipfs_id: string | null; note: string | null; date_created: string; date_accessed: string | null; file_paths: FilePath[]; media_data: MediaData | null } | null } | 
+        { key: "files.get", input: LibraryArgs<GetArgs>, result: { id: number; pub_id: number[]; kind: number; key_id: number | null; hidden: boolean; favorite: boolean; important: boolean; has_thumbstrip: boolean; has_video_preview: boolean; ipfs_id: string | null; note: string | null; date_created: string; date_accessed: string | null; file_paths: FilePath[]; media_data: MediaData | null } | null } | 
         { key: "files.getRecent", input: LibraryArgs<number>, result: ExplorerItem[] } | 
         { key: "jobs.getHistory", input: LibraryArgs<null>, result: JobReport[] } | 
         { key: "jobs.getRunning", input: LibraryArgs<null>, result: JobReport[] } | 
@@ -185,8 +185,6 @@ export type Nonce = { XChaCha20Poly1305: number[] } | { Aes256Gcm: number[] }
 
 export type UnlockKeyManagerArgs = { password: Protected<string>; secret_key: Protected<string> }
 
-export type MediaData = { id: number; pixel_width: number | null; pixel_height: number | null; longitude: number | null; latitude: number | null; fps: number | null; capture_device_make: string | null; capture_device_model: string | null; capture_device_software: string | null; duration_seconds: number | null; codecs: string | null; streams: number | null }
-
 export type TagCreateArgs = { name: string; color: string }
 
 export type FileEncryptorJobInit = { location_id: number; path_id: number; key_uuid: string; algorithm: Algorithm; metadata: boolean; preview_media: boolean; output_path: string | null }
@@ -210,9 +208,9 @@ export type Node = { id: number; pub_id: number[]; name: string; platform: numbe
 
 export type FileCutterJobInit = { source_location_id: number; source_path_id: number; target_location_id: number; target_path: string }
 
-export type FilePathWithObject = { id: number; pub_id: number[]; is_dir: boolean; cas_id: string | null; integrity_checksum: string | null; location_id: number; materialized_path: string; name: string; extension: string; size_in_bytes: string; inode: number[]; device: number[]; object_id: number | null; parent_id: number[] | null; key_id: number | null; date_created: string; date_modified: string; date_indexed: string; object: Object | null }
+export type Object = { id: number; pub_id: number[]; kind: number; key_id: number | null; hidden: boolean; favorite: boolean; important: boolean; has_thumbstrip: boolean; has_video_preview: boolean; ipfs_id: string | null; note: string | null; date_created: string; date_accessed: string | null }
 
-export type IndexerRule = { id: number; kind: number; name: string; default: boolean; parameters: number[]; date_created: string; date_modified: string }
+export type FilePathWithObject = { id: number; pub_id: number[]; is_dir: boolean; cas_id: string | null; integrity_checksum: string | null; location_id: number; materialized_path: string; name: string; extension: string; size_in_bytes: string; inode: number[]; device: number[]; object_id: number | null; parent_id: number[] | null; key_id: number | null; date_created: string; date_modified: string; date_indexed: string; object: Object | null }
 
 export type JobStatus = "Queued" | "Running" | "Completed" | "Canceled" | "Failed" | "Paused"
 
@@ -224,8 +222,6 @@ export type LocationExplorerArgs = { location_id: number; path?: string | null; 
 
 export type TagAssignArgs = { object_id: number; tag_id: number; unassign: boolean }
 
-export type RenameFileArgs = { location_id: number; file_name: string; new_file_name: string }
-
 export type FileDeleterJobInit = { location_id: number; path_id: number }
 
 /**
@@ -233,7 +229,7 @@ export type FileDeleterJobInit = { location_id: number; path_id: number }
  */
 export type Algorithm = "XChaCha20Poly1305" | "Aes256Gcm"
 
-export type Tag = { id: number; pub_id: number[]; name: string | null; color: string | null; total_objects: number | null; redundancy_goal: number | null; date_created: string; date_modified: string }
+export type IndexerRule = { id: number; kind: number; name: string; default: boolean; parameters: number[]; date_created: string; date_modified: string }
 
 export type JobReport = { id: string; name: string; action: string | null; data: number[] | null; metadata: any | null; is_background: boolean; created_at: string | null; started_at: string | null; completed_at: string | null; parent_id: string | null; status: JobStatus; task_count: number; completed_task_count: number; message: string }
 
@@ -247,6 +243,8 @@ export type Statistics = { id: number; date_captured: string; total_object_count
  * TODO: P2P event for the frontend
  */
 export type P2PEvent = { type: "DiscoveredPeer"; peer_id: PeerId; metadata: PeerMetadata } | { type: "SpacedropRequest"; id: string; peer_id: PeerId; name: string }
+
+export type Tag = { id: number; pub_id: number[]; name: string | null; color: string | null; total_objects: number | null; redundancy_goal: number | null; date_created: string; date_modified: string }
 
 export type SpacedropArgs = { peer_id: PeerId; file_path: string[] }
 
@@ -282,6 +280,8 @@ export type LibraryArgs<T> = { library_id: string; arg: T }
 
 export type IdentifyUniqueFilesArgs = { id: number; path: string }
 
+export type RenameFileArgs = { location_id: number; file_name: string; new_file_name: string }
+
 export type ExplorerContext = ({ type: "Location" } & Location) | ({ type: "Tag" } & Tag)
 
 export type OwnedOperationData = { Create: { [key: string]: any } } | { CreateMany: { values: ([any, { [key: string]: any }])[]; skip_duplicates: boolean } } | { Update: { [key: string]: any } } | "Delete"
@@ -291,8 +291,6 @@ export type SharedOperationData = SharedOperationCreateData | { field: string; v
 export type FileCopierJobInit = { source_location_id: number; source_path_id: number; target_location_id: number; target_path: string; target_file_name_suffix: string | null }
 
 export type ChangeNodeNameArgs = { name: string }
-
-export type Object = { id: number; pub_id: number[]; kind: number; key_id: number | null; hidden: boolean; favorite: boolean; important: boolean; has_thumbnail: boolean; has_thumbstrip: boolean; has_video_preview: boolean; ipfs_id: string | null; note: string | null; date_created: string; date_accessed: string | null }
 
 /**
  * This defines all available password hashing algorithms.
@@ -312,13 +310,15 @@ export type CreateLibraryArgs = { name: string }
 
 export type FileDecryptorJobInit = { location_id: number; path_id: number; mount_associated_key: boolean; output_path: string | null; password: string | null; save_to_library: boolean | null }
 
+export type MediaData = { id: number; pixel_width: number | null; pixel_height: number | null; longitude: number | null; latitude: number | null; fps: number | null; capture_device_make: string | null; capture_device_model: string | null; capture_device_software: string | null; duration_seconds: number | null; codecs: string | null; streams: number | null }
+
 export type AutomountUpdateArgs = { uuid: string; status: boolean }
 
 export type Protected<T> = T
 
 export type RestoreBackupArgs = { password: Protected<string>; secret_key: Protected<string>; path: string }
 
-export type ObjectWithFilePaths = { id: number; pub_id: number[]; kind: number; key_id: number | null; hidden: boolean; favorite: boolean; important: boolean; has_thumbnail: boolean; has_thumbstrip: boolean; has_video_preview: boolean; ipfs_id: string | null; note: string | null; date_created: string; date_accessed: string | null; file_paths: FilePath[] }
+export type ObjectWithFilePaths = { id: number; pub_id: number[]; kind: number; key_id: number | null; hidden: boolean; favorite: boolean; important: boolean; has_thumbstrip: boolean; has_video_preview: boolean; ipfs_id: string | null; note: string | null; date_created: string; date_accessed: string | null; file_paths: FilePath[] }
 
 export type RelationOperation = { relation_item: string; relation_group: string; relation: string; data: RelationOperationData }
 


### PR DESCRIPTION
For whatever reason, the `has_thumbnail` column in the `Object` table is never actually used, and as such it is not a good metric for checking whether or not a thumbnail actually exists. This PR changes that, and instead uses the `library.has_thumnail()` function.

I have not tested whether or not this fixes thumbnails in the recent files view.

I think a good solution would be to allow the thumbnailer and indexers to check whether or not each object has a thumbail, and update the database accordingly. This means that even if the user deletes a specific thumbnail, the database can stay up to date. It would also mean that we don't need to rely on a separate function just for checking if a thumbnail exists or not, we can just source it from the database.