### PR TITLE
Fix Typescript

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -67,6 +67,7 @@
 		"@types/react": "~18.0.27",
 		"babel-plugin-module-resolver": "^5.0.0",
 		"eslint-plugin-react-native": "^4.0.0",
-		"react-native-svg-transformer": "^1.0.0"
+		"react-native-svg-transformer": "^1.0.0",
+		"typescript": "^5.0.4"
 	}
 }

--- a/interface/app/$libraryId/Explorer/ListView.tsx
+++ b/interface/app/$libraryId/Explorer/ListView.tsx
@@ -13,7 +13,7 @@ import byteSize from 'byte-size';
 import clsx from 'clsx';
 import dayjs from 'dayjs';
 import { CaretDown, CaretUp } from 'phosphor-react';
-import { memo, useEffect, useMemo, useState } from 'react';
+import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { useKey, useOnWindowResize } from 'rooks';
 import { ExplorerItem, FilePath, ObjectKind, isObject, isPath } from '@sd/client';
 import { useDismissibleNoticeStore } from '~/hooks/useDismissibleNoticeStore';
@@ -77,9 +77,6 @@ export default () => {
 	const [sorting, setSorting] = useState<SortingState>([]);
 	const [columnSizing, setColumnSizing] = useState<ColumnSizingState>({});
 	const [locked, setLocked] = useState(true);
-	const [lastSelectedIndex, setLastSelectedIndex] = useState<number>(
-		explorerStore.selectedRowIndex
-	);
 
 	const paddingX = 16;
 	const scrollBarWidth = 8;
@@ -263,22 +260,24 @@ export default () => {
 	// Resize view on window resize
 	useOnWindowResize(handleResize);
 
+	const lastSelectedIndex = useRef(explorerStore.selectedRowIndex);
+
 	// Resize view on item selection/deselection
 	useEffect(() => {
-		const index = explorerStore.selectedRowIndex;
+		const { selectedRowIndex } = explorerStore;
+
 		if (
 			explorerStore.showInspector &&
-			((lastSelectedIndex === -1 && index !== -1) ||
-				(lastSelectedIndex !== -1 && index === -1))
-		) {
+			typeof lastSelectedIndex.current !== typeof selectedRowIndex
+		)
 			handleResize();
-		}
-		setLastSelectedIndex(index);
+
+		lastSelectedIndex.current = selectedRowIndex;
 	}, [explorerStore.selectedRowIndex]);
 
 	// Resize view on inspector toggle
 	useEffect(() => {
-		if (explorerStore.selectedRowIndex !== -1) handleResize();
+		if (explorerStore.selectedRowIndex !== null) handleResize();
 	}, [explorerStore.showInspector]);
 
 	// Force recalculate range
@@ -293,11 +292,15 @@ export default () => {
 		'ArrowUp',
 		(e) => {
 			e.preventDefault();
-			if (explorerStore.selectedRowIndex > 0) {
-				const currentIndex = rows.findIndex(
-					(row) => row.index === explorerStore.selectedRowIndex
-				);
+
+			const { selectedRowIndex } = explorerStore;
+
+			if (selectedRowIndex === null) return;
+
+			if (selectedRowIndex > 0) {
+				const currentIndex = rows.findIndex((row) => row.index === selectedRowIndex);
 				const newIndex = rows[currentIndex - 1]?.index;
+
 				if (newIndex !== undefined) getExplorerStore().selectedRowIndex = newIndex;
 			}
 		},
@@ -309,14 +312,15 @@ export default () => {
 		'ArrowDown',
 		(e) => {
 			e.preventDefault();
-			if (
-				explorerStore.selectedRowIndex !== -1 &&
-				explorerStore.selectedRowIndex !== (data.length ?? 1) - 1
-			) {
-				const currentIndex = rows.findIndex(
-					(row) => row.index === explorerStore.selectedRowIndex
-				);
+
+			const { selectedRowIndex } = explorerStore;
+
+			if (selectedRowIndex === null) return;
+
+			if (selectedRowIndex !== data.length - 1) {
+				const currentIndex = rows.findIndex((row) => row.index === selectedRowIndex);
 				const newIndex = rows[currentIndex + 1]?.index;
+
 				if (newIndex !== undefined) getExplorerStore().selectedRowIndex = newIndex;
 			}
 		},

--- a/interface/app/$libraryId/Explorer/MediaView.tsx
+++ b/interface/app/$libraryId/Explorer/MediaView.tsx
@@ -116,9 +116,10 @@ export default () => {
 	// Resize view on initial render and reset selected item
 	useEffect(() => {
 		handleWindowResize();
-		getExplorerStore().selectedRowIndex = -1;
+		getExplorerStore().selectedRowIndex = null;
+
 		return () => {
-			getExplorerStore().selectedRowIndex = -1;
+			getExplorerStore().selectedRowIndex = null;
 		};
 	}, []);
 
@@ -127,20 +128,18 @@ export default () => {
 
 	// Resize view on item selection/deselection
 	useEffect(() => {
-		const index = explorerStore.selectedRowIndex;
-		if (
-			explorerStore.showInspector &&
-			((lastSelectedIndex === -1 && index !== -1) ||
-				(lastSelectedIndex !== -1 && index === -1))
-		) {
+		const { selectedRowIndex } = explorerStore;
+
+		setLastSelectedIndex(selectedRowIndex);
+
+		if (explorerStore.showInspector && typeof lastSelectedIndex !== typeof selectedRowIndex) {
 			handleWindowResize();
 		}
-		setLastSelectedIndex(index);
 	}, [explorerStore.selectedRowIndex]);
 
 	// Resize view on inspector toggle
 	useEffect(() => {
-		if (explorerStore.selectedRowIndex !== -1) {
+		if (explorerStore.selectedRowIndex !== null) {
 			handleWindowResize();
 		}
 	}, [explorerStore.showInspector]);
@@ -163,23 +162,27 @@ export default () => {
 	// Select item with arrow up key
 	useKey('ArrowUp', (e) => {
 		e.preventDefault();
-		if (explorerStore.selectedRowIndex > 0) {
-			getExplorerStore().selectedRowIndex = explorerStore.selectedRowIndex - 1;
-		}
+
+		const { selectedRowIndex } = explorerStore;
+
+		if (selectedRowIndex === null) return;
+
+		getExplorerStore().selectedRowIndex = Math.max(selectedRowIndex - 1, 0);
 	});
 
 	// Select item with arrow down key
 	useKey('ArrowDown', (e) => {
 		e.preventDefault();
-		if (
-			explorerStore.selectedRowIndex !== -1 &&
-			explorerStore.selectedRowIndex !== (data.length ?? 1) - 1
-		) {
-			getExplorerStore().selectedRowIndex = explorerStore.selectedRowIndex + 1;
-		}
+
+		const { selectedRowIndex } = explorerStore;
+
+		if (selectedRowIndex === null) return;
+
+		getExplorerStore().selectedRowIndex = Math.min(selectedRowIndex + 1, data.length - 1);
 	});
 
 	if (!width) return null;
+
 	return (
 		<div
 			className="relative"

--- a/interface/app/$libraryId/Explorer/View.tsx
+++ b/interface/app/$libraryId/Explorer/View.tsx
@@ -10,7 +10,6 @@ import {
 } from 'react';
 import { createSearchParams, useMatch, useNavigate } from 'react-router-dom';
 import { ExplorerItem, isPath, useLibraryContext } from '@sd/client';
-import { Button } from '@sd/ui';
 import { getExplorerStore, useExplorerStore } from '~/hooks/useExplorerStore';
 import { TOP_BAR_HEIGHT } from '../TopBar';
 import DismissibleNotice from './DismissibleNotice';
@@ -42,10 +41,12 @@ export const ViewItem = ({
 				pathname: `/${library.uuid}/location/${getItemFilePath(data)?.location_id}`,
 				search: createSearchParams({ path: data.item.materialized_path }).toString()
 			});
-			getExplorerStore().selectedRowIndex = -1;
+
+			getExplorerStore().selectedRowIndex = null;
 		} else {
 			const { kind } = getExplorerItemData(data);
-			if (kind === 'Video' || kind === 'Image' || kind === 'Audio') {
+
+			if (['Video', 'Image', 'Audio'].includes(kind)) {
 				getExplorerStore().quickViewObject = data;
 			}
 		}
@@ -106,7 +107,7 @@ export default memo((props: Props) => {
 				props.viewClassName
 			)}
 			style={{ paddingTop: TOP_BAR_HEIGHT }}
-			onClick={() => (getExplorerStore().selectedRowIndex = -1)}
+			onClick={() => (getExplorerStore().selectedRowIndex = null)}
 		>
 			{!isOverview && <DismissibleNotice />}
 			<context.Provider

--- a/interface/app/$libraryId/Explorer/index.tsx
+++ b/interface/app/$libraryId/Explorer/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useKey } from 'rooks';
 import { ExplorerData, useLibrarySubscription } from '@sd/client';
 import { getExplorerStore, useExplorerStore } from '~/hooks/useExplorerStore';
@@ -29,15 +29,19 @@ export default function Explorer(props: Props) {
 	});
 
 	useEffect(() => {
-		getExplorerStore().selectedRowIndex = -1;
+		getExplorerStore().selectedRowIndex = null;
 	}, [path]);
+
+	const selectedItem = useMemo(() => {
+		if (selectedRowIndex === null) return null;
+
+		return props.items?.[selectedRowIndex] ?? null;
+	}, [selectedRowIndex, props.items]);
 
 	useKey('Space', (e) => {
 		e.preventDefault();
-		if (selectedRowIndex !== -1) {
-			const item = props.items?.[selectedRowIndex];
-			if (item) getExplorerStore().quickViewObject = item;
-		}
+
+		if (selectedItem) getExplorerStore().quickViewObject = selectedItem;
 	});
 
 	return (
@@ -57,9 +61,9 @@ export default function Explorer(props: Props) {
 					</div>
 				</ExplorerContextMenu>
 
-				{expStore.showInspector && props.items?.[selectedRowIndex] && (
+				{expStore.showInspector && selectedItem !== null && (
 					<div className="w-[260px] shrink-0">
-						<Inspector data={props.items?.[selectedRowIndex]} />
+						<Inspector data={selectedItem} />
 					</div>
 				)}
 			</div>

--- a/interface/app/$libraryId/search.tsx
+++ b/interface/app/$libraryId/search.tsx
@@ -27,18 +27,16 @@ const ExplorerStuff = memo((props: { args: SearchArgs }) => {
 	});
 
 	const items = useMemo(() => {
-		const queryData = query.data;
-		if (explorerStore.layoutMode !== 'media') return queryData;
+		if (explorerStore.layoutMode !== 'media') return query.data;
 
-		const mediaItems = queryData?.filter((item) => {
+		return query.data?.filter((item) => {
 			const { kind } = getExplorerItemData(item);
 			return kind === 'Video' || kind === 'Image';
 		});
-		return mediaItems;
 	}, [query.data, explorerStore.layoutMode]);
 
 	useEffect(() => {
-		getExplorerStore().selectedRowIndex = -1;
+		getExplorerStore().selectedRowIndex = null;
 	}, [props.args.search]);
 
 	return (

--- a/interface/hooks/useExplorerStore.tsx
+++ b/interface/hooks/useExplorerStore.tsx
@@ -44,16 +44,16 @@ const explorerStore = proxy({
 	reset: () => resetStore(explorerStore, state),
 	addNewThumbnail: (cas_id: string) => {
 		explorerStore.newThumbnails[cas_id] = true;
-	},
-	selectMore: (indexes: number[]) => {
-		if (!explorerStore.multiSelectIndexes.length && indexes.length) {
-			explorerStore.multiSelectIndexes = [explorerStore.selectedRowIndex, ...indexes];
-		} else {
-			explorerStore.multiSelectIndexes = [
-				...new Set([...explorerStore.multiSelectIndexes, ...indexes])
-			];
-		}
 	}
+	// selectMore: (indexes: number[]) => {
+	// 	if (!explorerStore.multiSelectIndexes.length && indexes.length) {
+	// 		explorerStore.multiSelectIndexes = [explorerStore.selectedRowIndex, ...indexes];
+	// 	} else {
+	// 		explorerStore.multiSelectIndexes = [
+	// 			...new Set([...explorerStore.multiSelectIndexes, ...indexes])
+	// 		];
+	// 	}
+	// }
 });
 
 export function useExplorerStore() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,7 @@ importers:
       react-native-svg-transformer: ^1.0.0
       react-native-wheel-color-picker: ^1.2.0
       twrnc: ^3.6.0
+      typescript: ^5.0.4
       use-count-up: ^3.0.1
       use-debounce: ^9.0.4
       valtio: ^1.10.4
@@ -245,7 +246,7 @@ importers:
       '@shopify/flash-list': 1.4.2_aim4q6r6ykgo64vi4fl5665p4i
       '@tanstack/react-query': 4.29.5_bblof3d6od7kdqr2urb3dykbey
       byte-size: 8.1.1
-      class-variance-authority: 0.5.3
+      class-variance-authority: 0.5.3_typescript@5.0.4
       dayjs: 1.11.7
       expo: 48.0.16_@babel+core@7.21.8
       expo-linking: 4.0.1_expo@48.0.16
@@ -281,6 +282,7 @@ importers:
       babel-plugin-module-resolver: 5.0.0
       eslint-plugin-react-native: 4.0.0_eslint@8.39.0
       react-native-svg-transformer: 1.0.0_csdbj5z546ts5ngzc62z27kx4u
+      typescript: 5.0.4
 
   apps/releases:
     specifiers:
@@ -8460,13 +8462,15 @@ packages:
       typescript: 4.9.5
     dev: false
 
-  /class-variance-authority/0.5.3:
+  /class-variance-authority/0.5.3_typescript@5.0.4:
     resolution: {integrity: sha512-vcMxnya/xxQSvTuXO9FWAOnmLihbzX82fPkQpMUwPHZ4tdopmFlM4X818fMgCPt2L6CirOIbN91vybifdScUVw==}
     peerDependencies:
       typescript: '>= 4.5.5 < 6'
     peerDependenciesMeta:
       typescript:
         optional: true
+    dependencies:
+      typescript: 5.0.4
     dev: false
 
   /classnames/2.3.2:


### PR DESCRIPTION
Accidentally included some stuff in a previous PR, this extends it and makes type checking succeed again.
`selectedRowIndex` is now `null` instead of `-1` when no row is selected.