### PR TITLE
[ENG-592] Prevent libraries with blank names/no names from being created

### DIFF
--- a/core/src/library/manager.rs
+++ b/core/src/library/manager.rs
@@ -59,6 +59,8 @@ pub enum LibraryManagerError {
 	KeyManager(#[from] sd_crypto::Error),
 	#[error("failed to run library migrations: {0}")]
 	MigratorError(#[from] crate::util::migrator::MigratorError),
+	#[error("invalid library configuration: {0}")]
+	InvalidConfig(String),
 }
 
 impl From<LibraryManagerError> for rspc::Error {
@@ -191,6 +193,12 @@ impl LibraryManager {
 		id: Uuid,
 		config: LibraryConfig,
 	) -> Result<LibraryConfigWrapped, LibraryManagerError> {
+		if config.name.is_empty() || config.name.chars().all(|x| x.is_whitespace()) {
+			return Err(LibraryManagerError::InvalidConfig(
+				"name cannot be empty".to_string(),
+			));
+		}
+
 		LibraryConfig::save(
 			Path::new(&self.libraries_dir).join(format!("{id}.sdlibrary")),
 			&config,

--- a/interface/app/onboarding/new-library.tsx
+++ b/interface/app/onboarding/new-library.tsx
@@ -71,7 +71,12 @@ export default function OnboardingNewLibrary() {
 						/>
 						<div className="flex grow" />
 						<div className="mt-7 space-x-2">
-							<Button type="submit" variant="accent" size="sm">
+							<Button
+								type="submit"
+								variant="accent"
+								disabled={!form.formState.isValid}
+								size="sm"
+							>
 								New library
 							</Button>
 							{/* <span className="px-2 text-xs font-bold text-ink-faint">OR</span>

--- a/interface/app/onboarding/new-library.tsx
+++ b/interface/app/onboarding/new-library.tsx
@@ -13,7 +13,8 @@ import {
 import { useUnlockOnboardingScreen } from './Progress';
 
 const schema = z.object({
-	name: z.string().min(1, 'Name is required').regex(/[\S]/g)
+	// the regex here validates that the entire string isn't purely whitespace
+	name: z.string().min(1, 'Name is required').regex(/[\S]/g).trim()
 });
 
 export default function OnboardingNewLibrary() {

--- a/interface/app/onboarding/new-library.tsx
+++ b/interface/app/onboarding/new-library.tsx
@@ -13,7 +13,7 @@ import {
 import { useUnlockOnboardingScreen } from './Progress';
 
 const schema = z.object({
-	name: z.string().min(1, 'Name is required')
+	name: z.string().min(1, 'Name is required').regex(/[\S]/g).trim()
 });
 
 export default function OnboardingNewLibrary() {

--- a/interface/app/onboarding/new-library.tsx
+++ b/interface/app/onboarding/new-library.tsx
@@ -13,7 +13,7 @@ import {
 import { useUnlockOnboardingScreen } from './Progress';
 
 const schema = z.object({
-	name: z.string().min(1, 'Name is required').regex(/[\S]/g).trim()
+	name: z.string().min(1, 'Name is required').regex(/[\S]/g)
 });
 
 export default function OnboardingNewLibrary() {


### PR DESCRIPTION
This PR adds validation to prevent libraries with either: entirely empty names, or names that consist of purely whitespaces, from being created. It adds validation in both Rust and TS, and they both work flawlessly.