### PR TITLE
[ENG-590] Uppercase file extensions are "unknown"

### DIFF
--- a/crates/file-ext/src/magic.rs
+++ b/crates/file-ext/src/magic.rs
@@ -62,8 +62,10 @@ macro_rules! extension_enum {
 			#[allow(clippy::should_implement_trait)]
 			pub fn from_str(s: &str) -> Option<ExtensionPossibility> {
 				use std::str::FromStr;
+				let s = s.to_lowercase();
+
 				let mut exts = [$(
-						$type::from_str(s).ok().map(Self::$variant)
+						$type::from_str(&s).ok().map(Self::$variant)
 					),*]
 					.into_iter()
 					.filter_map(|s| s)


### PR DESCRIPTION
This PR converts all extensions to lowercase before attempting to match them. This means that files with uppercase extensions (e.g. `.MOV`) will be identified correctly.