### PR TITLE
deps: remove ffmpeg-next from the core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2211,17 +2211,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ffmpeg-next"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8af03c47ad26832ab3aabc4cdbf210af3d3b878783edd5a7ba044ba33aab7a60"
-dependencies = [
- "bitflags",
- "ffmpeg-sys-next",
- "libc",
-]
-
-[[package]]
 name = "ffmpeg-sys-next"
 version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6743,7 +6732,6 @@ dependencies = [
  "ctor",
  "dashmap",
  "enumflags2 0.7.5",
- "ffmpeg-next",
  "futures",
  "globset",
  "hostname",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,8 +10,11 @@ rust-version = "1.68.1"
 
 [features]
 default = []
-mobile = [] # This feature allows features to be disabled when the Core is running on mobile.
-ffmpeg = ["dep:ffmpeg-next", "dep:sd-ffmpeg"] # This feature controls whether the Spacedrive Core contains functionality which requires FFmpeg.
+mobile = [
+] # This feature allows features to be disabled when the Core is running on mobile.
+ffmpeg = [
+	"dep:sd-ffmpeg",
+] # This feature controls whether the Spacedrive Core contains functionality which requires FFmpeg.
 location-watcher = ["dep:notify"]
 sync-messages = []
 
@@ -27,7 +30,13 @@ sd-file-ext = { path = "../crates/file-ext" }
 sd-sync = { path = "../crates/sync" }
 sd-p2p = { path = "../crates/p2p", features = ["specta", "serde"] }
 
-rspc = { workspace = true, features = ["uuid", "chrono", "tracing", "alpha", "unstable"] }
+rspc = { workspace = true, features = [
+	"uuid",
+	"chrono",
+	"tracing",
+	"alpha",
+	"unstable",
+] }
 httpz = { workspace = true }
 prisma-client-rust = { workspace = true }
 specta = { workspace = true }
@@ -68,7 +77,6 @@ http-range = "0.1.5"
 mini-moka = "0.10.0"
 serde_with = "2.2.0"
 dashmap = { version = "5.4.0", features = ["serde"] }
-ffmpeg-next = { version = "6.0.0", optional = true, features = [] }
 notify = { version = "5.0.0", default-features = false, features = [
 	"macos_fsevent",
 ], optional = true }


### PR DESCRIPTION
This PR simply removes `ffmpeg-next` from the core.

It turns out that this crate is not used _anywhere_ within the core, except for some commented (pretty old) code.