### PR TITLE
[ENG-609] Remove file from recent files

### DIFF
--- a/core/src/api/files.rs
+++ b/core/src/api/files.rs
@@ -123,6 +123,23 @@ pub(crate) fn mount() -> AlphaRouter<Ctx> {
 					Ok(())
 				})
 		})
+		.procedure("removeAccessTime", {
+			R.with2(library())
+				.mutation(|(_, library), id: i32| async move {
+					library
+						.db
+						.object()
+						.update(
+							object::id::equals(id),
+							vec![object::date_accessed::set(None)],
+						)
+						.exec()
+						.await?;
+
+					invalidate_query!(library, "files.getRecent");
+					Ok(())
+				})
+		})
 		.procedure("getRecent", {
 			R.with2(library())
 				.query(|(_, library), amount: i32| async move {

--- a/interface/app/$libraryId/Explorer/File/ContextMenu.tsx
+++ b/interface/app/$libraryId/Explorer/File/ContextMenu.tsx
@@ -53,6 +53,8 @@ export default ({ data, className, ...props }: Props) => {
 
 	const copyFiles = useLibraryMutation('files.copyFiles');
 
+	const removeFromRecents = useLibraryMutation('files.removeAccessTime');
+
 	return (
 		<div onClick={(e) => e.stopPropagation()} className={clsx('flex', className)}>
 			<ContextMenu.Root trigger={props.children}>
@@ -79,6 +81,15 @@ export default ({ data, className, ...props }: Props) => {
 					keybind="Enter"
 					onClick={() => (getExplorerStore().isRenaming = true)}
 				/>
+
+				{data.type == 'Path' && data.item.object && data.item.object.date_accessed && (
+					<ContextMenu.Item
+						label="Remove from recents"
+						onClick={() =>
+							data.item.object_id && removeFromRecents.mutate(data.item.object_id)
+						}
+					/>
+				)}
 
 				<ContextMenu.Item
 					label="Cut"

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -41,6 +41,7 @@ export type Procedures = {
         { key: "files.duplicateFiles", input: LibraryArgs<FileCopierJobInit>, result: null } | 
         { key: "files.encryptFiles", input: LibraryArgs<FileEncryptorJobInit>, result: null } | 
         { key: "files.eraseFiles", input: LibraryArgs<FileEraserJobInit>, result: null } | 
+        { key: "files.removeAccessTime", input: LibraryArgs<number>, result: null } | 
         { key: "files.renameFile", input: LibraryArgs<RenameFileArgs>, result: null } | 
         { key: "files.setFavorite", input: LibraryArgs<SetFavoriteArgs>, result: null } | 
         { key: "files.setNote", input: LibraryArgs<SetNoteArgs>, result: null } | 
@@ -280,8 +281,6 @@ export type LibraryArgs<T> = { library_id: string; arg: T }
 
 export type IdentifyUniqueFilesArgs = { id: number; path: string }
 
-export type RenameFileArgs = { location_id: number; file_name: string; new_file_name: string }
-
 export type ExplorerContext = ({ type: "Location" } & Location) | ({ type: "Tag" } & Tag)
 
 export type OwnedOperationData = { Create: { [key: string]: any } } | { CreateMany: { values: ([any, { [key: string]: any }])[]; skip_duplicates: boolean } } | { Update: { [key: string]: any } } | "Delete"
@@ -298,6 +297,8 @@ export type Object = { id: number; pub_id: number[]; kind: number; key_id: numbe
  * This defines all available password hashing algorithms.
  */
 export type HashingAlgorithm = { name: "Argon2id"; params: Params } | { name: "BalloonBlake3"; params: Params }
+
+export type RenameFileArgs = { location_id: number; file_name: string; new_file_name: string }
 
 export type LocationWithIndexerRules = { id: number; pub_id: number[]; node_id: number; name: string; path: string; total_capacity: number | null; available_capacity: number | null; is_archived: boolean; generate_preview_media: boolean; sync_preview_media: boolean; hidden: boolean; date_created: string; indexer_rules: ({ indexer_rule: IndexerRule })[] }
 


### PR DESCRIPTION
I spent some time thinking about whether this should only show in the recent files view, or if it should show globally for all recent files (in the explorer, too).

To handle the former, we'd need to use `useLocation()` and check the path, or we'd need to somehow tell the Explorer/context menu that we're viewing it from a recent files perspective.

I ended up just checking if the associated object has an access time, and showing the context menu item based on that - we can't remove a file from recents if it was never there to begin with.