### PR TITLE
Orphan Object Remover

### DIFF
--- a/core/src/library/library.rs
+++ b/core/src/library/library.rs
@@ -16,6 +16,7 @@ use std::{
 };
 
 use sd_crypto::keys::keymanager::KeyManager;
+use tokio::sync::mpsc::Sender;
 use tracing::warn;
 use uuid::Uuid;
 
@@ -39,6 +40,7 @@ pub struct Library {
 	pub node_local_id: i32,
 	/// node_context holds the node context for the node which this library is running on.
 	pub(super) node_context: NodeContext,
+	pub orphan_remover_tx: Sender<()>,
 }
 
 impl Debug for Library {

--- a/core/src/library/library.rs
+++ b/core/src/library/library.rs
@@ -3,7 +3,7 @@ use crate::{
 	job::{IntoJob, JobInitData, JobManagerError, StatefulJob},
 	location::{file_path_helper::MaterializedPath, LocationManager},
 	node::NodeConfigManager,
-	object::preview::get_thumbnail_path,
+	object::{orphan_remover::OrphanRemoverActor, preview::get_thumbnail_path},
 	prisma::{file_path, location, PrismaClient},
 	sync::SyncManager,
 	NodeContext,
@@ -16,7 +16,6 @@ use std::{
 };
 
 use sd_crypto::keys::keymanager::KeyManager;
-use tokio::sync::mpsc::Sender;
 use tracing::warn;
 use uuid::Uuid;
 
@@ -40,7 +39,7 @@ pub struct Library {
 	pub node_local_id: i32,
 	/// node_context holds the node context for the node which this library is running on.
 	pub(super) node_context: NodeContext,
-	pub orphan_remover_tx: Sender<()>,
+	pub orphan_remover: OrphanRemoverActor,
 }
 
 impl Debug for Library {

--- a/core/src/library/manager.rs
+++ b/core/src/library/manager.rs
@@ -1,6 +1,7 @@
 use crate::{
 	invalidate_query,
 	node::Platform,
+	object::orphan_remover::OrphanRemoverActor,
 	prisma::{node, PrismaClient},
 	sync::{SyncManager, SyncMessage},
 	util::{
@@ -387,7 +388,7 @@ impl LibraryManager {
 			config,
 			key_manager,
 			sync: Arc::new(sync_manager),
-			orphan_remover_tx: crate::object::orphan_remover::start(db.clone()),
+			orphan_remover: OrphanRemoverActor::spawn(db.clone()),
 			db,
 			node_local_id: node_data.id,
 			node_context,

--- a/core/src/library/manager.rs
+++ b/core/src/library/manager.rs
@@ -387,6 +387,7 @@ impl LibraryManager {
 			config,
 			key_manager,
 			sync: Arc::new(sync_manager),
+			orphan_remover_tx: crate::object::orphan_remover::start(db.clone()),
 			db,
 			node_local_id: node_data.id,
 			node_context,

--- a/core/src/location/indexer/shallow_indexer_job.rs
+++ b/core/src/location/indexer/shallow_indexer_job.rs
@@ -186,6 +186,8 @@ impl StatefulJob for ShallowIndexerJob {
 				.await
 				.map_err(IndexerError::from)?;
 
+		ctx.library.orphan_remover_tx.send(()).await.ok();
+
 		// Filter out paths that are already in the databases
 		let new_paths = found_paths
 			.into_iter()

--- a/core/src/location/indexer/shallow_indexer_job.rs
+++ b/core/src/location/indexer/shallow_indexer_job.rs
@@ -186,7 +186,7 @@ impl StatefulJob for ShallowIndexerJob {
 				.await
 				.map_err(IndexerError::from)?;
 
-		ctx.library.orphan_remover_tx.send(()).await.ok();
+		ctx.library.orphan_remover.invoke().await;
 
 		// Filter out paths that are already in the databases
 		let new_paths = found_paths

--- a/core/src/location/manager/watcher/macos.rs
+++ b/core/src/location/manager/watcher/macos.rs
@@ -122,7 +122,6 @@ impl<'lib> EventHandler<'lib> for MacOsEventHandler<'lib> {
 			EventKind::Modify(ModifyKind::Name(RenameMode::Any)) => {
 				self.handle_single_rename_event(paths.remove(0)).await?;
 			}
-
 			EventKind::Remove(_) => {
 				remove(self.location_id, &paths[0], self.library).await?;
 			}

--- a/core/src/location/manager/watcher/utils.rs
+++ b/core/src/location/manager/watcher/utils.rs
@@ -642,6 +642,8 @@ pub(super) async fn remove_by_file_path(
 						.await?;
 				}
 			}
+
+			library.orphan_remover_tx.send(()).await.ok();
 		}
 		Err(e) => return Err(e.into()),
 	}

--- a/core/src/location/manager/watcher/utils.rs
+++ b/core/src/location/manager/watcher/utils.rs
@@ -643,7 +643,7 @@ pub(super) async fn remove_by_file_path(
 				}
 			}
 
-			library.orphan_remover_tx.send(()).await.ok();
+			library.orphan_remover.invoke().await;
 		}
 		Err(e) => return Err(e.into()),
 	}

--- a/core/src/location/mod.rs
+++ b/core/src/location/mod.rs
@@ -645,6 +645,8 @@ pub async fn delete_location(library: &Library, location_id: i32) -> Result<(), 
 		}
 	}
 
+	library.orphan_remover.invoke().await;
+
 	info!("Location {} deleted", location_id);
 	invalidate_query!(library, "locations.list");
 

--- a/core/src/object/mod.rs
+++ b/core/src/object/mod.rs
@@ -6,6 +6,7 @@ use specta::Type;
 pub mod cas;
 pub mod file_identifier;
 pub mod fs;
+pub mod orphan_remover;
 pub mod preview;
 pub mod tag;
 pub mod validation;

--- a/core/src/object/orphan_remover.rs
+++ b/core/src/object/orphan_remover.rs
@@ -4,51 +4,69 @@ use tracing::{debug, error};
 
 use crate::prisma::*;
 
-pub fn start(db: Arc<PrismaClient>) -> Sender<()> {
-	let (tx, mut rx) = channel(4);
+// Actor that can be invoked to find and delete objects with no matching file paths
+#[derive(Clone)]
+pub struct OrphanRemoverActor {
+	tx: Sender<()>,
+}
 
-	tokio::spawn(async move {
-		while let Some(()) = rx.recv().await {
-			// prevents timeouts
-			tokio::time::sleep(Duration::from_millis(10)).await;
+impl OrphanRemoverActor {
+	pub fn spawn(db: Arc<PrismaClient>) -> Self {
+		let (tx, mut rx) = channel(4);
 
-			loop {
-				let objs = match db
-					.object()
-					.find_many(vec![object::file_paths::none(vec![])])
-					.take(512)
-					.select(object::select!({ id pub_id }))
-					.exec()
-					.await
-				{
-					Ok(objs) => objs,
-					Err(e) => {
-						error!("Failed to fetch orphaned objects: {e}");
-						break;
+		tokio::spawn({
+			let tx = tx.clone();
+			async move {
+				tx.send(()).await.ok();
+
+				while let Some(()) = rx.recv().await {
+					// prevents timeouts
+					tokio::time::sleep(Duration::from_millis(10)).await;
+
+					loop {
+						let objs = match db
+							.object()
+							.find_many(vec![object::file_paths::none(vec![])])
+							.take(512)
+							.select(object::select!({ id pub_id }))
+							.exec()
+							.await
+						{
+							Ok(objs) => objs,
+							Err(e) => {
+								error!("Failed to fetch orphaned objects: {e}");
+								break;
+							}
+						};
+
+						if objs.is_empty() {
+							break;
+						}
+
+						debug!("Removing {} orphaned objects", objs.len());
+
+						let ids: Vec<_> = objs.iter().map(|o| o.id).collect();
+
+						if let Err(e) = db
+							._batch((
+								db.tag_on_object().delete_many(vec![
+									tag_on_object::object_id::in_vec(ids.clone()),
+								]),
+								db.object().delete_many(vec![object::id::in_vec(ids)]),
+							))
+							.await
+						{
+							error!("Failed to remove orphaned objects: {e}");
+						}
 					}
-				};
-
-				if objs.is_empty() {
-					break;
-				}
-
-				debug!("Removing {} orphaned objects", objs.len());
-
-				let ids: Vec<_> = objs.iter().map(|o| o.id).collect();
-
-				if let Err(e) = db
-					._batch((
-						db.tag_on_object()
-							.delete_many(vec![tag_on_object::object_id::in_vec(ids.clone())]),
-						db.object().delete_many(vec![object::id::in_vec(ids)]),
-					))
-					.await
-				{
-					error!("Failed to remove orphaned objects: {e}");
 				}
 			}
-		}
-	});
+		});
 
-	tx
+		Self { tx }
+	}
+
+	pub async fn invoke(&self) {
+		self.tx.send(()).await.ok();
+	}
 }

--- a/core/src/object/orphan_remover.rs
+++ b/core/src/object/orphan_remover.rs
@@ -1,0 +1,47 @@
+use std::{sync::Arc, time::Duration};
+use tokio::sync::mpsc::*;
+use tracing::{debug, error};
+
+use crate::prisma::*;
+
+pub fn start(db: Arc<PrismaClient>) -> Sender<()> {
+	let (tx, mut rx) = channel(4);
+
+	tokio::spawn(async move {
+		while let Some(()) = rx.recv().await {
+			tokio::time::sleep(Duration::from_millis(10)).await;
+
+			let Ok(objs) = db
+				.object()
+				.find_many(vec![object::file_paths::none(vec![])])
+				.take(512)
+				.select(object::select!({ id pub_id }))
+				.exec()
+				.await else {
+                    continue;
+                };
+
+			if objs.is_empty() {
+				continue;
+			}
+
+			debug!("Removing {} orphaned objects", objs.len());
+
+			let ids: Vec<_> = objs.iter().map(|o| o.id).collect();
+
+			if let Err(e) = db
+				._batch((
+					db.tag_on_object()
+						.delete_many(vec![tag_on_object::object_id::in_vec(ids.clone())]),
+					db.object()
+						.delete_many(vec![object::id::in_vec(ids.clone())]),
+				))
+				.await
+			{
+				error!("Failed to remove orphaned objects: {e}");
+			}
+		}
+	});
+
+	tx
+}

--- a/core/src/object/orphan_remover.rs
+++ b/core/src/object/orphan_remover.rs
@@ -9,36 +9,43 @@ pub fn start(db: Arc<PrismaClient>) -> Sender<()> {
 
 	tokio::spawn(async move {
 		while let Some(()) = rx.recv().await {
+			// prevents timeouts
 			tokio::time::sleep(Duration::from_millis(10)).await;
 
-			let Ok(objs) = db
-				.object()
-				.find_many(vec![object::file_paths::none(vec![])])
-				.take(512)
-				.select(object::select!({ id pub_id }))
-				.exec()
-				.await else {
-                    continue;
-                };
+			loop {
+				let objs = match db
+					.object()
+					.find_many(vec![object::file_paths::none(vec![])])
+					.take(512)
+					.select(object::select!({ id pub_id }))
+					.exec()
+					.await
+				{
+					Ok(objs) => objs,
+					Err(e) => {
+						error!("Failed to fetch orphaned objects: {e}");
+						break;
+					}
+				};
 
-			if objs.is_empty() {
-				continue;
-			}
+				if objs.is_empty() {
+					break;
+				}
 
-			debug!("Removing {} orphaned objects", objs.len());
+				debug!("Removing {} orphaned objects", objs.len());
 
-			let ids: Vec<_> = objs.iter().map(|o| o.id).collect();
+				let ids: Vec<_> = objs.iter().map(|o| o.id).collect();
 
-			if let Err(e) = db
-				._batch((
-					db.tag_on_object()
-						.delete_many(vec![tag_on_object::object_id::in_vec(ids.clone())]),
-					db.object()
-						.delete_many(vec![object::id::in_vec(ids.clone())]),
-				))
-				.await
-			{
-				error!("Failed to remove orphaned objects: {e}");
+				if let Err(e) = db
+					._batch((
+						db.tag_on_object()
+							.delete_many(vec![tag_on_object::object_id::in_vec(ids.clone())]),
+						db.object().delete_many(vec![object::id::in_vec(ids)]),
+					))
+					.await
+				{
+					error!("Failed to remove orphaned objects: {e}");
+				}
 			}
 		}
 	});


### PR DESCRIPTION
Adds an `orphan_remover` actor that runs in the background and can be triggered by sending a message to the `Library.orphan_remover_tx` channel. It could be argued that this should be a job, but I decided against it since:

1) It's not user-initiated
2) It's code that _could_ just be put in a function and called in different places.

I think an actor is a better choice to reduce db contention and have it performed asynchronously from latency-sensitive file path operations.5

Closes ENG-583