### PR TITLE
Fix Spacedrive process being `Killed` during lauch on macOS

### DIFF
--- a/.github/scripts/setup-system.sh
+++ b/.github/scripts/setup-system.sh
@@ -312,8 +312,15 @@ elif [ "$SYSNAME" = "Darwin" ]; then
     sleep 1
   done
 
-  # Symlink the FFMpeg.framework libs to the lib directory
+  # Sign and Symlink the FFMpeg.framework libs to the lib directory
   for _lib in "${_frameworks_dir}/FFMpeg.framework/Libraries/"*; do
+    if [ -f "$_lib" ]; then
+      # Sign the lib with the local machine certificate (Required for it to work on macOS 13+)
+      if ! codesign -s - -f "$_lib" 1>/dev/null 2>&1; then
+        err "Failed to sign: ${_lib#"$_frameworks_dir"}" \
+          'Please open an issue on https://github.com/spacedriveapp/spacedrive/issues'
+      fi
+    fi
     _lib="${_lib#"${_frameworks_dir}/FFMpeg.framework/Libraries/"}"
     ln -s "../FFMpeg.framework/Libraries/${_lib}" "${_frameworks_dir}/lib/${_lib}"
   done


### PR DESCRIPTION
macOS (Ventura? arm?) requires all `dylibs` to be signed to allow a process to launch[¹].

This PR locally signs our ffmpeg `dylibs` with the machine's local certificate in the `setup-system` script after downloading them to work around this issue.

[¹]: https://github.com/tpoechtrager/osxcross/issues/355