### PR TITLE
[ENG-591] - Fix some funky behaviors

### DIFF
--- a/interface/app/$libraryId/Explorer/File/DecryptDialog.tsx
+++ b/interface/app/$libraryId/Explorer/File/DecryptDialog.tsx
@@ -21,7 +21,6 @@ interface Props extends UseDialogProps {
 
 export default (props: Props) => {
 	const platform = usePlatform();
-	const dialog = useDialog(props);
 
 	const mountedUuids = useLibraryQuery(['keys.listMounted'], {
 		onSuccess: (data) => {
@@ -63,22 +62,20 @@ export default (props: Props) => {
 		schema
 	});
 
-	const onSubmit = form.handleSubmit((data) =>
-		decryptFile.mutateAsync({
-			location_id: props.location_id,
-			path_id: props.path_id,
-			output_path: data.outputPath !== '' ? data.outputPath : null,
-			mount_associated_key: data.mountAssociatedKey,
-			password: data.type === 'password' ? data.password : null,
-			save_to_library: data.type === 'password' ? data.saveToKeyManager : null
-		})
-	);
-
 	return (
 		<Dialog
 			form={form}
-			dialog={dialog}
-			onSubmit={onSubmit}
+			dialog={useDialog(props)}
+			onSubmit={(data) =>
+				decryptFile.mutateAsync({
+					location_id: props.location_id,
+					path_id: props.path_id,
+					output_path: data.outputPath !== '' ? data.outputPath : null,
+					mount_associated_key: data.mountAssociatedKey,
+					password: data.type === 'password' ? data.password : null,
+					save_to_library: data.type === 'password' ? data.saveToKeyManager : null
+				})
+			}
 			title="Decrypt a file"
 			description="Leave the output file blank for the default."
 			loading={decryptFile.isLoading}

--- a/interface/app/$libraryId/Explorer/File/DecryptDialog.tsx
+++ b/interface/app/$libraryId/Explorer/File/DecryptDialog.tsx
@@ -3,7 +3,7 @@ import { Info } from 'phosphor-react';
 import { useLibraryMutation, useLibraryQuery } from '@sd/client';
 import { Button, Dialog, Tooltip, UseDialogProps, useDialog } from '@sd/ui';
 import { PasswordInput, Switch, useZodForm, z } from '@sd/ui/src/forms';
-import { showAlertDialog } from '~/components/AlertDialog';
+import { showAlertDialog } from '~/components';
 import { usePlatform } from '~/util/Platform';
 
 const schema = z.object({

--- a/interface/app/$libraryId/Explorer/File/DeleteDialog.tsx
+++ b/interface/app/$libraryId/Explorer/File/DeleteDialog.tsx
@@ -8,23 +8,18 @@ interface Propps extends UseDialogProps {
 }
 
 export default (props: Propps) => {
-	const dialog = useDialog(props);
 	const deleteFile = useLibraryMutation('files.deleteFiles');
-
-	const form = useZodForm();
-
-	const onSubmit = form.handleSubmit(() =>
-		deleteFile.mutateAsync({
-			location_id: props.location_id,
-			path_id: props.path_id
-		})
-	);
 
 	return (
 		<Dialog
-			form={form}
-			onSubmit={onSubmit}
-			dialog={dialog}
+			form={useZodForm()}
+			onSubmit={() =>
+				deleteFile.mutateAsync({
+					location_id: props.location_id,
+					path_id: props.path_id
+				})
+			}
+			dialog={useDialog(props)}
 			title="Delete a file"
 			description="Configure your deletion settings."
 			loading={deleteFile.isLoading}

--- a/interface/app/$libraryId/Explorer/File/EncryptDialog.tsx
+++ b/interface/app/$libraryId/Explorer/File/EncryptDialog.tsx
@@ -7,7 +7,7 @@ import {
 } from '@sd/client';
 import { Button, Dialog, Select, SelectOption, UseDialogProps, useDialog } from '@sd/ui';
 import { CheckBox, useZodForm, z } from '@sd/ui/src/forms';
-import { showAlertDialog } from '~/components/AlertDialog';
+import { showAlertDialog } from '~/components';
 import { usePlatform } from '~/util/Platform';
 import { KeyListSelectOptions } from '../../KeyManager/List';
 

--- a/interface/app/$libraryId/Explorer/File/EncryptDialog.tsx
+++ b/interface/app/$libraryId/Explorer/File/EncryptDialog.tsx
@@ -26,7 +26,6 @@ const schema = z.object({
 });
 
 export default (props: Props) => {
-	const dialog = useDialog(props);
 	const platform = usePlatform();
 
 	const UpdateKey = (uuid: string) => {
@@ -64,23 +63,21 @@ export default (props: Props) => {
 		schema
 	});
 
-	const onSubmit = form.handleSubmit((data) =>
-		encryptFile.mutateAsync({
-			algorithm: data.encryptionAlgo as Algorithm,
-			key_uuid: data.key,
-			location_id: props.location_id,
-			path_id: props.path_id,
-			metadata: data.metadata,
-			preview_media: data.previewMedia,
-			output_path: data.outputPath || null
-		})
-	);
-
 	return (
 		<Dialog
 			form={form}
-			onSubmit={onSubmit}
-			dialog={dialog}
+			onSubmit={(data) =>
+				encryptFile.mutateAsync({
+					algorithm: data.encryptionAlgo as Algorithm,
+					key_uuid: data.key,
+					location_id: props.location_id,
+					path_id: props.path_id,
+					metadata: data.metadata,
+					preview_media: data.previewMedia,
+					output_path: data.outputPath || null
+				})
+			}
+			dialog={useDialog(props)}
 			title="Encrypt a file"
 			description="Configure your encryption settings. Leave the output file blank for the default."
 			loading={encryptFile.isLoading}

--- a/interface/app/$libraryId/Explorer/File/EraseDialog.tsx
+++ b/interface/app/$libraryId/Explorer/File/EraseDialog.tsx
@@ -13,8 +13,6 @@ const schema = z.object({
 });
 
 export default (props: Props) => {
-	const dialog = useDialog(props);
-
 	const eraseFile = useLibraryMutation('files.eraseFiles');
 
 	const form = useZodForm({
@@ -24,21 +22,19 @@ export default (props: Props) => {
 		}
 	});
 
-	const onSubmit = form.handleSubmit((data) =>
-		eraseFile.mutateAsync({
-			location_id: props.location_id,
-			path_id: props.path_id,
-			passes: data.passes.toString()
-		})
-	);
-
 	const [passes, setPasses] = useState([4]);
 
 	return (
 		<Dialog
 			form={form}
-			onSubmit={onSubmit}
-			dialog={dialog}
+			onSubmit={(data) =>
+				eraseFile.mutateAsync({
+					location_id: props.location_id,
+					path_id: props.path_id,
+					passes: data.passes.toString()
+				})
+			}
+			dialog={useDialog(props)}
 			title="Erase a file"
 			description="Configure your erasure settings."
 			loading={eraseFile.isLoading}

--- a/interface/app/$libraryId/Explorer/File/Thumb.tsx
+++ b/interface/app/$libraryId/Explorer/File/Thumb.tsx
@@ -96,7 +96,7 @@ const Thumbnail = ({
 						cover
 							? 'bottom-1 right-1'
 							: 'left-1/2 top-1/2 -translate-x-full -translate-y-full',
-						'absolute rounded',
+						'absolute rounded !text-white',
 						'bg-black/60 px-1 py-0.5 text-[9px] font-semibold uppercase opacity-70'
 					)}
 				>

--- a/interface/app/$libraryId/Explorer/File/Thumb.tsx
+++ b/interface/app/$libraryId/Explorer/File/Thumb.tsx
@@ -191,9 +191,9 @@ function FileThumb({ size, cover, ...props }: ThumbProps) {
 			className={clsx(
 				'relative flex shrink-0 items-center justify-center',
 				size &&
-				kind !== 'Video' &&
-				thumbType !== ThumbType.Icon &&
-				'border-2 border-transparent',
+					kind !== 'Video' &&
+					thumbType !== ThumbType.Icon &&
+					'border-2 border-transparent',
 				size || ['h-full', cover ? 'w-full overflow-hidden' : 'w-[90%]'],
 				props.className
 			)}
@@ -288,9 +288,9 @@ function FileThumb({ size, cover, ...props }: ThumbProps) {
 										'shadow shadow-black/30'
 									],
 									size &&
-									(kind === 'Video'
-										? 'border-x-0 border-black'
-										: size > 60 && 'border-2 border-app-line'),
+										(kind === 'Video'
+											? 'border-x-0 border-black'
+											: size > 60 && 'border-2 border-app-line'),
 									props.className
 								)}
 								crossOrigin={ThumbType.Original && 'anonymous'} // Here it is ok, because it is not a react attr

--- a/interface/app/$libraryId/Explorer/File/Thumb.tsx
+++ b/interface/app/$libraryId/Explorer/File/Thumb.tsx
@@ -299,7 +299,7 @@ function FileThumb({ size, cover, ...props }: ThumbProps) {
 								}
 								videoExtension={
 									(kind === 'Video' &&
-										(size == null || size > 80) &&
+										(cover || size == null || size > 80) &&
 										extension) ||
 									''
 								}

--- a/interface/app/$libraryId/Explorer/Inspector/index.tsx
+++ b/interface/app/$libraryId/Explorer/Inspector/index.tsx
@@ -1,5 +1,5 @@
 // import types from '../../constants/file-types.json';
-import { Image } from '@sd/assets/icons';
+import { Image, Image_Light } from '@sd/assets/icons';
 import clsx from 'clsx';
 import dayjs from 'dayjs';
 import { Barcode, CircleWavyCheck, Clock, Cube, Hash, Link, Lock, Snowflake } from 'phosphor-react';
@@ -14,7 +14,7 @@ import {
 	useLibraryQuery
 } from '@sd/client';
 import { Button, Divider, DropdownMenu, Tooltip, tw } from '@sd/ui';
-import { useExplorerStore } from '~/hooks/useExplorerStore';
+import { useExplorerStore, useIsDark } from '~/hooks';
 import { TOP_BAR_HEIGHT } from '../../TopBar';
 import AssignTagMenuItems from '../AssignTagMenuItems';
 import FileThumb from '../File/Thumb';
@@ -42,6 +42,7 @@ interface Props extends Omit<ComponentProps<'div'>, 'onScroll'> {
 }
 
 export const Inspector = ({ data, context, className, ...elementProps }: Props) => {
+	const isDark = useIsDark();
 	const objectData = data ? getItemObject(data) : null;
 	const filePathData = data ? getItemFilePath(data) : null;
 	const explorerStore = useExplorerStore();
@@ -118,16 +119,21 @@ export const Inspector = ({ data, context, className, ...elementProps }: Props) 
 							<MetaContainer>
 								<MetaTitle>URI</MetaTitle>
 								<MetaValue>
-									{`${context.path}/${data.item.materialized_path}${data.item.name}${data.item.is_dir ? `.${data.item.extension}` : '/'
-										}`}
+									{`${context.path}/${data.item.materialized_path}${
+										data.item.name
+									}${data.item.is_dir ? `.${data.item.extension}` : '/'}`}
 								</MetaValue>
 							</MetaContainer>
 						)}
 						<Divider />
 						<MetaContainer>
 							<div className="flex flex-wrap gap-1 overflow-hidden">
-								<InfoPill>{isDir ? 'Folder' : ObjectKind[objectData?.kind || 0]}</InfoPill>
-								{filePathData?.extension && <InfoPill>{filePathData.extension}</InfoPill>}
+								<InfoPill>
+									{isDir ? 'Folder' : ObjectKind[objectData?.kind || 0]}
+								</InfoPill>
+								{filePathData?.extension && (
+									<InfoPill>{filePathData.extension}</InfoPill>
+								)}
 								{tags.data?.map((tag) => (
 									<Tooltip
 										key={tag.id}
@@ -167,7 +173,9 @@ export const Inspector = ({ data, context, className, ...elementProps }: Props) 
 								<MetaTextLine>
 									<InspectorIcon component={Clock} />
 									<span className="mr-1.5">Duration</span>
-									<MetaValue>{fullObjectData.data.media_data.duration_seconds}</MetaValue>
+									<MetaValue>
+										{fullObjectData.data.media_data.duration_seconds}
+									</MetaValue>
 								</MetaTextLine>
 							)}
 						</MetaContainer>
@@ -177,7 +185,9 @@ export const Inspector = ({ data, context, className, ...elementProps }: Props) 
 								<MetaTextLine>
 									<InspectorIcon component={Clock} />
 									<MetaKeyName className="mr-1.5">Created</MetaKeyName>
-									<MetaValue>{dayjs(item.date_created).format('MMM Do YYYY')}</MetaValue>
+									<MetaValue>
+										{dayjs(item.date_created).format('MMM Do YYYY')}
+									</MetaValue>
 								</MetaTextLine>
 							</Tooltip>
 							<Tooltip label={dayjs(item.date_created).format('h:mm:ss a')}>
@@ -207,8 +217,12 @@ export const Inspector = ({ data, context, className, ...elementProps }: Props) 
 										<Tooltip label={filePathData?.integrity_checksum || ''}>
 											<MetaTextLine>
 												<InspectorIcon component={CircleWavyCheck} />
-												<MetaKeyName className="mr-1.5">Checksum</MetaKeyName>
-												<MetaValue>{filePathData?.integrity_checksum}</MetaValue>
+												<MetaKeyName className="mr-1.5">
+													Checksum
+												</MetaKeyName>
+												<MetaValue>
+													{filePathData?.integrity_checksum}
+												</MetaValue>
 											</MetaTextLine>
 										</Tooltip>
 									)}
@@ -216,7 +230,9 @@ export const Inspector = ({ data, context, className, ...elementProps }: Props) 
 										<Tooltip label={pub_id || ''}>
 											<MetaTextLine>
 												<InspectorIcon component={Hash} />
-												<MetaKeyName className="mr-1.5">Object ID</MetaKeyName>
+												<MetaKeyName className="mr-1.5">
+													Object ID
+												</MetaKeyName>
 												<MetaValue>{pub_id}</MetaValue>
 											</MetaTextLine>
 										</Tooltip>
@@ -228,7 +244,7 @@ export const Inspector = ({ data, context, className, ...elementProps }: Props) 
 				</>
 			) : (
 				<div className="flex w-full flex-col items-center justify-center">
-					<img src={Image} />
+					<img src={isDark ? Image : Image_Light} />
 					<div
 						className="mt-[15px] flex h-[390px] w-[245px] select-text items-center justify-center
 					rounded-lg border border-app-line bg-app-box py-0.5 shadow-app-shade/10"

--- a/interface/app/$libraryId/Explorer/ListView.tsx
+++ b/interface/app/$libraryId/Explorer/ListView.tsx
@@ -177,7 +177,7 @@ export default () => {
 			{
 				header: 'Content ID',
 				size: 180,
-				accessorFn: (file) => getExplorerItemData(file).cas_id
+				accessorFn: (file) => getExplorerItemData(file).casId
 			}
 		],
 		[explorerStore.selectedRowIndex, explorerStore.isRenaming, sorting]

--- a/interface/app/$libraryId/Explorer/ListView.tsx
+++ b/interface/app/$libraryId/Explorer/ListView.tsx
@@ -163,12 +163,12 @@ export default () => {
 						return aName === bName
 							? 0
 							: aName > bName
-								? desc
-									? 1
-									: -1
-								: desc
-									? -1
-									: 1;
+							? desc
+								? 1
+								: -1
+							: desc
+							? -1
+							: 1;
 					}
 
 					return aDate > bDate ? 1 : -1;
@@ -226,13 +226,13 @@ export default () => {
 						...sizing,
 						...(scrollWidth && nameWidth
 							? {
-								Name:
-									nameWidth +
-									scrollWidth -
-									paddingX * 2 -
-									scrollBarWidth -
-									tableLength
-							}
+									Name:
+										nameWidth +
+										scrollWidth -
+										paddingX * 2 -
+										scrollBarWidth -
+										tableLength
+							  }
 							: {})
 					};
 				});
@@ -361,8 +361,8 @@ export default () => {
 											i === 0
 												? size + paddingX
 												: i === headerGroup.headers.length - 1
-													? size - paddingX
-													: size
+												? size - paddingX
+												: size
 									}}
 									onClick={header.column.getToggleSortingHandler()}
 								>
@@ -382,16 +382,16 @@ export default () => {
 											{(i !== headerGroup.headers.length - 1 ||
 												(i === headerGroup.headers.length - 1 &&
 													!locked)) && (
-													<div
-														onClick={(e) => e.stopPropagation()}
-														onMouseDown={(e) => {
-															setLocked(false);
-															header.getResizeHandler()(e);
-														}}
-														onTouchStart={header.getResizeHandler()}
-														className="absolute right-0 h-[70%] w-2 cursor-col-resize border-r border-app-line/50"
-													/>
-												)}
+												<div
+													onClick={(e) => e.stopPropagation()}
+													onMouseDown={(e) => {
+														setLocked(false);
+														header.getResizeHandler()(e);
+													}}
+													onTouchStart={header.getResizeHandler()}
+													className="absolute right-0 h-[70%] w-2 cursor-col-resize border-r border-app-line/50"
+												/>
+											)}
 										</div>
 									)}
 								</div>

--- a/interface/app/$libraryId/Explorer/util.ts
+++ b/interface/app/$libraryId/Explorer/util.ts
@@ -2,19 +2,6 @@ import { z } from 'zod';
 import { ExplorerItem, ObjectKind, ObjectKindKey, Ordering, isObject, isPath } from '@sd/client';
 import { useExplorerStore, useZodSearchParams } from '~/hooks';
 
-export function getExplorerItemData(data: ExplorerItem, hasNewThumbnail?: boolean) {
-	const objectData = getItemObject(data);
-	const filePath = getItemFilePath(data);
-
-	return {
-		cas_id: filePath?.cas_id || null,
-		isDir: isPath(data) && data.item.is_dir,
-		kind: (ObjectKind[objectData?.kind ?? 0] as ObjectKindKey) || null,
-		hasThumbnail: data.has_thumbnail || hasNewThumbnail,
-		extension: filePath?.extension || null
-	};
-}
-
 export function useExplorerOrder(): Ordering | undefined {
 	const explorerStore = useExplorerStore();
 
@@ -29,6 +16,21 @@ export function getItemObject(data: ExplorerItem) {
 
 export function getItemFilePath(data: ExplorerItem) {
 	return isObject(data) ? data.item.file_paths[0] : data.item;
+}
+
+export function getExplorerItemData(data: ExplorerItem) {
+	const filePath = getItemFilePath(data);
+	const objectData = getItemObject(data);
+
+	const casId = filePath?.cas_id || null;
+
+	return {
+		kind: (ObjectKind[objectData?.kind ?? 0] as ObjectKindKey) || null,
+		casId,
+		isDir: isPath(data) && data.item.is_dir,
+		extension: filePath?.extension || null,
+		hasThumbnail: data.has_thumbnail
+	};
 }
 
 export const SEARCH_PARAMS = z.object({

--- a/interface/app/$libraryId/Explorer/util.ts
+++ b/interface/app/$libraryId/Explorer/util.ts
@@ -22,11 +22,9 @@ export function getExplorerItemData(data: ExplorerItem) {
 	const filePath = getItemFilePath(data);
 	const objectData = getItemObject(data);
 
-	const casId = filePath?.cas_id || null;
-
 	return {
 		kind: (ObjectKind[objectData?.kind ?? 0] as ObjectKindKey) || null,
-		casId,
+		casId: filePath?.cas_id || null,
 		isDir: isPath(data) && data.item.is_dir,
 		extension: filePath?.extension || null,
 		hasThumbnail: data.has_thumbnail

--- a/interface/app/$libraryId/Layout/Sidebar/index.tsx
+++ b/interface/app/$libraryId/Layout/Sidebar/index.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
-import NavigationButtons from '~/components/NavigationButtons';
-import { MacTrafficLights } from '~/components/TrafficLights';
+import { MacTrafficLights, NavigationButtons } from '~/components';
 import { useOperatingSystem } from '~/hooks/useOperatingSystem';
 import Contents from './Contents';
 import Footer from './Footer';
@@ -20,7 +19,7 @@ export default () => {
 		>
 			{showControls && <MacTrafficLights className="absolute left-[13px] top-[13px] z-50" />}
 			{(os !== 'browser' || showControls) && (
-				<div className="-mt-[4px] flex justify-end">
+				<div className="mt-[-4px] flex justify-end">
 					<NavigationButtons />
 				</div>
 			)}

--- a/interface/app/$libraryId/Layout/Sidebar/index.tsx
+++ b/interface/app/$libraryId/Layout/Sidebar/index.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import { MacTrafficLights, NavigationButtons } from '~/components';
-import { useOperatingSystem } from '~/hooks/useOperatingSystem';
+import { useOperatingSystem } from '~/hooks';
 import Contents from './Contents';
 import Footer from './Footer';
 import LibrariesDropdown from './LibrariesDropdown';

--- a/interface/app/$libraryId/overview/index.tsx
+++ b/interface/app/$libraryId/overview/index.tsx
@@ -133,7 +133,6 @@ export const Component = () => {
 				isFetchingNextPage={query.isFetchingNextPage}
 				scrollRef={page?.ref}
 			>
-
 				<Statistics />
 				<div className="no-scrollbar sticky top-0 z-50 mt-2 flex space-x-[1px] overflow-x-scroll bg-app/90 px-5 py-1.5 backdrop-blur">
 					{categories.data?.map((category) => {
@@ -150,7 +149,6 @@ export const Component = () => {
 						);
 					})}
 				</div>
-
 			</Explorer>
 		</>
 	);

--- a/interface/app/$libraryId/overview/index.tsx
+++ b/interface/app/$libraryId/overview/index.tsx
@@ -70,7 +70,7 @@ export const Component = () => {
 
 	const categories = useLibraryQuery(['categories.list']);
 
-	const isFavoritesCategory = selectedCategory === "Favorites";
+	const isFavoritesCategory = selectedCategory === 'Favorites';
 
 	// TODO: Make a custom double click handler for directories to take users to the location explorer.
 	// For now it's not needed because folders shouldn't show.
@@ -84,7 +84,13 @@ export const Component = () => {
 					order: useExplorerOrder(),
 					favorite: isFavoritesCategory ? true : undefined,
 					...(explorerStore.layoutMode === 'media'
-						? { kind: [5, 7].includes(kind) ? [kind] : isFavoritesCategory ? [5, 7] : [5, 7, kind] }
+						? {
+								kind: [5, 7].includes(kind)
+									? [kind]
+									: isFavoritesCategory
+									? [5, 7]
+									: [5, 7, kind]
+						  }
 						: { kind: isFavoritesCategory ? [] : [kind] })
 				}
 			}

--- a/interface/app/$libraryId/overview/index.tsx
+++ b/interface/app/$libraryId/overview/index.tsx
@@ -1,4 +1,7 @@
-import * as icons from '@sd/assets/icons';
+import { getIcon, iconNames } from '@sd/assets/icons/util';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useMemo, useState } from 'react';
+import 'react-loading-skeleton/dist/skeleton.css';
 import {
 	ExplorerItem,
 	ObjectKind,
@@ -8,10 +11,7 @@ import {
 	useRspcLibraryContext
 } from '@sd/client';
 import { z } from '@sd/ui/src/forms';
-import { useInfiniteQuery } from '@tanstack/react-query';
-import { useMemo, useState } from 'react';
-import 'react-loading-skeleton/dist/skeleton.css';
-import { useExplorerStore, useExplorerTopBarOptions } from '~/hooks';
+import { useExplorerStore, useExplorerTopBarOptions, useIsDark } from '~/hooks';
 import Explorer from '../Explorer';
 import { SEARCH_PARAMS, useExplorerOrder } from '../Explorer/util';
 import { usePageLayout } from '../PageLayout';
@@ -21,21 +21,21 @@ import Statistics from '../overview/Statistics';
 
 // TODO: Replace left hand type with Category enum type (doesn't exist yet)
 const CategoryToIcon: Record<string, string> = {
-	Recents: 'Collection',
-	Favorites: 'HeartFlat',
-	Photos: 'Image',
-	Videos: 'Video',
-	Movies: 'Movie',
-	Music: 'Audio',
-	Documents: 'Document',
-	Downloads: 'Package',
-	Applications: 'Application',
-	Games: "Game",
-	Books: 'Book',
-	Encrypted: 'EncryptedLock',
-	Archives: 'Database',
-	Projects: 'Folder',
-	Trash: 'Trash'
+	Recents: iconNames.Collection,
+	Favorites: iconNames.HeartFlat,
+	Photos: iconNames.Image,
+	Videos: iconNames.Video,
+	Movies: iconNames.Movie,
+	Music: iconNames.Audio,
+	Documents: iconNames.Document,
+	Downloads: iconNames.Package,
+	Applications: iconNames.Application,
+	Games: iconNames.Game,
+	Books: iconNames.Book,
+	Encrypted: iconNames.EncryptedLock,
+	Archives: iconNames.Database,
+	Projects: iconNames.Folder,
+	Trash: iconNames.Trash
 };
 
 // Map the category to the ObjectKind for searching
@@ -45,17 +45,19 @@ const SearchableCategories: Record<string, ObjectKindKey> = {
 	Music: 'Audio',
 	Documents: 'Document',
 	Encrypted: 'Encrypted',
-	Books: 'Book',
-}
+	Books: 'Book'
+};
 
 export type SearchArgs = z.infer<typeof SEARCH_PARAMS>;
 
 export const Component = () => {
 	const page = usePageLayout();
+	const isDark = useIsDark();
 	const explorerStore = useExplorerStore();
 	const ctx = useRspcLibraryContext();
 	const { library } = useLibraryContext();
-	const { explorerViewOptions, explorerControlOptions, explorerToolOptions } = useExplorerTopBarOptions();
+	const { explorerViewOptions, explorerControlOptions, explorerToolOptions } =
+		useExplorerTopBarOptions();
 
 	const [selectedCategory, setSelectedCategory] = useState<string>('Recents');
 
@@ -93,7 +95,7 @@ export const Component = () => {
 				{
 					...queryKey[1].arg,
 					cursor
-				},
+				}
 			]),
 		getNextPageParam: (lastPage) => lastPage.cursor ?? undefined
 	});
@@ -113,11 +115,12 @@ export const Component = () => {
 
 	return (
 		<>
-			<TopBarChildren toolOptions={[explorerViewOptions, explorerToolOptions, explorerControlOptions]} />
+			<TopBarChildren
+				toolOptions={[explorerViewOptions, explorerToolOptions, explorerControlOptions]}
+			/>
 			<Explorer
 				inspectorClassName="!pt-0 !fixed !top-[50px] !right-[10px] !w-[260px]"
 				viewClassName="!pl-0 !pt-0 !h-auto"
-				explorerClassName="!overflow-visible"
 				items={items}
 				onLoadMore={query.fetchNextPage}
 				hasNextPage={query.hasNextPage}
@@ -129,12 +132,11 @@ export const Component = () => {
 				<div className="no-scrollbar sticky top-0 z-50 mt-2 flex space-x-[1px] overflow-x-scroll bg-app/90 px-5 py-1.5 backdrop-blur">
 					{categories.data?.map((category) => {
 						const iconString = CategoryToIcon[category.name] || 'Document';
-						const icon = icons[iconString as keyof typeof icons];
 						return (
 							<CategoryButton
 								key={category.name}
 								category={category.name}
-								icon={icon}
+								icon={getIcon(iconString, isDark)}
 								items={category.count}
 								selected={selectedCategory === category.name}
 								onClick={() => setSelectedCategory(category.name)}
@@ -147,5 +149,3 @@ export const Component = () => {
 		</>
 	);
 };
-
-

--- a/interface/app/$libraryId/settings/library/general.tsx
+++ b/interface/app/$libraryId/settings/library/general.tsx
@@ -1,7 +1,7 @@
 import { useBridgeMutation, useLibraryContext } from '@sd/client';
 import { Button, Input, dialogManager } from '@sd/ui';
 import { useZodForm, z } from '@sd/ui/src/forms';
-import { useDebouncedFormWatch } from '~/hooks/useDebouncedForm';
+import { useDebouncedFormWatch } from '~/hooks';
 import { Heading } from '../Layout';
 import Setting from '../Setting';
 import DeleteLibraryDialog from '../node/libraries/DeleteDialog';

--- a/interface/app/$libraryId/settings/library/general.tsx
+++ b/interface/app/$libraryId/settings/library/general.tsx
@@ -1,16 +1,23 @@
-import { useForm } from 'react-hook-form';
 import { useBridgeMutation, useLibraryContext } from '@sd/client';
 import { Button, Input, dialogManager } from '@sd/ui';
+import { useZodForm, z } from '@sd/ui/src/forms';
 import { useDebouncedFormWatch } from '~/hooks/useDebouncedForm';
 import { Heading } from '../Layout';
 import Setting from '../Setting';
 import DeleteLibraryDialog from '../node/libraries/DeleteDialog';
 
+const schema = z.object({
+	id: z.string(),
+	name: z.string().min(1),
+	description: z.string()
+});
+
 export const Component = () => {
 	const { library } = useLibraryContext();
 	const editLibrary = useBridgeMutation('library.edit');
 
-	const form = useForm({
+	const form = useZodForm({
+		schema,
 		defaultValues: { id: library!.uuid, ...library?.config }
 	});
 
@@ -28,6 +35,9 @@ export const Component = () => {
 				title="Library Settings"
 				description="General settings related to the currently active library."
 			/>
+
+			<input type="hidden" {...form.register('id')} />
+
 			<div className="flex flex-row space-x-5 pb-3">
 				<div className="flex grow flex-col">
 					<span className="mb-1 text-sm font-medium">Name</span>
@@ -52,6 +62,7 @@ export const Component = () => {
 					<Switch checked={false} />
 				</div>
 			</Setting> */}
+
 			{/* <Setting mini title="Export Library" description="Export this library to a file.">
 				<div className="mt-2">
 					<Button size="sm" variant="gray">
@@ -59,6 +70,7 @@ export const Component = () => {
 					</Button>
 				</div>
 			</Setting> */}
+
 			<Setting
 				mini
 				title="Delete Library"

--- a/interface/app/$libraryId/settings/library/keys/BackupRestoreDialog.tsx
+++ b/interface/app/$libraryId/settings/library/keys/BackupRestoreDialog.tsx
@@ -54,7 +54,7 @@ export default (props: UseDialogProps) => {
 								secret_key: data.secretKey,
 								path: data.filePath
 							})
-							.then(() => form.reset())
+							.finally(() => form.reset())
 					: null
 			}
 			dialog={useDialog(props)}

--- a/interface/app/$libraryId/settings/library/keys/BackupRestoreDialog.tsx
+++ b/interface/app/$libraryId/settings/library/keys/BackupRestoreDialog.tsx
@@ -2,7 +2,7 @@ import { Eye, EyeSlash } from 'phosphor-react';
 import { useState } from 'react';
 import { useLibraryMutation } from '@sd/client';
 import { Button, Dialog, UseDialogProps, forms, useDialog } from '@sd/ui';
-import { showAlertDialog } from '~/components/AlertDialog';
+import { showAlertDialog } from '~/components';
 import { usePlatform } from '~/util/Platform';
 
 const { Input, useZodForm, z } = forms;

--- a/interface/app/$libraryId/settings/library/keys/BackupRestoreDialog.tsx
+++ b/interface/app/$libraryId/settings/library/keys/BackupRestoreDialog.tsx
@@ -36,8 +36,6 @@ export default (props: UseDialogProps) => {
 		secretKey: false
 	});
 
-	const dialog = useDialog(props);
-
 	const MPCurrentEyeIcon = show.masterPassword ? EyeSlash : Eye;
 	const SKCurrentEyeIcon = show.secretKey ? EyeSlash : Eye;
 
@@ -45,22 +43,21 @@ export default (props: UseDialogProps) => {
 		schema
 	});
 
-	const onSubmit = form.handleSubmit((data) => {
-		if (data.filePath !== '') {
-			restoreKeystoreMutation.mutate({
-				password: data.masterPassword,
-				secret_key: data.secretKey,
-				path: data.filePath
-			});
-			form.reset();
-		}
-	});
-
 	return (
 		<Dialog
 			form={form}
-			onSubmit={onSubmit}
-			dialog={dialog}
+			onSubmit={(data) =>
+				data.filePath !== ''
+					? restoreKeystoreMutation
+							.mutateAsync({
+								password: data.masterPassword,
+								secret_key: data.secretKey,
+								path: data.filePath
+							})
+							.then(() => form.reset())
+					: null
+			}
+			dialog={useDialog(props)}
 			title="Restore Keys"
 			description="Restore keys from a backup."
 			loading={restoreKeystoreMutation.isLoading}

--- a/interface/app/$libraryId/settings/library/keys/KeyViewerDialog.tsx
+++ b/interface/app/$libraryId/settings/library/keys/KeyViewerDialog.tsx
@@ -33,9 +33,6 @@ export const KeyUpdater = (props: {
 };
 
 export default (props: UseDialogProps) => {
-	const form = useZodForm();
-	const dialog = useDialog(props);
-
 	const keys = useLibraryQuery(['keys.list'], {
 		onSuccess: (data) => {
 			if (key === '' && data.length !== 0) {
@@ -52,9 +49,8 @@ export default (props: UseDialogProps) => {
 
 	return (
 		<Dialog
-			form={form}
-			onSubmit={form.handleSubmit(() => {})}
-			dialog={dialog}
+			form={useZodForm()}
+			dialog={useDialog(props)}
 			title="View Key Values"
 			description="Here you can view the values of your keys."
 			ctaLabel="Done"

--- a/interface/app/$libraryId/settings/library/keys/MasterPasswordDialog.tsx
+++ b/interface/app/$libraryId/settings/library/keys/MasterPasswordDialog.tsx
@@ -9,8 +9,7 @@ import {
 } from '@sd/client';
 import { Button, Dialog, Input, Select, SelectOption, UseDialogProps, useDialog } from '@sd/ui';
 import { useZodForm, z } from '@sd/ui/src/forms';
-import { showAlertDialog } from '~/components/AlertDialog';
-import { PasswordMeter } from '~/components/PasswordMeter';
+import { PasswordMeter, showAlertDialog } from '~/components';
 import { generatePassword } from '~/util';
 
 const schema = z.object({

--- a/interface/app/$libraryId/settings/library/keys/MasterPasswordDialog.tsx
+++ b/interface/app/$libraryId/settings/library/keys/MasterPasswordDialog.tsx
@@ -42,8 +42,6 @@ export default (props: UseDialogProps) => {
 		masterPassword2: false
 	});
 
-	const dialog = useDialog(props);
-
 	const MP1CurrentEyeIcon = show.masterPassword ? EyeSlash : Eye;
 	const MP2CurrentEyeIcon = show.masterPassword2 ? EyeSlash : Eye;
 
@@ -57,7 +55,7 @@ export default (props: UseDialogProps) => {
 		}
 	});
 
-	const onSubmit = form.handleSubmit((data) => {
+	const onSubmit: Parameters<typeof form.handleSubmit>[0] = (data) => {
 		if (data.masterPassword !== data.masterPassword2) {
 			showAlertDialog({
 				title: 'Error',
@@ -72,13 +70,13 @@ export default (props: UseDialogProps) => {
 				password: data.masterPassword
 			});
 		}
-	});
+	};
 
 	return (
 		<Dialog
 			form={form}
 			onSubmit={onSubmit}
-			dialog={dialog}
+			dialog={useDialog(props)}
 			title="Change Master Password"
 			description="Select a new master password for your key manager."
 			ctaDanger={true}

--- a/interface/app/$libraryId/settings/library/locations/$id.tsx
+++ b/interface/app/$libraryId/settings/library/locations/$id.tsx
@@ -1,21 +1,18 @@
-import { useLibraryMutation, useLibraryQuery } from '@sd/client';
-import { Button, Divider, RadioGroup, Tooltip, forms, tw } from '@sd/ui';
 import { useQueryClient } from '@tanstack/react-query';
 import { Archive, ArrowsClockwise, Info, Trash } from 'phosphor-react';
 import { useState } from 'react';
 import { Controller } from 'react-hook-form';
 import { useNavigate } from 'react-router';
-import { showAlertDialog } from '~/components/AlertDialog';
+import { useLibraryMutation, useLibraryQuery } from '@sd/client';
+import { Button, Divider, Label, RadioGroup, Tooltip, tw } from '@sd/ui';
+import { Form, InfoText, Input, Switch, useZodForm, z } from '@sd/ui/src/forms';
+import ModalLayout from '~/app/$libraryId/settings/ModalLayout';
+import { showAlertDialog } from '~/components';
 import { useZodRouteParams } from '~/hooks';
-import ModalLayout from '../../ModalLayout';
 import IndexerRuleEditor from './IndexerRuleEditor';
 
-const Label = tw.label`mb-1 text-sm font-medium`;
 const FlexCol = tw.label`flex flex-col flex-1`;
-const InfoText = tw.p`mt-2 text-xs text-ink-faint`;
 const ToggleSection = tw.label`flex flex-row w-full`;
-
-const { Form, Input, Switch, useZodForm, z } = forms;
 
 const schema = z.object({
 	name: z.string(),
@@ -36,7 +33,7 @@ export const Component = () => {
 		schema,
 		defaultValues: {
 			indexerRulesIds: [],
-			locationType: 'normal',
+			locationType: 'normal'
 		}
 	});
 
@@ -46,7 +43,6 @@ export const Component = () => {
 	const fullRescan = useLibraryMutation('locations.fullRescan');
 	const queryClient = useQueryClient();
 	const [isFirstLoad, setIsFirstLoad] = useState(true);
-	const [toggleNewRule, setToggleNewRule] = useState(false);
 	const updateLocation = useLibraryMutation('locations.update', {
 		onError: () => {
 			showAlertDialog({
@@ -129,7 +125,7 @@ export const Component = () => {
 				<div className="flex space-x-4">
 					<FlexCol>
 						<Input label="Display Name" {...form.register('name')} />
-						<InfoText>
+						<InfoText className="mt-2">
 							The name of this Location, this is what will be displayed in the
 							sidebar. Will not rename the actual folder on disk.
 						</InfoText>
@@ -141,7 +137,7 @@ export const Component = () => {
 							className="text-ink-dull"
 							{...form.register('path')}
 						/>
-						<InfoText>
+						<InfoText className="mt-2">
 							The path to this Location, this is where the files will be stored on
 							disk.
 						</InfoText>
@@ -150,25 +146,36 @@ export const Component = () => {
 				<Divider />
 				<div className="space-y-2">
 					<Label className="grow">Location Type</Label>
-					<RadioGroup.Root className='flex flex-row !space-y-0 space-x-2' {...form.register('locationType')}>
+					<RadioGroup.Root
+						className="flex flex-row !space-y-0 space-x-2"
+						{...form.register('locationType')}
+					>
 						<RadioGroup.Item key="normal" value="normal">
 							<h1 className="font-bold">Normal</h1>
-							<p className="text-sm text-ink-faint">Contents will be indexed as-is, new files will not be automatically sorted.</p>
+							<p className="text-sm text-ink-faint">
+								Contents will be indexed as-is, new files will not be automatically
+								sorted.
+							</p>
 						</RadioGroup.Item>
-						<span className='opacity-30'>
+						<span className="opacity-30">
 							<RadioGroup.Item disabled key="managed" value="managed">
 								<h1 className="font-bold">Managed</h1>
-								<p className="text-sm text-ink-faint">Spacedrive will sort files for you. If Location isn't empty a "spacedrive" folder will be created.</p>
+								<p className="text-sm text-ink-faint">
+									Spacedrive will sort files for you. If Location isn't empty a
+									"spacedrive" folder will be created.
+								</p>
 							</RadioGroup.Item>
 						</span>
-						<span className='opacity-30'>
+						<span className="opacity-30">
 							<RadioGroup.Item disabled key="replica" value="replica">
 								<h1 className="font-bold">Replica</h1>
-								<p className="text-sm text-ink-faint ">This Location is a replica of another, its contents will be automatically synchronized.</p>
+								<p className="text-sm text-ink-faint ">
+									This Location is a replica of another, its contents will be
+									automatically synchronized.
+								</p>
 							</RadioGroup.Item>
 						</span>
 					</RadioGroup.Root>
-
 				</div>
 				<Divider />
 				<div className="space-y-2">
@@ -193,34 +200,19 @@ export const Component = () => {
 					</ToggleSection>
 				</div>
 				<Divider />
-				<div className="flex flex-col rounded-md border border-app-line bg-app-overlay px-5 py-5">
-					<div className="flex w-full items-start justify-between">
-						<div>
-							<Label className="!mb-2 grow !text-sm !font-bold">Indexer rules</Label>
-							<InfoText className="!mt-0 mb-4">
-								Indexer rules allow you to specify paths to ignore using RegEx.
-							</InfoText>
-						</div>
-						<Button
-							onClick={() => setToggleNewRule(!toggleNewRule)}
-							className="px-5"
-							variant="accent"
-						>
-							+ New
-						</Button>
-					</div>
-					<Controller
-						name="indexerRulesIds"
-						render={({ field }) => (
-							<IndexerRuleEditor
-								setToggleNewRule={setToggleNewRule}
-								toggleNewRule={toggleNewRule}
-								field={field}
-							/>
-						)}
-						control={form.control}
-					/>
-				</div>
+				<Controller
+					name="indexerRulesIds"
+					render={({ field }) => (
+						<IndexerRuleEditor
+							field={field}
+							label="Indexer rules"
+							editable={true}
+							infoText="Indexer rules allow you to specify paths to ignore using RegEx."
+							className="flex flex-col rounded-md border border-app-line bg-app-overlay p-5"
+						/>
+					)}
+					control={form.control}
+				/>
 				<Divider />
 				<div className="flex space-x-5">
 					<FlexCol>
@@ -234,7 +226,9 @@ export const Component = () => {
 								Full Reindex
 							</Button>
 						</div>
-						<InfoText>Perform a full rescan of this Location.</InfoText>
+						<InfoText className="mt-2">
+							Perform a full rescan of this Location.
+						</InfoText>
 					</FlexCol>
 					<FlexCol>
 						<div>
@@ -248,7 +242,7 @@ export const Component = () => {
 								Archive
 							</Button>
 						</div>
-						<InfoText>
+						<InfoText className="mt-2">
 							Extract data from Library as an archive, useful to preserve Location
 							folder structure.
 						</InfoText>
@@ -264,7 +258,7 @@ export const Component = () => {
 								Delete
 							</Button>
 						</div>
-						<InfoText>
+						<InfoText className="mt-2">
 							This will not delete the actual folder on disk. Preview media will be
 						</InfoText>
 					</FlexCol>

--- a/interface/app/$libraryId/settings/library/locations/AddLocationDialog.tsx
+++ b/interface/app/$libraryId/settings/library/locations/AddLocationDialog.tsx
@@ -145,14 +145,14 @@ export const AddLocationDialog = ({
 
 	useCallbackToWatchForm(
 		async (values, { name }) => {
-			if (name !== 'method')
-				// Remote errors should not be cleared by method changes,
+			if (name === 'path') {
+				// Remote errors should only be cleared when path changes,
 				// as the previous error is used to notify the user of this change
 				form.clearErrors(REMOTE_ERROR_FORM_FIELD);
 
-			if (name === 'path' && form.getValues().method !== method)
 				// Reset method when path changes
-				form.setValue('method', method);
+				if (form.getValues().method !== method) form.setValue('method', method);
+			}
 
 			if (values.path === '') return;
 

--- a/interface/app/$libraryId/settings/library/locations/AddLocationDialog.tsx
+++ b/interface/app/$libraryId/settings/library/locations/AddLocationDialog.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { useCallback, useEffect, useMemo } from 'react';
 import { Controller, get } from 'react-hook-form';
 import {
@@ -211,22 +212,23 @@ export const AddLocationDialog = ({
 						.catch((error) => showAlertDialog({ title: 'Error', value: String(error) }))
 				}
 				readOnly={platform.platform !== 'web'}
-				className="mb-3 cursor-pointer"
+				className={clsx('mb-3', platform.platform === 'web' || 'cursor-pointer')}
 				{...form.register('path')}
 			/>
 
 			<input type="hidden" {...form.register('method')} />
 
-			<div className="relative flex flex-col">
-				<p className="my-2 text-sm font-bold">File indexing rules:</p>
-				<div className="w-full text-xs font-medium">
-					<Controller
-						name="indexerRulesIds"
-						render={({ field }) => <IndexerRuleEditor field={field} />}
-						control={form.control}
+			<Controller
+				name="indexerRulesIds"
+				render={({ field }) => (
+					<IndexerRuleEditor
+						field={field}
+						label="File indexing rules:"
+						className="relative flex flex-col"
 					/>
-				</div>
-			</div>
+				)}
+				control={form.control}
+			/>
 		</Dialog>
 	);
 };

--- a/interface/app/$libraryId/settings/library/locations/AddLocationDialog.tsx
+++ b/interface/app/$libraryId/settings/library/locations/AddLocationDialog.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo } from 'react';
-import { Controller } from 'react-hook-form';
+import { Controller, get } from 'react-hook-form';
 import {
 	UnionToTuple,
 	extractInfoRSPCError,
@@ -135,7 +135,7 @@ export const AddLocationDialog = ({
 				}
 			}
 
-			if (message)
+			if (message && get(form.formState.errors, REMOTE_ERROR_FORM_FIELD)?.message !== message)
 				form.setError(REMOTE_ERROR_FORM_FIELD, { type: 'remote', message: message });
 			return true;
 		},
@@ -203,7 +203,6 @@ export const AddLocationDialog = ({
 			<ErrorMessage name={REMOTE_ERROR_FORM_FIELD} variant="large" className="mb-4 mt-2" />
 
 			<Input
-				name="path"
 				size="md"
 				label="Path:"
 				onClick={() =>
@@ -213,6 +212,7 @@ export const AddLocationDialog = ({
 				}
 				readOnly={platform.platform !== 'web'}
 				className="mb-3 cursor-pointer"
+				{...form.register('path')}
 			/>
 
 			<input type="hidden" {...form.register('method')} />

--- a/interface/app/$libraryId/settings/library/locations/DeleteDialog.tsx
+++ b/interface/app/$libraryId/settings/library/locations/DeleteDialog.tsx
@@ -8,10 +8,7 @@ interface Props extends UseDialogProps {
 }
 
 export default (props: Props) => {
-	const dialog = useDialog(props);
 	const submitPlausibleEvent = usePlausibleEvent();
-
-	const form = useZodForm();
 
 	const deleteLocation = useLibraryMutation('locations.delete', {
 		onSuccess: () => {
@@ -22,9 +19,9 @@ export default (props: Props) => {
 
 	return (
 		<Dialog
-			form={form}
-			onSubmit={form.handleSubmit(() => deleteLocation.mutateAsync(props.locationId))}
-			dialog={dialog}
+			form={useZodForm()}
+			onSubmit={() => deleteLocation.mutateAsync(props.locationId)}
+			dialog={useDialog(props)}
 			title="Delete Location"
 			description="Deleting a location will also remove all files associated with it from the Spacedrive database, the files themselves will not be deleted."
 			ctaDanger

--- a/interface/app/$libraryId/settings/library/locations/IndexerRuleEditor/RuleButton.tsx
+++ b/interface/app/$libraryId/settings/library/locations/IndexerRuleEditor/RuleButton.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { Dispatch, SetStateAction } from 'react';
+import { useRef } from 'react';
 import { IndexerRule } from '@sd/client';
 import { InfoPill } from '~/app/$libraryId/Explorer/Inspector';
 import { IndexerRuleIdFieldType } from '.';
@@ -7,43 +7,48 @@ import { IndexerRuleIdFieldType } from '.';
 interface RuleButtonProps<T extends IndexerRuleIdFieldType> {
 	rule: IndexerRule;
 	field?: T;
-	setRuleSelected: Dispatch<SetStateAction<IndexerRule | undefined>>;
-	ruleSelected: IndexerRule | undefined;
+	onClick?: React.ComponentProps<'div'>['onClick'];
+	className?: string;
 }
 
 function RuleButton<T extends IndexerRuleIdFieldType>({
 	rule,
 	field,
-	ruleSelected,
-	setRuleSelected
+	onClick,
+	className
 }: RuleButtonProps<T>) {
 	const value = field?.value ?? [];
+	const toggleRef = useRef<HTMLElement>(null);
 	const ruleEnabled = value.includes(rule.id);
 
 	return (
 		<div
+			onClick={
+				onClick ??
+				(() => {
+					if (toggleRef.current) toggleRef.current.click();
+				})
+			}
 			className={clsx(
-				ruleSelected?.id === rule.id ? 'bg-app-darkBox' : 'bg-app-input',
-				!rule.default && 'cursor-pointer',
-				`relative flex w-[100px] min-w-[150px] justify-between gap-2 rounded-md border border-app-line py-2`
+				`relative flex w-[100px] min-w-[150px] justify-between gap-2 rounded-md border border-app-line py-2`,
+				className
 			)}
-			onClick={() => {
-				if (rule.default) return;
-				ruleSelected?.id === rule.id ? setRuleSelected(undefined) : setRuleSelected(rule);
-			}}
 		>
 			<div className="w-full">
 				<p className="mb-2 text-center text-sm">{rule.name}</p>
 				<div className="flex flex-wrap justify-center gap-2">
 					<InfoPill
+						ref={toggleRef}
 						onClick={
 							field &&
-							(() =>
+							((e) => {
+								e.stopPropagation();
 								field.onChange(
 									ruleEnabled
 										? value.filter((v) => v !== rule.id)
 										: Array.from(new Set([...value, rule.id]))
-								))
+								);
+							})
 						}
 						className={clsx(
 							'hover:brightness-125',

--- a/interface/app/$libraryId/settings/library/tags/CreateDialog.tsx
+++ b/interface/app/$libraryId/settings/library/tags/CreateDialog.tsx
@@ -1,7 +1,7 @@
 import { useLibraryMutation, usePlausibleEvent } from '@sd/client';
 import { Dialog, UseDialogProps, useDialog } from '@sd/ui';
 import { Input, useZodForm, z } from '@sd/ui/src/forms';
-import ColorPicker from '~/components/ColorPicker';
+import { ColorPicker } from '~/components';
 
 const schema = z.object({
 	name: z.string(),

--- a/interface/app/$libraryId/settings/library/tags/CreateDialog.tsx
+++ b/interface/app/$libraryId/settings/library/tags/CreateDialog.tsx
@@ -3,19 +3,15 @@ import { Dialog, UseDialogProps, useDialog } from '@sd/ui';
 import { Input, useZodForm, z } from '@sd/ui/src/forms';
 import ColorPicker from '~/components/ColorPicker';
 
+const schema = z.object({
+	name: z.string(),
+	color: z.string()
+});
+
 export default (props: UseDialogProps & { assignToObject?: number }) => {
-	const dialog = useDialog(props);
 	const submitPlausibleEvent = usePlausibleEvent();
 
-	const form = useZodForm({
-		schema: z.object({
-			name: z.string(),
-			color: z.string()
-		}),
-		defaultValues: {
-			color: '#A717D9'
-		}
-	});
+	const form = useZodForm({ schema: schema, defaultValues: { color: '#A717D9' } });
 
 	const createTag = useLibraryMutation('tags.create', {
 		onSuccess: (tag) => {
@@ -41,8 +37,9 @@ export default (props: UseDialogProps & { assignToObject?: number }) => {
 
 	return (
 		<Dialog
-			{...{ dialog, form }}
-			onSubmit={form.handleSubmit((data) => createTag.mutateAsync(data))}
+			form={form}
+			dialog={useDialog(props)}
+			onSubmit={(data) => createTag.mutateAsync(data)}
 			title="Create New Tag"
 			description="Choose a name and color."
 			ctaLabel="Create"

--- a/interface/app/$libraryId/settings/library/tags/DeleteDialog.tsx
+++ b/interface/app/$libraryId/settings/library/tags/DeleteDialog.tsx
@@ -8,10 +8,7 @@ interface Props extends UseDialogProps {
 }
 
 export default (props: Props) => {
-	const dialog = useDialog(props);
 	const submitPlausibleEvent = usePlausibleEvent();
-
-	const form = useZodForm();
 
 	const deleteTag = useLibraryMutation('tags.delete', {
 		onSuccess: () => {
@@ -22,8 +19,9 @@ export default (props: Props) => {
 
 	return (
 		<Dialog
-			{...{ form, dialog }}
-			onSubmit={form.handleSubmit(() => deleteTag.mutateAsync(props.tagId))}
+			form={useZodForm()}
+			dialog={useDialog(props)}
+			onSubmit={() => deleteTag.mutateAsync(props.tagId)}
 			title="Delete Tag"
 			description="Are you sure you want to delete this tag? This cannot be undone and tagged files will be unlinked."
 			ctaDanger

--- a/interface/app/$libraryId/settings/library/tags/EditForm.tsx
+++ b/interface/app/$libraryId/settings/library/tags/EditForm.tsx
@@ -2,8 +2,8 @@ import { Trash } from 'phosphor-react';
 import { Tag, useLibraryMutation } from '@sd/client';
 import { Button, Switch, Tooltip, dialogManager } from '@sd/ui';
 import { Form, Input, useZodForm, z } from '@sd/ui/src/forms';
-import ColorPicker from '~/components/ColorPicker';
-import { useDebouncedFormWatch } from '~/hooks/useDebouncedForm';
+import { ColorPicker } from '~/components';
+import { useDebouncedFormWatch } from '~/hooks';
 import Setting from '../../Setting';
 import DeleteDialog from './DeleteDialog';
 

--- a/interface/app/$libraryId/settings/node/libraries/CreateDialog.tsx
+++ b/interface/app/$libraryId/settings/node/libraries/CreateDialog.tsx
@@ -8,8 +8,8 @@ const { Input, z, useZodForm } = forms;
 const schema = z.object({
 	name: z.string().min(1)
 });
+
 export default (props: UseDialogProps) => {
-	const dialog = useDialog(props);
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
 	const submitPlausibleEvent = usePlausibleEvent();
@@ -32,21 +32,13 @@ export default (props: UseDialogProps) => {
 		onError: (err) => console.log(err)
 	});
 
-	const form = useZodForm({
-		schema: schema
-	});
-
-	const onSubmit = form.handleSubmit(async (data) => {
-		await createLibrary.mutateAsync({
-			name: data.name
-		});
-	});
+	const form = useZodForm({ schema: schema });
 
 	return (
 		<Dialog
 			form={form}
-			onSubmit={onSubmit}
-			dialog={dialog}
+			onSubmit={(data) => createLibrary.mutateAsync({ name: data.name })}
+			dialog={useDialog(props)}
 			submitDisabled={!form.formState.isValid}
 			title="Create New Library"
 			description="Libraries are a secure, on-device database. Your files remain where they are, the Library catalogs them and stores all Spacedrive related data."

--- a/interface/app/$libraryId/settings/node/libraries/DeleteDialog.tsx
+++ b/interface/app/$libraryId/settings/node/libraries/DeleteDialog.tsx
@@ -9,7 +9,6 @@ interface Props extends UseDialogProps {
 }
 
 export default function DeleteLibraryDialog(props: Props) {
-	const dialog = useDialog(props);
 	const submitPlausibleEvent = usePlausibleEvent();
 
 	const queryClient = useQueryClient();
@@ -27,13 +26,11 @@ export default function DeleteLibraryDialog(props: Props) {
 
 	const form = useZodForm({ schema: z.object({}) });
 
-	const onSubmit = form.handleSubmit(() => deleteLib.mutateAsync(props.libraryUuid));
-
 	return (
 		<Dialog
 			form={form}
-			onSubmit={onSubmit}
-			dialog={dialog}
+			onSubmit={() => deleteLib.mutateAsync(props.libraryUuid)}
+			dialog={useDialog(props)}
 			title="Delete Library"
 			description="Deleting a library will permanently the database, the files themselves will not be deleted."
 			ctaDanger

--- a/interface/app/Spacedrop.tsx
+++ b/interface/app/Spacedrop.tsx
@@ -40,7 +40,6 @@ export function SpacedropUI() {
 
 function SpacedropDialog(props: UseDialogProps) {
 	const [[discoveredPeers], setDiscoveredPeer] = useState([new Map<string, PeerMetadata>()]);
-	const dialog = useDialog(props);
 	const form = useZodForm({
 		// We aren't using this but it's required for the Dialog :(
 		schema: z.object({
@@ -57,22 +56,21 @@ function SpacedropDialog(props: UseDialogProps) {
 	});
 
 	const doSpacedrop = useBridgeMutation('p2p.spacedrop');
-	const onSubmit = form.handleSubmit((data) =>
-		doSpacedrop.mutate({
-			file_path: getSpacedropState().droppedFiles,
-			peer_id: data.target_peer
-		})
-	);
 
 	return (
 		<Dialog
 			form={form}
-			dialog={dialog}
+			dialog={useDialog(props)}
 			title="Spacedrop a File"
 			loading={doSpacedrop.isLoading}
 			ctaLabel="Send"
 			closeLabel="Cancel"
-			onSubmit={onSubmit}
+			onSubmit={(data) =>
+				doSpacedrop.mutateAsync({
+					file_path: getSpacedropState().droppedFiles,
+					peer_id: data.target_peer
+				})
+			}
 		>
 			<div className="space-y-2 py-2">
 				<Select
@@ -93,7 +91,6 @@ function SpacedropDialog(props: UseDialogProps) {
 function SpacedropRequestDialog(
 	props: { dropId: string; name: string; peerId: string } & UseDialogProps
 ) {
-	const dialog = useDialog(props);
 	const form = useZodForm({
 		// We aren't using this but it's required for the Dialog :(
 		schema: z.object({
@@ -102,21 +99,18 @@ function SpacedropRequestDialog(
 	});
 
 	const acceptSpacedrop = useBridgeMutation('p2p.acceptSpacedrop');
-	const onSubmit = form.handleSubmit((data) =>
-		acceptSpacedrop.mutate([props.dropId, data.file_path])
-	);
 
 	// TODO: Automatically close this after 60 seconds cause the Spacedrop would have expired
 
 	return (
 		<Dialog
 			form={form}
-			dialog={dialog}
+			dialog={useDialog(props)}
 			title="Received Spacedrop"
 			loading={acceptSpacedrop.isLoading}
 			ctaLabel="Send"
 			closeLabel="Cancel"
-			onSubmit={onSubmit}
+			onSubmit={(data) => acceptSpacedrop.mutateAsync([props.dropId, data.file_path])}
 			onCancelled={() => acceptSpacedrop.mutate([props.dropId, null])}
 		>
 			<div className="space-y-2 py-2">

--- a/interface/components/AlertDialog.tsx
+++ b/interface/components/AlertDialog.tsx
@@ -1,6 +1,6 @@
 import { Clipboard } from 'phosphor-react';
 import { Button, Dialog, Input, UseDialogProps, dialogManager, useDialog } from '@sd/ui';
-import { useZodForm, z } from '@sd/ui/src/forms';
+import { useZodForm } from '@sd/ui/src/forms';
 
 interface Props extends UseDialogProps {
 	title: string; // dialog title
@@ -11,19 +11,17 @@ interface Props extends UseDialogProps {
 }
 
 const AlertDialog = (props: Props) => {
-	const dialog = useDialog(props);
-	const form = useZodForm({ schema: z.object({}) });
 	// maybe a copy-to-clipboard button would be beneficial too
 	return (
 		<Dialog
 			title={props.title}
-			form={form}
-			onSubmit={form.handleSubmit(() => {})}
-			dialog={dialog}
+			form={useZodForm()}
+			dialog={useDialog(props)}
 			description={props.description}
 			ctaLabel={props.label !== undefined ? props.label : 'Done'}
+			onCancelled={false}
 		>
-			{props.inputBox && (
+			{props.inputBox ? (
 				<Input
 					value={props.value}
 					disabled
@@ -40,9 +38,9 @@ const AlertDialog = (props: Props) => {
 						</Button>
 					}
 				/>
+			) : (
+				<div className="text-sm">{props.value}</div>
 			)}
-
-			{!props.inputBox && <div className="text-sm">{props.value}</div>}
 		</Dialog>
 	);
 };

--- a/interface/components/ColorPicker.tsx
+++ b/interface/components/ColorPicker.tsx
@@ -7,7 +7,7 @@ interface Props<T extends FieldValues> extends UseControllerProps<T> {
 	className?: string;
 }
 
-export default <T extends FieldValues>({ className, ...props }: Props<T>) => {
+export const ColorPicker = <T extends FieldValues>({ className, ...props }: Props<T>) => {
 	const { field } = useController({ name: props.name });
 
 	return (

--- a/interface/components/ExternalObject.tsx
+++ b/interface/components/ExternalObject.tsx
@@ -1,0 +1,51 @@
+import { useLayoutEffect } from 'react';
+
+export interface ExternalObjectProps
+	extends Omit<React.ComponentProps<'object'>, 'chidren' | 'onLoad' | 'onError'> {
+	data: string;
+	onLoad?: (event: Event) => void;
+	onError?: (event: string | Event) => void;
+	crossOrigin?: React.ComponentProps<'link'>['crossOrigin'];
+}
+
+export const ExternalObject = ({
+	data,
+	onLoad,
+	onError,
+	crossOrigin,
+	...props
+}: ExternalObjectProps) => {
+	// Use link preload as a hack to get access to an onLoad and onError events for the object tag
+	useLayoutEffect(
+		() => {
+			if (!(onLoad && onError)) return;
+
+			const link = document.createElement('link');
+			link.as = 'fetch';
+			link.rel = 'preload';
+			if (crossOrigin) link.crossOrigin = crossOrigin;
+			link.href = data;
+
+			link.onload = (e) => {
+				link.remove();
+				onLoad(e);
+			};
+
+			link.onerror = (e) => {
+				link.remove();
+				onError(e);
+			};
+
+			document.head.appendChild(link);
+
+			() => link.remove();
+		},
+		// Disable this rule because onLoad and onError changed should not trigger this effect
+		// TODO: Remove this after useEffectEvent enters stable React
+		// https://react.dev/learn/separating-events-from-effects#declaring-an-effect-event
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[data, crossOrigin]
+	);
+
+	return <object data={data} {...props} />;
+};

--- a/interface/components/NavigationButtons.tsx
+++ b/interface/components/NavigationButtons.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router';
 import { Button, Tooltip } from '@sd/ui';
 import { useSearchStore } from '~/hooks/useSearchStore';
 
-export default () => {
+export const NavigationButtons = () => {
 	const navigate = useNavigate();
 	const { isFocused } = useSearchStore();
 	const idx = history.state.idx as number;

--- a/interface/components/NavigationButtons.tsx
+++ b/interface/components/NavigationButtons.tsx
@@ -1,7 +1,7 @@
 import { ArrowLeft, ArrowRight } from 'phosphor-react';
 import { useNavigate } from 'react-router';
 import { Button, Tooltip } from '@sd/ui';
-import { useSearchStore } from '~/hooks/useSearchStore';
+import { useSearchStore } from '~/hooks';
 
 export const NavigationButtons = () => {
 	const navigate = useNavigate();

--- a/interface/components/index.ts
+++ b/interface/components/index.ts
@@ -3,6 +3,8 @@ export * from './Codeblock';
 export * from './ColorPicker';
 export * from './DismissibleNotice';
 export * from './DragRegion';
+export * from './ExternalObject';
+export * from './NavigationButtons';
 export * from './PasswordMeter';
 export * from './SubtleButton';
 export * from './TrafficLights';

--- a/interface/hooks/index.ts
+++ b/interface/hooks/index.ts
@@ -4,6 +4,8 @@ export * from './useClickOutside';
 export * from './useCounter';
 export * from './useDebouncedForm';
 export * from './useDismissibleNoticeStore';
+export * from './useExplorerConfigStore';
+export * from './useExplorerItemData';
 export * from './useExplorerStore';
 export * from './useExplorerTopBarOptions';
 export * from './useFocusState';

--- a/interface/hooks/useExplorerItemData.ts
+++ b/interface/hooks/useExplorerItemData.ts
@@ -1,0 +1,18 @@
+import { useMemo } from 'react';
+import { ExplorerItem } from '@sd/client';
+import { getExplorerItemData, getItemFilePath } from '~/app/$libraryId/Explorer/util';
+import { useExplorerStore } from './useExplorerStore';
+
+export function useExplorerItemData(explorerItem: ExplorerItem) {
+	const filePath = getItemFilePath(explorerItem);
+	const { newThumbnails } = useExplorerStore();
+
+	const newThumbnail = newThumbnails?.[filePath?.cas_id || ''] || false;
+	return useMemo(() => {
+		const itemData = getExplorerItemData(explorerItem);
+		if (!itemData.hasThumbnail) {
+			itemData.hasThumbnail = newThumbnail;
+		}
+		return itemData;
+	}, [explorerItem, newThumbnail]);
+}

--- a/interface/hooks/useExplorerStore.tsx
+++ b/interface/hooks/useExplorerStore.tsx
@@ -30,7 +30,7 @@ const state = {
 	multiSelectIndexes: [] as number[],
 	contextMenuObjectId: null as number | null,
 	contextMenuActiveObject: null as object | null,
-	newThumbnails: {} as Record<string, boolean>,
+	newThumbnails: {} as Record<string, boolean | undefined>,
 	cutCopyState: {
 		sourcePath: '', // this is used solely for preventing copy/cutting to the same path (as that will truncate the file)
 		sourceLocationId: 0,
@@ -51,8 +51,8 @@ const state = {
 const explorerStore = proxy({
 	...state,
 	reset: () => resetStore(explorerStore, state),
-	addNewThumbnail: (cas_id: string) => {
-		explorerStore.newThumbnails[cas_id] = true;
+	addNewThumbnail: (casId: string) => {
+		explorerStore.newThumbnails[casId] = true;
 	}
 });
 

--- a/interface/hooks/useExplorerStore.tsx
+++ b/interface/hooks/useExplorerStore.tsx
@@ -44,7 +44,7 @@ const state = {
 	mediaAspectSquare: true,
 	orderBy: 'dateCreated' as ExplorerOrderByKeys,
 	orderByDirection: 'desc' as ExplorerDirection,
-	groupBy: 'none',
+	groupBy: 'none'
 };
 
 // Keep the private and use `useExplorerState` or `getExplorerStore` or you will get production build issues.

--- a/interface/hooks/useIsDark.ts
+++ b/interface/hooks/useIsDark.ts
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 const lightMediaQuery = matchMedia('(prefers-color-scheme: light)');
 
 export function useIsDark(): boolean {
-	const [isDark, setIsDark] = useState(true);
+	const [isDark, setIsDark] = useState(!lightMediaQuery.matches);
 
 	useEffect(() => {
 		const handleChange = () => setIsDark(!lightMediaQuery.matches);

--- a/packages/assets/icons/util.tsx
+++ b/packages/assets/icons/util.tsx
@@ -1,24 +1,35 @@
 import * as icons from '.';
 
+// Record is defined as follows inside TypeScript
+export type IconTypes<K = keyof typeof icons> = K extends `${string}_${string}` ? never : K;
+
+export const iconNames = Object.fromEntries(
+	Object.keys(icons)
+		.filter((key) => !key.includes('_'))
+		.map((key) => [key, key])
+) as Record<IconTypes, string>;
+
 export const getIcon = (
 	kind: string,
-	isDir?: boolean,
 	isDark?: boolean,
-	extension?: string | null
+	extension?: string | null,
+	isDir?: boolean
 ) => {
 	if (isDir) return icons[isDark ? 'Folder' : 'Folder_Light'];
 
 	let document: Extract<keyof typeof icons, 'Document' | 'Document_Light'> = 'Document';
 	if (extension) extension = `${kind}_${extension.toLowerCase()}`;
 	if (!isDark) {
-		kind = kind + '_Light';
 		document = 'Document_Light';
 		if (extension) extension = extension + '_Light';
 	}
 
+	const lightKind = kind + '_Light';
 	return icons[
 		(extension && extension in icons
 			? extension
+			: !isDark && lightKind in icons
+			? lightKind
 			: kind in icons
 			? kind
 			: document) as keyof typeof icons

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -21,7 +21,6 @@
 	"dependencies": {
 		"@headlessui/react": "^1.7.3",
 		"@headlessui/tailwindcss": "^0.1.1",
-		"@hookform/error-message": "^2.0.1",
 		"@hookform/resolvers": "^3.1.0",
 		"@radix-ui/react-checkbox": "^1.0.3",
 		"@radix-ui/react-context-menu": "^1.0.0",
@@ -32,6 +31,7 @@
 		"@radix-ui/react-select": "^1.1.2",
 		"@radix-ui/react-switch": "^1.0.1",
 		"@radix-ui/react-tabs": "^1.0.1",
+		"@react-spring/web": "9.6.0",
 		"@sd/assets": "workspace:*",
 		"@tailwindcss/forms": "^0.5.3",
 		"class-variance-authority": "^0.4.0",
@@ -42,7 +42,6 @@
 		"react-dom": "^18.2.0",
 		"react-loading-icons": "^1.1.0",
 		"react-router-dom": "6.9.0",
-		"@react-spring/web": "9.6.0",
 		"tailwindcss-radix": "^2.6.0",
 		"use-debounce": "^9.0.4",
 		"zod": "^3.21.4"

--- a/packages/ui/src/Dialog.tsx
+++ b/packages/ui/src/Dialog.tsx
@@ -1,14 +1,4 @@
-import {
-	Close as DialogClose,
-	Content as DialogContent,
-	Description as DialogDescription,
-	Overlay as DialogOverlay,
-	Portal as DialogPortal,
-	DialogProps as DialogPrimitiveProps,
-	Root as DialogRoot,
-	Title as DialogTitle,
-	Trigger as DialogTrigger
-} from '@radix-ui/react-dialog';
+import * as RDialog from '@radix-ui/react-dialog';
 import { animated, useTransition } from '@react-spring/web';
 import clsx from 'clsx';
 import { ReactElement, ReactNode, useEffect } from 'react';
@@ -113,11 +103,11 @@ export function Dialogs() {
 	);
 }
 
-const AnimatedDialogContent = animated(DialogContent);
-const AnimatedDialogOverlay = animated(DialogOverlay);
+const AnimatedDialogContent = animated(RDialog.Content);
+const AnimatedDialogOverlay = animated(RDialog.Overlay);
 
 export interface DialogProps<S extends FieldValues>
-	extends DialogPrimitiveProps,
+	extends RDialog.DialogProps,
 		Omit<FormProps<S>, 'onSubmit'> {
 	title?: string;
 	dialog: ReturnType<typeof useDialog>;
@@ -157,11 +147,11 @@ export function Dialog<S extends FieldValues>({
 	const setOpen = (v: boolean) => (dialog.state.open = v);
 
 	return (
-		<DialogRoot open={stateSnap.open} onOpenChange={setOpen}>
-			{props.trigger && <DialogTrigger asChild>{props.trigger}</DialogTrigger>}
+		<RDialog.Root open={stateSnap.open} onOpenChange={setOpen}>
+			{props.trigger && <RDialog.Trigger asChild>{props.trigger}</RDialog.Trigger>}
 			{transitions((styles, show) =>
 				show ? (
-					<DialogPortal forceMount>
+					<RDialog.Portal forceMount>
 						<AnimatedDialogOverlay
 							className="z-49 fixed inset-0 m-[1px] grid place-items-center overflow-y-auto rounded-xl bg-app/50"
 							style={{
@@ -183,14 +173,14 @@ export function Dialog<S extends FieldValues>({
 								className="!pointer-events-auto my-8 min-w-[300px] max-w-[400px] rounded-md border border-app-line bg-app-box text-ink shadow-app-shade"
 							>
 								<div className="p-5">
-									<DialogTitle className="mb-2 font-bold">
+									<RDialog.Title className="mb-2 font-bold">
 										{props.title}
-									</DialogTitle>
+									</RDialog.Title>
 
 									{props.description && (
-										<DialogDescription className="mb-2 text-sm text-ink-dull">
+										<RDialog.Description className="mb-2 text-sm text-ink-dull">
 											{props.description}
-										</DialogDescription>
+										</RDialog.Description>
 									)}
 
 									{props.children}
@@ -201,7 +191,7 @@ export function Dialog<S extends FieldValues>({
 									<div className="grow" />
 
 									{onCancelled && (
-										<DialogClose asChild>
+										<RDialog.Close asChild>
 											<Button
 												disabled={props.loading}
 												size="sm"
@@ -214,7 +204,7 @@ export function Dialog<S extends FieldValues>({
 											>
 												{props.closeLabel || 'Close'}
 											</Button>
-										</DialogClose>
+										</RDialog.Close>
 									)}
 
 									<Button
@@ -234,9 +224,9 @@ export function Dialog<S extends FieldValues>({
 							</Form>
 							<Remover id={dialog.id} />
 						</AnimatedDialogContent>
-					</DialogPortal>
+					</RDialog.Portal>
 				) : null
 			)}
-		</DialogRoot>
+		</RDialog.Root>
 	);
 }

--- a/packages/ui/src/Dialog.tsx
+++ b/packages/ui/src/Dialog.tsx
@@ -186,14 +186,20 @@ export function Dialog<S extends FieldValues>({
 									<DialogTitle className="mb-2 font-bold">
 										{props.title}
 									</DialogTitle>
-									<DialogDescription className="text-sm text-ink-dull">
-										{props.description}
-									</DialogDescription>
+
+									{props.description && (
+										<DialogDescription className="mb-2 text-sm text-ink-dull">
+											{props.description}
+										</DialogDescription>
+									)}
+
 									{props.children}
 								</div>
 								<div className="flex flex-row justify-end space-x-2 border-t border-app-line bg-app-selected p-3">
 									{form.formState.isSubmitting && <Loader />}
+
 									<div className="grow" />
+
 									{onCancelled && (
 										<DialogClose asChild>
 											<Button
@@ -210,6 +216,7 @@ export function Dialog<S extends FieldValues>({
 											</Button>
 										</DialogClose>
 									)}
+
 									<Button
 										type="submit"
 										size="sm"

--- a/packages/ui/src/Input.tsx
+++ b/packages/ui/src/Input.tsx
@@ -118,10 +118,14 @@ export const TextArea = ({ size, variant, error, ...props }: TextareaProps) => {
 	);
 };
 
-export function Label(props: PropsWithChildren<{ slug?: string }>) {
+export interface LabelProps extends Omit<React.ComponentProps<'label'>, 'htmlFor'> {
+	slug?: string;
+}
+
+export function Label({ slug, children, className, ...props }: LabelProps) {
 	return (
-		<label className="text-sm font-bold" htmlFor={props.slug}>
-			{props.children}
+		<label htmlFor={slug} className={clsx('text-sm font-bold', className)} {...props}>
+			{children}
 		</label>
 	);
 }

--- a/packages/ui/src/forms/Form.tsx
+++ b/packages/ui/src/forms/Form.tsx
@@ -69,12 +69,12 @@ export const useZodForm = <S extends z.ZodSchema = z.ZodObject<Record<string, ne
 };
 
 export const errorStyles = cva(
-	'inline-block  whitespace-pre-wrap rounded border border-red-400/40 bg-red-400/40 text-white',
+	'inline-block whitespace-pre-wrap rounded border border-red-400/40 bg-red-400/40 text-white',
 	{
 		variants: {
 			variant: {
 				none: '',
-				default: 'text-xs',
+				default: 'px-1 text-xs',
 				large: 'w-full px-3 py-2 text-center text-sm font-semibold'
 			}
 		},
@@ -98,7 +98,7 @@ export const ErrorMessage = ({ name, variant, className }: ErrorMessageProps) =>
 		leave: { opacity: 0 },
 		clamp: true,
 		config: { mass: 0.4, tension: 200, friction: 10, bounce: 0 },
-		exitBeforeEnter: true,
+		exitBeforeEnter: true
 	});
 
 	return (

--- a/packages/ui/src/forms/Form.tsx
+++ b/packages/ui/src/forms/Form.tsx
@@ -1,6 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { animated, useTransition } from '@react-spring/web';
 import { VariantProps, cva } from 'class-variance-authority';
+import clsx from 'clsx';
 import { ComponentProps } from 'react';
 import {
 	FieldErrors,
@@ -37,9 +38,15 @@ export const Form = <T extends FieldValues>({
 				}}
 				{...props}
 			>
-				{/* <fieldset> passes the form's 'disabled' state to all of its elements,
-            allowing us to handle disabled style variants with just css */}
-				<fieldset disabled={disabled || form.formState.isSubmitting}>{children}</fieldset>
+				{/**
+				 * <fieldset> passes the form's 'disabled' state to all of its elements,
+				 * allowing us to handle disabled style variants with just css.
+				 * <fieldset> has a default `min-width: min-content`, which causes it to behave weirdly,
+				 * so we override it.
+				 */}
+				<fieldset disabled={disabled || form.formState.isSubmitting} className="min-w-0">
+					{children}
+				</fieldset>
 			</form>
 		</FormProvider>
 	);
@@ -89,7 +96,9 @@ export const ErrorMessage = ({ name, variant, className }: ErrorMessageProps) =>
 		from: { opacity: 0 },
 		enter: { opacity: 1 },
 		leave: { opacity: 0 },
-		config: { mass: 0.4, tension: 200, friction: 10, bounce: 0 }
+		clamp: true,
+		config: { mass: 0.4, tension: 200, friction: 10, bounce: 0 },
+		exitBeforeEnter: true,
 	});
 
 	return (

--- a/packages/ui/src/forms/Form.tsx
+++ b/packages/ui/src/forms/Form.tsx
@@ -1,14 +1,17 @@
-import { ErrorMessage as ErrorMessagePrimitive } from '@hookform/error-message';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { animated, useTransition } from '@react-spring/web';
 import { VariantProps, cva } from 'class-variance-authority';
 import { ComponentProps } from 'react';
 import {
+	FieldErrors,
 	FieldValues,
 	FormProvider,
 	UseFormHandleSubmit,
 	UseFormProps,
 	UseFormReturn,
-	useForm
+	get,
+	useForm,
+	useFormContext
 } from 'react-hook-form';
 import { z } from 'zod';
 
@@ -58,26 +61,49 @@ export const useZodForm = <S extends z.ZodSchema = z.ZodObject<Record<string, ne
 	});
 };
 
-export const errorStyles = cva('inline-block  whitespace-pre-wrap rounded border border-red-400/40 bg-red-400/40 text-white', {
-	variants: {
-		variant: {
-			none: '',
-			default: 'text-xs',
-			large: 'w-full px-3 py-2 text-center text-sm font-semibold'
+export const errorStyles = cva(
+	'inline-block  whitespace-pre-wrap rounded border border-red-400/40 bg-red-400/40 text-white',
+	{
+		variants: {
+			variant: {
+				none: '',
+				default: 'text-xs',
+				large: 'w-full px-3 py-2 text-center text-sm font-semibold'
+			}
+		},
+		defaultVariants: {
+			variant: 'default'
 		}
-	},
-	defaultVariants: {
-		variant: 'default'
 	}
-});
+);
 
 export interface ErrorMessageProps extends VariantProps<typeof errorStyles> {
 	name: string;
 	className: string;
 }
 
-export const ErrorMessage = ({ name, variant, className }: ErrorMessageProps) => (
-	<ErrorMessagePrimitive as="span" name={name} className={errorStyles({ variant, className })} />
-);
+export const ErrorMessage = ({ name, variant, className }: ErrorMessageProps) => {
+	const methods = useFormContext();
+	const error = get(methods.formState.errors, name) as FieldErrors | undefined;
+	const transitions = useTransition(error, {
+		from: { opacity: 0 },
+		enter: { opacity: 1 },
+		leave: { opacity: 0 },
+		config: { mass: 0.4, tension: 200, friction: 10, bounce: 0 }
+	});
+
+	return (
+		<>
+			{transitions((styles, error) => {
+				const message = error?.message;
+				return typeof message === 'string' ? (
+					<animated.span style={styles} className={errorStyles({ variant, className })}>
+						{message}
+					</animated.span>
+				) : null;
+			})}
+		</>
+	);
+};
 
 export { z } from 'zod';

--- a/packages/ui/src/forms/FormField.tsx
+++ b/packages/ui/src/forms/FormField.tsx
@@ -1,6 +1,10 @@
 import { PropsWithChildren, ReactNode, useId } from 'react';
 import { useFormContext } from 'react-hook-form';
+import { Label } from '../Input';
+import { tw } from '../utils';
 import { ErrorMessage } from './Form';
+
+export const InfoText = tw.p`text-xs text-ink-faint`;
 
 export interface UseFormFieldProps extends PropsWithChildren {
 	name: string;
@@ -30,9 +34,9 @@ export const FormField = (props: FormFieldProps) => {
 	return (
 		<div className={props.className}>
 			{props.label && (
-				<label htmlFor={props.id} className="mb-1 flex text-sm font-medium">
+				<Label slug={props.id} className="mb-1 flex font-medium">
 					{props.label}
-				</label>
+				</Label>
 			)}
 			{props.children}
 			<ErrorMessage name={props.name} className="mt-1 w-full text-xs" />

--- a/packages/ui/style/colors.scss
+++ b/packages/ui/style/colors.scss
@@ -71,6 +71,8 @@
 		// main
 		--color-app: var(--light-hue), 5%, 100%;
 		--color-app-box: var(--light-hue), 5%, 98%;
+		--color-app-dark-box: var(--light-hue), 5%, 93%;
+		--color-app-light-box: var(--light-hue), 5%, 100%;
 		--color-app-overlay: var(--light-hue), 5%, 100%;
 		--color-app-input: var(--light-hue), 5%, 100%;
 		--color-app-focus: var(--light-hue), 5%, 98%;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -906,9 +906,6 @@ importers:
       '@headlessui/tailwindcss':
         specifier: ^0.1.1
         version: 0.1.1(tailwindcss@3.1.8)
-      '@hookform/error-message':
-        specifier: ^2.0.1
-        version: 2.0.1(react-dom@18.2.0)(react-hook-form@7.43.9)(react@18.2.0)
       '@hookform/resolvers':
         specifier: ^3.1.0
         version: 3.1.0(react-hook-form@7.43.9)
@@ -3376,18 +3373,6 @@ packages:
       tailwindcss: 3.1.8(postcss@8.4.17)
     dev: false
 
-  /@hookform/error-message@2.0.1(react-dom@18.2.0)(react-hook-form@7.43.9)(react@18.2.0):
-    resolution: {integrity: sha512-U410sAr92xgxT1idlu9WWOVjndxLdgPUHEB8Schr27C9eh7/xUnITWpCMF93s+lGiG++D4JnbSnrb5A21AdSNg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      react-hook-form: ^7.0.0
-    dependencies:
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-hook-form: 7.43.9(react@18.2.0)
-    dev: false
-
   /@hookform/resolvers@3.1.0(react-hook-form@7.43.9):
     resolution: {integrity: sha512-z0A8K+Nxq+f83Whm/ajlwE6VtQlp/yPHZnXw7XWVPIGm1Vx0QV8KThU3BpbBRfAZ7/dYqCKKBNnQh85BkmBKkA==}
     peerDependencies:
@@ -3540,7 +3525,7 @@ packages:
       magic-string: 0.27.0
       react-docgen-typescript: 2.2.2(typescript@4.9.4)
       typescript: 4.9.4
-      vite: 4.2.0(less@4.1.3)
+      vite: 4.2.0(@types/node@18.15.11)(sass@1.55.0)
 
   /@jridgewell/gen-mapping@0.3.3:
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
@@ -5864,7 +5849,7 @@ packages:
       remark-slug: 6.1.0
       rollup: 3.21.7
       typescript: 4.9.4
-      vite: 4.2.0(less@4.1.3)
+      vite: 4.2.0(@types/node@18.15.11)(sass@1.55.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6325,7 +6310,7 @@ packages:
       react: 18.2.0
       react-docgen: 6.0.0-alpha.3
       react-dom: 18.2.0(react@18.2.0)
-      vite: 4.2.0(less@4.1.3)
+      vite: 4.2.0(@types/node@18.15.11)(sass@1.55.0)
     transitivePeerDependencies:
       - '@preact/preset-vite'
       - supports-color
@@ -6624,7 +6609,7 @@ packages:
       tailwindcss: '>=3.0.0 || >= 3.0.0-alpha.1'
     dependencies:
       mini-svg-data-uri: 1.4.4
-      tailwindcss: 3.1.8(postcss@8.4.23)
+      tailwindcss: 3.1.8(postcss@8.4.17)
     dev: false
 
   /@tailwindcss/line-clamp@0.4.2(tailwindcss@3.1.8):


### PR DESCRIPTION
- [x] Fixes `Dialog`
	- [X] Fix `Dialog` closing even when the form submits fails
	- [X] Allow `Dialog` to not show the cancel button (useful for alert dialogs)
	- [X] Rework all dialog uses due to the above change
	- [X] Fix Dialog not respecting max-width due to the weird default behavior of fieldset
	- [X] Fix some dialogs submit listeners using the synchronous version of mutate, instead of returning mutateAsync to ensure the operation successfully concludes
- [X] Fixes for white theme
	- [X] Fix `useIsDark` not reading the initial theme value (only reacting to theme changes)
	- [X] Fix `Inspector` always showing a dark image when no item was selected
	- [X] Add some missing colors to white theme
	- [X] Fix `getIcon` fallbacking to Document instead of the dark version of an icon if it exists
	- [X] Fix `Overview` always using dark icons
	- [X] Fix `Inspector` empty view, always using the dark icon for `Image`
- [X] Fixes for Thumb
	- [X] Fix `Thumb` video extension using black text on light theme
	- [X] Fix broken image showing for `Thumb` due a race condition when props are updated
	- [X] Implement an `useExplorerItemData` (slightly better fix for thumbnail flicker)
	- [X] Implement an `ExternalObject` component that hacks a solution for missing `onLoad` and `onError` events on `<object>`
- [X] Fixes for IndexerRuleEditor
	- [X] Add an editable prop to `IndexerRuleEditor` to disable all editable functions in `AddLocationDialog`
	- [X] Fix `IndexerRuleEditor` closing the new rule form even when the rule creation fails
	- [X] Improve the way `IndexerRuleEditor` handles rules deletion
	- [X] Improve `IndexerRuleEditor` UX in `AddLocationDialog`
- [X] Fix `Overview` broken layout when `Inspector` is open and window is small
- [X] Remove `@hookform/error-message`, replace it with a simple span
- [X] Implement transitions to form error messages + fix weird jumps/flashs

