### PR TITLE
SPDX license and workspace inheritence for re-used metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,32 +1,37 @@
 [workspace]
 resolver = "2"
 members = [
-  "core",
-  "crates/*",
-  # "crates/p2p/tunnel",
-  # "crates/p2p/tunnel/utils",
-  "apps/cli",
-  "apps/desktop/src-tauri",
-  "apps/desktop/crates/*",
-  "apps/mobile/crates/*",
-  "apps/server",
+	"core",
+	"crates/*",
+	# "crates/p2p/tunnel",
+	# "crates/p2p/tunnel/utils",
+	"apps/cli",
+	"apps/desktop/src-tauri",
+	"apps/desktop/crates/*",
+	"apps/mobile/crates/*",
+	"apps/server",
 ]
 
+[workspace.package]
+license = "AGPL-3.0-only"
+edition = "2021"
+repository = "https://github.com/spacedriveapp/spacedrive"
+
 [workspace.dependencies]
-prisma-client-rust =  { git = "https://github.com/Brendonovich/prisma-client-rust", rev = "5d8029e0a0b590e1b8f674339ba880114a1becc8", features = [
-  "rspc",
-  "sqlite-create-many",
-  "migrations",
-  "sqlite",
+prisma-client-rust = { git = "https://github.com/Brendonovich/prisma-client-rust", rev = "5d8029e0a0b590e1b8f674339ba880114a1becc8", features = [
+	"rspc",
+	"sqlite-create-many",
+	"migrations",
+	"sqlite",
 ] }
 prisma-client-rust-cli = { git = "https://github.com/Brendonovich/prisma-client-rust", rev = "5d8029e0a0b590e1b8f674339ba880114a1becc8", features = [
-  "rspc",
-  "sqlite-create-many",
-  "migrations",
-  "sqlite",
+	"rspc",
+	"sqlite-create-many",
+	"migrations",
+	"sqlite",
 ] }
 prisma-client-rust-sdk = { git = "https://github.com/Brendonovich/prisma-client-rust", rev = "5d8029e0a0b590e1b8f674339ba880114a1becc8", features = [
-  "sqlite",
+	"sqlite",
 ] }
 
 rspc = { version = "0.1.4" }

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "cli"
 version = "0.1.0"
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/apps/desktop/crates/macos/Cargo.toml
+++ b/apps/desktop/crates/macos/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "sd-desktop-macos"
 version = "0.1.0"
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -3,15 +3,22 @@ name = "spacedrive"
 version = "0.1.0"
 description = "The universal file manager."
 authors = ["Spacedrive Technology Inc."]
-license = ""
-repository = "https://github.com/spacedriveapp/spacedrive"
 default-run = "spacedrive"
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
 
 [dependencies]
-tauri = { version = "1.3.0", features = ["api-all", "linux-protocol-headers", "macos-private-api"] }
+tauri = { version = "1.3.0", features = [
+	"api-all",
+	"linux-protocol-headers",
+	"macos-private-api",
+] }
 rspc = { workspace = true, features = ["tauri"] }
-httpz = { workspace = true, features = ["axum", "tauri"] } # TODO: The `axum` feature should be only enabled on Linux but this currently can't be done: https://github.com/rust-lang/cargo/issues/1197
+httpz = { workspace = true, features = [
+	"axum",
+	"tauri",
+] } # TODO: The `axum` feature should be only enabled on Linux but this currently can't be done: https://github.com/rust-lang/cargo/issues/1197
 sd-core = { path = "../../../core", features = ["ffmpeg", "location-watcher"] }
 tokio = { workspace = true, features = ["sync"] }
 window-shadows = "0.2.0"

--- a/apps/mobile/crates/android/Cargo.toml
+++ b/apps/mobile/crates/android/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "sd-mobile-android"
 version = "0.1.0"
-edition = "2021"
 rust-version = "1.64.0"
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
 
 [lib]
 # Android can use dynamic linking since all FFI is done via JNI
@@ -15,5 +17,5 @@ jni = "0.19.0"
 # Core mobile handling stuff
 sd-mobile-core = { path = "../core" }
 
-# Other 
+# Other
 tracing = "0.1.37"

--- a/apps/mobile/crates/core/Cargo.toml
+++ b/apps/mobile/crates/core/Cargo.toml
@@ -1,22 +1,24 @@
 [package]
 name = "sd-mobile-core"
 version = "0.1.0"
-edition = "2021"
 rust-version = "1.64.0"
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
 
 [dependencies]
 once_cell = "1.15.0"
 sd-core = { path = "../../../../core", features = [
-  "mobile",
+	"mobile",
 ], default-features = false }
 rspc.workspace = true
 serde_json = "1.0.85"
 tokio = { workspace = true }
 openssl = { version = "0.10.42", features = [
-  "vendored",
+	"vendored",
 ] } # Override features of transitive dependencies
 openssl-sys = { version = "0.9.76", features = [
-  "vendored",
+	"vendored",
 ] } # Override features of transitive dependencies to support IOS Simulator on M1
 futures = "0.3.24"
 tracing = "0.1.37"

--- a/apps/mobile/crates/ios/Cargo.toml
+++ b/apps/mobile/crates/ios/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "sd-mobile-ios"
 version = "0.1.0"
-edition = "2021"
-
 rust-version = "1.64.0"
- 
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+
+
 [lib]
 # iOS requires static linking
 # Makes sense considering this lib needs to link against call_resolve and get_data_directory,

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "server"
 version = "0.1.0"
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
 
 [dependencies]
 sd-core = { path = "../../core", features = ["ffmpeg"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -3,10 +3,10 @@ name = "sd-core"
 version = "0.1.0"
 description = "Virtual distributed filesystem engine that powers Spacedrive."
 authors = ["Spacedrive Technology Inc."]
-license = "GNU GENERAL PUBLIC LICENSE"
-repository = "https://github.com/spacedriveapp/spacedrive"
-edition = "2021"
 rust-version = "1.68.1"
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
 
 [features]
 default = []

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -4,8 +4,10 @@ version = "0.0.0"
 authors = ["Jake Robinson <jake@spacedrive.com>"]
 readme = "README.md"
 description = "A library to handle cryptographic functions within Spacedrive"
-edition = "2021"
 rust-version = "1.67.0"
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
 
 [features]
 rspc = ["dep:rspc", "dep:specta"]
@@ -65,6 +67,6 @@ security-framework = { version = "2.8.1", optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = [
-    "fs",
-    "macros",
+	"fs",
+	"macros",
 ] } # features needed for examples

--- a/crates/deps-generator/Cargo.toml
+++ b/crates/deps-generator/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "deps-generator"
 version = "0.0.0"
-edition = "2021"
 authors = ["Jake Robinson <jake@spacedrive.com>"]
 description = "A tool to compile all Spacedrive dependencies and their respective licenses"
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
 
 [dependencies]
 reqwest = { version = "0.11.14", features = ["blocking"] }

--- a/crates/ffmpeg/Cargo.toml
+++ b/crates/ffmpeg/Cargo.toml
@@ -2,12 +2,12 @@
 name = "sd-ffmpeg"
 version = "0.1.0"
 authors = ["Ericson Soares <ericson.ds999@gmail.com>"]
-edition = "2021"
 readme = "README.md"
 description = "A simple library to generate video thumbnails using ffmpeg with the webp format"
-license = "MIT"
 rust-version = "1.64.0"
-resolver = "2"
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/file-ext/Cargo.toml
+++ b/crates/file-ext/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "sd-file-ext"
 version = "0.0.0"
-edition = "2021"
 authors = [
-    "Brendan Allen <brendan@spacedrive.com>",
-    "Jamie Pine <jamie@spacedrive.com>",
+	"Brendan Allen <brendan@spacedrive.com>",
+	"Jamie Pine <jamie@spacedrive.com>",
 ]
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/macos/Cargo.toml
+++ b/crates/macos/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "sd-macos"
 version = "0.1.0"
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -3,7 +3,9 @@ name = "sd-p2p"
 version = "0.1.0"
 description = "Rust Peer to Peer Networking Library"
 authors = ["Oscar Beaumont <oscar@otbeaumont.me>"]
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
 
 [features]
 default = []
@@ -11,7 +13,13 @@ serde = []
 specta = []
 
 [dependencies]
-tokio = { workspace = true, features = ["macros", "sync", "time", "io-util", "fs"] }
+tokio = { workspace = true, features = [
+	"macros",
+	"sync",
+	"time",
+	"io-util",
+	"fs",
+] }
 libp2p = { version = "0.51.0", features = ["tokio", "quic", "serde"] }
 mdns-sd = "0.6.1"
 thiserror = "1.0.39"

--- a/crates/prisma-cli/Cargo.toml
+++ b/crates/prisma-cli/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "prisma-cli"
 version = "0.1.0"
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
 
 [dependencies]
 prisma-client-rust-cli = { workspace = true }

--- a/crates/sync-generator/Cargo.toml
+++ b/crates/sync-generator/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "sd-sync-generator"
 version = "0.1.0"
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/sync/Cargo.toml
+++ b/crates/sync/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "sd-sync"
 version = "0.1.0"
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
 
 [dependencies]
 rand = "0.8.5"

--- a/crates/sync/example/Cargo.toml
+++ b/crates/sync/example/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "sd-sync-example"
 version = "0.1.0"
-edition = "2021"
 rust-version = "1.64"
 publish = false
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
 
 [dependencies]
 serde_json = "1.0.85"


### PR DESCRIPTION
This makes our license identifier valid (SPDX) and applies it to all of our crates. I added it to every `Cargo.toml` (as well as `repository` and `edition`) just for consistency, so all re-used metadata is correctly declared everywhere.