### PR TITLE
[END-634] Coerce file extensions to lowercase

### DIFF
--- a/core/src/location/file_path_helper/isolated_file_path_data.rs
+++ b/core/src/location/file_path_helper/isolated_file_path_data.rs
@@ -33,23 +33,13 @@ impl IsolatedFilePathData<'static> {
 
 		let extension = (!is_dir)
 			.then(|| {
-				let extension = full_path
+				full_path
 					.extension()
 					.unwrap_or_default()
 					.to_str()
-					.unwrap_or_default();
-
-				#[cfg(debug_assertions)]
-				{
-					// In dev mode, we lowercase the extension as we don't use the SQL migration,
-					// and using prisma.schema directly we can't set `COLLATE NOCASE` in the
-					// `extension` column at `file_path` table
-					extension.to_lowercase()
-				}
-				#[cfg(not(debug_assertions))]
-				{
-					extension.to_string()
-				}
+					.unwrap_or_default()
+					// Coerce extension to lowercase to make it case-insensitive
+					.to_lowercase()
 			})
 			.unwrap_or_default();
 


### PR DESCRIPTION
There appears to be no benifit to preserving the file extention casing, especially only in production. Everything works great in dev, but in prod on macOS uppercase extensions are not compatible with Spacedrive, most notably the thumbnailer.

After some light research it appears all modern file systems are case insensitive, though this has only been tested in macOS. 

This PR removes the debug assertion encasing the lowercase coercion.

![screenshot_2023-05-20_at_5 23 55_pm](https://github.com/spacedriveapp/spacedrive/assets/32987599/ed0136eb-a13e-4464-924a-2780d3eefdc8)
_Dev VS Prod without this fix_
