### PR TITLE
[ENG-576] Debounce location.create dry-runs

### DIFF
--- a/interface/app/$libraryId/Explorer/File/DecryptDialog.tsx
+++ b/interface/app/$libraryId/Explorer/File/DecryptDialog.tsx
@@ -66,7 +66,7 @@ export default (props: Props) => {
 		<Dialog
 			form={form}
 			dialog={useDialog(props)}
-			onSubmit={(data) =>
+			onSubmit={form.handleSubmit((data) =>
 				decryptFile.mutateAsync({
 					location_id: props.location_id,
 					path_id: props.path_id,
@@ -75,7 +75,7 @@ export default (props: Props) => {
 					password: data.type === 'password' ? data.password : null,
 					save_to_library: data.type === 'password' ? data.saveToKeyManager : null
 				})
-			}
+			)}
 			title="Decrypt a file"
 			description="Leave the output file blank for the default."
 			loading={decryptFile.isLoading}

--- a/interface/app/$libraryId/Explorer/File/DeleteDialog.tsx
+++ b/interface/app/$libraryId/Explorer/File/DeleteDialog.tsx
@@ -10,15 +10,17 @@ interface Propps extends UseDialogProps {
 export default (props: Propps) => {
 	const deleteFile = useLibraryMutation('files.deleteFiles');
 
+	const form = useZodForm();
+
 	return (
 		<Dialog
-			form={useZodForm()}
-			onSubmit={() =>
+			form={form}
+			onSubmit={form.handleSubmit(() =>
 				deleteFile.mutateAsync({
 					location_id: props.location_id,
 					path_id: props.path_id
 				})
-			}
+			)}
 			dialog={useDialog(props)}
 			title="Delete a file"
 			description="Configure your deletion settings."

--- a/interface/app/$libraryId/Explorer/File/EncryptDialog.tsx
+++ b/interface/app/$libraryId/Explorer/File/EncryptDialog.tsx
@@ -66,7 +66,7 @@ export default (props: Props) => {
 	return (
 		<Dialog
 			form={form}
-			onSubmit={(data) =>
+			onSubmit={form.handleSubmit((data) =>
 				encryptFile.mutateAsync({
 					algorithm: data.encryptionAlgo as Algorithm,
 					key_uuid: data.key,
@@ -76,7 +76,7 @@ export default (props: Props) => {
 					preview_media: data.previewMedia,
 					output_path: data.outputPath || null
 				})
-			}
+			)}
 			dialog={useDialog(props)}
 			title="Encrypt a file"
 			description="Configure your encryption settings. Leave the output file blank for the default."

--- a/interface/app/$libraryId/Explorer/File/EraseDialog.tsx
+++ b/interface/app/$libraryId/Explorer/File/EraseDialog.tsx
@@ -27,13 +27,13 @@ export default (props: Props) => {
 	return (
 		<Dialog
 			form={form}
-			onSubmit={(data) =>
+			onSubmit={form.handleSubmit((data) =>
 				eraseFile.mutateAsync({
 					location_id: props.location_id,
 					path_id: props.path_id,
 					passes: data.passes.toString()
 				})
-			}
+			)}
 			dialog={useDialog(props)}
 			title="Erase a file"
 			description="Configure your erasure settings."

--- a/interface/app/$libraryId/Layout/Sidebar/Contents.tsx
+++ b/interface/app/$libraryId/Layout/Sidebar/Contents.tsx
@@ -1,12 +1,10 @@
 import {
 	ArchiveBox,
 	Broadcast,
-	CirclesFour,
 	CopySimple,
 	Crosshair,
 	Eraser,
 	FilmStrip,
-	MonitorPlay,
 	Planet
 } from 'phosphor-react';
 import { useClientContext } from '@sd/client';

--- a/interface/app/$libraryId/Layout/Sidebar/LibrarySection.tsx
+++ b/interface/app/$libraryId/Layout/Sidebar/LibrarySection.tsx
@@ -2,7 +2,7 @@ import { Laptop } from '@sd/assets/icons';
 import clsx from 'clsx';
 import { Link, NavLink } from 'react-router-dom';
 import { arraysEqual, useBridgeQuery, useLibraryQuery, useOnlineLocations } from '@sd/client';
-import { Button, Folder } from '@sd/ui';
+import { Folder } from '@sd/ui';
 import { AddLocationButton } from '~/app/$libraryId/settings/library/locations/AddLocationButton';
 import { SubtleButton } from '~/components/SubtleButton';
 import SidebarLink from './Link';

--- a/interface/app/$libraryId/settings/library/keys/BackupRestoreDialog.tsx
+++ b/interface/app/$libraryId/settings/library/keys/BackupRestoreDialog.tsx
@@ -39,14 +39,12 @@ export default (props: UseDialogProps) => {
 	const MPCurrentEyeIcon = show.masterPassword ? EyeSlash : Eye;
 	const SKCurrentEyeIcon = show.secretKey ? EyeSlash : Eye;
 
-	const form = useZodForm({
-		schema
-	});
+	const form = useZodForm({ schema });
 
 	return (
 		<Dialog
 			form={form}
-			onSubmit={(data) =>
+			onSubmit={form.handleSubmit((data) =>
 				data.filePath !== ''
 					? restoreKeystoreMutation
 							.mutateAsync({
@@ -56,7 +54,7 @@ export default (props: UseDialogProps) => {
 							})
 							.finally(() => form.reset())
 					: null
-			}
+			)}
 			dialog={useDialog(props)}
 			title="Restore Keys"
 			description="Restore keys from a backup."

--- a/interface/app/$libraryId/settings/library/keys/MasterPasswordDialog.tsx
+++ b/interface/app/$libraryId/settings/library/keys/MasterPasswordDialog.tsx
@@ -54,7 +54,7 @@ export default (props: UseDialogProps) => {
 		}
 	});
 
-	const onSubmit: Parameters<typeof form.handleSubmit>[0] = (data) => {
+	const onSubmit = form.handleSubmit((data) => {
 		if (data.masterPassword !== data.masterPassword2) {
 			showAlertDialog({
 				title: 'Error',
@@ -69,7 +69,7 @@ export default (props: UseDialogProps) => {
 				password: data.masterPassword
 			});
 		}
-	};
+	});
 
 	return (
 		<Dialog

--- a/interface/app/$libraryId/settings/library/locations/AddLocationDialog.tsx
+++ b/interface/app/$libraryId/settings/library/locations/AddLocationDialog.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import { useCallback, useEffect, useMemo } from 'react';
 import { Controller, get } from 'react-hook-form';
+import { useDebouncedCallback } from 'use-debounce';
 import {
 	UnionToTuple,
 	extractInfoRSPCError,
@@ -147,7 +148,7 @@ export const AddLocationDialog = ({
 	);
 
 	useCallbackToWatchForm(
-		async (values, { name }) => {
+		useDebouncedCallback(async (values, { name }) => {
 			if (name === 'path') {
 				// Remote errors should only be cleared when path changes,
 				// as the previous error is used to notify the user of this change
@@ -164,11 +165,11 @@ export const AddLocationDialog = ({
 			} catch (error) {
 				handleAddError(error);
 			}
-		},
+		}, 200),
 		[form, method, addLocation, handleAddError]
 	);
 
-	const onSubmit: Parameters<typeof form.handleSubmit>[0] = async (values) => {
+	const onSubmit = form.handleSubmit(async (values) => {
 		try {
 			await addLocation(values);
 		} catch (error) {
@@ -188,7 +189,7 @@ export const AddLocationDialog = ({
 		}
 
 		await listLocations.refetch();
-	};
+	});
 
 	return (
 		<Dialog

--- a/interface/app/$libraryId/settings/library/locations/DeleteDialog.tsx
+++ b/interface/app/$libraryId/settings/library/locations/DeleteDialog.tsx
@@ -17,10 +17,12 @@ export default (props: Props) => {
 		}
 	});
 
+	const form = useZodForm();
+
 	return (
 		<Dialog
-			form={useZodForm()}
-			onSubmit={() => deleteLocation.mutateAsync(props.locationId)}
+			form={form}
+			onSubmit={form.handleSubmit(() => deleteLocation.mutateAsync(props.locationId))}
 			dialog={useDialog(props)}
 			title="Delete Location"
 			description="Deleting a location will also remove all files associated with it from the Spacedrive database, the files themselves will not be deleted."

--- a/interface/app/$libraryId/settings/library/tags/CreateDialog.tsx
+++ b/interface/app/$libraryId/settings/library/tags/CreateDialog.tsx
@@ -39,7 +39,7 @@ export default (props: UseDialogProps & { assignToObject?: number }) => {
 		<Dialog
 			form={form}
 			dialog={useDialog(props)}
-			onSubmit={(data) => createTag.mutateAsync(data)}
+			onSubmit={form.handleSubmit((data) => createTag.mutateAsync(data))}
 			title="Create New Tag"
 			description="Choose a name and color."
 			ctaLabel="Create"

--- a/interface/app/$libraryId/settings/library/tags/DeleteDialog.tsx
+++ b/interface/app/$libraryId/settings/library/tags/DeleteDialog.tsx
@@ -17,11 +17,13 @@ export default (props: Props) => {
 		}
 	});
 
+	const form = useZodForm();
+
 	return (
 		<Dialog
-			form={useZodForm()}
+			form={form}
 			dialog={useDialog(props)}
-			onSubmit={() => deleteTag.mutateAsync(props.tagId)}
+			onSubmit={form.handleSubmit(() => deleteTag.mutateAsync(props.tagId))}
 			title="Delete Tag"
 			description="Are you sure you want to delete this tag? This cannot be undone and tagged files will be unlinked."
 			ctaDanger

--- a/interface/app/$libraryId/settings/node/libraries/CreateDialog.tsx
+++ b/interface/app/$libraryId/settings/node/libraries/CreateDialog.tsx
@@ -37,7 +37,7 @@ export default (props: UseDialogProps) => {
 	return (
 		<Dialog
 			form={form}
-			onSubmit={(data) => createLibrary.mutateAsync({ name: data.name })}
+			onSubmit={form.handleSubmit((data) => createLibrary.mutateAsync({ name: data.name }))}
 			dialog={useDialog(props)}
 			submitDisabled={!form.formState.isValid}
 			title="Create New Library"

--- a/interface/app/$libraryId/settings/node/libraries/DeleteDialog.tsx
+++ b/interface/app/$libraryId/settings/node/libraries/DeleteDialog.tsx
@@ -29,7 +29,7 @@ export default function DeleteLibraryDialog(props: Props) {
 	return (
 		<Dialog
 			form={form}
-			onSubmit={() => deleteLib.mutateAsync(props.libraryUuid)}
+			onSubmit={form.handleSubmit(() => deleteLib.mutateAsync(props.libraryUuid))}
 			dialog={useDialog(props)}
 			title="Delete Library"
 			description="Deleting a library will permanently the database, the files themselves will not be deleted."

--- a/interface/app/Spacedrop.tsx
+++ b/interface/app/Spacedrop.tsx
@@ -65,12 +65,12 @@ function SpacedropDialog(props: UseDialogProps) {
 			loading={doSpacedrop.isLoading}
 			ctaLabel="Send"
 			closeLabel="Cancel"
-			onSubmit={(data) =>
+			onSubmit={form.handleSubmit((data) =>
 				doSpacedrop.mutateAsync({
 					file_path: getSpacedropState().droppedFiles,
 					peer_id: data.target_peer
 				})
-			}
+			)}
 		>
 			<div className="space-y-2 py-2">
 				<Select
@@ -110,7 +110,9 @@ function SpacedropRequestDialog(
 			loading={acceptSpacedrop.isLoading}
 			ctaLabel="Send"
 			closeLabel="Cancel"
-			onSubmit={(data) => acceptSpacedrop.mutateAsync([props.dropId, data.file_path])}
+			onSubmit={form.handleSubmit((data) =>
+				acceptSpacedrop.mutateAsync([props.dropId, data.file_path])
+			)}
 			onCancelled={() => acceptSpacedrop.mutate([props.dropId, null])}
 		>
 			<div className="space-y-2 py-2">

--- a/packages/ui/src/Dialog.tsx
+++ b/packages/ui/src/Dialog.tsx
@@ -2,7 +2,7 @@ import * as RDialog from '@radix-ui/react-dialog';
 import { animated, useTransition } from '@react-spring/web';
 import clsx from 'clsx';
 import { ReactElement, ReactNode, useEffect } from 'react';
-import { FieldValues, SubmitHandler } from 'react-hook-form';
+import { FieldValues, UseFormHandleSubmit } from 'react-hook-form';
 import { proxy, ref, subscribe, useSnapshot } from 'valtio';
 import { Button, Loader } from '../';
 import { Form, FormProps } from './forms/Form';
@@ -114,7 +114,7 @@ export interface DialogProps<S extends FieldValues>
 	loading?: boolean;
 	trigger?: ReactNode;
 	ctaLabel?: string;
-	onSubmit?: SubmitHandler<S>;
+	onSubmit?: ReturnType<UseFormHandleSubmit<S>>;
 	children?: ReactNode;
 	ctaDanger?: boolean;
 	closeLabel?: string;
@@ -165,11 +165,11 @@ export function Dialog<S extends FieldValues>({
 						>
 							<Form
 								form={form}
-								onSubmit={form.handleSubmit(async (...args) => {
-									await onSubmit?.(...args);
+								onSubmit={async (e) => {
+									await onSubmit?.(e);
 									dialog.onSubmit?.();
 									setOpen(false);
-								})}
+								}}
 								className="!pointer-events-auto my-8 min-w-[300px] max-w-[400px] rounded-md border border-app-line bg-app-box text-ink shadow-app-shade"
 							>
 								<div className="p-5">


### PR DESCRIPTION
Adds a `useDebouncedCallback` around the location validation logic.
Also made using `form.handleSubmit` in all dialogs a requirement, means we don't have any huge manual typings for `onSubmit` functions. idk why it was changed.