### PR TITLE
move prisma codegen into sd-prisma

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6814,6 +6814,7 @@ dependencies = [
  "sd-file-ext",
  "sd-heif",
  "sd-p2p",
+ "sd-prisma",
  "sd-sync",
  "serde",
  "serde-hashkey",
@@ -6962,6 +6963,16 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "sd-prisma"
+version = "0.1.0"
+dependencies = [
+ "prisma-client-rust",
+ "sd-sync",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -31,6 +31,7 @@ sd-heif = { path = "../crates/heif", optional = true }
 sd-file-ext = { path = "../crates/file-ext" }
 sd-sync = { path = "../crates/sync" }
 sd-p2p = { path = "../crates/p2p", features = ["specta", "serde"] }
+sd-prisma = { path = "../crates/prisma" }
 
 rspc = { workspace = true, features = [
 	"uuid",

--- a/core/prisma/schema.prisma
+++ b/core/prisma/schema.prisma
@@ -4,13 +4,14 @@ datasource db {
 }
 
 generator client {
-    provider = "cargo prisma"
-    output   = "../src/prisma.rs"
+    provider    = "cargo prisma"
+    output      = "../../crates/prisma/src/prisma.rs"
+    module_path = "crate::prisma"
 }
 
 generator sync {
     provider = "cargo prisma-sync"
-    output   = "../src/prisma_sync.rs"
+    output   = "../../crates/prisma/src/prisma_sync.rs"
 }
 
 //// Sync ////

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -7,6 +7,8 @@ use crate::{
 	p2p::P2PManager,
 };
 
+pub use sd_prisma::*;
+
 use std::{path::Path, sync::Arc};
 use thiserror::Error;
 use tokio::{fs, sync::broadcast};
@@ -25,10 +27,6 @@ pub(crate) mod p2p;
 pub(crate) mod sync;
 pub(crate) mod util;
 pub(crate) mod volume;
-
-#[allow(warnings, unused)]
-mod prisma;
-pub(crate) mod prisma_sync;
 
 #[derive(Clone)]
 pub struct NodeContext {

--- a/crates/prisma/Cargo.toml
+++ b/crates/prisma/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "sd-prisma"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+prisma-client-rust = { workspace = true }
+serde = "1.0"
+serde_json = "1.0"
+sd-sync = { path = "../sync" }

--- a/crates/prisma/src/lib.rs
+++ b/crates/prisma/src/lib.rs
@@ -1,0 +1,4 @@
+#[allow(warnings, unused)]
+pub mod prisma;
+#[allow(warnings, unused)]
+pub mod prisma_sync;


### PR DESCRIPTION
Moves generated Prisma stuff into a separate cate with the aim of improving compile times. Might not help that much but ehh.