### PR TITLE
[ENG-642] Minor UI Tweaks 

### DIFF
--- a/interface/app/$libraryId/Layout/Sidebar/Link.tsx
+++ b/interface/app/$libraryId/Layout/Sidebar/Link.tsx
@@ -36,7 +36,8 @@ export default ({
 					styles({ active: isActive, transparent: os === 'macOS' }),
 					disabled && 'pointer-events-none opacity-50',
 					className,
-					os === 'browser' && 'border border-transparent !ring-0 focus:border-accent '
+					os === 'browser' &&
+						'!ring-1 !ring-inset ring-transparent focus:ring-accent focus:!ring-offset-0'
 				)
 			}
 			{...props}

--- a/interface/app/$libraryId/Layout/Sidebar/Link.tsx
+++ b/interface/app/$libraryId/Layout/Sidebar/Link.tsx
@@ -35,7 +35,8 @@ export default ({
 				clsx(
 					styles({ active: isActive, transparent: os === 'macOS' }),
 					disabled && 'pointer-events-none opacity-50',
-					className
+					className,
+					os === 'browser' && 'border border-transparent !ring-0 focus:border-accent '
 				)
 			}
 			{...props}

--- a/interface/app/$libraryId/settings/library/locations/IndexerRuleEditor/RulesForm.tsx
+++ b/interface/app/$libraryId/settings/library/locations/IndexerRuleEditor/RulesForm.tsx
@@ -43,8 +43,8 @@ const RulesForm = ({ onSubmitted }: Props) => {
 	const createIndexerRules = useLibraryMutation(['locations.indexer_rules.create']);
 	const formId = useId();
 	const modeOptions: { value: RuleKind; label: string }[] = [
-		{ value: 'RejectFilesByGlob', label: 'Reject files by glob' },
-		{ value: 'AcceptFilesByGlob', label: 'Accept files by glob' }
+		{ value: 'RejectFilesByGlob', label: 'Reject files' },
+		{ value: 'AcceptFilesByGlob', label: 'Accept files' }
 	];
 	const form = useZodForm({
 		schema,
@@ -151,7 +151,7 @@ const RulesForm = ({ onSubmitted }: Props) => {
 						<h3>Value</h3>
 						<h3 className="flex items-center justify-center gap-1">
 							Mode
-							<Tooltip label="By default, an indexer rule functions as a Reject, resulting in the exclusion of any files that match its criteria. Enabling this option will transform it into a Allow, allowing the location to solely index files that meet its specified rules.">
+							<Tooltip label="By default, an indexer rule functions as a Reject list, resulting in the exclusion of any files that match its criteria. Enabling this option will transform it into a Allow list, allowing the location to solely index files that meet its specified rules.">
 								<Info />
 							</Tooltip>
 						</h3>
@@ -187,7 +187,7 @@ const RulesForm = ({ onSubmitted }: Props) => {
 									control={form.control}
 									render={({ field }) => {
 										return (
-											<div className="flex w-full flex-col">
+											<div className="flex flex-col w-full">
 												<RuleInput
 													className={clsx(
 														'!h-[30px]',


### PR DESCRIPTION
This PR does the following:

- Focus button of sidebar link now looks better
- Tooltip text adjustment for index rules UI
- Removed 'by glob' in index rules UI dropdown when selecting a mode.

**The web version of the focus of a sidebar link is now this, ugly effect is gone**:

<img width="177" alt="Screenshot 2023-05-29 at 2 05 50 PM" src="https://github.com/spacedriveapp/spacedrive/assets/33054370/df7abd5a-0593-44c4-a26b-0136d13528b0">

**Updated dropdown text**

<img width="245" alt="Screenshot 2023-05-29 at 2 06 13 PM" src="https://github.com/spacedriveapp/spacedrive/assets/33054370/a7d3592b-a3bf-40f8-8cc3-e3604e25aeed">
