### PR TITLE
[ENG-661] Tooltip Topbar Bug fix

### DIFF
--- a/interface/app/$libraryId/TopBar/TopBarOptions.tsx
+++ b/interface/app/$libraryId/TopBar/TopBarOptions.tsx
@@ -37,7 +37,7 @@ export default ({ options }: TopBarChildrenProps) => {
 	}, []);
 
 	return (
-		<div data-tauri-drag-region className="flex w-full flex-row justify-end">
+		<div data-tauri-drag-region className="flex flex-row justify-end w-full">
 			<div data-tauri-drag-region className={`flex gap-0`}>
 				{options?.map((group, groupIndex) => {
 					return group.map(
@@ -71,7 +71,7 @@ export default ({ options }: TopBarChildrenProps) => {
 										`hidden items-center`
 									)}
 								>
-									<Tooltip label={toolTipLabel}>
+									<>
 										{popOverComponent ? (
 											<Popover
 												className="focus:outline-none"
@@ -81,7 +81,9 @@ export default ({ options }: TopBarChildrenProps) => {
 														active={topBarActive}
 														onClick={onClick}
 													>
-														{icon}
+														<Tooltip label={toolTipLabel}>
+															{icon}
+														</Tooltip>
 													</TopBarButton>
 												}
 											>
@@ -95,10 +97,10 @@ export default ({ options }: TopBarChildrenProps) => {
 												active={topBarActive}
 												onClick={onClick ?? undefined}
 											>
-												{icon}
+												<Tooltip label={toolTipLabel}>{icon}</Tooltip>
 											</TopBarButton>
 										)}
-									</Tooltip>
+									</>
 									{index + 1 === group.length &&
 										groupIndex + 1 !== groupCount && (
 											<div


### PR DESCRIPTION
**This is a simple change that fixes the following issue demonstrated in this image**:

Clicking elements within the Popover component would trigger the tooltip.

![image](https://github.com/spacedriveapp/spacedrive/assets/33054370/e61ac89d-c3fd-4ab2-a9df-5f6329e22708)

**Result of this change confirming the fix**:

https://github.com/spacedriveapp/spacedrive/assets/33054370/d2fcbd1c-7e6d-470f-aa42-0412f1e0eeec

