### PR TITLE
[ENG-666] Index rules UI tweak

### DIFF
--- a/interface/app/$libraryId/settings/library/locations/AddLocationDialog.tsx
+++ b/interface/app/$libraryId/settings/library/locations/AddLocationDialog.tsx
@@ -229,6 +229,8 @@ export const AddLocationDialog = ({
 						field={field}
 						label="File indexing rules:"
 						className="relative flex flex-col"
+						rulesContainerClass="grid grid-cols-2 gap-1"
+						ruleButtonClass="w-full"
 					/>
 				)}
 				control={form.control}

--- a/interface/app/$libraryId/settings/library/locations/IndexerRuleEditor/index.tsx
+++ b/interface/app/$libraryId/settings/library/locations/IndexerRuleEditor/index.tsx
@@ -20,11 +20,15 @@ export interface IndexerRuleEditorProps<T extends IndexerRuleIdFieldType> {
 	infoText?: string;
 	editable?: boolean;
 	className?: string;
+	ruleButtonClass?: string;
+	rulesContainerClass?: string;
 }
 
 export default function IndexerRuleEditor<T extends IndexerRuleIdFieldType>({
 	infoText,
 	editable,
+	ruleButtonClass,
+	rulesContainerClass,
 	...props
 }: IndexerRuleEditorProps<T>) {
 	const listIndexerRules = useLibraryQuery(['locations.indexer_rules.list']);
@@ -95,7 +99,7 @@ export default function IndexerRuleEditor<T extends IndexerRuleIdFieldType>({
 				)}
 			</div>
 
-			<div className="flex flex-wrap justify-center gap-1">
+			<div className={clsx(rulesContainerClass, 'flex flex-wrap gap-1')}>
 				{indexRules ? (
 					indexRules.map((rule) => (
 						<RuleButton
@@ -116,7 +120,8 @@ export default function IndexerRuleEditor<T extends IndexerRuleIdFieldType>({
 							className={clsx(
 								!(editable && rule.default) && 'cursor-pointer',
 								editable || 'select-none',
-								selectedRule?.id === rule.id ? 'bg-app-darkBox' : 'bg-app-input'
+								selectedRule?.id === rule.id ? 'bg-app-darkBox' : 'bg-app-input',
+								ruleButtonClass
 							)}
 						/>
 					))

--- a/interface/app/$libraryId/settings/library/locations/IndexerRuleEditor/index.tsx
+++ b/interface/app/$libraryId/settings/library/locations/IndexerRuleEditor/index.tsx
@@ -68,8 +68,8 @@ export default function IndexerRuleEditor<T extends IndexerRuleIdFieldType>({
 	return (
 		<div className={props.className} onClick={() => setSelectedRule(undefined)}>
 			<div className={'flex items-start justify-between'}>
-				<div className="grow">
-					<Label className="mb-2">{props.label || 'Indexer rules'}</Label>
+				<div className="mb-1 grow">
+					<Label>{props.label || 'Indexer rules'}</Label>
 					{infoText && <InfoText className="mb-4">{infoText}</InfoText>}
 				</div>
 				{editable && (


### PR DESCRIPTION
In preps for release, this is a minor UI tweak to the index rules UI. I also added props to allow us to modify the classes when we use the component in other places.

**Screenshots**:

<img width="389" alt="Screenshot 2023-05-30 at 1 50 32 PM" src="https://github.com/spacedriveapp/spacedrive/assets/33054370/36e9d6c1-1825-4185-812d-7f8d972e7040">

<img width="853" alt="Screenshot 2023-05-30 at 1 40 53 PM" src="https://github.com/spacedriveapp/spacedrive/assets/33054370/e4f01e38-5230-4679-81a0-8c5c55b86f17">



