### PR TITLE
[ENG-688] Invalidate search.paths in shallow operations

### DIFF
--- a/core/src/location/indexer/shallow.rs
+++ b/core/src/location/indexer/shallow.rs
@@ -1,5 +1,5 @@
 use crate::{
-	file_paths_db_fetcher_fn,
+	file_paths_db_fetcher_fn, invalidate_query,
 	job::JobError,
 	library::Library,
 	location::file_path_helper::{
@@ -100,6 +100,8 @@ pub async fn shallow(
 	for step in steps {
 		execute_indexer_save_step(&location, &step, &library).await?;
 	}
+
+	invalidate_query!(&library, "search.paths");
 
 	library.orphan_remover.invoke().await;
 

--- a/core/src/object/file_identifier/shallow.rs
+++ b/core/src/object/file_identifier/shallow.rs
@@ -109,9 +109,7 @@ pub async fn shallow(
 		.await?;
 	}
 
-	if orphan_count > 0 {
-		invalidate_query!(library, "search.paths");
-	}
+	invalidate_query!(library, "search.paths");
 
 	Ok(())
 }

--- a/core/src/object/preview/thumbnail/shallow.rs
+++ b/core/src/object/preview/thumbnail/shallow.rs
@@ -3,6 +3,7 @@ use super::{
 	THUMBNAIL_CACHE_DIR_NAME,
 };
 use crate::{
+	invalidate_query,
 	job::JobError,
 	library::Library,
 	location::{
@@ -119,6 +120,8 @@ pub async fn shallow_thumbnailer(
 		thumbnail::inner_process_step(&file, &location_path, &thumbnail_dir, location, &library)
 			.await?;
 	}
+
+	invalidate_query!(library, "search.paths");
 
 	Ok(())
 }


### PR DESCRIPTION
Location watchers aren't sending updates for me but at least the shallow operations can notify the frontend of invalidations now