### PR TITLE
[ENG-694] Remove Spacedrop

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -9,16 +9,7 @@ repository.workspace = true
 edition.workspace = true
 
 [dependencies]
-tauri = { version = "1.3.0", features = [
-	"dialog-all",
-	"linux-protocol-headers",
-	"macos-private-api",
-	"os-all",
-	"path-all",
-	"protocol-all",
-	"shell-all",
-	"window-all",
-] }
+tauri = { version = "1.3.0", features = ["dialog-all", "linux-protocol-headers", "macos-private-api", "os-all", "path-all", "protocol-all", "shell-all", "window-all"] }
 rspc = { workspace = true, features = ["tauri"] }
 httpz = { workspace = true, features = [
 	"axum",

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -52,7 +52,7 @@ async fn open_logs_dir(node: tauri::State<'_, Arc<Node>>) -> Result<(), ()> {
 
 pub fn tauri_error_plugin<R: Runtime>(err: NodeError) -> TauriPlugin<R> {
 	tauri::plugin::Builder::new("spacedrive")
-		.js_init_script(format!(r#"window.__SD_ERROR__ = "{err}";"#))
+		.js_init_script(format!(r#"window.__SD_ERROR__ = `{err}`;"#))
 		.build()
 }
 

--- a/core/src/p2p/p2p_manager.rs
+++ b/core/src/p2p/p2p_manager.rs
@@ -106,7 +106,8 @@ impl P2PManager {
 								.ok();
 
 							// TODO: Don't just connect to everyone when we find them. We should only do it if we know them.
-							event.dial().await;
+							// TODO(Spacedrop): Disable Spacedrop for now
+							// event.dial().await;
 						}
 						Event::PeerMessage(mut event) => {
 							let events = events.clone();

--- a/interface/ErrorFallback.tsx
+++ b/interface/ErrorFallback.tsx
@@ -61,7 +61,9 @@ export function ErrorPage({
 		>
 			<p className="m-3 text-sm font-bold text-ink-faint">APP CRASHED</p>
 			<h1 className="text-2xl font-bold text-ink">We're past the event horizon...</h1>
-			<pre className="m-2 text-ink">{message}</pre>
+			<pre className="m-2 max-w-[650px] whitespace-normal text-center text-ink">
+				{message}
+			</pre>
 			{submessage && <pre className="m-2 text-sm text-ink-dull">{submessage}</pre>}
 			<div className="flex flex-row space-x-2 text-ink">
 				{reloadBtn && (
@@ -74,7 +76,9 @@ export function ErrorPage({
 						Send report
 					</Button>
 				)}
-				{message === 'failed to initialize config' && (
+				{(message === 'failed to initialize config' ||
+					message ===
+						'failed to initialize library manager: failed to run library migrations') && (
 					<div className="flex flex-col items-center pt-12">
 						<p className="text-md max-w-[650px] text-center">
 							We detected you may have created your library with an older version of

--- a/interface/ErrorFallback.tsx
+++ b/interface/ErrorFallback.tsx
@@ -32,6 +32,13 @@ export default ({ error, resetErrorBoundary }: FallbackProps) => (
 	/>
 );
 
+// This is sketchy but these are all edge cases that will only be encountered by developers if everything works as expected so it's probs fine
+const errorsThatRequireACoreReset = [
+	'failed to initialize config',
+	'failed to initialize library manager: failed to run library migrations',
+	'failed to initialize config: We detected a Spacedrive config from a super early version of the app!'
+];
+
 export function ErrorPage({
 	reloadBtn,
 	sendReportBtn,
@@ -76,9 +83,7 @@ export function ErrorPage({
 						Send report
 					</Button>
 				)}
-				{(message === 'failed to initialize config' ||
-					message ===
-						'failed to initialize library manager: failed to run library migrations') && (
+				{errorsThatRequireACoreReset.includes(message) && (
 					<div className="flex flex-col items-center pt-12">
 						<p className="text-md max-w-[650px] text-center">
 							We detected you may have created your library with an older version of
@@ -96,7 +101,7 @@ export function ErrorPage({
 								window.__TAURI_INVOKE__('reset_spacedrive');
 							}}
 						>
-							Reset Library
+							Reset Spacedrive
 						</Button>
 					</div>
 				)}

--- a/interface/app/Spacedrop.tsx
+++ b/interface/app/Spacedrop.tsx
@@ -14,6 +14,9 @@ import { getSpacedropState, subscribeSpacedropState } from '../hooks/useSpacedro
 const { Input, useZodForm, z } = forms;
 
 export function SpacedropUI() {
+	// TODO(Spacedrop): Disable Spacedrop for now
+	return null;
+
 	useEffect(() =>
 		subscribeSpacedropState(() => {
 			dialogManager.create((dp) => <SpacedropDialog {...dp} />);


### PR DESCRIPTION
Spacedrop's UI isn't ready to be in anyone hands because we need to keep a high standard in our UI.

Also fixing a bunch of random problems, including better support for people coming from a super old version of Spacedrive.