### PR TITLE
[ENG-708] Thumbnail sharding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cipher 0.3.0",
  "cpufeatures",
  "opaque-debug",
@@ -81,7 +81,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cipher 0.4.4",
  "cpufeatures",
 ]
@@ -358,7 +358,7 @@ checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
 dependencies = [
  "async-lock",
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.0",
  "concurrent-queue",
  "futures-lite",
  "log",
@@ -569,7 +569,7 @@ checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "miniz_oxide 0.6.2",
  "object",
@@ -735,7 +735,7 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "constant_time_eq",
  "digest 0.10.7",
 ]
@@ -1023,6 +1023,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -1033,7 +1039,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c80e5460aa66fe3b91d40bcbdab953a597b60053e34d684ac6903f863b680a6"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cipher 0.3.0",
  "cpufeatures",
  "zeroize",
@@ -1045,7 +1051,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cipher 0.4.4",
  "cpufeatures",
 ]
@@ -1402,7 +1408,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1411,7 +1417,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -1421,7 +1427,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -1433,7 +1439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
  "memoffset 0.8.0",
  "scopeguard",
@@ -1445,7 +1451,7 @@ version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1620,7 +1626,7 @@ version = "4.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d4ba9852b42210c7538b75484f9daa0655e9a3ac04f693747bb0f02cf3cfe16"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fiat-crypto",
  "packed_simd_2",
  "platforms",
@@ -1704,7 +1710,7 @@ version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
@@ -1900,7 +1906,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "dirs-sys-next",
 ]
 
@@ -2087,7 +2093,7 @@ version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -2311,7 +2317,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall 0.2.16",
  "windows-sys 0.48.0",
@@ -2664,7 +2670,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -2675,7 +2681,7 @@ version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -3430,7 +3436,30 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "int-enum"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b1428b2b1abe959e6eedb0a17d0ab12f6ba20e1106cc29fc4874e3ba393c177"
+dependencies = [
+ "cfg-if 0.1.10",
+ "int-enum-impl",
+]
+
+[[package]]
+name = "int-enum-impl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2c3cecaad8ca1a5020843500c696de2b9a07b63b624ddeef91f85f9bafb3671"
+dependencies = [
+ "cfg-if 0.1.10",
+ "proc-macro-crate 0.1.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3728,7 +3757,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "winapi",
 ]
 
@@ -4140,7 +4169,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "generator",
  "scoped-tls",
  "serde",
@@ -4722,7 +4751,7 @@ checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "memoffset 0.6.5",
 ]
@@ -4734,7 +4763,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "memoffset 0.6.5",
 ]
@@ -4746,7 +4775,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "static_assertions",
 ]
@@ -5056,7 +5085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12df40a956736488b7b44fe79fe12d4f245bb5b3f5a1f6095e499760015be392"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "foreign-types",
  "libc",
  "once_cell",
@@ -5195,7 +5224,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libm 0.1.4",
 ]
 
@@ -5257,7 +5286,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
  "redox_syscall 0.2.16",
@@ -5271,7 +5300,7 @@ version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall 0.2.16",
  "smallvec",
@@ -5584,7 +5613,7 @@ checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
 dependencies = [
  "autocfg",
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "concurrent-queue",
  "libc",
  "log",
@@ -5620,7 +5649,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "opaque-debug",
  "universal-hash 0.4.1",
@@ -5632,7 +5661,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef234e08c11dfcb2e56f79fd70f6f2eb7f025c0ce2333e82f4f0518ecad30c6"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "opaque-debug",
  "universal-hash 0.5.1",
@@ -6839,6 +6868,7 @@ dependencies = [
  "httpz 0.0.3",
  "image",
  "include_dir",
+ "int-enum",
  "itertools",
  "mini-moka",
  "normpath",
@@ -7336,7 +7366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
@@ -7348,7 +7378,7 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.7",
 ]
@@ -7360,7 +7390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
@@ -7372,7 +7402,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.7",
 ]
@@ -7891,7 +7921,7 @@ version = "0.28.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c2f3ca6693feb29a89724516f016488e9aafc7f37264f898593ee4b942f31b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "core-foundation-sys",
  "libc",
  "ntapi",
@@ -8251,7 +8281,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fastrand",
  "redox_syscall 0.3.5",
  "rustix",
@@ -8310,7 +8340,7 @@ version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "once_cell",
 ]
 
@@ -8548,7 +8578,7 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "log",
  "pin-project-lite",
  "tracing-attributes 0.1.24",
@@ -8750,7 +8780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f7f83d1e4a0e4358ac54c5c3681e5d7da5efc5a7a632c90bb6d6669ddd9bc26"
 dependencies = [
  "async-trait",
- "cfg-if",
+ "cfg-if 1.0.0",
  "data-encoding",
  "enum-as-inner",
  "futures-channel",
@@ -8775,7 +8805,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aff21aa4dcefb0a1afbfac26deb0adc93888c7d295fb63ab273ef276ba2b7cfe"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "futures-util",
  "ipconfig",
  "lazy_static",
@@ -9154,7 +9184,7 @@ version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
@@ -9179,7 +9209,7 @@ version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d1985d03709c53167ce907ff394f5316aa22cb4e12761295c5dc57dacb6297e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -9960,7 +9990,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a1a57ff50e9b408431e8f97d5456f2807f8eb2a2cd79b06068fc87f8ecf189"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "winapi",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6833,6 +6833,7 @@ dependencies = [
  "enumflags2 0.7.7",
  "futures",
  "globset",
+ "hex",
  "hostname",
  "http-range",
  "httpz 0.0.3",

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -58,7 +58,7 @@ if (customUriServerUrl && !customUriServerUrl?.endsWith('/')) {
 
 const platform: Platform = {
 	platform: 'tauri',
-	getThumbnailUrlById: (casId, shard_hex) => convertFileSrc(`thumbnail/${shard_hex}/${casId}`, 'spacedrive'),
+	getThumbnailUrlByThumbKey: (keyParts) => convertFileSrc(`thumbnail/${keyParts.map(i => encodeURIComponent(i)).join("/")}`, 'spacedrive'),
 	getFileUrl: (libraryId, locationLocalId, filePathId, _linux_workaround) => {
 		const path = `file/${libraryId}/${locationLocalId}/${filePathId}`;
 		if (_linux_workaround && customUriServerUrl) {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -58,7 +58,7 @@ if (customUriServerUrl && !customUriServerUrl?.endsWith('/')) {
 
 const platform: Platform = {
 	platform: 'tauri',
-	getThumbnailUrlById: (casId) => convertFileSrc(`thumbnail/${casId}`, 'spacedrive'),
+	getThumbnailUrlById: (casId, shard_hex) => convertFileSrc(`thumbnail/${shard_hex}/${casId}`, 'spacedrive'),
 	getFileUrl: (libraryId, locationLocalId, filePathId, _linux_workaround) => {
 		const path = `file/${libraryId}/${locationLocalId}/${filePathId}`;
 		if (_linux_workaround && customUriServerUrl) {

--- a/apps/mobile/src/components/explorer/FileThumb.tsx
+++ b/apps/mobile/src/components/explorer/FileThumb.tsx
@@ -15,8 +15,10 @@ type FileThumbProps = {
 	size?: number;
 };
 
-export const getThumbnailUrlById = (casId: string) =>
-	`${DocumentDirectoryPath}/thumbnails/${encodeURIComponent(casId)}.webp`;
+export const getThumbnailUrlById = (keyParts: string[]) =>
+	`${DocumentDirectoryPath}/thumbnails/${keyParts
+		.map((i) => encodeURIComponent(i))
+		.join('/')}.webp`;
 
 type KindType = keyof typeof icons | 'Unknown';
 
@@ -29,7 +31,8 @@ function getExplorerItemData(data: ExplorerItem) {
 		casId: filePath?.cas_id || null,
 		isDir: isPath(data) && data.item.is_dir,
 		kind: ObjectKind[objectData?.kind || 0] as KindType,
-		hasThumbnail: data.has_thumbnail,
+		hasLocalThumbnail: data.has_local_thumbnail, // this will be overwritten if new thumbnail is generated
+		thumbnailKey: data.thumbnail_key,
 		extension: filePath?.extension
 	};
 }
@@ -41,7 +44,8 @@ const FileThumbWrapper = ({ children, size = 1 }: PropsWithChildren<{ size: numb
 );
 
 export default function FileThumb({ data, size = 1 }: FileThumbProps) {
-	const { casId, isDir, kind, hasThumbnail, extension } = getExplorerItemData(data);
+	const { casId, isDir, kind, hasLocalThumbnail, extension, thumbnailKey } =
+		getExplorerItemData(data);
 
 	if (isPath(data) && data.item.is_dir) {
 		return (
@@ -51,12 +55,12 @@ export default function FileThumb({ data, size = 1 }: FileThumbProps) {
 		);
 	}
 
-	if (hasThumbnail && casId) {
+	if (hasLocalThumbnail && thumbnailKey) {
 		// TODO: Handle Image checkers bg?
 		return (
 			<FileThumbWrapper size={size}>
 				<Image
-					source={{ uri: getThumbnailUrlById(casId) }}
+					source={{ uri: getThumbnailUrlById(thumbnailKey) }}
 					resizeMode="contain"
 					style={tw`h-full w-full`}
 				/>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -28,8 +28,8 @@ const spacedriveProtocol = `${http}://${serverOrigin}/spacedrive`;
 
 const platform: Platform = {
 	platform: 'web',
-	getThumbnailUrlById: (casId, shard_hex) =>
-		`${spacedriveProtocol}/thumbnail/${shard_hex}/${encodeURIComponent(casId)}.webp`,
+	getThumbnailUrlByThumbKey: (keyParts) =>
+		`${spacedriveProtocol}/thumbnail/${keyParts.map(i => encodeURIComponent(i)).join("/")}.webp`,
 	getFileUrl: (libraryId, locationLocalId, filePathId) =>
 		`${spacedriveProtocol}/file/${encodeURIComponent(libraryId)}/${encodeURIComponent(
 			locationLocalId

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -28,8 +28,8 @@ const spacedriveProtocol = `${http}://${serverOrigin}/spacedrive`;
 
 const platform: Platform = {
 	platform: 'web',
-	getThumbnailUrlById: (casId) =>
-		`${spacedriveProtocol}/thumbnail/${encodeURIComponent(casId)}.webp`,
+	getThumbnailUrlById: (casId, shard_hex) =>
+		`${spacedriveProtocol}/thumbnail/${shard_hex}/${encodeURIComponent(casId)}.webp`,
 	getFileUrl: (libraryId, locationLocalId, filePathId) =>
 		`${spacedriveProtocol}/file/${encodeURIComponent(libraryId)}/${encodeURIComponent(
 			locationLocalId
@@ -42,12 +42,12 @@ const queryClient = new QueryClient({
 	defaultOptions: {
 		queries: import.meta.env.VITE_SD_DEMO_MODE
 			? {
-					refetchOnWindowFocus: false,
-					staleTime: Infinity,
-					cacheTime: Infinity,
-					networkMode: 'offlineFirst',
-					enabled: false
-			  }
+				refetchOnWindowFocus: false,
+				staleTime: Infinity,
+				cacheTime: Infinity,
+				networkMode: 'offlineFirst',
+				enabled: false
+			}
 			: undefined
 		// TODO: Mutations can't be globally disable which is annoying!
 	}

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -89,6 +89,7 @@ tracing-appender = { git = "https://github.com/tokio-rs/tracing", rev = "2914626
 strum = { version = "0.24", features = ["derive"] }
 strum_macros = "0.24"
 hex = "0.4.3"
+int-enum = "0.4.0"
 
 
 [target.'cfg(windows)'.dependencies.winapi-util]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,11 +10,8 @@ edition.workspace = true
 
 [features]
 default = []
-mobile = [
-] # This feature allows features to be disabled when the Core is running on mobile.
-ffmpeg = [
-	"dep:sd-ffmpeg",
-] # This feature controls whether the Spacedrive Core contains functionality which requires FFmpeg.
+mobile = [] # This feature allows features to be disabled when the Core is running on mobile.
+ffmpeg = ["dep:sd-ffmpeg"] # This feature controls whether the Spacedrive Core contains functionality which requires FFmpeg.
 location-watcher = ["dep:notify"]
 sync-messages = []
 heif = ["dep:sd-heif"]
@@ -91,6 +88,7 @@ normpath = { version = "1.1.1", features = ["localization"] }
 tracing-appender = { git = "https://github.com/tokio-rs/tracing", rev = "29146260fb4615d271d2e899ad95a753bb42915e" } # Unreleased changes for log deletion
 strum = { version = "0.24", features = ["derive"] }
 strum_macros = "0.24"
+hex = "0.4.3"
 
 
 [target.'cfg(windows)'.dependencies.winapi-util]

--- a/core/src/api/jobs.rs
+++ b/core/src/api/jobs.rs
@@ -120,7 +120,7 @@ pub(crate) fn mount() -> AlphaRouter<Ctx> {
 					async_stream::stream! {
 						while let Ok(event) = event_bus_rx.recv().await {
 							match event {
-								CoreEvent::NewThumbnail { cas_id } => yield cas_id,
+								CoreEvent::NewThumbnail { thumb_key } => yield thumb_key,
 								_ => {}
 							}
 						}

--- a/core/src/api/locations.rs
+++ b/core/src/api/locations.rs
@@ -30,10 +30,12 @@ pub enum ExplorerItem {
 	Path {
 		// has_thumbnail is determined by the local existence of a thumbnail
 		has_thumbnail: bool,
+		shard_hex: Option<String>,
 		item: file_path_with_object::Data,
 	},
 	Object {
 		has_thumbnail: bool,
+		shard_hex: Option<String>,
 		item: object_with_file_paths::Data,
 	},
 }

--- a/core/src/api/locations.rs
+++ b/core/src/api/locations.rs
@@ -28,14 +28,16 @@ pub enum ExplorerContext {
 #[serde(tag = "type")]
 pub enum ExplorerItem {
 	Path {
-		// has_thumbnail is determined by the local existence of a thumbnail
-		has_thumbnail: bool,
-		shard_hex: Option<String>,
+		// has_local_thumbnail is true only if there is local existence of a thumbnail
+		has_local_thumbnail: bool,
+		// thumbnail_key is present if there is a cas_id
+		// it includes the shard hex formatted as (["f0", "cab34a76fbf3469f"])
+		thumbnail_key: Option<Vec<String>>,
 		item: file_path_with_object::Data,
 	},
 	Object {
-		has_thumbnail: bool,
-		shard_hex: Option<String>,
+		has_local_thumbnail: bool,
+		thumbnail_key: Option<Vec<String>>,
 		item: object_with_file_paths::Data,
 	},
 }

--- a/core/src/api/mod.rs
+++ b/core/src/api/mod.rs
@@ -16,7 +16,7 @@ pub type Router = rspc::Router<Ctx>;
 /// Represents an internal core event, these are exposed to client via a rspc subscription.
 #[derive(Debug, Clone, Serialize, Type)]
 pub enum CoreEvent {
-	NewThumbnail { cas_id: String },
+	NewThumbnail { thumb_key: Vec<String> },
 	InvalidateOperation(InvalidateOperationEvent),
 }
 

--- a/core/src/api/search.rs
+++ b/core/src/api/search.rs
@@ -1,6 +1,6 @@
 use crate::{
 	location::file_path_helper::{check_file_path_exists, IsolatedFilePathData},
-	object::preview::calc_shard_hex,
+	object::preview::get_thumb_key,
 };
 use std::collections::BTreeSet;
 
@@ -324,7 +324,7 @@ pub fn mount() -> AlphaRouter<Ctx> {
 					let mut items = Vec::with_capacity(file_paths.len());
 
 					for file_path in file_paths {
-						let has_thumbnail = if let Some(cas_id) = &file_path.cas_id {
+						let thumbnail_exists_locally = if let Some(cas_id) = &file_path.cas_id {
 							library
 								.thumbnail_exists(cas_id)
 								.await
@@ -334,8 +334,8 @@ pub fn mount() -> AlphaRouter<Ctx> {
 						};
 
 						items.push(ExplorerItem::Path {
-							has_thumbnail,
-							shard_hex: file_path.cas_id.clone().map(|id| calc_shard_hex(&id)),
+							has_local_thumbnail: thumbnail_exists_locally,
+							thumbnail_key: file_path.cas_id.as_ref().map(|i| get_thumb_key(i)),
 							item: file_path,
 						})
 					}
@@ -393,7 +393,7 @@ pub fn mount() -> AlphaRouter<Ctx> {
 							.map(|fp| fp.cas_id.as_ref())
 							.find_map(|c| c);
 
-						let has_thumbnail = if let Some(cas_id) = cas_id {
+						let thumbnail_exists_locally = if let Some(cas_id) = cas_id {
 							library.thumbnail_exists(cas_id).await.map_err(|e| {
 								rspc::Error::with_cause(
 									ErrorCode::InternalServerError,
@@ -406,8 +406,8 @@ pub fn mount() -> AlphaRouter<Ctx> {
 						};
 
 						items.push(ExplorerItem::Object {
-							has_thumbnail,
-							shard_hex: cas_id.map(|id| calc_shard_hex(&id)),
+							has_local_thumbnail: thumbnail_exists_locally,
+							thumbnail_key: cas_id.map(|i| get_thumb_key(i)),
 							item: object,
 						});
 					}

--- a/core/src/api/search.rs
+++ b/core/src/api/search.rs
@@ -1,4 +1,7 @@
-use crate::location::file_path_helper::{check_file_path_exists, IsolatedFilePathData};
+use crate::{
+	location::file_path_helper::{check_file_path_exists, IsolatedFilePathData},
+	object::preview::calc_shard_hex,
+};
 use std::collections::BTreeSet;
 
 use chrono::{DateTime, FixedOffset, Utc};
@@ -332,6 +335,7 @@ pub fn mount() -> AlphaRouter<Ctx> {
 
 						items.push(ExplorerItem::Path {
 							has_thumbnail,
+							shard_hex: file_path.cas_id.clone().map(|id| calc_shard_hex(&id)),
 							item: file_path,
 						})
 					}
@@ -403,6 +407,7 @@ pub fn mount() -> AlphaRouter<Ctx> {
 
 						items.push(ExplorerItem::Object {
 							has_thumbnail,
+							shard_hex: cas_id.map(|id| calc_shard_hex(&id)),
 							item: object,
 						});
 					}

--- a/core/src/custom_uri.rs
+++ b/core/src/custom_uri.rs
@@ -100,14 +100,18 @@ async fn handle_thumbnail(
 		return Ok(response?);
 	}
 
-	let file_cas_id = path
+	let shard_hex = path
 		.get(1)
+		.ok_or_else(|| HandleCustomUriError::BadRequest("Invalid number of parameters!"))?;
+	let file_cas_id = path
+		.get(2)
 		.ok_or_else(|| HandleCustomUriError::BadRequest("Invalid number of parameters!"))?;
 
 	let filename = node
 		.config
 		.data_directory()
 		.join("thumbnails")
+		.join(shard_hex)
 		.join(file_cas_id)
 		.with_extension("webp");
 

--- a/core/src/object/preview/thumbnail/directory.rs
+++ b/core/src/object/preview/thumbnail/directory.rs
@@ -1,4 +1,4 @@
-use std::{io, path::PathBuf};
+use std::path::PathBuf;
 use tokio::fs as async_fs;
 
 use int_enum::IntEnum;
@@ -21,7 +21,8 @@ pub async fn init_thumbnail_dir(data_dir: PathBuf) -> Result<PathBuf, Thumbnaile
 	let thumbnail_dir = data_dir.join(THUMBNAIL_CACHE_DIR_NAME);
 
 	let version_file = thumbnail_dir.join("version.txt");
-	let version_manager = VersionManager::<ThumbnailVersion>::new(version_file.to_str().unwrap());
+	let version_manager =
+		VersionManager::<ThumbnailVersion>::new(version_file.to_str().expect("Invalid path"));
 
 	info!("Thumbnail directory: {:?}", thumbnail_dir);
 
@@ -72,7 +73,11 @@ async fn move_webp_files(dir: &PathBuf) -> Result<(), ThumbnailerError> {
 		if path.is_file() {
 			if let Some(extension) = path.extension() {
 				if extension == "webp" {
-					let filename = path.file_name().unwrap().to_str().unwrap(); // we know they're cas_id's, so they're valid utf8
+					let filename = path
+						.file_name()
+						.expect("Missing file name")
+						.to_str()
+						.expect("Failed to parse UTF8"); // we know they're cas_id's, so they're valid utf8
 					let shard_folder = get_shard_hex(filename);
 
 					let new_dir = dir.join(shard_folder);

--- a/core/src/object/preview/thumbnail/directory.rs
+++ b/core/src/object/preview/thumbnail/directory.rs
@@ -1,0 +1,97 @@
+use std::{io, path::PathBuf};
+use tokio::fs as async_fs;
+
+use int_enum::IntEnum;
+use tracing::{error, info};
+
+use crate::util::{error::FileIOError, version_manager::VersionManager};
+
+use super::{calc_shard_hex, ThumbnailerError, THUMBNAIL_CACHE_DIR_NAME};
+
+#[derive(IntEnum, Debug, Clone, Copy, Eq, PartialEq)]
+#[repr(i32)]
+pub enum ThumbnailVersion {
+	V1 = 1,
+	V2 = 2,
+	Unknown = 0,
+}
+
+pub async fn init_thumbnail_dir(data_dir: PathBuf) -> Result<PathBuf, ThumbnailerError> {
+	info!("Initializing thumbnail directory");
+	let thumbnail_dir = data_dir.join(THUMBNAIL_CACHE_DIR_NAME);
+
+	let version_file = thumbnail_dir.join("version.txt");
+	let version_manager = VersionManager::<ThumbnailVersion>::new(version_file.to_str().unwrap());
+
+	info!("Thumbnail directory: {:?}", thumbnail_dir);
+
+	// create all necessary directories if they don't exist
+	async_fs::create_dir_all(&thumbnail_dir)
+		.await
+		.map_err(|e| FileIOError::from((&thumbnail_dir, e)))?;
+
+	let mut current_version = match version_manager.get_version() {
+		Ok(version) => version,
+		Err(_) => {
+			info!("Thumbnail version file does not exist, starting fresh");
+			// Version file does not exist, start fresh
+			version_manager.set_version(ThumbnailVersion::V1)?;
+			ThumbnailVersion::V1
+		}
+	};
+
+	while current_version != ThumbnailVersion::V2 {
+		match current_version {
+			ThumbnailVersion::V1 => {
+				let thumbnail_dir_for_task = thumbnail_dir.clone();
+				// If the migration fails, it will return the error and exit the function
+				move_webp_files(&thumbnail_dir_for_task).await?;
+				version_manager.set_version(ThumbnailVersion::V2)?;
+				current_version = ThumbnailVersion::V2;
+			}
+			// If the current version is not handled explicitly, break the loop or return an error.
+			_ => {
+				error!("Thumbnail version is not handled: {:?}", current_version);
+			}
+		}
+	}
+
+	Ok(thumbnail_dir)
+}
+
+/// This function moves all webp files in the thumbnail directory to their respective shard folders.
+/// It is used to migrate from V1 to V2.
+async fn move_webp_files(dir: &PathBuf) -> Result<(), ThumbnailerError> {
+	let mut dir_entries = async_fs::read_dir(dir)
+		.await
+		.map_err(|source| FileIOError::from((dir, source)))?;
+	let mut count = 0;
+
+	while let Ok(Some(entry)) = dir_entries.next_entry().await {
+		let path = entry.path();
+		if path.is_file() {
+			if let Some(extension) = path.extension() {
+				if extension == "webp" {
+					let filename = path.file_name().unwrap().to_str().unwrap(); // we know they're cas_id's, so they're valid utf8
+					let shard_folder = calc_shard_hex(filename);
+
+					let new_dir = dir.join(shard_folder);
+					async_fs::create_dir_all(&new_dir)
+						.await
+						.map_err(|source| FileIOError::from((new_dir.clone(), source)))?;
+
+					let new_path = new_dir.join(filename);
+					async_fs::rename(&path, &new_path)
+						.await
+						.map_err(|source| FileIOError::from((path.clone(), source)))?;
+					count += 1;
+				}
+			}
+		}
+	}
+	info!(
+		"Moved {} webp files to their respective shard folders.",
+		count
+	);
+	Ok(())
+}

--- a/core/src/object/preview/thumbnail/directory.rs
+++ b/core/src/object/preview/thumbnail/directory.rs
@@ -6,7 +6,7 @@ use tracing::{error, info};
 
 use crate::util::{error::FileIOError, version_manager::VersionManager};
 
-use super::{calc_shard_hex, ThumbnailerError, THUMBNAIL_CACHE_DIR_NAME};
+use super::{get_shard_hex, ThumbnailerError, THUMBNAIL_CACHE_DIR_NAME};
 
 #[derive(IntEnum, Debug, Clone, Copy, Eq, PartialEq)]
 #[repr(i32)]
@@ -73,7 +73,7 @@ async fn move_webp_files(dir: &PathBuf) -> Result<(), ThumbnailerError> {
 			if let Some(extension) = path.extension() {
 				if extension == "webp" {
 					let filename = path.file_name().unwrap().to_str().unwrap(); // we know they're cas_id's, so they're valid utf8
-					let shard_folder = calc_shard_hex(filename);
+					let shard_folder = get_shard_hex(filename);
 
 					let new_dir = dir.join(shard_folder);
 					async_fs::create_dir_all(&new_dir)

--- a/core/src/object/preview/thumbnail/mod.rs
+++ b/core/src/object/preview/thumbnail/mod.rs
@@ -8,7 +8,7 @@ use crate::{
 		LocationId,
 	},
 	prisma::location,
-	util::error::FileIOError,
+	util::{error::FileIOError, version_manager::VersionManagerError},
 };
 
 use std::{
@@ -32,10 +32,12 @@ use webp::Encoder;
 
 use self::thumbnailer_job::ThumbnailerJob;
 
+mod directory;
 mod shallow;
 mod shard;
 pub mod thumbnailer_job;
 
+pub use directory::*;
 pub use shallow::*;
 pub use shard::*;
 
@@ -98,6 +100,8 @@ pub enum ThumbnailerError {
 	FilePath(#[from] FilePathError),
 	#[error(transparent)]
 	FileIO(#[from] FileIOError),
+	#[error(transparent)]
+	VersionManager(#[from] VersionManagerError),
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/core/src/object/preview/thumbnail/mod.rs
+++ b/core/src/object/preview/thumbnail/mod.rs
@@ -51,7 +51,7 @@ pub fn get_thumbnail_path(library: &Library, cas_id: &str) -> PathBuf {
 		.config()
 		.data_directory()
 		.join(THUMBNAIL_CACHE_DIR_NAME)
-		.join(calc_shard_hex(cas_id))
+		.join(get_shard_hex(cas_id))
 		.join(cas_id)
 		.with_extension("webp")
 }
@@ -59,7 +59,7 @@ pub fn get_thumbnail_path(library: &Library, cas_id: &str) -> PathBuf {
 // this is used to pass the relevant data to the frontend so it can request the thumbnail
 // it supports extending the shard hex to support deeper directory structures in the future
 pub fn get_thumb_key(cas_id: &str) -> Vec<String> {
-	vec![calc_shard_hex(cas_id), cas_id.to_string()]
+	vec![get_shard_hex(cas_id), cas_id.to_string()]
 }
 
 #[cfg(feature = "ffmpeg")]
@@ -282,7 +282,7 @@ pub async fn inner_process_step(
 		return Ok(());
 	};
 
-	let thumb_dir = thumbnail_dir.join(calc_shard_hex(cas_id));
+	let thumb_dir = thumbnail_dir.join(get_shard_hex(cas_id));
 
 	// Create the directory if it doesn't exist
 	if let Err(e) = fs::create_dir_all(&thumb_dir).await {

--- a/core/src/object/preview/thumbnail/shallow.rs
+++ b/core/src/object/preview/thumbnail/shallow.rs
@@ -1,6 +1,5 @@
 use super::{
 	ThumbnailerError, ThumbnailerJobStep, ThumbnailerJobStepKind, FILTERED_IMAGE_EXTENSIONS,
-	THUMBNAIL_CACHE_DIR_NAME,
 };
 use crate::{
 	invalidate_query,
@@ -19,6 +18,7 @@ use crate::{
 };
 use sd_file_ext::extensions::Extension;
 use std::path::{Path, PathBuf};
+use thumbnail::init_thumbnail_dir;
 use tokio::fs;
 use tracing::info;
 
@@ -32,10 +32,7 @@ pub async fn shallow_thumbnailer(
 ) -> Result<(), JobError> {
 	let Library { db, .. } = &library;
 
-	let thumbnail_dir = library
-		.config()
-		.data_directory()
-		.join(THUMBNAIL_CACHE_DIR_NAME);
+	let thumbnail_dir = init_thumbnail_dir(library.config().data_directory()).await?;
 
 	let location_id = location.id;
 	let location_path = PathBuf::from(&location.path);

--- a/core/src/object/preview/thumbnail/shard.rs
+++ b/core/src/object/preview/thumbnail/shard.rs
@@ -3,7 +3,7 @@ use hex::encode;
 
 /// The practice of dividing files into hex coded folders, often called "sharding," is mainly used to optimize file system performance. File systems can start to slow down as the number of files in a directory increases. Thus, it's often beneficial to split files into multiple directories to avoid this performance degradation.
 
-/// `calc_shard_hex` takes a filename as input, computes a SHA256 hash of the filename, and returns the first two characters of the hash as the directory name. Because we're using the first two characters of a blake3 hash, this will give us 256 (16*16) possible directories, named 00 to ff.
+/// `calc_shard_hex` takes a cas_id as input, computes a blake3 hash of the filename, and returns the first two characters of the hash as the directory name. Because we're using the first two characters of a blake3 hash, this will give us 256 (16*16) possible directories, named 00 to ff.
 pub fn calc_shard_hex(filename: &str) -> String {
 	let mut hasher = Hasher::new();
 

--- a/core/src/object/preview/thumbnail/shard.rs
+++ b/core/src/object/preview/thumbnail/shard.rs
@@ -1,18 +1,8 @@
-use blake3::Hasher;
-use hex::encode;
-
 /// The practice of dividing files into hex coded folders, often called "sharding," is mainly used to optimize file system performance. File systems can start to slow down as the number of files in a directory increases. Thus, it's often beneficial to split files into multiple directories to avoid this performance degradation.
 
-/// `calc_shard_hex` takes a cas_id as input, computes a blake3 hash of the cas_id, and returns the first two characters of the hash as the directory name. Because we're using the first two characters of a blake3 hash, this will give us 256 (16*16) possible directories, named 00 to ff.
-pub fn calc_shard_hex(cas_id: &str) -> String {
-	let mut hasher = Hasher::new();
-
-	hasher.update(cas_id.as_bytes());
-
-	let result = hasher.finalize();
-	let hex_result = encode(result.as_bytes());
-
+/// `get_shard_hex` takes a cas_id (a hexadecimal hash) as input and returns the first two characters of the hash as the directory name. Because we're using the first two characters of a the hash, this will give us 256 (16*16) possible directories, named 00 to ff.
+pub fn get_shard_hex(cas_id: &str) -> String {
 	// Use the first two characters of the hash as the directory name
-	let directory_name = &hex_result[0..2];
+	let directory_name = &cas_id[0..2];
 	directory_name.to_string()
 }

--- a/core/src/object/preview/thumbnail/shard.rs
+++ b/core/src/object/preview/thumbnail/shard.rs
@@ -1,0 +1,18 @@
+use blake3::Hasher;
+use hex::encode;
+
+/// The practice of dividing files into hex coded folders, often called "sharding," is mainly used to optimize file system performance. File systems can start to slow down as the number of files in a directory increases. Thus, it's often beneficial to split files into multiple directories to avoid this performance degradation.
+
+/// `calc_shard_hex` takes a filename as input, computes a SHA256 hash of the filename, and returns the first two characters of the hash as the directory name. Because we're using the first two characters of a blake3 hash, this will give us 256 (16*16) possible directories, named 00 to ff.
+pub fn calc_shard_hex(filename: &str) -> String {
+	let mut hasher = Hasher::new();
+
+	hasher.update(filename.as_bytes());
+
+	let result = hasher.finalize();
+	let hex_result = encode(result.as_bytes());
+
+	// Use the first two characters of the hash as the directory name
+	let directory_name = &hex_result[0..2];
+	directory_name.to_string()
+}

--- a/core/src/object/preview/thumbnail/shard.rs
+++ b/core/src/object/preview/thumbnail/shard.rs
@@ -3,11 +3,11 @@ use hex::encode;
 
 /// The practice of dividing files into hex coded folders, often called "sharding," is mainly used to optimize file system performance. File systems can start to slow down as the number of files in a directory increases. Thus, it's often beneficial to split files into multiple directories to avoid this performance degradation.
 
-/// `calc_shard_hex` takes a cas_id as input, computes a blake3 hash of the filename, and returns the first two characters of the hash as the directory name. Because we're using the first two characters of a blake3 hash, this will give us 256 (16*16) possible directories, named 00 to ff.
-pub fn calc_shard_hex(filename: &str) -> String {
+/// `calc_shard_hex` takes a cas_id as input, computes a blake3 hash of the cas_id, and returns the first two characters of the hash as the directory name. Because we're using the first two characters of a blake3 hash, this will give us 256 (16*16) possible directories, named 00 to ff.
+pub fn calc_shard_hex(cas_id: &str) -> String {
 	let mut hasher = Hasher::new();
 
-	hasher.update(filename.as_bytes());
+	hasher.update(cas_id.as_bytes());
 
 	let result = hasher.finalize();
 	let hex_result = encode(result.as_bytes());

--- a/core/src/util/mod.rs
+++ b/core/src/util/mod.rs
@@ -4,5 +4,6 @@ pub mod db;
 pub mod debug_initializer;
 pub mod error;
 pub mod migrator;
+pub mod version_manager;
 
 pub use abort_on_drop::*;

--- a/core/src/util/version_manager.rs
+++ b/core/src/util/version_manager.rs
@@ -42,7 +42,7 @@ impl<T: IntEnum<Int = i32>> VersionManager<T> {
 	pub fn get_version(&self) -> Result<T, VersionManagerError> {
 		if Path::new(&self.version_file_path).exists() {
 			let contents = fs::read_to_string(&self.version_file_path)?;
-			let version = i32::from_str(&contents.trim())?;
+			let version = i32::from_str(contents.trim())?;
 			T::from_int(version).map_err(|_| VersionManagerError::IntConversionError)
 		} else {
 			Err(VersionManagerError::VersionFileDoesNotExist)

--- a/core/src/util/version_manager.rs
+++ b/core/src/util/version_manager.rs
@@ -1,0 +1,76 @@
+use int_enum::IntEnum;
+use std::fs;
+use std::io::prelude::*;
+use std::path::Path;
+use std::str::FromStr;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum VersionManagerError {
+	#[error("Invalid version")]
+	InvalidVersion,
+	#[error("Version file does not exist")]
+	VersionFileDoesNotExist,
+	#[error("Error while converting integer to enum")]
+	IntConversionError,
+	#[error("Malformed version file")]
+	MalformedVersionFile,
+	#[error(transparent)]
+	IO(#[from] std::io::Error),
+	#[error(transparent)]
+	ParseIntError(#[from] std::num::ParseIntError),
+}
+
+///
+/// An abstract system for saving a text file containing a version number.
+/// The version number is an integer that can be converted to and from an enum.
+/// The enum must implement the IntEnum trait.
+///
+pub struct VersionManager<T: IntEnum<Int = i32>> {
+	version_file_path: String,
+	_marker: std::marker::PhantomData<T>,
+}
+
+impl<T: IntEnum<Int = i32>> VersionManager<T> {
+	pub fn new(version_file_path: &str) -> Self {
+		VersionManager {
+			version_file_path: version_file_path.to_string(),
+			_marker: std::marker::PhantomData,
+		}
+	}
+
+	pub fn get_version(&self) -> Result<T, VersionManagerError> {
+		if Path::new(&self.version_file_path).exists() {
+			let contents = fs::read_to_string(&self.version_file_path)?;
+			let version = i32::from_str(&contents.trim())?;
+			T::from_int(version).map_err(|_| VersionManagerError::IntConversionError)
+		} else {
+			Err(VersionManagerError::VersionFileDoesNotExist)
+		}
+	}
+
+	pub fn set_version(&self, version: T) -> Result<(), VersionManagerError> {
+		let mut file = fs::File::create(&self.version_file_path)?;
+		file.write_all(version.int_value().to_string().as_bytes())?;
+		Ok(())
+	}
+
+	// pub async fn migrate<F: FnMut(T) -> Result<(), VersionManagerError>>(
+	// 	&self,
+	// 	current: T,
+	// 	latest: T,
+	// 	mut migrate_fn: F,
+	// ) -> Result<(), VersionManagerError> {
+	// 	for version_int in (current.int_value() + 1)..=latest.int_value() {
+	// 		let version = match T::from_int(version_int) {
+	// 			Ok(version) => version,
+	// 			Err(_) => return Err(VersionManagerError::IntConversionError),
+	// 		};
+	// 		migrate_fn(version)?;
+	// 	}
+
+	// 	self.set_version(latest)?;
+
+	// 	Ok(())
+	// }
+}

--- a/interface/app/$libraryId/Explorer/File/Thumb.tsx
+++ b/interface/app/$libraryId/Explorer/File/Thumb.tsx
@@ -131,7 +131,7 @@ function FileThumb({ size, cover, ...props }: ThumbProps) {
 
 		if (props.loadOriginal) {
 			setThumbType(ThumbType.Original);
-		} else if (itemData.hasThumbnail) {
+		} else if (itemData.hasLocalThumbnail) {
 			setThumbType(ThumbType.Thumbnail);
 		} else {
 			setThumbType(ThumbType.Icon);
@@ -139,7 +139,7 @@ function FileThumb({ size, cover, ...props }: ThumbProps) {
 	}, [props.loadOriginal, itemData]);
 
 	useEffect(() => {
-		const { casId, kind, isDir, extension, locationId: itemLocationId, shard_hex } = itemData;
+		const { casId, kind, isDir, extension, locationId: itemLocationId, thumbnailKey } = itemData;
 		const locationId = itemLocationId ?? explorerLocationId;
 		switch (thumbType) {
 			case ThumbType.Original:
@@ -158,9 +158,8 @@ function FileThumb({ size, cover, ...props }: ThumbProps) {
 				}
 				break;
 			case ThumbType.Thumbnail:
-				if (casId && shard_hex) {
-					console.log(platform.getThumbnailUrlById(casId, shard_hex))
-					setSrc(platform.getThumbnailUrlById(casId, shard_hex));
+				if (casId && thumbnailKey) {
+					setSrc(platform.getThumbnailUrlByThumbKey(thumbnailKey));
 				} else {
 					setThumbType(ThumbType.Icon);
 				}
@@ -184,7 +183,7 @@ function FileThumb({ size, cover, ...props }: ThumbProps) {
 	const onError = () => {
 		setLoaded(false);
 		setThumbType((prevThumbType) => {
-			return prevThumbType === ThumbType.Original && itemData.hasThumbnail
+			return prevThumbType === ThumbType.Original && itemData.hasLocalThumbnail
 				? ThumbType.Thumbnail
 				: ThumbType.Icon;
 		});

--- a/interface/app/$libraryId/Explorer/File/Thumb.tsx
+++ b/interface/app/$libraryId/Explorer/File/Thumb.tsx
@@ -139,7 +139,7 @@ function FileThumb({ size, cover, ...props }: ThumbProps) {
 	}, [props.loadOriginal, itemData]);
 
 	useEffect(() => {
-		const { casId, kind, isDir, extension, locationId: itemLocationId } = itemData;
+		const { casId, kind, isDir, extension, locationId: itemLocationId, shard_hex } = itemData;
 		const locationId = itemLocationId ?? explorerLocationId;
 		switch (thumbType) {
 			case ThumbType.Original:
@@ -158,8 +158,9 @@ function FileThumb({ size, cover, ...props }: ThumbProps) {
 				}
 				break;
 			case ThumbType.Thumbnail:
-				if (casId) {
-					setSrc(platform.getThumbnailUrlById(casId));
+				if (casId && shard_hex) {
+					console.log(platform.getThumbnailUrlById(casId, shard_hex))
+					setSrc(platform.getThumbnailUrlById(casId, shard_hex));
 				} else {
 					setThumbType(ThumbType.Icon);
 				}

--- a/interface/app/$libraryId/Explorer/index.tsx
+++ b/interface/app/$libraryId/Explorer/index.tsx
@@ -42,9 +42,8 @@ export default function Explorer(props: Props) {
 		onError: (err) => {
 			console.error('Error in RSPC subscription new thumbnail', err);
 		},
-		onData: (cas_id) => {
-			console.log({ cas_id });
-			explorerStore.addNewThumbnail(cas_id);
+		onData: (thumbKey) => {
+			explorerStore.addNewThumbnail(thumbKey);
 		}
 	});
 

--- a/interface/app/$libraryId/Explorer/util.ts
+++ b/interface/app/$libraryId/Explorer/util.ts
@@ -49,8 +49,8 @@ export function getExplorerItemData(data: ExplorerItem) {
 		isDir: isPath(data) && data.item.is_dir,
 		extension: filePath?.extension || null,
 		locationId: filePath?.location_id || null,
-		hasThumbnail: data.has_thumbnail,
-		shard_hex: data.shard_hex
+		hasLocalThumbnail: data.has_local_thumbnail, // this will be overwritten if new thumbnail is generated
+		thumbnailKey: data.thumbnail_key
 	};
 }
 

--- a/interface/app/$libraryId/Explorer/util.ts
+++ b/interface/app/$libraryId/Explorer/util.ts
@@ -49,7 +49,8 @@ export function getExplorerItemData(data: ExplorerItem) {
 		isDir: isPath(data) && data.item.is_dir,
 		extension: filePath?.extension || null,
 		locationId: filePath?.location_id || null,
-		hasThumbnail: data.has_thumbnail
+		hasThumbnail: data.has_thumbnail,
+		shard_hex: data.shard_hex
 	};
 }
 

--- a/interface/app/$libraryId/location/$id.tsx
+++ b/interface/app/$libraryId/location/$id.tsx
@@ -42,7 +42,7 @@ export const Component = () => {
 				sub_path: path ?? ''
 			}
 		],
-		{ onData() {} }
+		{ onData() { } }
 	);
 
 	const explorerStore = getExplorerStore();
@@ -114,7 +114,8 @@ const useItems = () => {
 				}
 			]),
 		getNextPageParam: (lastPage) => lastPage.cursor ?? undefined,
-		keepPreviousData: true
+		keepPreviousData: true,
+		onSuccess: () => getExplorerStore().resetNewThumbnails()
 	});
 
 	const items = useMemo(() => query.data?.pages.flatMap((d) => d.items) || null, [query.data]);

--- a/interface/app/$libraryId/overview/data.ts
+++ b/interface/app/$libraryId/overview/data.ts
@@ -11,7 +11,7 @@ import {
 	useLibraryContext,
 	useRspcLibraryContext
 } from '@sd/client';
-import { useExplorerStore } from '~/hooks';
+import { getExplorerStore, useExplorerStore } from '~/hooks';
 import { useExplorerOrder } from '../Explorer/util';
 
 export const IconForCategory: Partial<Record<Category, string>> = {
@@ -86,7 +86,8 @@ export function useItems(selectedCategory: Category) {
 					cursor
 				}
 			]),
-		getNextPageParam: (lastPage) => lastPage.cursor ?? undefined
+		getNextPageParam: (lastPage) => lastPage.cursor ?? undefined,
+		onSuccess: () => getExplorerStore().resetNewThumbnails()
 	});
 
 	const pathsItems = useMemo(

--- a/interface/app/$libraryId/search.tsx
+++ b/interface/app/$libraryId/search.tsx
@@ -22,7 +22,7 @@ export const SEARCH_PARAMS = z.object({
 
 export type SearchArgs = z.infer<typeof SEARCH_PARAMS>;
 
-const ExplorerStuff = memo((props: { args: SearchArgs }) => {
+const SearchExplorer = memo((props: { args: SearchArgs }) => {
 	const explorerStore = useExplorerStore();
 	const { explorerViewOptions, explorerControlOptions, explorerToolOptions } =
 		useExplorerTopBarOptions();
@@ -41,7 +41,8 @@ const ExplorerStuff = memo((props: { args: SearchArgs }) => {
 		],
 		{
 			suspense: true,
-			enabled: !!search
+			enabled: !!search,
+			onSuccess: () => getExplorerStore().resetNewThumbnails()
 		}
 	);
 
@@ -98,7 +99,7 @@ export const Component = () => {
 
 	return (
 		<Suspense fallback="LOADING FIRST RENDER">
-			<ExplorerStuff args={search} />
+			<SearchExplorer args={search} />
 		</Suspense>
 	);
 };

--- a/interface/hooks/useExplorerItemData.ts
+++ b/interface/hooks/useExplorerItemData.ts
@@ -1,18 +1,23 @@
 import { useMemo } from 'react';
 import { ExplorerItem } from '@sd/client';
-import { getExplorerItemData, getItemFilePath } from '~/app/$libraryId/Explorer/util';
-import { useExplorerStore } from './useExplorerStore';
+import { getExplorerItemData } from '~/app/$libraryId/Explorer/util';
+import { flattenThumbnailKey, useExplorerStore } from './useExplorerStore';
 
 export function useExplorerItemData(explorerItem: ExplorerItem) {
-	const filePath = getItemFilePath(explorerItem);
-	const { newThumbnails } = useExplorerStore();
+	const explorerStore = useExplorerStore();
 
-	const newThumbnail = newThumbnails?.[filePath?.cas_id || ''] || false;
+	const newThumbnail = !!(
+		explorerItem.thumbnail_key &&
+		explorerStore.newThumbnails.has(flattenThumbnailKey(explorerItem.thumbnail_key))
+	);
+
 	return useMemo(() => {
 		const itemData = getExplorerItemData(explorerItem);
-		if (!itemData.hasThumbnail) {
-			itemData.hasThumbnail = newThumbnail;
+
+		if (!itemData.hasLocalThumbnail) {
+			itemData.hasLocalThumbnail = newThumbnail;
 		}
+
 		return itemData;
 	}, [explorerItem, newThumbnail]);
 }

--- a/interface/hooks/useExplorerStore.tsx
+++ b/interface/hooks/useExplorerStore.tsx
@@ -1,13 +1,13 @@
-import { proxy, useSnapshot } from 'valtio';
-import { proxyMap, proxySet } from 'valtio/utils';
+import { proxy, useSnapshot, subscribe } from 'valtio';
+import { proxySet } from 'valtio/utils';
 import { z } from 'zod';
 import { ExplorerItem, FilePathSearchOrdering, ObjectSearchOrdering } from '@sd/client';
 import { resetStore } from '@sd/client';
 
 type Join<K, P> = K extends string | number
 	? P extends string | number
-		? `${K}${'' extends P ? '' : '.'}${P}`
-		: never
+	? `${K}${'' extends P ? '' : '.'}${P}`
+	: never
 	: never;
 
 type Leaves<T> = T extends object ? { [K in keyof T]-?: Join<K, Leaves<T[K]>> }[keyof T] : '';
@@ -25,7 +25,7 @@ export enum ExplorerKind {
 export type CutCopyType = 'Cut' | 'Copy';
 
 export type FilePathSearchOrderingKeys = UnionKeys<FilePathSearchOrdering> | 'none';
-export type ObjectSearchOrderingKyes = UnionKeys<ObjectSearchOrdering> | 'none';
+export type ObjectSearchOrderingKeys = UnionKeys<ObjectSearchOrdering> | 'none';
 
 export const SortOrder = z.union([z.literal('Asc'), z.literal('Desc')]);
 
@@ -39,7 +39,7 @@ const state = {
 	tagAssignMode: false,
 	showInspector: false,
 	multiSelectIndexes: [] as number[],
-	newThumbnails: {} as Record<string, boolean | undefined>,
+	newThumbnails: proxySet() as Set<string>,
 	cutCopyState: {
 		sourcePath: '', // this is used solely for preventing copy/cutting to the same path (as that will truncate the file)
 		sourceLocationId: 0,
@@ -56,13 +56,21 @@ const state = {
 	groupBy: 'none'
 };
 
+export function flattenThumbnailKey(thumbKey: string[]) {
+	return thumbKey.join('/');
+}
+
 // Keep the private and use `useExplorerState` or `getExplorerStore` or you will get production build issues.
 const explorerStore = proxy({
 	...state,
 	reset: () => resetStore(explorerStore, state),
-	addNewThumbnail: (casId: string) => {
-		explorerStore.newThumbnails[casId] = true;
-	}
+	addNewThumbnail: (thumbKey: string[]) => {
+		explorerStore.newThumbnails.add(flattenThumbnailKey(thumbKey))
+	},
+	// this should be done when the explorer query is refreshed
+	resetNewThumbnails: () => {
+		explorerStore.newThumbnails.clear();
+	},
 });
 
 export function useExplorerStore() {

--- a/interface/hooks/useExplorerStore.tsx
+++ b/interface/hooks/useExplorerStore.tsx
@@ -1,8 +1,7 @@
-import { proxy, useSnapshot, subscribe } from 'valtio';
+import { ExplorerItem, FilePathSearchOrdering, ObjectSearchOrdering, resetStore } from '@sd/client';
+import { proxy, useSnapshot } from 'valtio';
 import { proxySet } from 'valtio/utils';
 import { z } from 'zod';
-import { ExplorerItem, FilePathSearchOrdering, ObjectSearchOrdering } from '@sd/client';
-import { resetStore } from '@sd/client';
 
 type Join<K, P> = K extends string | number
 	? P extends string | number
@@ -68,6 +67,7 @@ const explorerStore = proxy({
 		explorerStore.newThumbnails.add(flattenThumbnailKey(thumbKey))
 	},
 	// this should be done when the explorer query is refreshed
+	// prevents memory leak
 	resetNewThumbnails: () => {
 		explorerStore.newThumbnails.clear();
 	},

--- a/interface/util/Platform.tsx
+++ b/interface/util/Platform.tsx
@@ -6,7 +6,7 @@ export type OperatingSystem = 'browser' | 'linux' | 'macOS' | 'windows' | 'unkno
 // This could be Tauri or web.
 export type Platform = {
 	platform: 'web' | 'tauri'; // This represents the specific platform implementation
-	getThumbnailUrlById: (casId: string) => string;
+	getThumbnailUrlById: (casId: string, shard_hex: string) => string;
 	getFileUrl: (
 		libraryId: string,
 		locationLocalId: number,

--- a/interface/util/Platform.tsx
+++ b/interface/util/Platform.tsx
@@ -6,7 +6,7 @@ export type OperatingSystem = 'browser' | 'linux' | 'macOS' | 'windows' | 'unkno
 // This could be Tauri or web.
 export type Platform = {
 	platform: 'web' | 'tauri'; // This represents the specific platform implementation
-	getThumbnailUrlById: (casId: string, shard_hex: string) => string;
+	getThumbnailUrlByThumbKey: (thumbKey: string[]) => string;
 	getFileUrl: (
 		libraryId: string,
 		locationLocalId: number,

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -127,7 +127,7 @@ export type EditLibraryArgs = { id: string; name: string | null; description: st
  */
 export type EncryptedKey = number[]
 
-export type ExplorerItem = { type: "Path"; has_thumbnail: boolean; item: FilePathWithObject } | { type: "Object"; has_thumbnail: boolean; item: ObjectWithFilePaths }
+export type ExplorerItem = { type: "Path"; has_thumbnail: boolean; shard_hex: string | null; item: FilePathWithObject } | { type: "Object"; has_thumbnail: boolean; shard_hex: string | null; item: ObjectWithFilePaths }
 
 export type FileCopierJobInit = { source_location_id: number; source_path_id: number; target_location_id: number; target_path: string; target_file_name_suffix: string | null }
 

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -87,7 +87,7 @@ export type Procedures = {
         { key: "tags.update", input: LibraryArgs<TagUpdateArgs>, result: null },
     subscriptions: 
         { key: "invalidation.listen", input: never, result: InvalidateOperationEvent[] } | 
-        { key: "jobs.newThumbnail", input: LibraryArgs<null>, result: string } | 
+        { key: "jobs.newThumbnail", input: LibraryArgs<null>, result: string[] } | 
         { key: "locations.online", input: never, result: number[][] } | 
         { key: "locations.quickRescan", input: LibraryArgs<LightScanArgs>, result: null } | 
         { key: "p2p.events", input: never, result: P2PEvent } | 
@@ -127,7 +127,7 @@ export type EditLibraryArgs = { id: string; name: string | null; description: st
  */
 export type EncryptedKey = number[]
 
-export type ExplorerItem = { type: "Path"; has_thumbnail: boolean; shard_hex: string | null; item: FilePathWithObject } | { type: "Object"; has_thumbnail: boolean; shard_hex: string | null; item: ObjectWithFilePaths }
+export type ExplorerItem = { type: "Path"; has_local_thumbnail: boolean; thumbnail_key: string[] | null; item: FilePathWithObject } | { type: "Object"; has_local_thumbnail: boolean; thumbnail_key: string[] | null; item: ObjectWithFilePaths }
 
 export type FileCopierJobInit = { source_location_id: number; source_path_id: number; target_location_id: number; target_path: string; target_file_name_suffix: string | null }
 


### PR DESCRIPTION
This is a simple PR to improve the way we store thumbnails in the data folder. After a nice chat with ChatGPT I discovered why most apps do this, I noticed even Apple apps store files internally in hex-coded folders to prevent directory sizes from growing too large. Since my thumbnail folder is well over 85,000 items and takes a minute to open in Finder it could probably become an issue faster than we'd expect. This is an industry standard format for storing large collections of cached files. 

`calc_shard_hex` takes a cas_id as input, computes a blake3 hash of the filename, and returns the first two characters of the hash as the directory name. Because we're using the first two characters of a blake3 hash, this will give us 256 (16*16) possible directories, named 00 to ff.

This PR also introduces the `version_manager` util which allows us to easily migrate app data structures with a rust version enum and a `version.txt` that contains a single int32. I wrote a migration for the thumbnail folder that moves existing `webp` files into their respective shard directory.

<img width="923" alt="Screenshot 2023-06-07 at 10 05 07 PM" src="https://github.com/spacedriveapp/spacedrive/assets/32987599/8c6ba754-1fee-4887-b659-9fbb918ae219">
