### PR TITLE
[ENG-718] checkbox bg color accent + delete file dialog tweak

### DIFF
--- a/interface/app/$libraryId/Explorer/File/DeleteDialog.tsx
+++ b/interface/app/$libraryId/Explorer/File/DeleteDialog.tsx
@@ -1,5 +1,5 @@
 import { useLibraryMutation } from '@sd/client';
-import { Dialog, UseDialogProps, useDialog } from '@sd/ui';
+import { CheckBox, Dialog, Tooltip, UseDialogProps, useDialog } from '@sd/ui';
 import { useZodForm } from '@sd/ui/src/forms';
 
 interface Propps extends UseDialogProps {
@@ -27,7 +27,12 @@ export default (props: Propps) => {
 			loading={deleteFile.isLoading}
 			ctaLabel="Delete"
 		>
-			<p>TODO: checkbox for "delete all matching files" (only if a file is selected)</p>
+			<Tooltip label="Coming soon">
+				<div className="flex items-center opacity-50">
+					<CheckBox disabled className="!mt-0" />
+					<p className="text-sm text-ink-faint">Delete all matching files</p>
+				</div>
+			</Tooltip>
 		</Dialog>
 	);
 };

--- a/packages/ui/src/CheckBox.tsx
+++ b/packages/ui/src/CheckBox.tsx
@@ -6,7 +6,7 @@ import { ComponentProps, forwardRef } from 'react';
 const styles = cva(
 	[
 		'form-check-input float-left mr-2 mt-1 h-4 w-4 appearance-none rounded-sm border border-gray-300 bg-white bg-contain bg-center bg-no-repeat align-top transition duration-200',
-		'checked:border-blue-600 checked:bg-blue-600 focus:outline-none '
+		'checked:border-accent checked:bg-accent focus:outline-none checked:hover:bg-accent/80'
 	],
 	{ variants: {} }
 );


### PR DESCRIPTION
This PR updates the delete dialog visually, it was weird having the TODO.

- Also updated the color of checkbox to our accent color.

<img width="395" alt="Screenshot 2023-06-12 at 12 41 35 PM" src="https://github.com/spacedriveapp/spacedrive/assets/33054370/eae0c8b7-d382-49fd-8ae0-7adafe0b977f">
