### PR TITLE
[ENG-594] `Open With` Windows + fixes

### DIFF
--- a/.github/scripts/setup-system.ps1
+++ b/.github/scripts/setup-system.ps1
@@ -345,7 +345,7 @@ while ($page -gt 0) {
 
         $_.workflow_runs | ForEach-Object {
             $artifactPath = (
-                    (Invoke-RestMethod -Uri ($_.artifacts_url | Out-String) -Method Get).artifacts `
+                (Invoke-RestMethodGithub -Uri ($_.artifacts_url | Out-String) -Method Get).artifacts `
                 | Where-Object {
                     $_.name -eq "ffmpeg-${ffmpegVersion}-x86_64"
                 } | ForEach-Object {

--- a/.github/scripts/setup-system.ps1
+++ b/.github/scripts/setup-system.ps1
@@ -178,6 +178,8 @@ https://learn.microsoft.com/windows/package-manager/winget/
     Write-Host
     Write-Host 'Installing Visual Studio Build Tools...' -ForegroundColor Yellow
     Write-Host 'This will take some time as it involves downloading several gigabytes of data....' -ForegroundColor Cyan
+    winget install -e --accept-source-agreements --force --disable-interactivity --id Microsoft.VisualStudio.2022.BuildTools `
+        --override 'updateall --quiet --wait'
     # Force install because BuildTools is itself a package manager, so let it decide if something needs to be installed or not
     winget install -e --accept-source-agreements --force --disable-interactivity --id Microsoft.VisualStudio.2022.BuildTools `
         --override '--wait --quiet --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended'
@@ -205,6 +207,8 @@ https://learn.microsoft.com/windows/package-manager/winget/
     } else {
         $LASTEXITCODE = 0
     }
+
+    # TODO: Install Strawberry perl, required by debug build of openssl-sys
 
     Write-Host
     Write-Host 'Installing NodeJS...' -ForegroundColor Yellow

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3756,9 +3756,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libheif-rs"
@@ -7002,6 +7002,7 @@ dependencies = [
 name = "sd-desktop-windows"
 version = "0.1.0"
 dependencies = [
+ "libc",
  "normpath",
  "thiserror",
  "windows 0.48.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6999,6 +6999,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sd-desktop-windows"
+version = "0.1.0"
+dependencies = [
+ "normpath",
+ "thiserror",
+ "windows 0.48.0",
+]
+
+[[package]]
 name = "sd-ffmpeg"
 version = "0.1.0"
 dependencies = [
@@ -7634,6 +7643,7 @@ dependencies = [
  "sd-core",
  "sd-desktop-linux",
  "sd-desktop-macos",
+ "sd-desktop-windows",
  "serde",
  "specta",
  "tauri",

--- a/apps/desktop/crates/linux/src/desktop_entry.rs
+++ b/apps/desktop/crates/linux/src/desktop_entry.rs
@@ -29,12 +29,14 @@ pub enum Mode {
 }
 
 fn terminal() -> Result<String> {
+	// TODO: Attemtp to read x-terminal-emulator bin (Debian/Ubuntu spec for setting default terminal)
 	SystemApps::get_entries()
 		.ok()
 		.and_then(|mut entries| {
-			entries.find(|(_handler, entry)| entry.categories.contains_key("TerminalEmulator"))
+			entries
+				.find(|DesktopEntry { categories, .. }| categories.contains_key("TerminalEmulator"))
 		})
-		.map(|e| e.1.exec)
+		.map(|e| e.exec)
 		.ok_or(Error::NoTerminal)
 }
 

--- a/apps/desktop/crates/linux/src/system.rs
+++ b/apps/desktop/crates/linux/src/system.rs
@@ -1,7 +1,7 @@
 use std::{
-	collections::{HashMap, HashSet},
+	collections::{BTreeSet, HashMap},
 	convert::TryFrom,
-	ffi::OsString,
+	ffi::OsStr,
 };
 
 use mime::Mime;
@@ -10,53 +10,53 @@ use xdg_mime::SharedMimeInfo;
 use crate::{DesktopEntry, Handler, HandlerType, Result};
 
 #[derive(Debug, Default, Clone)]
-pub struct SystemApps(pub HashMap<Mime, Vec<Handler>>);
+pub struct SystemApps(pub HashMap<Mime, BTreeSet<Handler>>);
 
 impl SystemApps {
-	pub fn get_handlers(&self, handler_type: HandlerType) -> Vec<Handler> {
-		let mut handlers = match handler_type {
+	pub fn get_handlers(&self, handler_type: HandlerType) -> impl Iterator<Item = &Handler> {
+		let mimes = match handler_type {
 			HandlerType::Ext(ext) => {
-				let mut handlers: HashSet<Handler> = HashSet::new();
-				for mime in SharedMimeInfo::new().get_mime_types_from_file_name(ext.as_str()) {
-					if let Some(mime_handlers) = self.0.get(&mime) {
-						for handler in mime_handlers {
-							handlers.insert(handler.clone());
-						}
-					}
-				}
-				handlers.into_iter().collect()
+				SharedMimeInfo::new().get_mime_types_from_file_name(ext.as_str())
 			}
-			HandlerType::Mime(mime) => self.0.get(&mime).unwrap_or(&Vec::new()).clone(),
+			HandlerType::Mime(mime) => vec![mime],
 		};
 
-		handlers.sort();
+		let mut handlers: BTreeSet<&Handler> = BTreeSet::new();
+		for mime in mimes {
+			if let Some(mime_handlers) = self.0.get(&mime) {
+				handlers.extend(mime_handlers.iter());
+			}
+		}
 
-		handlers
+		handlers.into_iter()
 	}
 
-	pub fn get_handler(&self, handler_type: HandlerType) -> Option<Handler> {
-		Some(self.get_handlers(handler_type).get(0)?.clone())
+	pub fn get_handler(&self, handler_type: HandlerType) -> Option<&Handler> {
+		self.get_handlers(handler_type).next()
 	}
 
-	pub fn get_entries() -> Result<impl Iterator<Item = (OsString, DesktopEntry)>> {
+	pub fn get_entries() -> Result<impl Iterator<Item = DesktopEntry>> {
 		Ok(xdg::BaseDirectories::new()?
 			.list_data_files_once("applications")
 			.into_iter()
-			.filter(|p| p.extension().and_then(|x| x.to_str()) == Some("desktop"))
-			.filter_map(|p| Some((p.file_name()?.to_owned(), DesktopEntry::try_from(&p).ok()?))))
+			.filter(|p| p.extension().map_or(false, |x| x == OsStr::new("desktop")))
+			.filter_map(|p| DesktopEntry::try_from(&p).ok()))
 	}
 
 	pub fn populate() -> Result<Self> {
-		let mut map = HashMap::<Mime, Vec<Handler>>::with_capacity(50);
+		let mut map = HashMap::<Mime, BTreeSet<Handler>>::with_capacity(50);
 
-		Self::get_entries()?.for_each(|(_, entry)| {
-			let (file_name, mimes) = (entry.file_name, entry.mimes);
-			mimes.into_iter().for_each(|mime| {
-				map.entry(mime)
-					.or_default()
-					.push(Handler::assume_valid(file_name.clone()));
-			});
-		});
+		Self::get_entries()?.for_each(
+			|DesktopEntry {
+			     mimes, file_name, ..
+			 }| {
+				mimes.into_iter().for_each(|mime| {
+					map.entry(mime)
+						.or_default()
+						.insert(Handler::assume_valid(file_name.clone()));
+				});
+			},
+		);
 
 		Ok(Self(map))
 	}

--- a/apps/desktop/crates/windows/Cargo.toml
+++ b/apps/desktop/crates/windows/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "sd-desktop-windows"
+version = "0.1.0"
+license = { workspace = true }
+repository = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+thiserror = "1.0.40"
+normpath = "1.1.1"
+
+[dependencies.windows]
+version = "0.48"
+features = ["Win32_UI_Shell", "Win32_System_Com"]

--- a/apps/desktop/crates/windows/Cargo.toml
+++ b/apps/desktop/crates/windows/Cargo.toml
@@ -8,6 +8,7 @@ edition = { workspace = true }
 [dependencies]
 thiserror = "1.0.40"
 normpath = "1.1.1"
+libc = "0.2.146"
 
 [dependencies.windows]
 version = "0.48"

--- a/apps/desktop/crates/windows/src/lib.rs
+++ b/apps/desktop/crates/windows/src/lib.rs
@@ -1,0 +1,81 @@
+#![cfg(target_os = "windows")]
+
+use std::ffi::{OsStr, OsString};
+use std::path::Path;
+
+use normpath::PathExt;
+use windows::core::HSTRING;
+use windows::Win32::System::Com::IDataObject;
+use windows::Win32::UI::Shell::{
+	BHID_DataObject, IAssocHandler, IShellItem, SHAssocEnumHandlers, SHCreateItemFromParsingName,
+	ASSOC_FILTER_NONE,
+};
+
+pub use windows::core::{Error, Result};
+
+// Use SHAssocEnumHandlers to get the list of apps associated with a file extension.
+// https://learn.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-shassocenumhandlers
+pub fn list_apps_associated_with_ext(ext: &OsStr) -> Result<Vec<IAssocHandler>> {
+	if ext.is_empty() {
+		return Ok(Vec::new());
+	}
+
+	// SHAssocEnumHandlers requires the extension to be prefixed with a dot
+	let ext = ext
+		.to_str()
+		.and_then(|str| str.chars().next())
+		.and_then(|c| {
+			if c == '.' {
+				None
+			} else {
+				let mut prefixed_ext = OsString::new();
+				prefixed_ext.push(".");
+				prefixed_ext.push(ext);
+				Some(prefixed_ext)
+			}
+		})
+		.unwrap_or(ext.to_os_string());
+
+	let assoc_handlers = unsafe { SHAssocEnumHandlers(&HSTRING::from(ext), ASSOC_FILTER_NONE) }?;
+
+	let mut vec = Vec::new();
+	loop {
+		let mut rgelt = [None; 1];
+		let mut pceltfetched = 0;
+		unsafe { assoc_handlers.Next(&mut rgelt, Some(&mut pceltfetched)) }?;
+
+		if pceltfetched == 0 {
+			break;
+		}
+
+		for handler in rgelt.into_iter().flatten() {
+			vec.push(handler);
+		}
+	}
+
+	Ok(vec)
+}
+
+pub fn open_file_path_with(path: &Path, url: String) -> Result<()> {
+	for handler in list_apps_associated_with_ext(path.extension().ok_or(Error::OK)?)?.iter() {
+		let name = unsafe { handler.GetName() }
+			.and_then(|name| -> Result<_> { unsafe { name.to_string() }.map_err(|_| Error::OK) })?;
+
+		if name == url {
+			let path = path.normalize_virtually().map_err(|_| Error::OK)?;
+			let path_str = path.as_os_str();
+			println!("Opening {:?} with {}", path_str, name);
+			let factory: IShellItem =
+				unsafe { SHCreateItemFromParsingName(&HSTRING::from(path_str), None) }?;
+			println!("SHCreateItemFromParsingName");
+			let data: IDataObject = unsafe { factory.BindToHandler(None, &BHID_DataObject) }?;
+			println!("BindToHandler");
+			unsafe { handler.Invoke(&data) }?;
+			println!("Invoke");
+
+			return Ok(());
+		}
+	}
+
+	Err(Error::OK)
+}

--- a/apps/desktop/crates/windows/src/lib.rs
+++ b/apps/desktop/crates/windows/src/lib.rs
@@ -96,14 +96,14 @@ pub fn list_apps_associated_with_ext(ext: &OsStr) -> Result<Vec<IAssocHandler>> 
 	Ok(vec)
 }
 
-pub fn open_file_path_with(path: &Path, url: String) -> Result<()> {
+pub fn open_file_path_with(path: &Path, url: &String) -> Result<()> {
 	ensure_com_initialized();
 
 	for handler in list_apps_associated_with_ext(path.extension().ok_or(Error::OK)?)?.iter() {
 		let name = unsafe { handler.GetName() }
 			.and_then(|name| -> Result<_> { unsafe { name.to_string() }.map_err(|_| Error::OK) })?;
 
-		if name == url {
+		if &name == url {
 			let path = path.normalize_virtually().map_err(|_| Error::OK)?;
 			let wide_path = path
 				.as_os_str()

--- a/apps/desktop/crates/windows/src/lib.rs
+++ b/apps/desktop/crates/windows/src/lib.rs
@@ -91,7 +91,7 @@ pub fn list_apps_associated_with_ext(ext: &OsStr) -> Result<Vec<IAssocHandler>> 
 			break;
 		}
 
-		for handler in rgelt.into_iter().flatten() {
+		if let Some(handler) = rgelt[0] {
 			vec.push(handler);
 		}
 	}

--- a/apps/desktop/crates/windows/src/lib.rs
+++ b/apps/desktop/crates/windows/src/lib.rs
@@ -23,6 +23,7 @@ use windows::{
 
 pub use windows::core::{Error, Result};
 
+// Based on: https://github.com/Byron/trash-rs/blob/841bc1388959ab3be4f05ad1a90b03aa6bcaea67/src/windows.rs#L212-L258
 struct CoInitializer {}
 impl CoInitializer {
 	fn new() -> CoInitializer {

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -39,6 +39,9 @@ sd-desktop-linux = { path = "../crates/linux" }
 [target.'cfg(target_os = "macos")'.dependencies]
 sd-desktop-macos = { path = "../crates/macos" }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+sd-desktop-windows = { path = "../crates/windows" }
+
 [build-dependencies]
 tauri-build = { version = "1.3.0", features = [] }
 

--- a/apps/desktop/src-tauri/src/file.rs
+++ b/apps/desktop/src-tauri/src/file.rs
@@ -50,23 +50,17 @@ pub async fn open_file_path(
 }
 
 #[derive(Serialize, Type)]
-#[serde(tag = "t", content = "c")]
-#[allow(dead_code)]
-pub enum OpenWithApplication {
-	File {
-		id: i32,
-		name: String,
-		#[cfg(target_os = "linux")]
-		url: std::path::PathBuf,
-		#[cfg(not(target_os = "linux"))]
-		url: String,
-	},
-	Error(i32, String),
+pub struct OpenWithApplication {
+	id: i32,
+	name: String,
+	#[cfg(target_os = "linux")]
+	url: std::path::PathBuf,
+	#[cfg(not(target_os = "linux"))]
+	url: String,
 }
 
 #[tauri::command(async)]
 #[specta::specta]
-#[allow(unused_variables)]
 pub async fn get_file_path_open_with_apps(
 	library: uuid::Uuid,
 	ids: Vec<i32>,
@@ -97,7 +91,7 @@ pub async fn get_file_path_open_with_apps(
 			unsafe { sd_desktop_macos::get_open_with_applications(&path.to_str().unwrap().into()) }
 				.as_slice()
 				.iter()
-				.map(|app| OpenWithApplication::File {
+				.map(|app| OpenWithApplication {
 					id,
 					name: app.name.to_string(),
 					url: app.url.to_string(),
@@ -136,7 +130,6 @@ pub async fn get_file_path_open_with_apps(
 
 				system_apps
 					.get_handlers(HandlerType::Ext(name))
-					.iter()
 					.map(|handler| {
 						handler
 							.get_path()
@@ -146,7 +139,7 @@ pub async fn get_file_path_open_with_apps(
 							.and_then(|path| {
 								DesktopEntry::try_from(&path)
 									// TODO: Ignore desktop entries that have commands that don't exist/aren't available in path
-									.map(|entry| OpenWithApplication::File {
+									.map(|entry| OpenWithApplication {
 										id,
 										name: entry.name,
 										url: path,
@@ -198,7 +191,7 @@ pub async fn get_file_path_open_with_apps(
 							return None
 						};
 
-							Some(OpenWithApplication::File { id, name, url })
+							Some(OpenWithApplication { id, name, url })
 						})
 						.collect::<Vec<_>>()
 				})

--- a/apps/desktop/src-tauri/src/file.rs
+++ b/apps/desktop/src-tauri/src/file.rs
@@ -254,14 +254,15 @@ pub async fn open_file_path_with(
 						};
 
 					#[cfg(target_os = "macos")]
-					{
-						return Ok(unsafe {
+					return {
+						unsafe {
 							sd_desktop_macos::open_file_path_with(
 								&path.into(),
 								&url.as_str().into(),
 							)
-						});
-					}
+						};
+						Ok(())
+					};
 
 					#[cfg(target_os = "linux")]
 					{

--- a/apps/desktop/src-tauri/src/file.rs
+++ b/apps/desktop/src-tauri/src/file.rs
@@ -72,23 +72,29 @@ pub async fn get_file_path_open_with_apps(
 	ids: Vec<i32>,
 	node: tauri::State<'_, Arc<Node>>,
 ) -> Result<Vec<OpenWithApplication>, ()> {
-	let Some(library) = node.library_manager.get_library(library).await else {
-        return Err(())
-    };
+	let Some(library) = node.library_manager.get_library(library).await
+		else {
+			return Ok(vec![]);
+		};
 
-	let Ok(paths) = library.get_file_paths(ids).await.map_err(|e| {error!("{e:#?}");})
-	else {
-		return Err(());
-	};
+	let Ok(paths) = library
+		.get_file_paths(ids).await
+		.map_err(|e| {error!("{e:#?}");})
+		else {
+			return Ok(vec![]);
+		};
 
 	#[cfg(target_os = "macos")]
 	return Ok(paths
 		.into_iter()
 		.flat_map(|(id, path)| {
-			if let Some(path) = path {
-				unsafe {
-					sd_desktop_macos::get_open_with_applications(&path.to_str().unwrap().into())
-				}
+			let Some(path) = path
+				else {
+					error!("File not found in database");
+					return vec![];
+				};
+
+			unsafe { sd_desktop_macos::get_open_with_applications(&path.to_str().unwrap().into()) }
 				.as_slice()
 				.iter()
 				.map(|app| OpenWithApplication::File {
@@ -97,12 +103,6 @@ pub async fn get_file_path_open_with_apps(
 					url: app.url.to_string(),
 				})
 				.collect::<Vec<_>>()
-			} else {
-				vec![OpenWithApplication::Error(
-					id,
-					"File not found in database".into(),
-				)]
-			}
 		})
 		.collect());
 
@@ -111,142 +111,148 @@ pub async fn get_file_path_open_with_apps(
 		use sd_desktop_linux::{DesktopEntry, HandlerType, SystemApps};
 
 		// TODO: cache this, and only update when the underlying XDG desktop apps changes
-		let system_apps = SystemApps::populate().map_err(|_| ())?;
+		let Ok(system_apps) = SystemApps::populate()
+			.map_err(|e| { error!("{e:#?}"); })
+			else {
+				return Ok(vec![]);
+			};
 
 		return Ok(paths
 			.into_iter()
 			.flat_map(|(id, path)| {
-				if let Some(path) = path {
-					let Some(name) = path.file_name()
-						.and_then(|name| name.to_str())
-						.map(|name| name.to_string())
+				let Some(path) = path
 					else {
-						return vec![OpenWithApplication::Error(
-							id,
-							"Failed to extract file name".into(),
-						)]
+						error!("File not found in database");
+						return vec![];
 					};
 
-					system_apps
-						.get_handlers(HandlerType::Ext(name))
-						.iter()
-						.map(|handler| {
-							handler
-								.get_path()
-								.map(|path| {
-									DesktopEntry::try_from(&path)
-										.map(|entry| OpenWithApplication::File {
-											id,
-											name: entry.name,
-											url: path,
-										})
-										.unwrap_or_else(|e| {
-											error!("{e:#?}");
-											OpenWithApplication::Error(
-												id,
-												"Failed to parse desktop entry".into(),
-											)
-										})
-								})
-								.unwrap_or_else(|e| {
-									error!("{e:#?}");
-									OpenWithApplication::Error(
+				let Some(name) = path.file_name()
+					.and_then(|name| name.to_str())
+					.map(|name| name.to_string())
+					else {
+						error!("Failed to extract file name");
+						return vec![];
+					};
+
+				system_apps
+					.get_handlers(HandlerType::Ext(name))
+					.iter()
+					.map(|handler| {
+						handler
+							.get_path()
+							.map_err(|e| {
+								error!("{e:#?}");
+							})
+							.and_then(|path| {
+								DesktopEntry::try_from(&path)
+									.map(|entry| OpenWithApplication::File {
 										id,
-										"Failed to get path from desktop entry".into(),
-									)
-								})
-						})
-						.collect::<Vec<_>>()
-				} else {
-					vec![OpenWithApplication::Error(
-						id,
-						"File not found in database".into(),
-					)]
-				}
+										name: entry.name,
+										url: path,
+									})
+									.map_err(|e| {
+										error!("{e:#?}");
+									})
+							})
+					})
+					.collect::<Result<Vec<_>, _>>()
+					.unwrap_or(vec![])
 			})
 			.collect());
 	}
 
 	#[cfg(windows)]
 	{
-		use sd_desktop_windows::{list_apps_associated_with_ext, Error, Result};
+		use sd_desktop_windows::list_apps_associated_with_ext;
 
-		return Ok(list_apps_associated_with_ext(path.extension().ok_or(())?)
-			.map_err(|_| ())?
-			.iter()
-			.filter_map(|handler| {
-				if let (Ok(name), Ok(url)) = (
-					unsafe { handler.GetUIName() }.and_then(|name| -> Result<_> {
-						unsafe { name.to_string() }.map_err(|_| Error::OK)
-					}),
-					unsafe { handler.GetName() }.and_then(|name| -> Result<_> {
-						unsafe { name.to_string() }.map_err(|_| Error::OK)
-					}),
-				) {
-					Some(OpenWithApplication { name, url })
-				} else {
-					None
-				}
+		return Ok(paths
+			.into_iter()
+			.flat_map(|(id, path)| {
+				let Some(path) = path
+					else {
+						error!("File not found in database");
+						return vec![];
+					};
+
+				let Some(ext) = path.extension()
+					else {
+						error!("Failed to extract file extension");
+						return vec![];
+					};
+
+				list_apps_associated_with_ext(ext)
+					.iter()
+					.filter_map(|handler| {
+						let (Ok(name), Ok(url)) = (
+							unsafe { handler.GetUIName() }.map_err(|e| { error!("{e:#?}");})
+								.and_then(|name| unsafe { name.to_string() }
+								.map_err(|e| { error!("{e:#?}");})),
+							unsafe { handler.GetName() }.map_err(|e| { error!("{e:#?}");})
+								.and_then(|name| unsafe { name.to_string() }
+								.map_err(|e| { error!("{e:#?}");})),
+						) else {
+							None
+						};
+
+						Some(OpenWithApplication { id, name, url })
+					})
+					.collect::<Vec<_>>()
 			})
-			.collect::<Vec<OpenWithApplication>>());
+			.collect());
 	}
 
 	#[allow(unreachable_code)]
-	Err(())
+	Ok(vec![])
 }
 
 type FileIdAndUrl = (i32, String);
 
-#[tauri::command(async)]
+#[tauri::command]
 #[specta::specta]
-#[allow(unused_variables)]
 pub async fn open_file_path_with(
 	library: uuid::Uuid,
 	file_ids_and_urls: Vec<FileIdAndUrl>,
 	node: tauri::State<'_, Arc<Node>>,
 ) -> Result<(), ()> {
-	let Some(library) = node.library_manager.get_library(library).await else {
-        return Err(())
-    };
+	let Some(library) = node.library_manager.get_library(library).await
+		else {
+			return Err(())
+		};
 
 	let url_by_id = file_ids_and_urls.into_iter().collect::<HashMap<_, _>>();
 	let ids = url_by_id.keys().copied().collect::<Vec<_>>();
 
-	#[cfg(target_os = "macos")]
-	{
-		library
-			.get_file_paths(ids)
-			.await
-			.map(|paths| {
-				paths.iter().for_each(|(id, path)| {
-					if let Some(path) = path {
-						unsafe {
-							sd_desktop_macos::open_file_path_with(
-								&path.to_str().unwrap().into(),
-								&url_by_id
-									.get(id)
-									.expect("we just created this hashmap")
-									.as_str()
-									.into(),
-							)
-						}
-					}
-				})
-			})
-			.map_err(|e| {
-				error!("{e:#?}");
-			})
-	}
+	library
+		.get_file_paths(ids)
+		.await
+		.map_err(|e| {
+			error!("{e:#?}");
+		})
+		.and_then(|paths| {
+			paths
+				.iter()
+				.map(|(id, path)| {
+					let Some(path) = path.as_ref().and_then(|path| path.to_str())
+						else {
+							error!("File not found in database");
+							return Err(());
+						};
 
-	#[cfg(target_os = "linux")]
-	{
-		library
-			.get_file_paths(ids)
-			.await
-			.map(|paths| {
-				paths.iter().for_each(|(id, path)| {
-					if let Some(path) = path.as_ref().and_then(|path| path.to_str()) {
-						if let Err(e) = sd_desktop_linux::Handler::assume_valid(
+					#[cfg(target_os = "macos")]
+					unsafe {
+						sd_desktop_macos::open_file_path_with(
+							&path.into(),
+							&url_by_id
+								.get(id)
+								.expect("we just created this hashmap")
+								.as_str()
+								.into(),
+						)
+					}
+
+					#[cfg(target_os = "linux")]
+					{
+						sd_desktop_linux::Handler::assume_valid(
 							url_by_id
 								.get(id)
 								.expect("we just created this hashmap")
@@ -254,21 +260,17 @@ pub async fn open_file_path_with(
 								.into(),
 						)
 						.open(&[path])
-						{
+						.map_err(|e| {
 							error!("{e:#?}");
-						}
+						})
 					}
+
+					#[cfg(windows)]
+					sd_desktop_windows::open_file_path_with(&path, url).map_err(|e| {
+						error!("{e:#?}");
+					})
 				})
-			})
-			.map_err(|e| {
-				error!("{e:#?}");
-			})
-	}
-
-	#[cfg(windows)]
-	{
-		sd_desktop_windows::open_file_path_with(&path, url).map_err(|_| ())?;
-	}
-
-	Ok(())
+				.collect::<Result<Vec<_>, _>>()
+				.map(|_| ())
+		})
 }

--- a/apps/desktop/src-tauri/src/file.rs
+++ b/apps/desktop/src-tauri/src/file.rs
@@ -256,7 +256,10 @@ pub async fn open_file_path_with(
 					#[cfg(target_os = "macos")]
 					{
 						return Ok(unsafe {
-							sd_desktop_macos::open_file_path_with(&path.into(), &url.into())
+							sd_desktop_macos::open_file_path_with(
+								&path.into(),
+								&url.as_str().into(),
+							)
 						});
 					}
 

--- a/apps/desktop/src-tauri/src/file.rs
+++ b/apps/desktop/src-tauri/src/file.rs
@@ -267,7 +267,7 @@ pub async fn open_file_path_with(
 
 	#[cfg(windows)]
 	{
-		sd_desktop_windows::open_file_path_with(&path, url).unwrap(); //.map_err(|_| ())?;
+		sd_desktop_windows::open_file_path_with(&path, url).map_err(|_| ())?;
 	}
 
 	Ok(())

--- a/apps/desktop/src-tauri/src/file.rs
+++ b/apps/desktop/src-tauri/src/file.rs
@@ -207,7 +207,7 @@ pub async fn get_file_path_open_with_apps(
 
 type FileIdAndUrl = (i32, String);
 
-#[tauri::command]
+#[tauri::command(async)]
 #[specta::specta]
 pub async fn open_file_path_with(
 	library: uuid::Uuid,
@@ -239,15 +239,17 @@ pub async fn open_file_path_with(
 						};
 
 					#[cfg(target_os = "macos")]
-					unsafe {
-						sd_desktop_macos::open_file_path_with(
-							&path.into(),
-							&url_by_id
-								.get(id)
-								.expect("we just created this hashmap")
-								.as_str()
-								.into(),
-						)
+					{
+						Ok(unsafe {
+							sd_desktop_macos::open_file_path_with(
+								&path.into(),
+								&url_by_id
+									.get(id)
+									.expect("we just created this hashmap")
+									.as_str()
+									.into(),
+							)
+						})
 					}
 
 					#[cfg(target_os = "linux")]

--- a/apps/desktop/src/commands.ts
+++ b/apps/desktop/src/commands.ts
@@ -38,6 +38,6 @@ export function lockAppTheme(themeType: AppThemeType) {
     return invoke()<null>("lock_app_theme", { themeType })
 }
 
-export type OpenWithApplication = { t: "File"; c: { id: number; name: string; url: string } } | { t: "Error"; c: [number, string] }
+export type OpenWithApplication = { id: number; name: string; url: string }
 export type AppThemeType = "Auto" | "Light" | "Dark"
 export type OpenFilePathResult = { t: "NoLibrary" } | { t: "NoFile"; c: number } | { t: "OpenError"; c: [number, string] } | { t: "AllGood"; c: number } | { t: "Internal"; c: string }

--- a/interface/app/$libraryId/Explorer/File/ContextMenu/OpenWith.tsx
+++ b/interface/app/$libraryId/Explorer/File/ContextMenu/OpenWith.tsx
@@ -49,18 +49,18 @@ const Items = ({
 						onClick={async () => {
 							try {
 								await actions.openFilePathWith(library.uuid, [
-									[filePath.id, data.c.url]
+									[filePath.id, data.url]
 								]);
 							} catch (e) {
 								console.error(e);
 								showAlertDialog({
 									title: 'Error',
-									value: `Failed to open file, with: ${data.c.url}`
+									value: `Failed to open file, with: ${data.url}`
 								});
 							}
 						}}
 					>
-						{data.c.name}
+						{data.name}
 					</ContextMenu.Item>
 				))
 			) : (

--- a/interface/app/$libraryId/Explorer/File/ContextMenu/OpenWith.tsx
+++ b/interface/app/$libraryId/Explorer/File/ContextMenu/OpenWith.tsx
@@ -61,7 +61,7 @@ const Items = ({
 					</ContextMenu.Item>
 				))
 			) : (
-				<p> No apps available </p>
+				<p className="w-full text-center text-sm text-gray-400"> No apps available </p>
 			)}
 		</>
 	);

--- a/interface/app/$libraryId/Explorer/File/ContextMenu/OpenWith.tsx
+++ b/interface/app/$libraryId/Explorer/File/ContextMenu/OpenWith.tsx
@@ -42,25 +42,27 @@ const Items = ({
 
 	return (
 		<>
-			{items.data?.map((data) => (
-				<ContextMenu.Item
-					key={data.name}
-					onClick={async () => {
-						try {
-							await actions.openFilePathWith(library.uuid, [
-								(filePath.id, data.c.url)
-							]);
-						} catch {
-							showAlertDialog({
-								title: 'Error',
-								value: `Failed to open file, with: ${data.url}`
-							});
-						}
-					}}
-				>
-					{data.name}
-				</ContextMenu.Item>
-			)) ?? <p> No apps available </p>}
+			{items.data && items.data.length > 0 ? (
+				items.data.map((data) => (
+					<ContextMenu.Item
+						key={data.name}
+						onClick={async () => {
+							try {
+								await actions.openFilePathWith(library.uuid, [(filePath.id, data.c.url)]);
+							} catch {
+								showAlertDialog({
+									title: 'Error',
+									value: `Failed to open file, with: ${data.url}`
+								});
+							}
+						}}
+					>
+						{data.name}
+					</ContextMenu.Item>
+				))
+			) : (
+				<p> No apps available </p>
+			)}
 		</>
 	);
 };

--- a/interface/app/$libraryId/Explorer/File/ContextMenu/OpenWith.tsx
+++ b/interface/app/$libraryId/Explorer/File/ContextMenu/OpenWith.tsx
@@ -34,7 +34,7 @@ const Items = ({
 }) => {
 	const { library } = useLibraryContext();
 
-	const items = useQuery<any[]>(
+	const items = useQuery<unknown>(
 		['openWith', filePath.id],
 		() => actions.getFilePathOpenWithApps(library.uuid, [filePath.id]),
 		{ suspense: true }
@@ -42,22 +42,25 @@ const Items = ({
 
 	return (
 		<>
-			{items.data && items.data.length > 0 ? (
-				items.data.map((data) => (
+			{Array.isArray(items.data) && items.data.length > 0 ? (
+				items.data.map((data, id) => (
 					<ContextMenu.Item
-						key={data.name}
+						key={id}
 						onClick={async () => {
 							try {
-								await actions.openFilePathWith(library.uuid, [(filePath.id, data.c.url)]);
-							} catch {
+								await actions.openFilePathWith(library.uuid, [
+									[filePath.id, data.c.url]
+								]);
+							} catch (e) {
+								console.error(e);
 								showAlertDialog({
 									title: 'Error',
-									value: `Failed to open file, with: ${data.url}`
+									value: `Failed to open file, with: ${data.c.url}`
 								});
 							}
 						}}
 					>
-						{data.name}
+						{data.c.name}
 					</ContextMenu.Item>
 				))
 			) : (

--- a/interface/app/$libraryId/overview/Categories.tsx
+++ b/interface/app/$libraryId/overview/Categories.tsx
@@ -90,7 +90,11 @@ export const Categories = (props: { selected: Category; onSelectedChanged(c: Cat
 							<motion.div
 								onViewportEnter={() => lastCategoryVisibleHandler(index)}
 								onViewportLeave={() => lastCategoryVisibleHandler(index)}
-								viewport={{ root: ref, margin: '0% -120px 0% 0%' }}
+								viewport={{
+									root: ref,
+									// WARNING: Edge breaks if the values are not postfixed with px or %
+									margin: '0% -120px 0% 0%'
+								}}
 								className="min-w-fit"
 								key={category}
 							>

--- a/interface/util/Platform.tsx
+++ b/interface/util/Platform.tsx
@@ -25,8 +25,8 @@ export type Platform = {
 	openLogsDir?(): void;
 	// Opens a file path with a given ID
 	openFilePath?(library: string, ids: number[]): any;
-	getFilePathOpenWithApps?(library: string, ids: number[]): any;
-	openFilePathWith?(library: string, fileIdsAndAppUrls: [number, string][]): any;
+	getFilePathOpenWithApps?(library: string, ids: number[]): Promise<unknown>;
+	openFilePathWith?(library: string, fileIdsAndAppUrls: [number, string][]): Promise<unknown>;
 	lockAppTheme?(themeType: 'Auto' | 'Light' | 'Dark'): any;
 };
 

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -264,7 +264,7 @@ export type SpacedropArgs = { peer_id: PeerId; file_path: string[] }
 
 export type Statistics = { id: number; date_captured: string; total_object_count: number; library_db_size: string; total_bytes_used: string; total_bytes_capacity: string; total_unique_bytes: string; total_bytes_free: string; preview_media_bytes: string }
 
-export type Tag = { id: number; pub_id: number[]; name: string | null; color: string | null; redundancy_goal: number | null; date_created: string | null; date_modified: string | null }
+export type Tag = { id: number; pub_id: number[]; name: string | null; color: string | null; total_objects: number | null; redundancy_goal: number | null; date_created: string; date_modified: string }
 
 export type TagAssignArgs = { object_ids: number[]; tag_id: number; unassign: boolean }
 

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -184,7 +184,7 @@ export type MaybeNot<T> = T | { not: T }
 
 export type MediaData = { id: number; pixel_width: number | null; pixel_height: number | null; longitude: number | null; latitude: number | null; fps: number | null; capture_device_make: string | null; capture_device_model: string | null; capture_device_software: string | null; duration_seconds: number | null; codecs: string | null; streams: number | null }
 
-export type Node = { id: number; pub_id: number[]; name: string; platform: number; version: string | null; last_seen: string; timezone: string | null; date_created: string }
+export type Node = { id: number; pub_id: number[]; name: string; platform: number; date_created: string }
 
 /**
  * NodeConfig is the configuration for a node. This is shared between all libraries and is stored in a JSON file on disk.

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -264,7 +264,7 @@ export type SpacedropArgs = { peer_id: PeerId; file_path: string[] }
 
 export type Statistics = { id: number; date_captured: string; total_object_count: number; library_db_size: string; total_bytes_used: string; total_bytes_capacity: string; total_unique_bytes: string; total_bytes_free: string; preview_media_bytes: string }
 
-export type Tag = { id: number; pub_id: number[]; name: string | null; color: string | null; total_objects: number | null; redundancy_goal: number | null; date_created: string; date_modified: string }
+export type Tag = { id: number; pub_id: number[]; name: string | null; color: string | null; redundancy_goal: number | null; date_created: string | null; date_modified: string | null }
 
 export type TagAssignArgs = { object_ids: number[]; tag_id: number; unassign: boolean }
 


### PR DESCRIPTION
 - [X] Windows `Open With`
   - [X] Implement logic to list applications capable of opening a certain file, based on its extension, using [`SHAssocEnumHandlers`](https://learn.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-shassocenumhandlers)
   - [x] Implement logic to execute a given application to open a file
   - [X] Fix `Open With` behavior when no apps are available
- [X] Add update step for VisualStudio Installer in windows setup-script.sh to fix it failing to execute due to outdated installations
- [X] Fix windows setup-script.sh being rate limited in CI runs
- [X] ~Fix App UI crashing on launch in Windows due to Edge Webview being stricter about CSS values~ (Fixed in main already)
- [X] Fix Windows, Linux and macOS `Open With` for compatibility with #927
- [X] Sort Linux file handlers entries to ensure a consistent app order in the `Open With` submenu
- [X] Make `get_file_path_open_with_apps` lenient with underline OS Api errors to allow a best-effort at returning something in the app list