### PR TITLE
added text wrapping with ... when folder name too long

### DIFF
--- a/interface/app/$libraryId/location/$id.tsx
+++ b/interface/app/$libraryId/location/$id.tsx
@@ -56,9 +56,9 @@ export const Component = () => {
 			<TopBarPortal
 				left={
 					<div className="group flex flex-row items-center space-x-2">
-						<span>
+						<span className="flex flex-row items-center">
 							<Folder size={22} className="ml-3 mr-2 mt-[-1px] inline-block" />
-							<span className="text-sm font-medium">
+							<span className="overflow-hidden text-ellipsis whitespace-nowrap text-sm font-medium">
 								{path ? getLastSectionOfPath(path) : location.data?.name}
 							</span>
 						</span>


### PR DESCRIPTION
Truncate the folder name when it's too long; otherwise, it's going to a new line, and I have centred the folder icon and the name.

<img width="1037" alt="CleanShot 2023-06-16 at 11 41 54@2x" src="https://github.com/spacedriveapp/spacedrive/assets/19343894/ade7ec6d-f200-48da-819d-004500ea947c">
