### PR TITLE
bug fix: Fix window flash when cmd+clicking on a link

### DIFF
--- a/interface/app/$libraryId/Layout/Sidebar/Link.tsx
+++ b/interface/app/$libraryId/Layout/Sidebar/Link.tsx
@@ -28,10 +28,18 @@ const Link = forwardRef<
 
 	return (
 		<NavLink
-			onClick={(e) => (disabled ? e.preventDefault() : onClick?.(e))}
+			onClick={(e) => {
+				// Prevent default action if Command (metaKey) or Control is pressed
+				if (e.metaKey || e.ctrlKey) {
+					e.preventDefault();
+				}
+				if (!disabled) {
+					onClick?.(e);
+				}
+			}}
 			className={({ isActive }) =>
 				clsx(
-					"ring-0", // Remove ugly outline ring on Chrome Windows & Linux
+					'ring-0', // Remove ugly outline ring on Chrome Windows & Linux
 					styles({ active: isActive, transparent: os === 'macOS' }),
 					disabled && 'pointer-events-none opacity-50',
 					className


### PR DESCRIPTION
This fixes an issue where cmd+click or ctrl+click on a link will cause the entire desktop window to flash. This is because it attempts to open the link in a new "tab" but results in the entire app reloading instead. I disabled this functionality and this can now be extended to support inline tabs in the future.

This PR solves this issue: https://github.com/spacedriveapp/spacedrive/issues/905

Closes #905 
