### PR TITLE
Bug fix: Remove unnecessary horizontal scrollbar on grid list to remove white square

### DIFF
--- a/interface/components/GridList.tsx
+++ b/interface/components/GridList.tsx
@@ -272,9 +272,9 @@ export default <T extends GridListSelection>({ selectable = true, ...props }: Gr
 	return (
 		<div
 			ref={ref}
-			className="relative w-full"
+			className='relative w-full overflow-x-hidden'
 			style={{
-				height: `${rowVirtualizer.getTotalSize()}px`
+				height: `${rowVirtualizer.getTotalSize()}px`,
 			}}
 		>
 			{multiSelect && (


### PR DESCRIPTION
When the horizontal scrollbar appears on window resizing, there is a white square on the bottom right corner for the grid list. This change only applies to the grid list. Because you cant horizontally scroll on the grid list due to the items resizing, I disabled the scrollbar entirely. The list view does not have this anymore because theres no horizontal scrollbar.

Closes #855
