### PR TITLE
[ENG-768 / ENG-769] Regen thumbnails / Generate checksums

### DIFF
--- a/core/src/api/jobs.rs
+++ b/core/src/api/jobs.rs
@@ -224,15 +224,17 @@ pub(crate) fn mount() -> AlphaRouter<Ctx> {
 
 			R.with2(library())
 				.mutation(|(_, library), args: ObjectValidatorArgs| async move {
-					if find_location(&library, args.id).exec().await?.is_none() {
+					let Some(location) =  find_location(&library, args.id)
+						.exec()
+						.await?
+						else {
 						return Err(LocationError::IdNotFound(args.id).into());
-					}
+					};
 
 					library
 						.spawn_job(ObjectValidatorJobInit {
-							location_id: args.id,
-							path: args.path,
-							background: true,
+							location,
+							sub_path: Some(args.path),
 						})
 						.await
 						.map_err(Into::into)

--- a/core/src/job/error.rs
+++ b/core/src/job/error.rs
@@ -2,7 +2,7 @@ use crate::{
 	location::{indexer::IndexerError, LocationError},
 	object::{
 		file_identifier::FileIdentifierJobError, fs::error::FileSystemJobsError,
-		preview::ThumbnailerError,
+		preview::ThumbnailerError, validation::ValidatorError,
 	},
 	util::{db::MissingFieldError, error::FileIOError},
 };
@@ -62,6 +62,8 @@ pub enum JobError {
 	ThumbnailError(#[from] ThumbnailerError),
 	#[error(transparent)]
 	IdentifierError(#[from] FileIdentifierJobError),
+	#[error(transparent)]
+	Validator(#[from] ValidatorError),
 	#[error(transparent)]
 	FileSystemJobsError(#[from] FileSystemJobsError),
 	#[error(transparent)]

--- a/core/src/location/file_path_helper/mod.rs
+++ b/core/src/location/file_path_helper/mod.rs
@@ -44,10 +44,6 @@ file_path::select!(file_path_for_object_validator {
 	name
 	extension
 	integrity_checksum
-	location: select {
-		id
-		pub_id
-	}
 });
 file_path::select!(file_path_for_thumbnailer {
 	materialized_path

--- a/core/src/location/indexer/shallow.rs
+++ b/core/src/location/indexer/shallow.rs
@@ -45,7 +45,7 @@ pub async fn shallow(
 		.collect::<Result<Vec<_>, _>>()
 		.map_err(IndexerError::from)?;
 
-	let (add_root, to_walk_path) = if sub_path != Path::new("") {
+	let (add_root, to_walk_path) = if sub_path != Path::new("") && sub_path != Path::new("/") {
 		let full_path = ensure_sub_path_is_in_location(&location_path, &sub_path)
 			.await
 			.map_err(IndexerError::from)?;

--- a/core/src/location/mod.rs
+++ b/core/src/location/mod.rs
@@ -22,10 +22,7 @@ use std::{
 
 use futures::future::TryFutureExt;
 use normpath::PathExt;
-use prisma_client_rust::{
-	operator::{and, or},
-	or, QueryError,
-};
+use prisma_client_rust::{operator::and, or, QueryError};
 use serde::Deserialize;
 use serde_json::json;
 use specta::Type;

--- a/core/src/object/file_identifier/shallow.rs
+++ b/core/src/object/file_identifier/shallow.rs
@@ -35,7 +35,7 @@ pub async fn shallow(
 	let location_id = location.id;
 	let location_path = maybe_missing(&location.path, "location.path").map(Path::new)?;
 
-	let sub_iso_file_path = if sub_path != Path::new("") {
+	let sub_iso_file_path = if sub_path != Path::new("") && sub_path != Path::new("/") {
 		let full_path = ensure_sub_path_is_in_location(location_path, &sub_path)
 			.await
 			.map_err(FileIdentifierJobError::from)?;

--- a/core/src/object/preview/thumbnail/shallow.rs
+++ b/core/src/object/preview/thumbnail/shallow.rs
@@ -37,7 +37,7 @@ pub async fn shallow_thumbnailer(
 		None => return Ok(()),
 	};
 
-	let (path, iso_file_path) = if sub_path != Path::new("") {
+	let (path, iso_file_path) = if sub_path != Path::new("") && sub_path != Path::new("/") {
 		let full_path = ensure_sub_path_is_in_location(&location_path, &sub_path)
 			.await
 			.map_err(ThumbnailerError::from)?;

--- a/core/src/object/validation/mod.rs
+++ b/core/src/object/validation/mod.rs
@@ -1,2 +1,22 @@
+use crate::{location::file_path_helper::FilePathError, util::error::FileIOError};
+
+use std::path::Path;
+
+use thiserror::Error;
+
 pub mod hash;
 pub mod validator_job;
+
+#[derive(Error, Debug)]
+pub enum ValidatorError {
+	#[error("sub path not found: <path='{}'>", .0.display())]
+	SubPathNotFound(Box<Path>),
+
+	// Internal errors
+	#[error("database error: {0}")]
+	Database(#[from] prisma_client_rust::QueryError),
+	#[error(transparent)]
+	FilePath(#[from] FilePathError),
+	#[error(transparent)]
+	FileIO(#[from] FileIOError),
+}

--- a/core/src/object/validation/validator_job.rs
+++ b/core/src/object/validation/validator_job.rs
@@ -4,19 +4,28 @@ use crate::{
 		JobError, JobInitData, JobReportUpdate, JobResult, JobState, StatefulJob, WorkerContext,
 	},
 	library::Library,
-	location::file_path_helper::{file_path_for_object_validator, IsolatedFilePathData},
+	location::file_path_helper::{
+		ensure_file_path_exists, ensure_sub_path_is_directory, ensure_sub_path_is_in_location,
+		file_path_for_object_validator, IsolatedFilePathData,
+	},
 	prisma::{file_path, location},
 	sync,
-	util::{db::maybe_missing, error::FileIOError},
+	util::{
+		db::{chain_optional_iter, maybe_missing},
+		error::FileIOError,
+	},
 };
 
-use std::path::PathBuf;
+use std::{
+	hash::{Hash, Hasher},
+	path::{Path, PathBuf},
+};
 
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tracing::info;
 
-use super::hash::file_checksum;
+use super::{hash::file_checksum, ValidatorError};
 
 // The Validator is able to:
 // - generate a full byte checksum for Objects in a Location
@@ -26,16 +35,24 @@ pub struct ObjectValidatorJob {}
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ObjectValidatorJobState {
-	pub root_path: PathBuf,
+	pub location_path: PathBuf,
 	pub task_count: usize,
 }
 
 // The validator can
-#[derive(Serialize, Deserialize, Debug, Hash)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct ObjectValidatorJobInit {
-	pub location_id: location::id::Type,
-	pub path: PathBuf,
-	pub background: bool,
+	pub location: location::Data,
+	pub sub_path: Option<PathBuf>,
+}
+
+impl Hash for ObjectValidatorJobInit {
+	fn hash<H: Hasher>(&self, state: &mut H) {
+		self.location.id.hash(state);
+		if let Some(ref sub_path) = self.sub_path {
+			sub_path.hash(state);
+		}
+	}
 }
 
 impl JobInitData for ObjectValidatorJobInit {
@@ -61,20 +78,58 @@ impl StatefulJob for ObjectValidatorJob {
 	) -> Result<(), JobError> {
 		let Library { db, .. } = &ctx.library;
 
+		let location_id = state.init.location.id;
+
+		let location_path =
+			maybe_missing(&state.init.location.path, "location.path").map(PathBuf::from)?;
+
+		let maybe_sub_iso_file_path = match &state.init.sub_path {
+			Some(sub_path) if sub_path != Path::new("") && sub_path != Path::new("/") => {
+				let full_path = ensure_sub_path_is_in_location(&location_path, sub_path)
+					.await
+					.map_err(ValidatorError::from)?;
+				ensure_sub_path_is_directory(&location_path, sub_path)
+					.await
+					.map_err(ValidatorError::from)?;
+
+				let sub_iso_file_path =
+					IsolatedFilePathData::new(location_id, &location_path, &full_path, true)
+						.map_err(ValidatorError::from)?;
+
+				ensure_file_path_exists(
+					sub_path,
+					&sub_iso_file_path,
+					db,
+					ValidatorError::SubPathNotFound,
+				)
+				.await?;
+
+				Some(sub_iso_file_path)
+			}
+			_ => None,
+		};
+
 		state.steps.extend(
 			db.file_path()
-				.find_many(vec![
-					file_path::location_id::equals(Some(state.init.location_id)),
-					file_path::is_dir::equals(Some(false)),
-					file_path::integrity_checksum::equals(None),
-				])
+				.find_many(chain_optional_iter(
+					[
+						file_path::location_id::equals(Some(state.init.location.id)),
+						file_path::is_dir::equals(Some(false)),
+						file_path::integrity_checksum::equals(None),
+					],
+					[maybe_sub_iso_file_path.and_then(|iso_sub_path| {
+						iso_sub_path
+							.materialized_path_for_children()
+							.map(file_path::materialized_path::starts_with)
+					})],
+				))
 				.select(file_path_for_object_validator::select())
 				.exec()
 				.await?,
 		);
 
 		state.data = Some(ObjectValidatorJobState {
-			root_path: state.init.path.clone(),
+			location_path,
 			task_count: state.steps.len(),
 		});
 
@@ -98,13 +153,13 @@ impl StatefulJob for ObjectValidatorJob {
 		// we can also compare old and new checksums here
 		// This if is just to make sure, we already queried objects where integrity_checksum is null
 		if file_path.integrity_checksum.is_none() {
-			let path = data.root_path.join(IsolatedFilePathData::try_from((
-				maybe_missing(&file_path.location, "file_path.location")?.id,
+			let full_path = data.location_path.join(IsolatedFilePathData::try_from((
+				state.init.location.id,
 				file_path,
 			))?);
-			let checksum = file_checksum(&path)
+			let checksum = file_checksum(&full_path)
 				.await
-				.map_err(|e| FileIOError::from((path, e)))?;
+				.map_err(|e| ValidatorError::FileIO(FileIOError::from((full_path, e))))?;
 
 			sync.write_op(
 				db,
@@ -137,8 +192,14 @@ impl StatefulJob for ObjectValidatorJob {
 	) -> JobResult {
 		let data = extract_job_data!(state);
 		info!(
-			"finalizing validator job at {}: {} tasks",
-			data.root_path.display(),
+			"finalizing validator job at {}{}: {} tasks",
+			data.location_path.display(),
+			state
+				.init
+				.sub_path
+				.as_ref()
+				.map(|p| format!("{}", p.display()))
+				.unwrap_or_default(),
 			data.task_count
 		);
 

--- a/interface/app/$libraryId/Explorer/ContextMenu.tsx
+++ b/interface/app/$libraryId/Explorer/ContextMenu.tsx
@@ -130,11 +130,13 @@ export default (props: PropsWithChildren) => {
 				<CM.Item
 					onClick={() =>
 						store.locationId &&
-						generateThumbsForLocation.mutate({ id: store.locationId, path: params.path ?? '' })
+						generateThumbsForLocation.mutate({
+							id: store.locationId,
+							path: params.path ?? ''
+						})
 					}
 					label="Regen Thumbnails"
 					icon={Image}
-					disabled
 				/>
 				<CM.Item
 					onClick={() =>
@@ -143,7 +145,6 @@ export default (props: PropsWithChildren) => {
 					}
 					label="Generate Checksums"
 					icon={ShieldCheck}
-					disabled
 				/>
 			</CM.SubMenu>
 		</CM.Root>

--- a/interface/app/$libraryId/Explorer/ContextMenu.tsx
+++ b/interface/app/$libraryId/Explorer/ContextMenu.tsx
@@ -128,7 +128,7 @@ export default (props: PropsWithChildren) => {
 				<CM.Item
 					onClick={() =>
 						store.locationId &&
-						generateThumbsForLocation.mutate({ id: store.locationId, path: '' })
+						generateThumbsForLocation.mutate({ id: store.locationId, path: params.path ?? '' })
 					}
 					label="Regen Thumbnails"
 					icon={Image}
@@ -136,7 +136,7 @@ export default (props: PropsWithChildren) => {
 				<CM.Item
 					onClick={() =>
 						store.locationId &&
-						objectValidator.mutate({ id: store.locationId, path: '' })
+						objectValidator.mutate({ id: store.locationId, path: params.path ?? '' })
 					}
 					label="Generate Checksums"
 					icon={ShieldCheck}

--- a/interface/app/$libraryId/Explorer/File/ContextMenu.tsx
+++ b/interface/app/$libraryId/Explorer/File/ContextMenu.tsx
@@ -234,7 +234,7 @@ export default ({ data }: Props) => {
 					onClick={() => {
 						generateThumbnails.mutate({
 							id: getExplorerStore().locationId!,
-							path: '/'
+							path: params.path ?? ''
 						});
 					}}
 					label="Regen Thumbnails"


### PR DESCRIPTION
Using `sub_paths` was a bit error prone, as sometimes an empty string was being passed to the backend, because of this now we have a better handling for `''` and also for `'/'` as the later is the location root path. This part was fixed on every job that accepted a `sub_path`.

Aside from this, `ObjectValidatorJob` was kinda broken, so now it is fixed. 

Also found some bugs on rename backend having conflicts with the file watcher. And now it will attempt to rename every file in the case of multiple rename, instead of stopping in the first error
