### PR TITLE
[ENG-828, ENG-633] Fix corrupt videos force crashing the app

### DIFF
--- a/crates/ffmpeg/Cargo.toml
+++ b/crates/ffmpeg/Cargo.toml
@@ -12,9 +12,9 @@ edition = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ffmpeg-sys-next = "6.0.0"
+ffmpeg-sys-next = "6.0.1"
 
-thiserror = "1.0.37"
+thiserror = "1.0.40"
 webp = "0.2.2"
 tokio = { workspace = true, features = ["fs", "rt"] }
 

--- a/crates/ffmpeg/src/error.rs
+++ b/crates/ffmpeg/src/error.rs
@@ -38,6 +38,8 @@ pub enum ThumbnailerError {
 	BackgroundTaskFailed(#[from] JoinError),
 	#[error("The video is most likely corrupt and will be skipped")]
 	CorruptVideo,
+	#[error("The video file contains subtitles and will be skipped")]
+	Subtitles,
 }
 
 /// Enum to represent possible errors from FFmpeg library

--- a/crates/ffmpeg/src/error.rs
+++ b/crates/ffmpeg/src/error.rs
@@ -36,6 +36,8 @@ pub enum ThumbnailerError {
 	InvalidQuality(f32),
 	#[error("Background task failed: {0}")]
 	BackgroundTaskFailed(#[from] JoinError),
+	#[error("The video is most likely corrupt and will be skipped")]
+	CorruptVideo,
 }
 
 /// Enum to represent possible errors from FFmpeg library

--- a/crates/ffmpeg/src/movie_decoder.rs
+++ b/crates/ffmpeg/src/movie_decoder.rs
@@ -101,6 +101,12 @@ impl MovieDecoder {
 			}
 		}
 
+		unsafe {
+			if (*decoder.format_context).probe_score == 1 {
+				return Err(ThumbnailerError::CorruptVideo);
+			}
+		}
+
 		decoder.initialize_video(prefer_embedded_metadata)?;
 
 		decoder.frame = unsafe { av_frame_alloc() };

--- a/crates/ffmpeg/src/movie_decoder.rs
+++ b/crates/ffmpeg/src/movie_decoder.rs
@@ -102,7 +102,7 @@ impl MovieDecoder {
 		}
 
 		unsafe {
-			if (*decoder.format_context).probe_score == 1 {
+			if (*decoder.format_context).probe_score == 100 {
 				return Err(ThumbnailerError::CorruptVideo);
 			}
 		}

--- a/crates/ffmpeg/src/movie_decoder.rs
+++ b/crates/ffmpeg/src/movie_decoder.rs
@@ -105,6 +105,11 @@ impl MovieDecoder {
 			if (*decoder.format_context).probe_score == 100 {
 				return Err(ThumbnailerError::CorruptVideo);
 			}
+
+			// TODO(brxken128): idk if this is needed but i think so
+			if (*decoder.format_context).subtitle_codec_id == AVCodecID::AV_CODEC_ID_NONE {
+				return Err(ThumbnailerError::Subtitles);
+			}
 		}
 
 		decoder.initialize_video(prefer_embedded_metadata)?;


### PR DESCRIPTION
If the FFmpeg lib ran into a video that was corrupt, the app would force close without warning. This resolves that.

If a video has subtitles, a thumbnail will not be generated.