### PR TITLE
[ENG-828-FIX] Make trivial changes to the previous ENG-828 merge

### DIFF
--- a/crates/ffmpeg/src/error.rs
+++ b/crates/ffmpeg/src/error.rs
@@ -38,8 +38,6 @@ pub enum ThumbnailerError {
 	BackgroundTaskFailed(#[from] JoinError),
 	#[error("The video is most likely corrupt and will be skipped")]
 	CorruptVideo,
-	#[error("The video file contains subtitles and will be skipped")]
-	Subtitles,
 }
 
 /// Enum to represent possible errors from FFmpeg library

--- a/crates/ffmpeg/src/movie_decoder.rs
+++ b/crates/ffmpeg/src/movie_decoder.rs
@@ -14,8 +14,8 @@ use ffmpeg_sys_next::{
 	avfilter_graph_create_filter, avfilter_graph_free, avfilter_link, avformat_close_input,
 	avformat_find_stream_info, avformat_open_input, AVCodec, AVCodecContext, AVCodecID,
 	AVFilterContext, AVFilterGraph, AVFormatContext, AVFrame, AVMediaType, AVPacket,
-	AVPacketSideDataType, AVRational, AVStream, AVERROR, AVERROR_EOF, AV_DICT_IGNORE_SUFFIX,
-	AV_TIME_BASE, EAGAIN,
+	AVPacketSideDataType, AVRational, AVStream, AVERROR, AVERROR_EOF, AVPROBE_SCORE_MAX,
+	AV_DICT_IGNORE_SUFFIX, AV_TIME_BASE, EAGAIN,
 };
 use std::{
 	ffi::{c_int, CString},
@@ -102,13 +102,10 @@ impl MovieDecoder {
 		}
 
 		unsafe {
-			if (*decoder.format_context).probe_score == 100 {
+			// This needs to remain at 100 or the app will force crash if it comes
+			// across a video with subtitles or any type of corruption.
+			if (*decoder.format_context).probe_score == AVPROBE_SCORE_MAX {
 				return Err(ThumbnailerError::CorruptVideo);
-			}
-
-			// TODO(brxken128): idk if this is needed but i think so
-			if (*decoder.format_context).subtitle_codec_id == AVCodecID::AV_CODEC_ID_NONE {
-				return Err(ThumbnailerError::Subtitles);
 			}
 		}
 


### PR DESCRIPTION
This uses the constant provided by the FFmpeg library, to be more correct.

This does **not** change the probe value, as that is the sole reason the app crashes when FFmpeg runs into an error.

A probe value of 100 means that the video is perfect and has no corruption, and any value less will certainly make the app crash if it runs into a video with either: subtitles, or is corrupt in any way. I have tested this logic briefly, by using a probe score of `<= 80`, and the app force crashed.

The other part of the code did nothing, hence the `TODO`, so it's been removed.