### PR TITLE
[ENG-829] Render QuickPreview in Explorer/View

### DIFF
--- a/interface/app/$libraryId/Explorer/Context.tsx
+++ b/interface/app/$libraryId/Explorer/Context.tsx
@@ -2,34 +2,34 @@ import { createContext, useContext } from 'react';
 import { FilePath, Location, NodeState, Tag } from '@sd/client';
 
 export type ExplorerParent =
-    | {
-        type: 'Location';
-        location: Location;
-        subPath?: FilePath;
-    }
-    | {
-        type: 'Tag';
-        tag: Tag;
-    }
-    | {
-        type: 'Node';
-        node: NodeState;
-    };
+	| {
+			type: 'Location';
+			location: Location;
+			subPath?: FilePath;
+	  }
+	| {
+			type: 'Tag';
+			tag: Tag;
+	  }
+	| {
+			type: 'Node';
+			node: NodeState;
+	  };
 
 interface ExplorerContext {
-    parent?: ExplorerParent;
+	parent?: ExplorerParent;
 }
 
 /**
  * Context that must wrap anything to do with the explorer.
  * This includes explorer views, the inspector, and top bar items.
-*/
+ */
 export const ExplorerContext = createContext<ExplorerContext | null>(null);
 
 export const useExplorerContext = () => {
-    const ctx = useContext(ExplorerContext);
+	const ctx = useContext(ExplorerContext);
 
-    if (ctx === null) throw new Error('ExplorerContext.Provider not found!');
+	if (ctx === null) throw new Error('ExplorerContext.Provider not found!');
 
-    return ctx;
+	return ctx;
 };

--- a/interface/app/$libraryId/Explorer/ContextMenu/FilePath/Items.tsx
+++ b/interface/app/$libraryId/Explorer/ContextMenu/FilePath/Items.tsx
@@ -11,50 +11,50 @@ import OpenWith from './OpenWith';
 export * from './CutCopyItems';
 
 interface FilePathProps {
-    filePath: FilePath;
+	filePath: FilePath;
 }
 
 export const Delete = ({ filePath }: FilePathProps) => {
-    const keybind = useKeybindFactory();
+	const keybind = useKeybindFactory();
 
-    const locationId = filePath.location_id;
+	const locationId = filePath.location_id;
 
-    return (
-        <>
-            {locationId != null && (
-                <ContextMenu.Item
-                    icon={Trash}
-                    label="Delete"
-                    variant="danger"
-                    keybind={keybind([ModifierKeys.Control], ['Delete'])}
-                    onClick={() =>
-                        dialogManager.create((dp) => (
-                            <DeleteDialog {...dp} location_id={locationId} path_id={filePath.id} />
-                        ))
-                    }
-                />
-            )}
-        </>
-    );
+	return (
+		<>
+			{locationId != null && (
+				<ContextMenu.Item
+					icon={Trash}
+					label="Delete"
+					variant="danger"
+					keybind={keybind([ModifierKeys.Control], ['Delete'])}
+					onClick={() =>
+						dialogManager.create((dp) => (
+							<DeleteDialog {...dp} location_id={locationId} path_id={filePath.id} />
+						))
+					}
+				/>
+			)}
+		</>
+	);
 };
 
 export const Compress = (_: FilePathProps) => {
-    const keybind = useKeybindFactory();
+	const keybind = useKeybindFactory();
 
-    return (
-        <ContextMenu.Item
-            label="Compress"
-            icon={Package}
-            keybind={keybind([ModifierKeys.Control], ['B'])}
-            disabled
-        />
-    );
+	return (
+		<ContextMenu.Item
+			label="Compress"
+			icon={Package}
+			keybind={keybind([ModifierKeys.Control], ['B'])}
+			disabled
+		/>
+	);
 };
 
 export const Crypto = (_: FilePathProps) => {
-    return (
-        <>
-            {/* <ContextMenu.Item
+	return (
+		<>
+			{/* <ContextMenu.Item
 					label="Encrypt"
 					icon={LockSimple}
 					keybind="⌘E"
@@ -80,8 +80,8 @@ export const Crypto = (_: FilePathProps) => {
 						}
 					}}
 				/> */}
-            {/* should only be shown if the file is a valid spacedrive-encrypted file (preferably going from the magic bytes) */}
-            {/* <ContextMenu.Item
+			{/* should only be shown if the file is a valid spacedrive-encrypted file (preferably going from the magic bytes) */}
+			{/* <ContextMenu.Item
 					label="Decrypt"
 					icon={LockSimpleOpen}
 					keybind="⌘D"
@@ -102,109 +102,109 @@ export const Crypto = (_: FilePathProps) => {
 						}
 					}}
 				/> */}
-        </>
-    );
+		</>
+	);
 };
 
 export const SecureDelete = ({ filePath }: FilePathProps) => {
-    const locationId = filePath.location_id;
+	const locationId = filePath.location_id;
 
-    return (
-        <>
-            {locationId && (
-                <ContextMenu.Item
-                    variant="danger"
-                    label="Secure delete"
-                    icon={TrashSimple}
-                    onClick={() =>
-                        dialogManager.create((dp) => (
-                            <EraseDialog {...dp} location_id={locationId} path_id={filePath.id} />
-                        ))
-                    }
-                    disabled
-                />
-            )}
-        </>
-    );
+	return (
+		<>
+			{locationId && (
+				<ContextMenu.Item
+					variant="danger"
+					label="Secure delete"
+					icon={TrashSimple}
+					onClick={() =>
+						dialogManager.create((dp) => (
+							<EraseDialog {...dp} location_id={locationId} path_id={filePath.id} />
+						))
+					}
+					disabled
+				/>
+			)}
+		</>
+	);
 };
 
 export const ParentFolderActions = ({
-    filePath,
-    locationId
+	filePath,
+	locationId
 }: FilePathProps & { locationId: number }) => {
-    const fullRescan = useLibraryMutation('locations.fullRescan');
-    const generateThumbnails = useLibraryMutation('jobs.generateThumbsForLocation');
+	const fullRescan = useLibraryMutation('locations.fullRescan');
+	const generateThumbnails = useLibraryMutation('jobs.generateThumbsForLocation');
 
-    return (
-        <>
-            <ContextMenu.Item
-                onClick={async () => {
-                    try {
-                        await fullRescan.mutateAsync(locationId);
-                    } catch (error) {
-                        showAlertDialog({
-                            title: 'Error',
-                            value: `Failed to rescan location, due to an error: ${error}`
-                        });
-                    }
-                }}
-                label="Rescan Directory"
-                icon={Package}
-            />
-            <ContextMenu.Item
-                onClick={async () => {
-                    try {
-                        await generateThumbnails.mutateAsync({
-                            id: locationId,
-                            path: filePath.materialized_path ?? '/'
-                        });
-                    } catch (error) {
-                        showAlertDialog({
-                            title: 'Error',
-                            value: `Failed to generate thumbnails, due to an error: ${error}`
-                        });
-                    }
-                }}
-                label="Regen Thumbnails"
-                icon={Image}
-            />
-        </>
-    );
+	return (
+		<>
+			<ContextMenu.Item
+				onClick={async () => {
+					try {
+						await fullRescan.mutateAsync(locationId);
+					} catch (error) {
+						showAlertDialog({
+							title: 'Error',
+							value: `Failed to rescan location, due to an error: ${error}`
+						});
+					}
+				}}
+				label="Rescan Directory"
+				icon={Package}
+			/>
+			<ContextMenu.Item
+				onClick={async () => {
+					try {
+						await generateThumbnails.mutateAsync({
+							id: locationId,
+							path: filePath.materialized_path ?? '/'
+						});
+					} catch (error) {
+						showAlertDialog({
+							title: 'Error',
+							value: `Failed to generate thumbnails, due to an error: ${error}`
+						});
+					}
+				}}
+				label="Regen Thumbnails"
+				icon={Image}
+			/>
+		</>
+	);
 };
 
 export const OpenOrDownload = ({ filePath }: { filePath: FilePath }) => {
-    const keybind = useKeybindFactory();
-    const { platform, openFilePaths: openFilePath } = usePlatform();
-    const updateAccessTime = useLibraryMutation('files.updateAccessTime');
+	const keybind = useKeybindFactory();
+	const { platform, openFilePaths: openFilePath } = usePlatform();
+	const updateAccessTime = useLibraryMutation('files.updateAccessTime');
 
-    const { library } = useLibraryContext();
+	const { library } = useLibraryContext();
 
-    if (platform === 'web') return <ContextMenu.Item label="Download" />;
-    else
-        return (
-            <>
-                {openFilePath && (
-                    <ContextMenu.Item
-                        label="Open"
-                        keybind={keybind([ModifierKeys.Control], ['O'])}
-                        onClick={async () => {
-                            if (filePath.object_id)
-                                updateAccessTime
-                                    .mutateAsync(filePath.object_id)
-                                    .catch(console.error);
+	if (platform === 'web') return <ContextMenu.Item label="Download" />;
+	else
+		return (
+			<>
+				{openFilePath && (
+					<ContextMenu.Item
+						label="Open"
+						keybind={keybind([ModifierKeys.Control], ['O'])}
+						onClick={async () => {
+							if (filePath.object_id)
+								updateAccessTime
+									.mutateAsync(filePath.object_id)
+									.catch(console.error);
 
-                            try {
-                                await openFilePath(library.uuid, [filePath.id]);
-                            } catch (error) {
-                                showAlertDialog({
-                                    title: 'Error',
-                                    value: `Failed to open file, due to an error: ${error}`
-                                });
-                            }
-                        }}
-                    />
-                )}
-                <OpenWith filePath={filePath} />
-            </>
-        );
+							try {
+								await openFilePath(library.uuid, [filePath.id]);
+							} catch (error) {
+								showAlertDialog({
+									title: 'Error',
+									value: `Failed to open file, due to an error: ${error}`
+								});
+							}
+						}}
+					/>
+				)}
+				<OpenWith filePath={filePath} />
+			</>
+		);
 };

--- a/interface/app/$libraryId/Explorer/ContextMenu/FilePath/index.tsx
+++ b/interface/app/$libraryId/Explorer/ContextMenu/FilePath/index.tsx
@@ -5,73 +5,71 @@ import { useExplorerContext } from '../../Context';
 import { FilePathItems, ObjectItems, SharedItems } from '../../ContextMenu';
 
 interface Props {
-    data: Extract<ExplorerItem, { type: 'Path' }>;
+	data: Extract<ExplorerItem, { type: 'Path' }>;
 }
 
 export default ({ data }: Props) => {
-    const filePath = data.item;
-    const { object } = filePath;
+	const filePath = data.item;
+	const { object } = filePath;
 
-    const { parent } = useExplorerContext();
+	const { parent } = useExplorerContext();
 
-    // const keyManagerUnlocked = useLibraryQuery(['keys.isUnlocked']).data ?? false;
-    // const mountedKeys = useLibraryQuery(['keys.listMounted']);
-    // const hasMountedKeys = mountedKeys.data?.length ?? 0 > 0;
+	// const keyManagerUnlocked = useLibraryQuery(['keys.isUnlocked']).data ?? false;
+	// const mountedKeys = useLibraryQuery(['keys.listMounted']);
+	// const hasMountedKeys = mountedKeys.data?.length ?? 0 > 0;
 
-    return (
-        <>
-            <FilePathItems.OpenOrDownload filePath={filePath} />
+	return (
+		<>
+			<FilePathItems.OpenOrDownload filePath={filePath} />
 
-            <SharedItems.OpenQuickView item={data} />
+			<SharedItems.OpenQuickView item={data} />
 
-            <ContextMenu.Separator />
+			<ContextMenu.Separator />
 
-            <SharedItems.Details />
+			<SharedItems.Details />
 
-            <ContextMenu.Separator />
+			<ContextMenu.Separator />
 
-            <SharedItems.RevealInNativeExplorer
-                filePath={filePath}
-            />
+			<SharedItems.RevealInNativeExplorer filePath={filePath} />
 
-            <SharedItems.Rename />
+			<SharedItems.Rename />
 
-            {object && <ObjectItems.RemoveFromRecents object={object} />}
+			{object && <ObjectItems.RemoveFromRecents object={object} />}
 
-            {parent?.type === 'Location' && (
-                <FilePathItems.CutCopyItems locationId={parent.location.id} filePath={filePath} />
-            )}
+			{parent?.type === 'Location' && (
+				<FilePathItems.CutCopyItems locationId={parent.location.id} filePath={filePath} />
+			)}
 
-            <SharedItems.Deselect />
+			<SharedItems.Deselect />
 
-            <ContextMenu.Separator />
+			<ContextMenu.Separator />
 
-            <SharedItems.Share />
+			<SharedItems.Share />
 
-            <ContextMenu.Separator />
+			<ContextMenu.Separator />
 
-            {object && <ObjectItems.AssignTag object={object} />}
+			{object && <ObjectItems.AssignTag object={object} />}
 
-            <ContextMenu.SubMenu label="More actions..." icon={Plus}>
-                <FilePathItems.Crypto filePath={filePath} />
+			<ContextMenu.SubMenu label="More actions..." icon={Plus}>
+				<FilePathItems.Crypto filePath={filePath} />
 
-                <FilePathItems.Compress filePath={filePath} />
+				<FilePathItems.Compress filePath={filePath} />
 
-                {object && <ObjectItems.ConvertObject filePath={filePath} object={object} />}
+				{object && <ObjectItems.ConvertObject filePath={filePath} object={object} />}
 
-                {parent?.type === 'Location' && (
-                    <FilePathItems.ParentFolderActions
-                        filePath={filePath}
-                        locationId={parent.location.id}
-                    />
-                )}
+				{parent?.type === 'Location' && (
+					<FilePathItems.ParentFolderActions
+						filePath={filePath}
+						locationId={parent.location.id}
+					/>
+				)}
 
-                <FilePathItems.SecureDelete filePath={filePath} />
-            </ContextMenu.SubMenu>
+				<FilePathItems.SecureDelete filePath={filePath} />
+			</ContextMenu.SubMenu>
 
-            <ContextMenu.Separator />
+			<ContextMenu.Separator />
 
-            <FilePathItems.Delete filePath={filePath} />
-        </>
-    );
+			<FilePathItems.Delete filePath={filePath} />
+		</>
+	);
 };

--- a/interface/app/$libraryId/Explorer/ContextMenu/Location/index.tsx
+++ b/interface/app/$libraryId/Explorer/ContextMenu/Location/index.tsx
@@ -1,29 +1,29 @@
-import { ExplorerItem } from "@sd/client";
+import { ExplorerItem } from '@sd/client';
 import { ContextMenu } from '@sd/ui';
-import { SharedItems } from "..";
+import { SharedItems } from '..';
 
 interface Props {
-    data: Extract<ExplorerItem, { type: 'Location' }>;
+	data: Extract<ExplorerItem, { type: 'Location' }>;
 }
 
 export default ({ data }: Props) => {
-    const location = data.item;
+	const location = data.item;
 
-    return <>
-        <SharedItems.OpenQuickView item={data} />
+	return (
+		<>
+			<SharedItems.OpenQuickView item={data} />
 
-        <ContextMenu.Separator />
+			<ContextMenu.Separator />
 
-        <SharedItems.Details />
+			<SharedItems.Details />
 
-        <ContextMenu.Separator />
+			<ContextMenu.Separator />
 
-        <SharedItems.RevealInNativeExplorer
-            locationId={location.id}
-        />
+			<SharedItems.RevealInNativeExplorer locationId={location.id} />
 
-        <ContextMenu.Separator />
+			<ContextMenu.Separator />
 
-        <SharedItems.Share />
-    </>
-}
+			<SharedItems.Share />
+		</>
+	);
+};

--- a/interface/app/$libraryId/Explorer/ContextMenu/Object/index.tsx
+++ b/interface/app/$libraryId/Explorer/ContextMenu/Object/index.tsx
@@ -4,55 +4,51 @@ import { ContextMenu } from '@sd/ui';
 import { FilePathItems, ObjectItems, SharedItems } from '..';
 
 interface Props {
-    data: Extract<ExplorerItem, { type: 'Object' }>;
+	data: Extract<ExplorerItem, { type: 'Object' }>;
 }
 
 export default ({ data }: Props) => {
-    const object = data.item;
-    const filePath = data.item.file_paths[0];
+	const object = data.item;
+	const filePath = data.item.file_paths[0];
 
-    return (
-        <>
-            {filePath && <FilePathItems.OpenOrDownload filePath={filePath} />}
+	return (
+		<>
+			{filePath && <FilePathItems.OpenOrDownload filePath={filePath} />}
 
-            <SharedItems.OpenQuickView item={data} />
+			<SharedItems.OpenQuickView item={data} />
 
-            <ContextMenu.Separator />
+			<ContextMenu.Separator />
 
-            <SharedItems.Details />
+			<SharedItems.Details />
 
-            <ContextMenu.Separator />
+			<ContextMenu.Separator />
 
-            {filePath && (
-                <SharedItems.RevealInNativeExplorer
-                    filePath={filePath}
-                />
-            )}
+			{filePath && <SharedItems.RevealInNativeExplorer filePath={filePath} />}
 
-            <SharedItems.Rename />
+			<SharedItems.Rename />
 
-            <ContextMenu.Separator />
+			<ContextMenu.Separator />
 
-            <SharedItems.Share />
+			<SharedItems.Share />
 
-            {(object || filePath) && <ContextMenu.Separator />}
+			{(object || filePath) && <ContextMenu.Separator />}
 
-            {object && <ObjectItems.AssignTag object={object} />}
+			{object && <ObjectItems.AssignTag object={object} />}
 
-            {filePath && (
-                <ContextMenu.SubMenu label="More actions..." icon={Plus}>
-                    <FilePathItems.Crypto filePath={filePath} />
-                    <FilePathItems.Compress filePath={filePath} />
-                    <ObjectItems.ConvertObject filePath={filePath} object={object} />
-                </ContextMenu.SubMenu>
-            )}
+			{filePath && (
+				<ContextMenu.SubMenu label="More actions..." icon={Plus}>
+					<FilePathItems.Crypto filePath={filePath} />
+					<FilePathItems.Compress filePath={filePath} />
+					<ObjectItems.ConvertObject filePath={filePath} object={object} />
+				</ContextMenu.SubMenu>
+			)}
 
-            {filePath && (
-                <>
-                    <ContextMenu.Separator />
-                    <FilePathItems.Delete filePath={filePath} />
-                </>
-            )}
-        </>
-    );
+			{filePath && (
+				<>
+					<ContextMenu.Separator />
+					<FilePathItems.Delete filePath={filePath} />
+				</>
+			)}
+		</>
+	);
 };

--- a/interface/app/$libraryId/Explorer/ContextMenu/SharedItems.tsx
+++ b/interface/app/$libraryId/Explorer/ContextMenu/SharedItems.tsx
@@ -9,122 +9,131 @@ import { useExplorerViewContext } from '../ViewContext';
 import { getExplorerStore, useExplorerStore } from '../store';
 
 export const OpenQuickView = ({ item }: { item: ExplorerItem }) => {
-    const keybind = useKeybindFactory();
+	const keybind = useKeybindFactory();
 
-    return (
-        <ContextMenu.Item
-            label="Quick view"
-            keybind={keybind([], [' '])}
-            onClick={() => (getExplorerStore().quickViewObject = item)}
-        />
-    );
+	return (
+		<ContextMenu.Item
+			label="Quick view"
+			keybind={keybind([], [' '])}
+			onClick={() => (getExplorerStore().quickViewObject = item)}
+		/>
+	);
 };
 
 export const Details = () => {
-    const { showInspector } = useExplorerStore();
-    const keybind = useKeybindFactory();
+	const { showInspector } = useExplorerStore();
+	const keybind = useKeybindFactory();
 
-    return (
-        <>
-            {!showInspector && (
-                <ContextMenu.Item
-                    label="Details"
-                    keybind={keybind([ModifierKeys.Control], ['I'])}
-                    // icon={Sidebar}
-                    onClick={() => (getExplorerStore().showInspector = true)}
-                />
-            )}
-        </>
-    );
+	return (
+		<>
+			{!showInspector && (
+				<ContextMenu.Item
+					label="Details"
+					keybind={keybind([ModifierKeys.Control], ['I'])}
+					// icon={Sidebar}
+					onClick={() => (getExplorerStore().showInspector = true)}
+				/>
+			)}
+		</>
+	);
 };
 
 export const Rename = () => {
-    const explorerStore = useExplorerStore();
-    const keybind = useKeybindFactory();
-    const explorerView = useExplorerViewContext();
+	const explorerStore = useExplorerStore();
+	const keybind = useKeybindFactory();
+	const explorerView = useExplorerViewContext();
 
-    return (
-        <>
-            {explorerStore.layoutMode !== 'media' && (
-                <ContextMenu.Item
-                    label="Rename"
-                    keybind={keybind([], ['Enter'])}
-                    onClick={() => explorerView.setIsRenaming(true)}
-                />
-            )}
-        </>
-    );
+	return (
+		<>
+			{explorerStore.layoutMode !== 'media' && (
+				<ContextMenu.Item
+					label="Rename"
+					keybind={keybind([], ['Enter'])}
+					onClick={() => explorerView.setIsRenaming(true)}
+				/>
+			)}
+		</>
+	);
 };
 
 export const RevealInNativeExplorer = (props: { locationId: number } | { filePath: FilePath }) => {
-    const os = useOperatingSystem();
-    const keybind = useKeybindFactory();
-    const { revealItems } = usePlatform();
-    const { library } = useLibraryContext();
+	const os = useOperatingSystem();
+	const keybind = useKeybindFactory();
+	const { revealItems } = usePlatform();
+	const { library } = useLibraryContext();
 
-    const osFileBrowserName = useMemo(() => {
-        const lookup: Record<string, string> = {
-            macOS: 'Finder',
-            windows: 'Explorer'
-        };
+	const osFileBrowserName = useMemo(() => {
+		const lookup: Record<string, string> = {
+			macOS: 'Finder',
+			windows: 'Explorer'
+		};
 
-        return lookup[os] ?? 'file manager';
-    }, [os]);
+		return lookup[os] ?? 'file manager';
+	}, [os]);
 
-    return (
-        <>
-            {revealItems && <ContextMenu.Item
-                label={`Reveal in ${osFileBrowserName}`}
-                keybind={keybind([ModifierKeys.Control], ['Y'])}
-                onClick={() => (console.log(props), revealItems(library.uuid, ['filePath' in props ? {
-                    FilePath: {
-                        id: props.filePath.id,
-                    }
-                } : {
-                    Location: {
-                        id: props.locationId
-                    }
-                }]))}
-            />}
-        </>
-    );
+	return (
+		<>
+			{revealItems && (
+				<ContextMenu.Item
+					label={`Reveal in ${osFileBrowserName}`}
+					keybind={keybind([ModifierKeys.Control], ['Y'])}
+					onClick={() => (
+						console.log(props),
+						revealItems(library.uuid, [
+							'filePath' in props
+								? {
+										FilePath: {
+											id: props.filePath.id
+										}
+								  }
+								: {
+										Location: {
+											id: props.locationId
+										}
+								  }
+						])
+					)}
+				/>
+			)}
+		</>
+	);
 };
 
 export const Deselect = () => {
-    const { cutCopyState } = useExplorerStore();
+	const { cutCopyState } = useExplorerStore();
 
-    return (
-        <ContextMenu.Item
-            label="Deselect"
-            hidden={!cutCopyState.active}
-            onClick={() => {
-                getExplorerStore().cutCopyState = {
-                    ...cutCopyState,
-                    active: false
-                };
-            }}
-            icon={FileX}
-        />
-    );
+	return (
+		<ContextMenu.Item
+			label="Deselect"
+			hidden={!cutCopyState.active}
+			onClick={() => {
+				getExplorerStore().cutCopyState = {
+					...cutCopyState,
+					active: false
+				};
+			}}
+			icon={FileX}
+		/>
+	);
 };
 
 export const Share = () => {
-    return (
-        <>
-            <ContextMenu.Item
-                label="Share"
-                icon={ShareIcon}
-                onClick={(e) => {
-                    e.preventDefault();
+	return (
+		<>
+			<ContextMenu.Item
+				label="Share"
+				icon={ShareIcon}
+				onClick={(e) => {
+					e.preventDefault();
 
-                    navigator.share?.({
-                        title: 'Spacedrive',
-                        text: 'Check out this cool app',
-                        url: 'https://spacedrive.com'
-                    });
-                }}
-                disabled
-            />
-        </>
-    );
+					navigator.share?.({
+						title: 'Spacedrive',
+						text: 'Check out this cool app',
+						url: 'https://spacedrive.com'
+					});
+				}}
+				disabled
+			/>
+		</>
+	);
 };

--- a/interface/app/$libraryId/Explorer/ContextMenu/index.tsx
+++ b/interface/app/$libraryId/Explorer/ContextMenu/index.tsx
@@ -1,19 +1,19 @@
+import { ExplorerItem } from '@sd/client';
+import FilePathCM from './FilePath';
+import LocationCM from './Location';
+import ObjectCM from './Object';
+
 export * as SharedItems from './SharedItems';
 export * as FilePathItems from './FilePath/Items';
 export * as ObjectItems from './Object/Items';
 
-import { ExplorerItem } from '@sd/client';
-import FilePathCM from "./FilePath"
-import ObjectCM from "./Object"
-import LocationCM from "./Location"
-
 export default ({ item }: { item: ExplorerItem }) => {
-    switch (item.type) {
-        case "Path":
-            return <FilePathCM data={item} />
-        case "Object":
-            return <ObjectCM data={item} />
-        case "Location":
-            return <LocationCM data={item} />
-    }
-}
+	switch (item.type) {
+		case 'Path':
+			return <FilePathCM data={item} />;
+		case 'Object':
+			return <ObjectCM data={item} />;
+		case 'Location':
+			return <LocationCM data={item} />;
+	}
+};

--- a/interface/app/$libraryId/Explorer/ParentContextMenu.tsx
+++ b/interface/app/$libraryId/Explorer/ParentContextMenu.tsx
@@ -11,155 +11,155 @@ import { getExplorerStore, useExplorerStore } from './store';
 import { useExplorerSearchParams } from './util';
 
 export default (props: PropsWithChildren) => {
-    const os = useOperatingSystem();
-    const keybind = keybindForOs(os);
-    const [{ path: currentPath }] = useExplorerSearchParams();
-    const { cutCopyState } = useExplorerStore();
+	const os = useOperatingSystem();
+	const keybind = keybindForOs(os);
+	const [{ path: currentPath }] = useExplorerSearchParams();
+	const { cutCopyState } = useExplorerStore();
 
-    const { parent } = useExplorerContext();
+	const { parent } = useExplorerContext();
 
-    const generateThumbsForLocation = useLibraryMutation('jobs.generateThumbsForLocation');
-    const objectValidator = useLibraryMutation('jobs.objectValidator');
-    const rescanLocation = useLibraryMutation('locations.fullRescan');
-    const copyFiles = useLibraryMutation('files.copyFiles');
-    const cutFiles = useLibraryMutation('files.cutFiles');
+	const generateThumbsForLocation = useLibraryMutation('jobs.generateThumbsForLocation');
+	const objectValidator = useLibraryMutation('jobs.objectValidator');
+	const rescanLocation = useLibraryMutation('locations.fullRescan');
+	const copyFiles = useLibraryMutation('files.copyFiles');
+	const cutFiles = useLibraryMutation('files.cutFiles');
 
-    return (
-        <CM.Root trigger={props.children}>
-            {parent?.type === 'Location' && (
-                <SharedItems.RevealInNativeExplorer locationId={parent.location.id} />
-            )}
+	return (
+		<CM.Root trigger={props.children}>
+			{parent?.type === 'Location' && (
+				<SharedItems.RevealInNativeExplorer locationId={parent.location.id} />
+			)}
 
-            <CM.Item
-                label="Share"
-                icon={Share}
-                onClick={(e) => {
-                    e.preventDefault();
+			<CM.Item
+				label="Share"
+				icon={Share}
+				onClick={(e) => {
+					e.preventDefault();
 
-                    navigator.share?.({
-                        title: 'Spacedrive',
-                        text: 'Check out this cool app',
-                        url: 'https://spacedrive.com'
-                    });
-                }}
-                disabled
-            />
+					navigator.share?.({
+						title: 'Spacedrive',
+						text: 'Check out this cool app',
+						url: 'https://spacedrive.com'
+					});
+				}}
+				disabled
+			/>
 
-            <CM.Separator />
+			<CM.Separator />
 
-            {parent?.type === 'Location' && (
-                <>
-                    <CM.Item
-                        onClick={async () => {
-                            try {
-                                await rescanLocation.mutateAsync(parent.location.id);
-                            } catch (error) {
-                                showAlertDialog({
-                                    title: 'Error',
-                                    value: `Failed to re-index location, due to an error: ${error}`
-                                });
-                            }
-                        }}
-                        label="Re-index"
-                        icon={Repeat}
-                    />
+			{parent?.type === 'Location' && (
+				<>
+					<CM.Item
+						onClick={async () => {
+							try {
+								await rescanLocation.mutateAsync(parent.location.id);
+							} catch (error) {
+								showAlertDialog({
+									title: 'Error',
+									value: `Failed to re-index location, due to an error: ${error}`
+								});
+							}
+						}}
+						label="Re-index"
+						icon={Repeat}
+					/>
 
-                    <CM.Item
-                        label="Paste"
-                        keybind={keybind([ModifierKeys.Control], ['V'])}
-                        hidden={!cutCopyState.active}
-                        onClick={async () => {
-                            const path = currentPath ?? '/';
-                            const { actionType, sourcePathId, sourceParentPath, sourceLocationId } =
-                                cutCopyState;
-                            const sameLocation =
-                                sourceLocationId === parent.location.id &&
-                                sourceParentPath === path;
-                            try {
-                                if (actionType == 'Copy') {
-                                    await copyFiles.mutateAsync({
-                                        source_location_id: sourceLocationId,
-                                        sources_file_path_ids: [sourcePathId],
-                                        target_location_id: parent.location.id,
-                                        target_location_relative_directory_path: path,
-                                        target_file_name_suffix: sameLocation ? ' copy' : null
-                                    });
-                                } else if (sameLocation) {
-                                    showAlertDialog({
-                                        title: 'Error',
-                                        value: `File already exists in this location`
-                                    });
-                                } else {
-                                    await cutFiles.mutateAsync({
-                                        source_location_id: sourceLocationId,
-                                        sources_file_path_ids: [sourcePathId],
-                                        target_location_id: parent.location.id,
-                                        target_location_relative_directory_path: path
-                                    });
-                                }
-                            } catch (error) {
-                                showAlertDialog({
-                                    title: 'Error',
-                                    value: `Failed to ${actionType.toLowerCase()} file, due to an error: ${error}`
-                                });
-                            }
-                        }}
-                        icon={Clipboard}
-                    />
-                </>
-            )}
+					<CM.Item
+						label="Paste"
+						keybind={keybind([ModifierKeys.Control], ['V'])}
+						hidden={!cutCopyState.active}
+						onClick={async () => {
+							const path = currentPath ?? '/';
+							const { actionType, sourcePathId, sourceParentPath, sourceLocationId } =
+								cutCopyState;
+							const sameLocation =
+								sourceLocationId === parent.location.id &&
+								sourceParentPath === path;
+							try {
+								if (actionType == 'Copy') {
+									await copyFiles.mutateAsync({
+										source_location_id: sourceLocationId,
+										sources_file_path_ids: [sourcePathId],
+										target_location_id: parent.location.id,
+										target_location_relative_directory_path: path,
+										target_file_name_suffix: sameLocation ? ' copy' : null
+									});
+								} else if (sameLocation) {
+									showAlertDialog({
+										title: 'Error',
+										value: `File already exists in this location`
+									});
+								} else {
+									await cutFiles.mutateAsync({
+										source_location_id: sourceLocationId,
+										sources_file_path_ids: [sourcePathId],
+										target_location_id: parent.location.id,
+										target_location_relative_directory_path: path
+									});
+								}
+							} catch (error) {
+								showAlertDialog({
+									title: 'Error',
+									value: `Failed to ${actionType.toLowerCase()} file, due to an error: ${error}`
+								});
+							}
+						}}
+						icon={Clipboard}
+					/>
+				</>
+			)}
 
-            <CM.Item
-                label="Deselect"
-                hidden={!cutCopyState.active}
-                onClick={() => {
-                    getExplorerStore().cutCopyState = {
-                        ...cutCopyState,
-                        active: false
-                    };
-                }}
-                icon={FileX}
-            />
+			<CM.Item
+				label="Deselect"
+				hidden={!cutCopyState.active}
+				onClick={() => {
+					getExplorerStore().cutCopyState = {
+						...cutCopyState,
+						active: false
+					};
+				}}
+				icon={FileX}
+			/>
 
-            {parent?.type === 'Location' && (
-                <CM.SubMenu label="More actions..." icon={Plus}>
-                    <CM.Item
-                        onClick={async () => {
-                            try {
-                                await generateThumbsForLocation.mutateAsync({
-                                    id: parent.location.id,
-                                    path: currentPath ?? '/'
-                                });
-                            } catch (error) {
-                                showAlertDialog({
-                                    title: 'Error',
-                                    value: `Failed to generate thumbanails, due to an error: ${error}`
-                                });
-                            }
-                        }}
-                        label="Regen Thumbnails"
-                        icon={Image}
-                    />
+			{parent?.type === 'Location' && (
+				<CM.SubMenu label="More actions..." icon={Plus}>
+					<CM.Item
+						onClick={async () => {
+							try {
+								await generateThumbsForLocation.mutateAsync({
+									id: parent.location.id,
+									path: currentPath ?? '/'
+								});
+							} catch (error) {
+								showAlertDialog({
+									title: 'Error',
+									value: `Failed to generate thumbanails, due to an error: ${error}`
+								});
+							}
+						}}
+						label="Regen Thumbnails"
+						icon={Image}
+					/>
 
-                    <CM.Item
-                        onClick={async () => {
-                            try {
-                                objectValidator.mutateAsync({
-                                    id: parent.location.id,
-                                    path: currentPath ?? '/'
-                                });
-                            } catch (error) {
-                                showAlertDialog({
-                                    title: 'Error',
-                                    value: `Failed to generate checksum, due to an error: ${error}`
-                                });
-                            }
-                        }}
-                        label="Generate Checksums"
-                        icon={ShieldCheck}
-                    />
-                </CM.SubMenu>
-            )}
-        </CM.Root>
-    );
+					<CM.Item
+						onClick={async () => {
+							try {
+								objectValidator.mutateAsync({
+									id: parent.location.id,
+									path: currentPath ?? '/'
+								});
+							} catch (error) {
+								showAlertDialog({
+									title: 'Error',
+									value: `Failed to generate checksum, due to an error: ${error}`
+								});
+							}
+						}}
+						label="Generate Checksums"
+						icon={ShieldCheck}
+					/>
+				</CM.SubMenu>
+			)}
+		</CM.Root>
+	);
 };

--- a/interface/app/$libraryId/Explorer/QuickPreview/Context.tsx
+++ b/interface/app/$libraryId/Explorer/QuickPreview/Context.tsx
@@ -1,26 +1,26 @@
 import { PropsWithChildren, RefObject, createContext, useContext, useRef } from 'react';
 
 interface QuickPreviewContext {
-    ref: RefObject<HTMLDivElement>;
+	ref: RefObject<HTMLDivElement>;
 }
 
 const QuickPreviewContext = createContext<QuickPreviewContext | null>(null);
 
 export const QuickPreviewContextProvider = ({ children }: PropsWithChildren) => {
-    const ref = useRef<HTMLDivElement>(null);
+	const ref = useRef<HTMLDivElement>(null);
 
-    return (
-        <QuickPreviewContext.Provider value={{ ref }}>
-            {children}
-            <div ref={ref} />
-        </QuickPreviewContext.Provider>
-    );
+	return (
+		<QuickPreviewContext.Provider value={{ ref }}>
+			{children}
+			<div ref={ref} />
+		</QuickPreviewContext.Provider>
+	);
 };
 
 export const useQuickPreviewContext = () => {
-    const context = useContext(QuickPreviewContext);
+	const context = useContext(QuickPreviewContext);
 
-    if (!context) throw new Error('QuickPreviewContext.Provider not found!');
+	if (!context) throw new Error('QuickPreviewContext.Provider not found!');
 
-    return context;
+	return context;
 };

--- a/interface/app/$libraryId/Explorer/View/index.tsx
+++ b/interface/app/$libraryId/Explorer/View/index.tsx
@@ -1,37 +1,40 @@
 import clsx from 'clsx';
 import { Columns, GridFour, Icon, MonitorPlay, Rows } from 'phosphor-react';
 import {
-    HTMLAttributes,
-    PropsWithChildren,
-    ReactNode,
-    isValidElement,
-    memo,
-    useCallback,
-    useEffect,
-    useMemo,
-    useState
+	HTMLAttributes,
+	PropsWithChildren,
+	ReactNode,
+	isValidElement,
+	memo,
+	useCallback,
+	useEffect,
+	useMemo,
+	useState
 } from 'react';
+import { createPortal } from 'react-dom';
 import { createSearchParams, useNavigate } from 'react-router-dom';
 import {
-    ExplorerItem,
-    getExplorerItemData,
-    getItemFilePath,
-    getItemLocation,
-    isPath,
-    useLibraryContext,
-    useLibraryMutation
+	ExplorerItem,
+	getExplorerItemData,
+	getItemFilePath,
+	getItemLocation,
+	isPath,
+	useLibraryContext,
+	useLibraryMutation
 } from '@sd/client';
 import { ContextMenu, ModifierKeys, dialogManager } from '@sd/ui';
 import { showAlertDialog } from '~/components';
 import { useOperatingSystem } from '~/hooks';
 import { usePlatform } from '~/util/Platform';
 import CreateDialog from '../../settings/library/tags/CreateDialog';
+import { QuickPreview } from '../QuickPreview';
+import { useQuickPreviewContext } from '../QuickPreview/Context';
 import {
-    ExplorerViewContext,
-    ExplorerViewSelection,
-    ExplorerViewSelectionChange,
-    ViewContext,
-    useExplorerViewContext
+	ExplorerViewContext,
+	ExplorerViewSelection,
+	ExplorerViewSelectionChange,
+	ViewContext,
+	useExplorerViewContext
 } from '../ViewContext';
 import { useExplorerConfigStore } from '../config';
 import { ExplorerLayoutMode, getExplorerStore } from '../store';
@@ -40,262 +43,269 @@ import ListView from './ListView';
 import MediaView from './MediaView';
 
 interface ViewItemProps extends PropsWithChildren, HTMLAttributes<HTMLDivElement> {
-    data: ExplorerItem;
+	data: ExplorerItem;
 }
 
 export const ViewItem = ({ data, children, ...props }: ViewItemProps) => {
-    const explorerView = useExplorerViewContext();
-    const { library } = useLibraryContext();
-    const navigate = useNavigate();
+	const explorerView = useExplorerViewContext();
+	const { library } = useLibraryContext();
+	const navigate = useNavigate();
 
-    const { openFilePaths } = usePlatform();
-    const updateAccessTime = useLibraryMutation('files.updateAccessTime');
-    const filePath = getItemFilePath(data);
-    const location = getItemLocation(data);
+	const { openFilePaths } = usePlatform();
+	const updateAccessTime = useLibraryMutation('files.updateAccessTime');
+	const filePath = getItemFilePath(data);
+	const location = getItemLocation(data);
 
-    const explorerConfig = useExplorerConfigStore();
+	const explorerConfig = useExplorerConfigStore();
 
-    const onDoubleClick = () => {
-        if (location) {
-            navigate({
-                pathname: `/${library.uuid}/location/${location.id}`,
-                search: createSearchParams({
-                    path: `/`
-                }).toString()
-            });
-        } else if (isPath(data) && data.item.is_dir) {
-            navigate({
-                pathname: `/${library.uuid}/location/${getItemFilePath(data)?.location_id}`,
-                search: createSearchParams({
-                    path: `${data.item.materialized_path}${data.item.name}/`
-                }).toString()
-            });
-        } else if (
-            openFilePaths &&
-            filePath &&
-            explorerConfig.openOnDoubleClick &&
-            !explorerView.isRenaming
-        ) {
-            if (data.type === 'Path' && data.item.object_id) {
-                updateAccessTime.mutate(data.item.object_id);
-            }
+	const onDoubleClick = () => {
+		if (location) {
+			navigate({
+				pathname: `/${library.uuid}/location/${location.id}`,
+				search: createSearchParams({
+					path: `/`
+				}).toString()
+			});
+		} else if (isPath(data) && data.item.is_dir) {
+			navigate({
+				pathname: `/${library.uuid}/location/${getItemFilePath(data)?.location_id}`,
+				search: createSearchParams({
+					path: `${data.item.materialized_path}${data.item.name}/`
+				}).toString()
+			});
+		} else if (
+			openFilePaths &&
+			filePath &&
+			explorerConfig.openOnDoubleClick &&
+			!explorerView.isRenaming
+		) {
+			if (data.type === 'Path' && data.item.object_id) {
+				updateAccessTime.mutate(data.item.object_id);
+			}
 
-            openFilePaths(library.uuid, [filePath.id]);
-        } else {
-            const { kind } = getExplorerItemData(data);
+			openFilePaths(library.uuid, [filePath.id]);
+		} else {
+			const { kind } = getExplorerItemData(data);
 
-            if (['Video', 'Image', 'Audio'].includes(kind)) {
-                getExplorerStore().quickViewObject = data;
-            }
-        }
-    };
+			if (['Video', 'Image', 'Audio'].includes(kind)) {
+				getExplorerStore().quickViewObject = data;
+			}
+		}
+	};
 
-    return (
-        <ContextMenu.Root
-            trigger={
-                <div onDoubleClick={onDoubleClick} {...props}>
-                    {children}
-                </div>
-            }
-            onOpenChange={explorerView.setIsContextMenuOpen}
-            disabled={!explorerView.contextMenu}
-            asChild={false}
-        >
-            {explorerView.contextMenu}
-        </ContextMenu.Root>
-    );
+	return (
+		<ContextMenu.Root
+			trigger={
+				<div onDoubleClick={onDoubleClick} {...props}>
+					{children}
+				</div>
+			}
+			onOpenChange={explorerView.setIsContextMenuOpen}
+			disabled={!explorerView.contextMenu}
+			asChild={false}
+		>
+			{explorerView.contextMenu}
+		</ContextMenu.Root>
+	);
 };
 
 export interface ExplorerViewProps<T extends ExplorerViewSelection = ExplorerViewSelection>
-    extends Omit<
-        ExplorerViewContext<T>,
-        'multiSelect' | 'selectable' | 'isRenaming' | 'setIsRenaming' | 'setIsContextMenuOpen'
-    > {
-    layout: ExplorerLayoutMode;
-    className?: string;
-    emptyNotice?: JSX.Element | { icon?: Icon | ReactNode; message?: ReactNode } | null;
+	extends Omit<
+		ExplorerViewContext<T>,
+		'multiSelect' | 'selectable' | 'isRenaming' | 'setIsRenaming' | 'setIsContextMenuOpen'
+	> {
+	layout: ExplorerLayoutMode;
+	className?: string;
+	emptyNotice?: JSX.Element | { icon?: Icon | ReactNode; message?: ReactNode } | null;
 }
 
 export default memo(
-    <T extends ExplorerViewSelection>({
-        layout,
-        className,
-        emptyNotice,
-        ...contextProps
-    }: ExplorerViewProps<T>) => {
-        const [isContextMenuOpen, setIsContextMenuOpen] = useState(false);
-        const [isRenaming, setIsRenaming] = useState(false);
+	<T extends ExplorerViewSelection>({
+		layout,
+		className,
+		emptyNotice,
+		...contextProps
+	}: ExplorerViewProps<T>) => {
+		const [isContextMenuOpen, setIsContextMenuOpen] = useState(false);
+		const [isRenaming, setIsRenaming] = useState(false);
 
-        const emptyNoticeIcon = (icon?: Icon) => {
-            const Icon =
-                icon ??
-                {
-                    grid: GridFour,
-                    media: MonitorPlay,
-                    columns: Columns,
-                    rows: Rows
-                }[layout];
+		const emptyNoticeIcon = (icon?: Icon) => {
+			const Icon =
+				icon ??
+				{
+					grid: GridFour,
+					media: MonitorPlay,
+					columns: Columns,
+					rows: Rows
+				}[layout];
 
-            return <Icon size={100} opacity={0.3} />;
-        };
+			return <Icon size={100} opacity={0.3} />;
+		};
 
-        useKeyDownHandlers({
-            items: contextProps.items,
-            selected: contextProps.selected,
-            isRenaming
-        });
+		useKeyDownHandlers({
+			items: contextProps.items,
+			selected: contextProps.selected,
+			isRenaming
+		});
 
-        return (
-            <div
-                className={clsx('h-full w-full', className)}
-                onMouseDown={() =>
-                    contextProps.onSelectedChange?.(
-                        (Array.isArray(contextProps.selected)
-                            ? []
-                            : undefined) as ExplorerViewSelectionChange<T>
-                    )
-                }
-            >
-                {contextProps.items === null ||
-                    (contextProps.items && contextProps.items.length > 0) ? (
-                    <ViewContext.Provider
-                        value={
-                            {
-                                ...contextProps,
-                                multiSelect: Array.isArray(contextProps.selected),
-                                selectable: !isContextMenuOpen,
-                                setIsContextMenuOpen,
-                                isRenaming,
-                                setIsRenaming
-                            } as ExplorerViewContext
-                        }
-                    >
-                        {layout === 'grid' && <GridView />}
-                        {layout === 'rows' && <ListView />}
-                        {layout === 'media' && <MediaView />}
-                    </ViewContext.Provider>
-                ) : emptyNotice === null ? null : isValidElement(emptyNotice) ? (
-                    emptyNotice
-                ) : (
-                    <div className="flex h-full flex-col items-center justify-center text-ink-faint">
-                        {emptyNotice && 'icon' in emptyNotice
-                            ? isValidElement(emptyNotice.icon)
-                                ? emptyNotice.icon
-                                : emptyNoticeIcon(emptyNotice.icon as Icon)
-                            : emptyNoticeIcon()}
+		const quickPreviewCtx = useQuickPreviewContext();
 
-                        <p className="mt-5 text-xs">
-                            {emptyNotice && 'message' in emptyNotice
-                                ? emptyNotice.message
-                                : 'This list is empty'}
-                        </p>
-                    </div>
-                )}
-            </div>
-        );
-    }
+		return (
+			<>
+				<div
+					className={clsx('h-full w-full', className)}
+					onMouseDown={() =>
+						contextProps.onSelectedChange?.(
+							(Array.isArray(contextProps.selected)
+								? []
+								: undefined) as ExplorerViewSelectionChange<T>
+						)
+					}
+				>
+					{contextProps.items === null ||
+					(contextProps.items && contextProps.items.length > 0) ? (
+						<ViewContext.Provider
+							value={
+								{
+									...contextProps,
+									multiSelect: Array.isArray(contextProps.selected),
+									selectable: !isContextMenuOpen,
+									setIsContextMenuOpen,
+									isRenaming,
+									setIsRenaming
+								} as ExplorerViewContext
+							}
+						>
+							{layout === 'grid' && <GridView />}
+							{layout === 'rows' && <ListView />}
+							{layout === 'media' && <MediaView />}
+						</ViewContext.Provider>
+					) : emptyNotice === null ? null : isValidElement(emptyNotice) ? (
+						emptyNotice
+					) : (
+						<div className="flex h-full flex-col items-center justify-center text-ink-faint">
+							{emptyNotice && 'icon' in emptyNotice
+								? isValidElement(emptyNotice.icon)
+									? emptyNotice.icon
+									: emptyNoticeIcon(emptyNotice.icon as Icon)
+								: emptyNoticeIcon()}
+
+							<p className="mt-5 text-xs">
+								{emptyNotice && 'message' in emptyNotice
+									? emptyNotice.message
+									: 'This list is empty'}
+							</p>
+						</div>
+					)}
+				</div>
+
+				{quickPreviewCtx.ref.current &&
+					createPortal(<QuickPreview />, quickPreviewCtx.ref.current)}
+			</>
+		);
+	}
 ) as <T extends ExplorerViewSelection>(props: ExplorerViewProps<T>) => JSX.Element;
 
 const useKeyDownHandlers = ({
-    items,
-    selected,
-    isRenaming
+	items,
+	selected,
+	isRenaming
 }: Pick<ExplorerViewProps, 'items' | 'selected'> & { isRenaming: boolean }) => {
-    const os = useOperatingSystem();
-    const { library } = useLibraryContext();
-    const { openFilePaths } = usePlatform();
+	const os = useOperatingSystem();
+	const { library } = useLibraryContext();
+	const { openFilePaths } = usePlatform();
 
-    const selectedItem = useMemo(
-        () =>
-            items?.find(
-                (item) => item.item.id === (Array.isArray(selected) ? selected[0] : selected)
-            ),
-        [items, selected]
-    );
+	const selectedItem = useMemo(
+		() =>
+			items?.find(
+				(item) => item.item.id === (Array.isArray(selected) ? selected[0] : selected)
+			),
+		[items, selected]
+	);
 
-    const itemPath = selectedItem ? getItemFilePath(selectedItem) : null;
+	const itemPath = selectedItem ? getItemFilePath(selectedItem) : null;
 
-    const handleNewTag = useCallback(
-        async (event: KeyboardEvent) => {
-            if (
-                itemPath == null ||
-                event.key.toUpperCase() !== 'N' ||
-                !event.getModifierState(os === 'macOS' ? ModifierKeys.Meta : ModifierKeys.Control)
-            )
-                return;
+	const handleNewTag = useCallback(
+		async (event: KeyboardEvent) => {
+			if (
+				itemPath == null ||
+				event.key.toUpperCase() !== 'N' ||
+				!event.getModifierState(os === 'macOS' ? ModifierKeys.Meta : ModifierKeys.Control)
+			)
+				return;
 
-            dialogManager.create((dp) => <CreateDialog {...dp} assignToObject={itemPath.id} />);
-        },
-        [os, itemPath]
-    );
+			dialogManager.create((dp) => <CreateDialog {...dp} assignToObject={itemPath.id} />);
+		},
+		[os, itemPath]
+	);
 
-    const handleOpenShortcut = useCallback(
-        async (event: KeyboardEvent) => {
-            if (
-                itemPath == null ||
-                openFilePaths == null ||
-                event.key.toUpperCase() !== 'O' ||
-                !event.getModifierState(os === 'macOS' ? ModifierKeys.Meta : ModifierKeys.Control)
-            )
-                return;
+	const handleOpenShortcut = useCallback(
+		async (event: KeyboardEvent) => {
+			if (
+				itemPath == null ||
+				openFilePaths == null ||
+				event.key.toUpperCase() !== 'O' ||
+				!event.getModifierState(os === 'macOS' ? ModifierKeys.Meta : ModifierKeys.Control)
+			)
+				return;
 
-            try {
-                await openFilePaths(library.uuid, [itemPath.id]);
-            } catch (error) {
-                showAlertDialog({
-                    title: 'Error',
-                    value: `Couldn't open file, due to an error: ${error}`
-                });
-            }
-        },
-        [os, itemPath, library.uuid, openFilePaths]
-    );
+			try {
+				await openFilePaths(library.uuid, [itemPath.id]);
+			} catch (error) {
+				showAlertDialog({
+					title: 'Error',
+					value: `Couldn't open file, due to an error: ${error}`
+				});
+			}
+		},
+		[os, itemPath, library.uuid, openFilePaths]
+	);
 
-    const handleOpenQuickPreview = useCallback(
-        async (event: KeyboardEvent) => {
-            if (event.key !== ' ') return;
-            if (!getExplorerStore().quickViewObject) {
-                if (selectedItem) {
-                    getExplorerStore().quickViewObject = selectedItem;
-                }
-            } else {
-                getExplorerStore().quickViewObject = null;
-            }
-        },
-        [selectedItem]
-    );
+	const handleOpenQuickPreview = useCallback(
+		async (event: KeyboardEvent) => {
+			if (event.key !== ' ') return;
+			if (!getExplorerStore().quickViewObject) {
+				if (selectedItem) {
+					getExplorerStore().quickViewObject = selectedItem;
+				}
+			} else {
+				getExplorerStore().quickViewObject = null;
+			}
+		},
+		[selectedItem]
+	);
 
-    const handleExplorerShortcut = useCallback(
-        (event: KeyboardEvent) => {
-            if (
-                event.key.toUpperCase() !== 'I' ||
-                !event.getModifierState(os === 'macOS' ? ModifierKeys.Meta : ModifierKeys.Control)
-            )
-                return;
+	const handleExplorerShortcut = useCallback(
+		(event: KeyboardEvent) => {
+			if (
+				event.key.toUpperCase() !== 'I' ||
+				!event.getModifierState(os === 'macOS' ? ModifierKeys.Meta : ModifierKeys.Control)
+			)
+				return;
 
-            getExplorerStore().showInspector = !getExplorerStore().showInspector;
-        },
-        [os]
-    );
+			getExplorerStore().showInspector = !getExplorerStore().showInspector;
+		},
+		[os]
+	);
 
-    useEffect(() => {
-        const handlers = [
-            handleNewTag,
-            handleOpenShortcut,
-            handleOpenQuickPreview,
-            handleExplorerShortcut
-        ];
-        const handler = (event: KeyboardEvent) => {
-            if (isRenaming) return;
-            for (const handler of handlers) handler(event);
-        };
-        document.body.addEventListener('keydown', handler);
-        return () => document.body.removeEventListener('keydown', handler);
-    }, [
-        isRenaming,
-        handleNewTag,
-        handleOpenShortcut,
-        handleOpenQuickPreview,
-        handleExplorerShortcut
-    ]);
+	useEffect(() => {
+		const handlers = [
+			handleNewTag,
+			handleOpenShortcut,
+			handleOpenQuickPreview,
+			handleExplorerShortcut
+		];
+		const handler = (event: KeyboardEvent) => {
+			if (isRenaming) return;
+			for (const handler of handlers) handler(event);
+		};
+		document.body.addEventListener('keydown', handler);
+		return () => document.body.removeEventListener('keydown', handler);
+	}, [
+		isRenaming,
+		handleNewTag,
+		handleOpenShortcut,
+		handleOpenQuickPreview,
+		handleExplorerShortcut
+	]);
 };

--- a/interface/app/$libraryId/Explorer/index.tsx
+++ b/interface/app/$libraryId/Explorer/index.tsx
@@ -1,6 +1,5 @@
 import { FolderNotchOpen } from 'phosphor-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
 import { ExplorerItem, useLibrarySubscription } from '@sd/client';
 import { useKeyDeleteFile } from '~/hooks';
 import { TOP_BAR_HEIGHT } from '../TopBar';
@@ -9,8 +8,6 @@ import ContextMenu from './ContextMenu';
 import DismissibleNotice from './DismissibleNotice';
 import { Inspector } from './Inspector';
 import ExplorerContextMenu from './ParentContextMenu';
-import { QuickPreview } from './QuickPreview';
-import { useQuickPreviewContext } from './QuickPreview/Context';
 import View, { ExplorerViewProps } from './View';
 import { useExplorerStore } from './store';
 import { useExplorerSearchParams } from './util';
@@ -61,8 +58,6 @@ export default function Explorer(props: Props) {
 
 	useEffect(() => setSelectedItemId(undefined), [path]);
 
-	const quickPreviewCtx = useQuickPreviewContext();
-
 	return (
 		<>
 			<ExplorerContextMenu>
@@ -95,9 +90,6 @@ export default function Explorer(props: Props) {
 					</div>
 				</div>
 			</ExplorerContextMenu>
-
-			{quickPreviewCtx.ref.current &&
-				createPortal(<QuickPreview />, quickPreviewCtx.ref.current)}
 
 			{explorerStore.showInspector && (
 				<Inspector

--- a/interface/app/$libraryId/Explorer/store.ts
+++ b/interface/app/$libraryId/Explorer/store.ts
@@ -4,10 +4,10 @@ import { ExplorerItem, FilePathSearchOrdering, ObjectSearchOrdering, resetStore 
 import { SortOrder } from '~/app/route-schemas';
 
 type Join<K, P> = K extends string | number
-    ? P extends string | number
-    ? `${K}${'' extends P ? '' : '.'}${P}`
-    : never
-    : never;
+	? P extends string | number
+		? `${K}${'' extends P ? '' : '.'}${P}`
+		: never
+	: never;
 
 type Leaves<T> = T extends object ? { [K in keyof T]-?: Join<K, Leaves<T[K]>> }[keyof T] : '';
 
@@ -16,9 +16,9 @@ type UnionKeys<T> = T extends any ? Leaves<T> : never;
 export type ExplorerLayoutMode = 'rows' | 'grid' | 'columns' | 'media';
 
 export enum ExplorerKind {
-    Location,
-    Tag,
-    Space
+	Location,
+	Tag,
+	Space
 }
 
 export type CutCopyType = 'Cut' | 'Copy';
@@ -27,60 +27,60 @@ export type FilePathSearchOrderingKeys = UnionKeys<FilePathSearchOrdering> | 'no
 export type ObjectSearchOrderingKeys = UnionKeys<ObjectSearchOrdering> | 'none';
 
 const state = {
-    layoutMode: 'grid' as ExplorerLayoutMode,
-    gridItemSize: 110,
-    listItemSize: 40,
-    showBytesInGridView: true,
-    tagAssignMode: false,
-    showInspector: false,
-    mediaPlayerVolume: 0.7,
-    multiSelectIndexes: [] as number[],
-    newThumbnails: proxySet() as Set<string>,
-    cutCopyState: {
-        sourceParentPath: '', // this is used solely for preventing copy/cutting to the same path (as that will truncate the file)
-        sourceLocationId: 0,
-        sourcePathId: 0,
-        actionType: 'Cut',
-        active: false
-    },
-    quickViewObject: null as ExplorerItem | null,
-    mediaColumns: 8,
-    mediaAspectSquare: false,
-    orderBy: 'dateCreated' as FilePathSearchOrderingKeys,
-    orderByDirection: 'Desc' as SortOrder,
-    groupBy: 'none'
+	layoutMode: 'grid' as ExplorerLayoutMode,
+	gridItemSize: 110,
+	listItemSize: 40,
+	showBytesInGridView: true,
+	tagAssignMode: false,
+	showInspector: false,
+	mediaPlayerVolume: 0.7,
+	multiSelectIndexes: [] as number[],
+	newThumbnails: proxySet() as Set<string>,
+	cutCopyState: {
+		sourceParentPath: '', // this is used solely for preventing copy/cutting to the same path (as that will truncate the file)
+		sourceLocationId: 0,
+		sourcePathId: 0,
+		actionType: 'Cut',
+		active: false
+	},
+	quickViewObject: null as ExplorerItem | null,
+	mediaColumns: 8,
+	mediaAspectSquare: false,
+	orderBy: 'dateCreated' as FilePathSearchOrderingKeys,
+	orderByDirection: 'Desc' as SortOrder,
+	groupBy: 'none'
 };
 
 export function flattenThumbnailKey(thumbKey: string[]) {
-    return thumbKey.join('/');
+	return thumbKey.join('/');
 }
 
 // Keep the private and use `useExplorerState` or `getExplorerStore` or you will get production build issues.
 const explorerStore = proxy({
-    ...state,
-    reset: () => resetStore(explorerStore, state),
-    addNewThumbnail: (thumbKey: string[]) => {
-        explorerStore.newThumbnails.add(flattenThumbnailKey(thumbKey));
-    },
-    // this should be done when the explorer query is refreshed
-    // prevents memory leak
-    resetNewThumbnails: () => {
-        explorerStore.newThumbnails.clear();
-    }
+	...state,
+	reset: () => resetStore(explorerStore, state),
+	addNewThumbnail: (thumbKey: string[]) => {
+		explorerStore.newThumbnails.add(flattenThumbnailKey(thumbKey));
+	},
+	// this should be done when the explorer query is refreshed
+	// prevents memory leak
+	resetNewThumbnails: () => {
+		explorerStore.newThumbnails.clear();
+	}
 });
 
 export function useExplorerStore() {
-    return useSnapshot(explorerStore);
+	return useSnapshot(explorerStore);
 }
 
 export function getExplorerStore() {
-    return explorerStore;
+	return explorerStore;
 }
 
 export function isCut(id: number) {
-    return (
-        explorerStore.cutCopyState.active &&
-        explorerStore.cutCopyState.actionType === 'Cut' &&
-        explorerStore.cutCopyState.sourcePathId === id
-    );
+	return (
+		explorerStore.cutCopyState.active &&
+		explorerStore.cutCopyState.actionType === 'Cut' &&
+		explorerStore.cutCopyState.sourcePathId === id
+	);
 }

--- a/interface/app/$libraryId/Layout/Sidebar/JobManager/Job.tsx
+++ b/interface/app/$libraryId/Layout/Sidebar/JobManager/Job.tsx
@@ -47,7 +47,6 @@ function Job({ job, className, isChild }: JobProps) {
 	// dayjs from seconds to time
 	// const timeText = isRunning ? formatEstimatedRemainingTime(job.estimated_completion) : undefined;
 
-
 	// I don't like sending TSX as a prop due to lack of hot-reload, but it's the only way to get the error log to show up
 	if (job.status === 'CompletedWithErrors') {
 		const JobError = (
@@ -84,22 +83,21 @@ function Job({ job, className, isChild }: JobProps) {
 			name={niceData.name}
 			circleIcon={niceData.icon}
 			textItems={
-				['Queued'].includes(job.status)
-					? [[{ text: job.status }]]
-					: niceData.textItems
+				['Queued'].includes(job.status) ? [[{ text: job.status }]] : niceData.textItems
 			}
 			// textItems={[[{ text: job.status }, { text: job.id, }]]}
 			isChild={isChild}
 		>
-			{isRunning || isPaused && (
-				<div className="my-1 ml-1.5 w-[335px]">
-					<ProgressBar
-						pending={task_count == 0}
-						value={completed_task_count}
-						total={task_count}
-					/>
-				</div>
-			)}
+			{isRunning ||
+				(isPaused && (
+					<div className="my-1 ml-1.5 w-[335px]">
+						<ProgressBar
+							pending={task_count == 0}
+							value={completed_task_count}
+							total={task_count}
+						/>
+					</div>
+				))}
 		</JobContainer>
 	);
 }

--- a/interface/app/$libraryId/Layout/Sidebar/JobManager/useJobInfo.tsx
+++ b/interface/app/$libraryId/Layout/Sidebar/JobManager/useJobInfo.tsx
@@ -22,19 +22,21 @@ export default function useJobInfo(
 
 	return {
 		indexer: {
-			name: `${isQueued ? 'Index' : isRunning ? 'Indexing' : 'Indexed'} files  ${indexedPath ? `at ${indexedPath}` : ``
-				}`,
+			name: `${isQueued ? 'Index' : isRunning ? 'Indexing' : 'Indexed'} files  ${
+				indexedPath ? `at ${indexedPath}` : ``
+			}`,
 			icon: Folder,
 			textItems: [
 				[
 					{
-						text:
-							isPaused ? job.message : isRunning && realtimeUpdate?.message
-								? realtimeUpdate.message
-								: `${comma(meta?.data?.total_paths)} ${plural(
+						text: isPaused
+							? job.message
+							: isRunning && realtimeUpdate?.message
+							? realtimeUpdate.message
+							: `${comma(meta?.data?.total_paths)} ${plural(
 									meta?.data?.total_paths,
 									'path'
-								)}`
+							  )}`
 					}
 				]
 			]
@@ -48,10 +50,11 @@ export default function useJobInfo(
 						text:
 							meta?.thumbnails_created === 0
 								? 'None generated'
-								: `${completedTaskCount
-									? comma(completedTaskCount || 0)
-									: comma(meta?.thumbnails_created)
-								} of ${taskCount} ${plural(taskCount, 'thumbnail')} generated`
+								: `${
+										completedTaskCount
+											? comma(completedTaskCount || 0)
+											: comma(meta?.thumbnails_created)
+								  } of ${taskCount} ${plural(taskCount, 'thumbnail')} generated`
 					},
 					{
 						text:
@@ -68,49 +71,53 @@ export default function useJobInfo(
 					? meta?.total_orphan_paths === 0
 						? [{ text: 'No files changed' }]
 						: [
-							{
-								text: `${comma(meta?.total_orphan_paths)} ${plural(
-									meta?.total_orphan_paths,
-									'file'
-								)}`
-							},
-							{
-								text: `${comma(meta?.total_objects_created)} ${plural(
-									meta?.total_objects_created,
-									'Object'
-								)} created`
-							},
-							{
-								text: `${comma(meta?.total_objects_linked)} ${plural(
-									meta?.total_objects_linked,
-									'Object'
-								)} linked`
-							}
-						]
+								{
+									text: `${comma(meta?.total_orphan_paths)} ${plural(
+										meta?.total_orphan_paths,
+										'file'
+									)}`
+								},
+								{
+									text: `${comma(meta?.total_objects_created)} ${plural(
+										meta?.total_objects_created,
+										'Object'
+									)} created`
+								},
+								{
+									text: `${comma(meta?.total_objects_linked)} ${plural(
+										meta?.total_objects_linked,
+										'Object'
+									)} linked`
+								}
+						  ]
 					: [{ text: realtimeUpdate?.message }]
 			]
 		},
 		file_copier: {
-			name: `${isQueued ? 'Copy' : isRunning ? 'Copying' : 'Copied'} ${isRunning ? completedTaskCount + 1 : completedTaskCount
-				} ${isRunning ? `of ${job.task_count}` : ``} ${plural(job.task_count, 'file')}`,
+			name: `${isQueued ? 'Copy' : isRunning ? 'Copying' : 'Copied'} ${
+				isRunning ? completedTaskCount + 1 : completedTaskCount
+			} ${isRunning ? `of ${job.task_count}` : ``} ${plural(job.task_count, 'file')}`,
 			icon: Copy,
 			textItems: [[{ text: job.status }]]
 		},
 		file_deleter: {
-			name: `${isQueued ? 'Delete' : isRunning ? 'Deleting' : 'Deleted'
-				} ${completedTaskCount} ${plural(completedTaskCount, 'file')}`,
+			name: `${
+				isQueued ? 'Delete' : isRunning ? 'Deleting' : 'Deleted'
+			} ${completedTaskCount} ${plural(completedTaskCount, 'file')}`,
 			icon: Trash,
 			textItems: [[{ text: job.status }]]
 		},
 		file_cutter: {
-			name: `${isQueued ? 'Cut' : isRunning ? 'Cutting' : 'Cut'
-				} ${completedTaskCount} ${plural(completedTaskCount, 'file')}`,
+			name: `${
+				isQueued ? 'Cut' : isRunning ? 'Cutting' : 'Cut'
+			} ${completedTaskCount} ${plural(completedTaskCount, 'file')}`,
 			icon: Scissors,
 			textItems: [[{ text: job.status }]]
 		},
 		object_validator: {
-			name: `${isQueued ? 'Validate' : isRunning ? 'Validating' : 'Validated'} ${!isQueued ? completedTaskCount : ''
-				} ${plural(completedTaskCount, 'object')}`,
+			name: `${isQueued ? 'Validate' : isRunning ? 'Validating' : 'Validated'} ${
+				!isQueued ? completedTaskCount : ''
+			} ${plural(completedTaskCount, 'object')}`,
 			icon: Fingerprint,
 			textItems: [[{ text: job.status }]]
 		}


### PR DESCRIPTION
The issue of the wrong items being rendered in the QuickPreview should have been fixed sometime around #1029, but I didn't consider that `QuickPreview` needs to be rendered outside of `Explorer` sometimes. Now we render it inside `View`.
This doesn't address objects only previewing with thumbnails, it's been that way for a while.