### PR TITLE
Hide DismissibleNotice when no items

### DIFF
--- a/interface/app/$libraryId/Explorer/index.tsx
+++ b/interface/app/$libraryId/Explorer/index.tsx
@@ -75,7 +75,8 @@ export default function Explorer(props: Props) {
 							paddingRight: explorerStore.showInspector ? INSPECTOR_WIDTH : 0
 						}}
 					>
-						<DismissibleNotice />
+						{props.items && props.items.length > 0 && <DismissibleNotice />}
+
 						<View
 							layout={explorerStore.layoutMode}
 							items={props.items}


### PR DESCRIPTION
If there's no items it doesn't really make sense to display the notice