### PR TITLE
[ENG-850] Wrongly labelled .ts files (as video)

### DIFF
--- a/apps/mobile/src/screens/settings/library/EditLocationSettings.tsx
+++ b/apps/mobile/src/screens/settings/library/EditLocationSettings.tsx
@@ -185,7 +185,7 @@ const EditLocationSettingsScreen = ({
 					<SettingsItem
 						title="Full Reindex"
 						rightArea={
-							<AnimatedButton size="sm" onPress={() => fullRescan.mutate(id)}>
+							<AnimatedButton size="sm" onPress={() => fullRescan.mutate({ location_id: id, reidentify_objects: true })}>
 								<ArrowsClockwise color="white" size={20} />
 							</AnimatedButton>
 						}

--- a/apps/mobile/src/screens/settings/library/LocationSettings.tsx
+++ b/apps/mobile/src/screens/settings/library/LocationSettings.tsx
@@ -73,7 +73,7 @@ function LocationItem({ location, index, navigation }: LocationItemProps) {
 				{/* Full Re-scan IS too much here */}
 				<Pressable
 					style={tw`items-center justify-center rounded-md border border-app-line bg-app-button px-3 py-1.5 shadow-sm`}
-					onPress={() => fullRescan.mutate(location.id)}
+					onPress={() => fullRescan.mutate({ location_id: location.id, reidentify_objects: true })}
 				>
 					<Repeat size={18} color="white" />
 				</Pressable>

--- a/core/src/job/worker.rs
+++ b/core/src/job/worker.rs
@@ -418,7 +418,15 @@ impl Worker {
 				report.status = JobStatus::CompletedWithErrors;
 				report.errors_text = errors;
 				report.data = None;
-				report.metadata = metadata;
+				report.metadata = match (report.metadata.take(), metadata) {
+					(Some(mut current_metadata), Some(new_metadata)) => {
+						current_metadata["output"] = new_metadata;
+						Some(current_metadata)
+					}
+					(None, Some(new_metadata)) => Some(json!({ "output": new_metadata })),
+					(Some(current_metadata), None) => Some(current_metadata),
+					_ => None,
+				};
 				report.completed_at = Some(Utc::now());
 				if let Err(e) = report.update(library).await {
 					error!("failed to update job report: {:#?}", e);

--- a/crates/file-ext/src/extensions.rs
+++ b/crates/file-ext/src/extensions.rs
@@ -262,6 +262,7 @@ extension_category_enum! {
 		Swift,
 		Mdx,
 		Astro,
+		Mts,
 	}
 }
 

--- a/crates/file-ext/src/magic.rs
+++ b/crates/file-ext/src/magic.rs
@@ -215,15 +215,19 @@ impl Extension {
 				}
 			}
 			ExtensionPossibility::Conflicts(ext) => match ext_str {
-				"ts" => {
-					let maybe_video_ext = if ext.iter().any(|e| matches!(e, Extension::Video(_))) {
-						verify_magic_bytes(VideoExtension::Ts, file)
-							.await
-							.map(Extension::Video)
-					} else {
-						None
-					};
-					Some(maybe_video_ext.unwrap_or(Extension::Code(CodeExtension::Ts)))
+				"ts" if ext.iter().any(|e| matches!(e, Extension::Video(_))) => {
+					verify_magic_bytes(VideoExtension::Ts, file)
+						.await
+						.map_or(Some(Extension::Code(CodeExtension::Ts)), |video_ext| {
+							Some(Extension::Video(video_ext))
+						})
+				}
+				"mts" if ext.iter().any(|e| matches!(e, Extension::Video(_))) => {
+					verify_magic_bytes(VideoExtension::Mts, file)
+						.await
+						.map_or(Some(Extension::Code(CodeExtension::Mts)), |video_ext| {
+							Some(Extension::Video(video_ext))
+						})
 				}
 				_ => None,
 			},

--- a/interface/app/$libraryId/Explorer/ContextMenu/FilePath/Items.tsx
+++ b/interface/app/$libraryId/Explorer/ContextMenu/FilePath/Items.tsx
@@ -140,7 +140,7 @@ export const ParentFolderActions = ({
 			<ContextMenu.Item
 				onClick={async () => {
 					try {
-						await fullRescan.mutateAsync(locationId);
+						await fullRescan.mutateAsync({ location_id: locationId, reidentify_objects: false });
 					} catch (error) {
 						showAlertDialog({
 							title: 'Error',

--- a/interface/app/$libraryId/Explorer/ParentContextMenu.tsx
+++ b/interface/app/$libraryId/Explorer/ParentContextMenu.tsx
@@ -52,7 +52,7 @@ export default (props: PropsWithChildren) => {
 					<CM.Item
 						onClick={async () => {
 							try {
-								await rescanLocation.mutateAsync(parent.location.id);
+								await rescanLocation.mutateAsync({ location_id: parent.location.id, reidentify_objects: false });
 							} catch (error) {
 								showAlertDialog({
 									title: 'Error',

--- a/interface/app/$libraryId/location/LocationOptions.tsx
+++ b/interface/app/$libraryId/location/LocationOptions.tsx
@@ -73,7 +73,7 @@ export default function LocationOptions({ location, path }: { location: Location
 						</PopoverSection>
 						<PopoverDivider />
 						<PopoverSection>
-							<OptionButton onClick={() => scanLocation.mutate(location.id)}>
+							<OptionButton onClick={() => scanLocation.mutate({ location_id: location.id, reidentify_objects: false })}>
 								<FolderDotted />
 								Re-index
 							</OptionButton>

--- a/interface/app/$libraryId/settings/library/locations/$id.tsx
+++ b/interface/app/$libraryId/settings/library/locations/$id.tsx
@@ -228,7 +228,7 @@ const EditLocationForm = () => {
 					<FlexCol>
 						<div>
 							<Button
-								onClick={() => fullRescan.mutate(locationId)}
+								onClick={() => fullRescan.mutate({ location_id: locationId, reidentify_objects: true })}
 								size="sm"
 								variant="outline"
 							>

--- a/interface/app/$libraryId/settings/library/locations/ListItem.tsx
+++ b/interface/app/$libraryId/settings/library/locations/ListItem.tsx
@@ -89,7 +89,7 @@ export default ({ location }: Props) => {
 					onClick={(e: { stopPropagation: () => void }) => {
 						e.stopPropagation();
 						// this should cause a lite directory rescan, but this will do for now, so the button does something useful
-						fullRescan.mutate(location.id);
+						fullRescan.mutate({ location_id: location.id, reidentify_objects: false });
 					}}
 				>
 					<Tooltip label="Rescan Location">

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -52,7 +52,7 @@ export type Procedures = {
         { key: "locations.addLibrary", input: LibraryArgs<LocationCreateArgs>, result: null } | 
         { key: "locations.create", input: LibraryArgs<LocationCreateArgs>, result: null } | 
         { key: "locations.delete", input: LibraryArgs<number>, result: null } | 
-        { key: "locations.fullRescan", input: LibraryArgs<number>, result: null } | 
+        { key: "locations.fullRescan", input: LibraryArgs<FullRescanArgs>, result: null } | 
         { key: "locations.indexer_rules.create", input: LibraryArgs<IndexerRuleCreateArgs>, result: null } | 
         { key: "locations.indexer_rules.delete", input: LibraryArgs<number>, result: null } | 
         { key: "locations.relink", input: LibraryArgs<string>, result: null } | 
@@ -116,6 +116,8 @@ export type FilePathSearchOrdering = { name: SortOrder } | { sizeInBytes: SortOr
 export type FilePathWithObject = { id: number; pub_id: number[]; is_dir: boolean | null; cas_id: string | null; integrity_checksum: string | null; location_id: number | null; materialized_path: string | null; name: string | null; extension: string | null; size_in_bytes: string | null; size_in_bytes_bytes: number[] | null; inode: number[] | null; device: number[] | null; object_id: number | null; key_id: number | null; date_created: string | null; date_modified: string | null; date_indexed: string | null; object: Object | null }
 
 export type FromPattern = { pattern: string; replace_all: boolean }
+
+export type FullRescanArgs = { location_id: number; reidentify_objects: boolean }
 
 export type GenerateThumbsForLocationArgs = { id: number; path: string }
 


### PR DESCRIPTION
Files with a `mts` extension were always showing as video files, where they could also be code files, as in `.d.mts` files. This way we try to check for `mts` video files magic bytes to be sure. 

I wasn't able to reproduce the bug for `.ts` files, I think this one is solved by recent location watcher improvements.