### PR TITLE
Check winget version and require update if necessary

### DIFF
--- a/.github/scripts/setup-system.ps1
+++ b/.github/scripts/setup-system.ps1
@@ -162,7 +162,13 @@ https://learn.microsoft.com/windows/package-manager/winget/
 '@
     }
 
-    # TODO: Check system winget version is greater or equal to v1.4.10052
+    # Check system winget version is greater or equal to v1.4.10052
+    $wingetVersion = [Version]((winget --version)  -replace '.*?(\d+)\.(\d+)\.(\d+).*', '$1.$2.$3')
+    $requiredVersion = [Version]'1.4.10052'
+    if ($wingetVersion.CompareTo($requiredVersion) -lt 0) {
+        $errorMessage = "You need to update your winget to version $requiredVersion or higher."
+        Exit-WithError $errorMessage
+    }
 
     # Check connectivity to GitHub
     $ProgressPreference = 'SilentlyContinue'


### PR DESCRIPTION
Added a check for the winget version to ensure it meets the minimum required version. If the winget version is outdated, the script now exits with an appropriate error message.

<!-- Put any information about this PR up here -->
This is just a commit that addresses this https://github.com/spacedriveapp/spacedrive/blob/5df1d9a091fec792c72fff45ef9acc5afd4a6a2b/.github/scripts/setup-system.ps1#L165

<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->
