### PR TITLE
[MOB-31] Separate analytics for mobile

### DIFF
--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -3,6 +3,7 @@ import 'event-target-polyfill';
 import * as SplashScreen from 'expo-splash-screen';
 import { Suspense, lazy } from 'react';
 import { Platform } from 'react-native';
+import { Dimensions } from 'react-native';
 import { reactNativeLink } from './lib/rspcReactNativeTransport';
 
 // Enable the splash screen
@@ -60,6 +61,32 @@ globalThis.rspcLinks = [
 	// }),
 	reactNativeLink()
 ];
+
+// Polyfill for Plausible to work properly (@sd/client/hooks/usePlausible)
+
+window.location = {
+	// @ts-ignore
+	ancestorOrigins: {},
+	href: 'https://spacedrive.com',
+	origin: 'https://spacedrive.com',
+	protocol: 'https:',
+	host: 'spacedrive.com',
+	hostname: 'spacedrive.com',
+	port: '',
+	pathname: '/',
+	search: '',
+	hash: ''
+};
+// @ts-ignore
+window.document = {};
+
+const { width, height } = Dimensions.get('window');
+
+//@ts-ignore
+window.screen = {
+	width,
+	height
+};
 
 /*
 	https://github.com/facebook/hermes/issues/23

--- a/packages/client/src/hooks/usePlausible.tsx
+++ b/packages/client/src/hooks/usePlausible.tsx
@@ -8,6 +8,7 @@ import { PlausiblePlatformType, telemetryStore, useTelemetryState } from './useT
  */
 const VERSION = '0.1.0';
 const DOMAIN = 'app.spacedrive.com';
+const MOBILE_DOMAIN = 'mobile.spacedrive.com';
 
 const PlausibleProvider = Plausible({
 	trackLocalhost: true,
@@ -190,6 +191,7 @@ const submitPlausibleEvent = async ({ event, debugState, ...props }: SubmitEvent
 			debug: debugState.enabled
 		},
 		options: {
+			domain: props.platformType === 'mobile' ? MOBILE_DOMAIN : DOMAIN,
 			deviceWidth: props.screenWidth ?? window.screen.width,
 			referrer: '',
 			...('plausibleOptions' in event ? event.plausibleOptions : undefined)


### PR DESCRIPTION
ez, why?
> It just doesn't make sense here. You would need to convert and match all the screen/route names and they just wont work together.