### PR TITLE
Removed Browsers AutoSuggestions from inputs

### DIFF
--- a/packages/ui/src/Input.tsx
+++ b/packages/ui/src/Input.tsx
@@ -86,6 +86,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
 						e.stopPropagation();
 					}}
 					ref={ref}
+					autoComplete={props.autoComplete || "off"}
 					{...props}
 				/>
 			</div>


### PR DESCRIPTION
I made modifications to the UI because every text input was suggesting an autocomplete.

However, you can still enable autocomplete by adding `autoComplete="on"` to the respective input fields.

Closes #1152 
