### PR TITLE
[ENG-960] pause inspector thumbnail while quick preview is open

### DIFF
--- a/interface/app/$libraryId/Explorer/FilePath/Thumb.tsx
+++ b/interface/app/$libraryId/Explorer/FilePath/Thumb.tsx
@@ -109,7 +109,7 @@ export interface ThumbProps {
 	className?: string;
 	loadOriginal?: boolean;
 	mediaControls?: boolean;
-	paused?: boolean;
+	pauseVideo?: boolean;
 }
 
 function FileThumb({ size, cover, ...props }: ThumbProps) {
@@ -198,9 +198,9 @@ function FileThumb({ size, cover, ...props }: ThumbProps) {
 
 	useEffect(() => {
 		if (video.current) {
-			props.paused ? video.current.pause() : video.current.play();
+			props.pauseVideo ? video.current.pause() : video.current.play();
 		}
-	}, [props.paused]);
+	}, [props.pauseVideo]);
 
 	const onLoad = () => setLoaded(true);
 
@@ -258,7 +258,7 @@ function FileThumb({ size, cover, ...props }: ThumbProps) {
 										ref={video}
 										src={src}
 										onError={onError}
-										autoPlay={!props.paused}
+										autoPlay={!props.pauseVideo}
 										onVolumeChange={(e) => {
 											const video = e.target as HTMLVideoElement;
 											getExplorerStore().mediaPlayerVolume = video.volume;

--- a/interface/app/$libraryId/Explorer/FilePath/Thumb.tsx
+++ b/interface/app/$libraryId/Explorer/FilePath/Thumb.tsx
@@ -109,6 +109,7 @@ export interface ThumbProps {
 	className?: string;
 	loadOriginal?: boolean;
 	mediaControls?: boolean;
+	paused?: boolean;
 }
 
 function FileThumb({ size, cover, ...props }: ThumbProps) {
@@ -122,6 +123,7 @@ function FileThumb({ size, cover, ...props }: ThumbProps) {
 	const [loaded, setLoaded] = useState<boolean>(false);
 	const [thumbType, setThumbType] = useState(ThumbType.Icon);
 	const { parent } = useExplorerContext();
+	const video = useRef<HTMLVideoElement>(null);
 
 	// useLayoutEffect is required to ensure the thumbType is always updated before the onError listener can execute,
 	// thus avoiding improper thumb types changes
@@ -194,6 +196,12 @@ function FileThumb({ size, cover, ...props }: ThumbProps) {
 		parent
 	]);
 
+	useEffect(() => {
+		if (video.current) {
+			props.paused ? video.current.pause() : video.current.play();
+		}
+	}, [props.paused]);
+
 	const onLoad = () => setLoaded(true);
 
 	const onError = () => {
@@ -247,9 +255,10 @@ function FileThumb({ size, cover, ...props }: ThumbProps) {
 									<video
 										// Order matter for crossOrigin attr
 										crossOrigin="anonymous"
+										ref={video}
 										src={src}
 										onError={onError}
-										autoPlay
+										autoPlay={!props.paused}
 										onVolumeChange={(e) => {
 											const video = e.target as HTMLVideoElement;
 											getExplorerStore().mediaPlayerVolume = video.volume;

--- a/interface/app/$libraryId/Explorer/Inspector/index.tsx
+++ b/interface/app/$libraryId/Explorer/Inspector/index.tsx
@@ -93,7 +93,7 @@ export const Inspector = ({ data, context, showThumbnail = true, ...props }: Pro
 					{showThumbnail && (
 						<div className="mb-2 aspect-square">
 							<FileThumb
-								paused={!!explorerStore.quickViewObject}
+								pauseVideo={!!explorerStore.quickViewObject}
 								loadOriginal
 								size={null}
 								data={data}

--- a/interface/app/$libraryId/Explorer/Inspector/index.tsx
+++ b/interface/app/$libraryId/Explorer/Inspector/index.tsx
@@ -2,7 +2,17 @@
 import { Image, Image_Light } from '@sd/assets/icons';
 import clsx from 'clsx';
 import dayjs from 'dayjs';
-import { Barcode, CircleWavyCheck, Clock, Cube, Hash, Link, Lock, Path, Snowflake } from 'phosphor-react';
+import {
+	Barcode,
+	CircleWavyCheck,
+	Clock,
+	Cube,
+	Hash,
+	Link,
+	Lock,
+	Path,
+	Snowflake
+} from 'phosphor-react';
 import { HTMLAttributes, useEffect, useState } from 'react';
 import {
 	ExplorerItem,
@@ -19,6 +29,7 @@ import { Button, Divider, DropdownMenu, Tooltip, tw } from '@sd/ui';
 import { useIsDark } from '~/hooks';
 import AssignTagMenuItems from '../ContextMenu/Object/AssignTagMenuItems';
 import FileThumb from '../FilePath/Thumb';
+import { useExplorerStore } from '../store.js';
 import FavoriteButton from './FavoriteButton';
 import Note from './Note';
 
@@ -46,6 +57,7 @@ export const Inspector = ({ data, context, showThumbnail = true, ...props }: Pro
 	const isDark = useIsDark();
 	const objectData = data ? getItemObject(data) : null;
 	const filePathData = data ? getItemFilePath(data) : null;
+	const explorerStore = useExplorerStore();
 
 	const isDir = data?.type === 'Path' ? data.item.is_dir : false;
 
@@ -80,7 +92,13 @@ export const Inspector = ({ data, context, showThumbnail = true, ...props }: Pro
 				<>
 					{showThumbnail && (
 						<div className="mb-2 aspect-square">
-							<FileThumb loadOriginal size={null} data={data} className="mx-auto" />
+							<FileThumb
+								paused={!!explorerStore.quickViewObject}
+								loadOriginal
+								size={null}
+								data={data}
+								className="mx-auto"
+							/>
 						</div>
 					)}
 					<div className="flex w-full select-text flex-col overflow-hidden rounded-lg border border-app-line bg-app-box py-0.5 shadow-app-shade/10">
@@ -203,9 +221,7 @@ export const Inspector = ({ data, context, showThumbnail = true, ...props }: Pro
 									<MetaTextLine>
 										<InspectorIcon component={Path} />
 										<MetaKeyName className="mr-1.5">Path</MetaKeyName>
-										<MetaValue>
-											{fileFullPath}
-										</MetaValue>
+										<MetaValue>{fileFullPath}</MetaValue>
 									</MetaTextLine>
 								</Tooltip>
 							)}


### PR DESCRIPTION
<!-- Put any information about this PR up here -->
Hi!
I gave this a try, let me know what you think :) 

A new "paused" prop on the FileThumb is used to pause and unpause when the quick-view is opened and closed.

<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->

Closes #1177
