### PR TITLE
Update command to run server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ To quickly run only the desktop app after `prep`, you can use:
 
 To run the web app:
 
-- `cargo run -p server` (runs the server)
+- `cargo run -p sd-server` (runs the server)
 - `pnpm web dev` (runs the web embed server)
 
 To run the landing page:


### PR DESCRIPTION
I encountered an issue where the cargo run -p server command was not functioning properly. It took me nearly an hour to pinpoint the problem, which turned out to be related to a modification in the Cargo.toml file. This change was made by @Brendonovich during their work on issue #1181, which pertained to *syncing ingestion*.

Initially, I believed that re-cloning the repository from GitHub would resolve the issue. However, after attempting this solution exactly 5 times, I realized my assumption was incorrect. Despite the time and effort spent, I was able to successfully identify and rectify the problem.

Closes #1181