### PR TITLE
Move onboarding form handling logic to Layout

### DIFF
--- a/interface/app/onboarding/Layout.tsx
+++ b/interface/app/onboarding/Layout.tsx
@@ -14,6 +14,7 @@ import { useOperatingSystem } from '~/hooks/useOperatingSystem';
 import DebugPopover from '../$libraryId/Layout/Sidebar/DebugPopover';
 import { macOnly } from '../$libraryId/Layout/Sidebar/helpers';
 import Progress from './Progress';
+import { OnboardingContext, useContextValue } from './context';
 
 export const OnboardingContainer = tw.div`flex flex-col items-center`;
 export const OnboardingTitle = tw.h2`mb-2 text-3xl font-bold`;
@@ -36,6 +37,7 @@ export const Component = () => {
 			// This is neat because restores the last active screen, but only if it is not the starting screen
 			// Ignoring if people navigate back to the start if progress has been made
 			if (obStore.unlockedScreens.length > 1 && !library) {
+				console.log(obStore.unlockedScreens);
 				navigate(`/onboarding/${obStore.lastActiveScreen}`, { replace: true });
 			}
 		},
@@ -43,34 +45,39 @@ export const Component = () => {
 		[]
 	);
 
+	const ctx = useContextValue();
+
 	if (libraries.isLoading) return null;
-	if (library?.uuid) return <Navigate to={`${library.uuid}/overview`} replace />;
+	if (library?.uuid) return <Navigate to={`/${library.uuid}/overview`} replace />;
+
 	return (
-		<div
-			className={clsx(
-				macOnly(os, 'bg-opacity-[0.75]'),
-				'flex h-screen flex-col bg-sidebar text-ink'
-			)}
-		>
-			<DragRegion className="z-50 h-9" />
-			<div className="-mt-5 flex grow flex-col gap-8 p-10">
-				<div className="flex grow flex-col items-center justify-center">
-					<Outlet />
+		<OnboardingContext.Provider value={ctx}>
+			<div
+				className={clsx(
+					macOnly(os, 'bg-opacity-[0.75]'),
+					'flex h-screen flex-col bg-sidebar text-ink'
+				)}
+			>
+				<DragRegion className="z-50 h-9" />
+				<div className="-mt-5 flex grow flex-col gap-8 p-10">
+					<div className="flex grow flex-col items-center justify-center">
+						<Outlet />
+					</div>
+					<Progress />
 				</div>
-				<Progress />
-			</div>
-			<div className="flex justify-center p-4">
-				<p className="text-xs text-ink-dull opacity-50">
-					&copy; 2022 Spacedrive Technology Inc.
-				</p>
-			</div>
-			<div className="absolute -z-10">
-				<div className="relative h-screen w-screen">
-					<img src={BloomOne} className="absolute h-[2000px] w-[2000px]" />
-					{/* <img src={BloomThree} className="absolute w-[2000px] h-[2000px] -right-[200px]" /> */}
+				<div className="flex justify-center p-4">
+					<p className="text-xs text-ink-dull opacity-50">
+						&copy; 2022 Spacedrive Technology Inc.
+					</p>
 				</div>
+				<div className="absolute -z-10">
+					<div className="relative h-screen w-screen">
+						<img src={BloomOne} className="absolute h-[2000px] w-[2000px]" />
+						{/* <img src={BloomThree} className="absolute w-[2000px] h-[2000px] -right-[200px]" /> */}
+					</div>
+				</div>
+				{debugState.enabled && <DebugPopover />}
 			</div>
-			{debugState.enabled && <DebugPopover />}
-		</div>
+		</OnboardingContext.Provider>
 	);
 };

--- a/interface/app/onboarding/Layout.tsx
+++ b/interface/app/onboarding/Layout.tsx
@@ -31,7 +31,9 @@ export const Component = () => {
 		unlockOnboardingScreen(screen, getOnboardingStore().unlockedScreens);
 	}, [match?.params?.screen]);
 
-	if (ctx.library?.uuid) return <Navigate to={`/${ctx.library.uuid}/overview`} replace />;
+	if (ctx.libraries.isLoading) return null;
+	if (ctx.library?.uuid !== undefined)
+		return <Navigate to={`/${ctx.library.uuid}/overview`} replace />;
 
 	return (
 		<OnboardingContext.Provider value={ctx}>

--- a/interface/app/onboarding/Layout.tsx
+++ b/interface/app/onboarding/Layout.tsx
@@ -1,8 +1,7 @@
 import { BloomOne } from '@sd/assets/images';
 import clsx from 'clsx';
-import { useEffect } from 'react';
-import { Navigate, Outlet, useMatch } from 'react-router';
-import { getOnboardingStore, unlockOnboardingScreen, useDebugState } from '@sd/client';
+import { Navigate, Outlet } from 'react-router';
+import { useDebugState } from '@sd/client';
 import { tw } from '@sd/ui';
 import DragRegion from '~/components/DragRegion';
 import { useOperatingSystem } from '~/hooks/useOperatingSystem';
@@ -22,15 +21,6 @@ export const Component = () => {
 
 	const ctx = useContextValue();
 
-	const match = useMatch('/onboarding/:screen');
-
-	useEffect(() => {
-		const screen = match?.params?.screen;
-		if (!screen) return;
-
-		unlockOnboardingScreen(screen, getOnboardingStore().unlockedScreens);
-	}, [match?.params?.screen]);
-
 	if (ctx.libraries.isLoading) return null;
 	if (ctx.library?.uuid !== undefined)
 		return <Navigate to={`/${ctx.library.uuid}/overview`} replace />;
@@ -48,7 +38,7 @@ export const Component = () => {
 					<div className="flex grow flex-col items-center justify-center">
 						<Outlet />
 					</div>
-					<Progress currentScreen={match?.params?.screen} />
+					<Progress />
 				</div>
 				<div className="flex justify-center p-4">
 					<p className="text-xs text-ink-dull opacity-50">

--- a/interface/app/onboarding/Progress.tsx
+++ b/interface/app/onboarding/Progress.tsx
@@ -1,32 +1,11 @@
 import clsx from 'clsx';
-import { useEffect } from 'react';
-import { useLocation, useNavigate } from 'react-router';
-import { getOnboardingStore, unlockOnboardingScreen, useOnboardingStore } from '@sd/client';
+import { useNavigate } from 'react-router';
+import { useOnboardingStore } from '@sd/client';
 import routes from '.';
 
-export const useCurrentOnboardingScreenKey = (): string | null => {
-	const { pathname } = useLocation();
-
-	if (pathname.startsWith(`/onboarding/`)) {
-		return pathname.split('/')[2] || null;
-	}
-
-	return null;
-};
-
-// screens are locked to prevent users from skipping ahead
-export function useUnlockOnboardingScreen() {
-	const currentScreenKey = useCurrentOnboardingScreenKey()!;
-
-	useEffect(() => {
-		unlockOnboardingScreen(currentScreenKey, getOnboardingStore().unlockedScreens);
-	}, [currentScreenKey]);
-}
-
-export default function OnboardingProgress() {
+export default function OnboardingProgress(props: { currentScreen?: string }) {
 	const obStore = useOnboardingStore();
 	const navigate = useNavigate();
-	const currentScreenKey = useCurrentOnboardingScreenKey();
 
 	return (
 		<div className="flex w-full items-center justify-center">
@@ -38,10 +17,10 @@ export default function OnboardingProgress() {
 						<button
 							key={path}
 							disabled={!obStore.unlockedScreens.includes(path)}
-							onClick={() => navigate(`/onboarding/${path}`, { replace: true })}
+							onClick={() => navigate(`./${path}`, { replace: true })}
 							className={clsx(
 								'h-2 w-2 rounded-full transition hover:bg-ink disabled:opacity-10',
-								currentScreenKey === path ? 'bg-ink' : 'bg-ink-faint'
+								props.currentScreen === path ? 'bg-ink' : 'bg-ink-faint'
 							)}
 						/>
 					);

--- a/interface/app/onboarding/Progress.tsx
+++ b/interface/app/onboarding/Progress.tsx
@@ -1,11 +1,22 @@
 import clsx from 'clsx';
-import { useNavigate } from 'react-router';
-import { useOnboardingStore } from '@sd/client';
+import { useEffect } from 'react';
+import { useMatch, useNavigate } from 'react-router';
+import { getOnboardingStore, unlockOnboardingScreen, useOnboardingStore } from '@sd/client';
 import routes from '.';
 
-export default function OnboardingProgress(props: { currentScreen?: string }) {
+export default function OnboardingProgress() {
 	const obStore = useOnboardingStore();
 	const navigate = useNavigate();
+
+	const match = useMatch('/onboarding/:screen');
+
+	const currentScreen = match?.params?.screen;
+
+	useEffect(() => {
+		if (!currentScreen) return;
+
+		unlockOnboardingScreen(currentScreen, getOnboardingStore().unlockedScreens);
+	}, [currentScreen]);
 
 	return (
 		<div className="flex w-full items-center justify-center">
@@ -20,7 +31,7 @@ export default function OnboardingProgress(props: { currentScreen?: string }) {
 							onClick={() => navigate(`./${path}`, { replace: true })}
 							className={clsx(
 								'h-2 w-2 rounded-full transition hover:bg-ink disabled:opacity-10',
-								props.currentScreen === path ? 'bg-ink' : 'bg-ink-faint'
+								currentScreen === path ? 'bg-ink' : 'bg-ink-faint'
 							)}
 						/>
 					);

--- a/interface/app/onboarding/alpha.tsx
+++ b/interface/app/onboarding/alpha.tsx
@@ -1,6 +1,5 @@
 import { AlphaBg, AlphaBg_Light, AppLogo } from '@sd/assets/images';
 import { Discord } from '@sd/assets/svgs/brands';
-import { useMatches, useNavigate } from 'react-router-dom';
 import { Button, ButtonLink } from '@sd/ui';
 import { useIsDark } from '~/hooks';
 import { usePlatform } from '~/util/Platform';

--- a/interface/app/onboarding/alpha.tsx
+++ b/interface/app/onboarding/alpha.tsx
@@ -1,13 +1,12 @@
 import { AlphaBg, AlphaBg_Light, AppLogo } from '@sd/assets/images';
 import { Discord } from '@sd/assets/svgs/brands';
-import { useNavigate } from 'react-router-dom';
-import { Button } from '@sd/ui';
+import { useMatches, useNavigate } from 'react-router-dom';
+import { Button, ButtonLink } from '@sd/ui';
 import { useIsDark } from '~/hooks';
 import { usePlatform } from '~/util/Platform';
 import { OnboardingContainer } from './Layout';
 
 export default function OnboardingAlpha() {
-	const navigate = useNavigate();
 	const platform = usePlatform();
 	const isDark = useIsDark();
 
@@ -34,23 +33,16 @@ export default function OnboardingAlpha() {
 					</p>
 					<div className="mt-0 flex w-full items-center justify-center gap-2">
 						<Button
-							onClick={() => {
-								platform.openLink('https://discord.gg/ukRnWSnAbG');
-							}}
+							onClick={() => platform.openLink('https://discord.gg/ukRnWSnAbG')}
 							className="flex gap-2"
 							variant="gray"
 						>
 							<Discord className="h-4 w-4 fill-ink" />
 							Join Discord
 						</Button>
-						<Button
-							onClick={() => {
-								navigate('/onboarding/new-library', { replace: true });
-							}}
-							variant="accent"
-						>
+						<ButtonLink to="../new-library" replace variant="accent">
 							Continue
-						</Button>
+						</ButtonLink>
 					</div>
 				</div>
 			</div>

--- a/interface/app/onboarding/context.tsx
+++ b/interface/app/onboarding/context.tsx
@@ -99,7 +99,7 @@ const useFormState = () => {
 			if (e instanceof Error) {
 				alert(`Failed to create library. Error: ${e.message}`);
 			}
-			navigate('/onboarding/privacy');
+			navigate('./privacy');
 		}
 	});
 

--- a/interface/app/onboarding/context.tsx
+++ b/interface/app/onboarding/context.tsx
@@ -1,0 +1,102 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { createContext, useContext } from 'react';
+import { SubmitHandler } from 'react-hook-form';
+import { useNavigate } from 'react-router';
+import {
+	getOnboardingStore,
+	resetOnboardingStore,
+	telemetryStore,
+	useBridgeMutation,
+	useOnboardingStore,
+	usePlausibleEvent
+} from '@sd/client';
+import { RadioGroupField, useZodForm, z } from '@sd/ui';
+
+export const OnboardingContext = createContext<ReturnType<typeof useContextValue> | null>(null);
+
+export const shareTelemetry = RadioGroupField.options([
+	z.literal('share-telemetry'),
+	z.literal('no-telemetry')
+]).details({
+	'share-telemetry': {
+		heading: 'Share anonymous usage',
+		description:
+			'Share completely anonymous telemetry data to help the developers improve the app'
+	},
+	'no-telemetry': {
+		heading: 'Share nothing',
+		description: 'Do not share any telemetry data with the developers'
+	}
+});
+
+const schema = z.object({
+	name: z.string().min(1, 'Name is required').regex(/[\S]/g).trim(),
+	shareTelemetry: shareTelemetry.schema
+});
+
+export const useContextValue = () => {
+	const obStore = useOnboardingStore();
+
+	const form = useZodForm({
+		schema,
+		defaultValues: {
+			name: obStore.newLibraryName,
+			shareTelemetry: 'share-telemetry'
+		}
+	});
+
+	const navigate = useNavigate();
+	const queryClient = useQueryClient();
+	const submitPlausibleEvent = usePlausibleEvent();
+
+	const createLibrary = useBridgeMutation('library.create');
+
+	const onSubmit = form.handleSubmit(async (data) => {
+		navigate('./creating-library', { replace: true });
+
+		// opted to place this here as users could change their mind before library creation/onboarding finalization
+		// it feels more fitting to configure it here (once)
+		telemetryStore.shareTelemetry = getOnboardingStore().shareTelemetry;
+
+		try {
+			// show creation screen for a bit for smoothness
+			const [library] = await Promise.all([
+				createLibrary.mutateAsync({
+					name: data.name
+				}),
+				new Promise((res) => setTimeout(res, 500))
+			]);
+
+			queryClient.setQueryData(['library.list'], (libraries: any) => [
+				...(libraries ?? []),
+				library
+			]);
+
+			if (telemetryStore.shareTelemetry) {
+				submitPlausibleEvent({ event: { type: 'libraryCreate' } });
+			}
+
+			resetOnboardingStore();
+			navigate(`/${library.uuid}/overview`, { replace: true });
+		} catch (e) {
+			if (e instanceof Error) {
+				alert(`Failed to create library. Error: ${e.message}`);
+			}
+			navigate('/onboarding/privacy');
+		}
+	});
+
+	return {
+		form,
+		onSubmit
+	};
+};
+
+export const useOnboardingContext = () => {
+	const ctx = useContext(OnboardingContext);
+
+	if (!ctx)
+		throw new Error('useOnboardingContext must be used within OnboardingContext.Provider');
+
+	return ctx;
+};

--- a/interface/app/onboarding/context.tsx
+++ b/interface/app/onboarding/context.tsx
@@ -26,6 +26,7 @@ export const useContextValue = () => {
 
 	return {
 		...form,
+		libraries,
 		library
 	};
 };

--- a/interface/app/onboarding/creating-library.tsx
+++ b/interface/app/onboarding/creating-library.tsx
@@ -1,10 +1,7 @@
 import { Loader } from '@sd/ui';
 import { OnboardingContainer, OnboardingDescription, OnboardingTitle } from './Layout';
-import { useUnlockOnboardingScreen } from './Progress';
 
 export default function OnboardingCreatingLibrary() {
-	useUnlockOnboardingScreen();
-
 	return (
 		<OnboardingContainer>
 			<span className="text-6xl">🛠</span>

--- a/interface/app/onboarding/creating-library.tsx
+++ b/interface/app/onboarding/creating-library.tsx
@@ -1,88 +1,15 @@
-import { useQueryClient } from '@tanstack/react-query';
-import { useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router';
-import {
-	resetOnboardingStore,
-	telemetryStore,
-	useBridgeMutation,
-	useDebugState,
-	useOnboardingStore,
-	usePlausibleEvent
-} from '@sd/client';
 import { Loader } from '@sd/ui';
 import { OnboardingContainer, OnboardingDescription, OnboardingTitle } from './Layout';
 import { useUnlockOnboardingScreen } from './Progress';
 
 export default function OnboardingCreatingLibrary() {
-	const navigate = useNavigate();
-	const queryClient = useQueryClient();
-	const debugState = useDebugState();
-	const submitPlausibleEvent = usePlausibleEvent();
-
-	const [status, setStatus] = useState('Creating your library...');
-
 	useUnlockOnboardingScreen();
-
-	const createLibrary = useBridgeMutation('library.create', {
-		onSuccess: (library) => {
-			queryClient.setQueryData(['library.list'], (libraries: any) => [
-				...(libraries || []),
-				library
-			]);
-
-			if (obStore.shareTelemetry) {
-				submitPlausibleEvent({ event: { type: 'libraryCreate' } });
-			}
-
-			resetOnboardingStore();
-			navigate(`/${library.uuid}/overview`, { replace: true });
-		},
-		onError: (e) => {
-			// resetOnboardingStore();
-			alert(`Failed to create library. Error: ${e.message}`);
-			navigate('/onboarding/privacy');
-		}
-	});
-
-	const obStore = useOnboardingStore();
-
-	const create = async () => {
-		// opted to place this here as users could change their mind before library creation/onboarding finalization
-		// it feels more fitting to configure it here (once)
-		telemetryStore.shareTelemetry = obStore.shareTelemetry;
-
-		console.log('creating');
-		createLibrary.mutate({
-			name: obStore.newLibraryName
-		});
-	};
-
-	const created = useRef(false);
-
-	useEffect(() => {
-		if (created.current) return;
-		created.current = true;
-		create();
-		const timer = setTimeout(() => {
-			setStatus('Almost done...');
-		}, 2000);
-		const timer2 = setTimeout(() => {
-			if (debugState.enabled) {
-				setStatus(`You're running in development, this will take longer...`);
-			}
-		}, 5000);
-		return () => {
-			clearTimeout(timer);
-			clearTimeout(timer2);
-		};
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
 
 	return (
 		<OnboardingContainer>
 			<span className="text-6xl">🛠</span>
 			<OnboardingTitle>Creating your library</OnboardingTitle>
-			<OnboardingDescription>{status}</OnboardingDescription>
+			<OnboardingDescription>Creating your library...</OnboardingDescription>
 			<Loader className="mt-5" />
 		</OnboardingContainer>
 	);

--- a/interface/app/onboarding/index.tsx
+++ b/interface/app/onboarding/index.tsx
@@ -10,9 +10,7 @@ const Index = () => {
 	const obStore = getOnboardingStore();
 	const ctx = useOnboardingContext();
 
-	// This is neat because restores the last active screen, but only if it is not the starting screen
-	// Ignoring if people navigate back to the start if progress has been made
-	if (obStore.lastActiveScreen && obStore.unlockedScreens.length > 1 && !ctx.library)
+	if (obStore.lastActiveScreen && !ctx.library)
 		return <Navigate to={obStore.lastActiveScreen} replace />;
 
 	return <Navigate to="alpha" replace />;

--- a/interface/app/onboarding/index.tsx
+++ b/interface/app/onboarding/index.tsx
@@ -1,13 +1,27 @@
 import { Navigate, RouteObject } from 'react-router';
+import { getOnboardingStore } from '@sd/client';
 import Alpha from './alpha';
+import { useOnboardingContext } from './context';
 import CreatingLibrary from './creating-library';
 import NewLibrary from './new-library';
 import Privacy from './privacy';
 
+const Index = () => {
+	const obStore = getOnboardingStore();
+	const ctx = useOnboardingContext();
+
+	// This is neat because restores the last active screen, but only if it is not the starting screen
+	// Ignoring if people navigate back to the start if progress has been made
+	if (obStore.lastActiveScreen && obStore.unlockedScreens.length > 1 && !ctx.library)
+		return <Navigate to={obStore.lastActiveScreen} replace />;
+
+	return <Navigate to="alpha" replace />;
+};
+
 export default [
 	{
 		index: true,
-		element: <Navigate to="alpha" replace />
+		element: <Index />
 	},
 	{ path: 'alpha', element: <Alpha /> },
 	{

--- a/interface/app/onboarding/new-library.tsx
+++ b/interface/app/onboarding/new-library.tsx
@@ -9,15 +9,12 @@ import {
 	OnboardingImg,
 	OnboardingTitle
 } from './Layout';
-import { useUnlockOnboardingScreen } from './Progress';
 import { useOnboardingContext } from './context';
 
 export default function OnboardingNewLibrary() {
 	const navigate = useNavigate();
 	const { form } = useOnboardingContext();
 	const [importMode, setImportMode] = useState(false);
-
-	useUnlockOnboardingScreen();
 
 	const handleImport = () => {
 		// TODO
@@ -29,7 +26,7 @@ export default function OnboardingNewLibrary() {
 			// manual onSubmit as we need to set the library name in the store
 			onSubmit={async () => {
 				getOnboardingStore().newLibraryName = form.getValues('name');
-				navigate('privacy', { replace: true });
+				navigate('../privacy', { replace: true });
 			}}
 		>
 			<OnboardingContainer>

--- a/interface/app/onboarding/new-library.tsx
+++ b/interface/app/onboarding/new-library.tsx
@@ -1,8 +1,8 @@
 import { Database } from '@sd/assets/icons';
 import { useState } from 'react';
 import { useNavigate } from 'react-router';
-import { getOnboardingStore, useOnboardingStore } from '@sd/client';
-import { Button, Form, InputField, useZodForm, z } from '@sd/ui';
+import { getOnboardingStore } from '@sd/client';
+import { Button, Form, InputField } from '@sd/ui';
 import {
 	OnboardingContainer,
 	OnboardingDescription,
@@ -10,38 +10,28 @@ import {
 	OnboardingTitle
 } from './Layout';
 import { useUnlockOnboardingScreen } from './Progress';
-
-const schema = z.object({
-	// the regex here validates that the entire string isn't purely whitespace
-	name: z.string().min(1, 'Name is required').regex(/[\S]/g).trim()
-});
+import { useOnboardingContext } from './context';
 
 export default function OnboardingNewLibrary() {
 	const navigate = useNavigate();
+	const { form } = useOnboardingContext();
 	const [importMode, setImportMode] = useState(false);
 
-	const obStore = useOnboardingStore();
-
-	const form = useZodForm({
-		schema,
-		defaultValues: {
-			name: obStore.newLibraryName
-		}
-	});
-
 	useUnlockOnboardingScreen();
-
-	const onSubmit = form.handleSubmit(async (data) => {
-		getOnboardingStore().newLibraryName = data.name;
-		navigate('/onboarding/privacy', { replace: true });
-	});
 
 	const handleImport = () => {
 		// TODO
 	};
 
 	return (
-		<Form form={form} onSubmit={onSubmit}>
+		<Form
+			form={form}
+			// manual onSubmit as we need to set the library name in the store
+			onSubmit={async () => {
+				getOnboardingStore().newLibraryName = form.getValues('name');
+				navigate('privacy', { replace: true });
+			}}
+		>
 			<OnboardingContainer>
 				<OnboardingImg src={Database} />
 				<OnboardingTitle>Create a Library</OnboardingTitle>

--- a/interface/app/onboarding/privacy.tsx
+++ b/interface/app/onboarding/privacy.tsx
@@ -1,48 +1,24 @@
-import { useNavigate } from 'react-router';
-import { getOnboardingStore } from '@sd/client';
-import { Button, Form, RadioGroupField, useZodForm, z } from '@sd/ui';
+import { Button, Form, RadioGroupField } from '@sd/ui';
+import { getOnboardingStore } from '~/../packages/client/src';
 import { OnboardingContainer, OnboardingDescription, OnboardingTitle } from './Layout';
 import { useUnlockOnboardingScreen } from './Progress';
-
-export const shareTelemetry = RadioGroupField.options([
-	z.literal('share-telemetry'),
-	z.literal('no-telemetry')
-]).details({
-	'share-telemetry': {
-		heading: 'Share anonymous usage',
-		description:
-			'Share completely anonymous telemetry data to help the developers improve the app'
-	},
-	'no-telemetry': {
-		heading: 'Share nothing',
-		description: 'Do not share any telemetry data with the developers'
-	}
-});
-
-const schema = z.object({
-	shareTelemetry: shareTelemetry.schema
-});
+import { shareTelemetry, useOnboardingContext } from './context';
 
 export default function OnboardingPrivacy() {
-	const navigate = useNavigate();
+	const { form, onSubmit } = useOnboardingContext();
 
 	useUnlockOnboardingScreen();
 
-	const form = useZodForm({
-		schema,
-		defaultValues: {
-			shareTelemetry: 'share-telemetry'
-		}
-	});
-
-	const onSubmit = form.handleSubmit((data) => {
-		getOnboardingStore().shareTelemetry = data.shareTelemetry === 'share-telemetry';
-
-		navigate('/onboarding/creating-library', { replace: true });
-	});
-
 	return (
-		<Form form={form} onSubmit={onSubmit} className="flex flex-col items-center">
+		<Form
+			form={form}
+			onSubmit={(e) => {
+				getOnboardingStore().shareTelemetry =
+					form.getValues('shareTelemetry') === 'share-telemetry';
+				return onSubmit(e);
+			}}
+			className="flex flex-col items-center"
+		>
 			<OnboardingContainer>
 				<OnboardingTitle>Your Privacy</OnboardingTitle>
 				<OnboardingDescription>
@@ -59,7 +35,7 @@ export default function OnboardingPrivacy() {
 						))}
 					</RadioGroupField.Root>
 				</div>
-				<Button className="text-center" type="submit" variant="accent" size="sm">
+				<Button type="submit" className="text-center" variant="accent" size="sm">
 					Continue
 				</Button>
 			</OnboardingContainer>

--- a/interface/app/onboarding/privacy.tsx
+++ b/interface/app/onboarding/privacy.tsx
@@ -1,13 +1,10 @@
 import { Button, Form, RadioGroupField } from '@sd/ui';
 import { getOnboardingStore } from '~/../packages/client/src';
 import { OnboardingContainer, OnboardingDescription, OnboardingTitle } from './Layout';
-import { useUnlockOnboardingScreen } from './Progress';
 import { shareTelemetry, useOnboardingContext } from './context';
 
 export default function OnboardingPrivacy() {
 	const { form, onSubmit } = useOnboardingContext();
-
-	useUnlockOnboardingScreen();
 
 	return (
 		<Form

--- a/packages/client/src/hooks/useOnboardingStore.ts
+++ b/packages/client/src/hooks/useOnboardingStore.ts
@@ -9,16 +9,16 @@ export enum UseCase {
 	Other = 'other'
 }
 
-const onboardingStoreDefaults = {
+const onboardingStoreDefaults = () => ({
 	newLibraryName: '',
 	unlockedScreens: ['alpha'],
 	lastActiveScreen: null as string | null,
 	shareTelemetry: true,
 	useCases: [] as UseCase[],
 	grantedFullDiskAccess: false
-};
+});
 
-const appOnboardingStore = valtioPersist('onboarding', onboardingStoreDefaults);
+const appOnboardingStore = valtioPersist('onboarding', onboardingStoreDefaults());
 
 export function useOnboardingStore() {
 	return useSnapshot(appOnboardingStore);
@@ -29,10 +29,7 @@ export function getOnboardingStore() {
 }
 
 export function resetOnboardingStore() {
-	for (const key in onboardingStoreDefaults) {
-		// @ts-expect-error - TODO: type needs to be fixed
-		appOnboardingStore[key] = onboardingStoreDefaults[key];
-	}
+	Object.assign(appOnboardingStore, onboardingStoreDefaults());
 }
 
 export function unlockOnboardingScreen(key: string, unlockedScreens: string[] = []) {

--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -1,7 +1,7 @@
 import { VariantProps, cva, cx } from 'class-variance-authority';
 import clsx from 'clsx';
-import { forwardRef } from 'react';
-import { Link, LinkProps } from 'react-router-dom';
+import { ComponentProps, forwardRef } from 'react';
+import { Link } from 'react-router-dom';
 
 export interface ButtonBaseProps extends VariantProps<typeof styles> {}
 
@@ -82,7 +82,7 @@ export const Button = forwardRef<
 
 export const ButtonLink = forwardRef<
 	HTMLAnchorElement,
-	ButtonBaseProps & LinkProps & React.RefAttributes<HTMLAnchorElement>
+	ButtonBaseProps & ComponentProps<typeof Link>
 >(({ className, size, variant, ...props }, ref) => {
 	return (
 		<Link

--- a/packages/ui/src/forms/Form.tsx
+++ b/packages/ui/src/forms/Form.tsx
@@ -34,6 +34,7 @@ export const Form = <T extends FieldValues>({
 			<form
 				onSubmit={(e) => {
 					e.stopPropagation();
+					e.preventDefault();
 					return onSubmit?.(e);
 				}}
 				{...props}


### PR DESCRIPTION
Currently, each onboarding page contains its own `useZodForm`, inserts data into `onboardingStore`, and then the `/onboarding/creating-library` route executes the `library.create` mutation in a `useEffect` (eew yucky).
Now, the onboarding `Layout` holds a singular form state that is provided via context to all the sub-routes. The sub-routes then consume this form in their own `Form` components, but none except the final `/onboarding/privacy` route actually call the main `onSubmit` handler, which when called is in charge of navigating to `/onboarding/creating-libraries` (rather than the other way around!).