### PR TITLE
scripts: filter actions by main branch in workflow runs

### DIFF
--- a/.github/scripts/setup-system.sh
+++ b/.github/scripts/setup-system.sh
@@ -280,9 +280,8 @@ elif [ "$SYSNAME" = "Darwin" ]; then
   echo "Download ffmpeg build..."
   _page=1
   while [ $_page -gt 0 ]; do
-    # TODO: Filter only actions triggered by the main branch
     _success=$(gh_curl "${_gh_url}/${_sd_gh_path}/actions/workflows/ffmpeg-macos.yml/runs?page=${_page}&per_page=100&status=success" \
-      | jq -r '. as $raw | .workflow_runs | if length == 0 then error("Error: \($raw)") else .[] | .artifacts_url end' \
+      | jq -r '. as $raw | .workflow_runs | if length == 0 then error("Error: \($raw)") else .[] | select(.head_branch == "main") | .artifacts_url end' \
       | while IFS= read -r _artifacts_url; do
         if _artifact_path="$(
           gh_curl "$_artifacts_url" \


### PR DESCRIPTION
<!-- Put any information about this PR up here -->
This pull request addresses the issue where actions triggered by non-main branches were being included in the workflow runs.
The code modification ensures that only actions triggered by the main branch are considered for further processing.

<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->