### PR TITLE
[ENG-904] Thumbnail for `svg`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1720,6 +1720,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-url"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7439c3735f405729d52c3fbbe4de140eaf938a1fe47d227c27f8254d4302a5"
+
+[[package]]
 name = "datamodel-renderer"
 version = "0.1.0"
 source = "git+https://github.com/Brendonovich/prisma-engines?branch=new-4.14.0-pcr#45b026c8b64ed0b60cb03deed5f478c457de645b"
@@ -2341,6 +2347,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
 name = "flume"
 version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2358,6 +2370,29 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "674e258f4b5d2dcd63888c01c68413c51f565e8af99d2f7701c7b81d79ef41c4"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af8d8cbea8f21307d7e84bca254772981296f058a1d36b461bf4d83a7499fc9e"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser 0.19.1",
+]
 
 [[package]]
 name = "foreign-types"
@@ -3341,6 +3376,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "imagesize"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "029d73f573d8e8d63e6d5020011d3255b28c3ba85d6cf870a07184ed23de9284"
+
+[[package]]
 name = "include_dir"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3712,6 +3753,15 @@ dependencies = [
  "html5ever",
  "matches",
  "selectors",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd85a5776cd9500c2e2059c8c76c3b01528566b7fcbaf8098b55a33fc298849b"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]
@@ -4335,6 +4385,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memmap2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d28bba84adfe6646737845bc5ebbfa2c08424eb1c37e94a1fd2a82adb56a872"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -5554,6 +5613,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6353,6 +6418,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rctree"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b42e27ef78c35d3998403c1d26f3efd9e135d3e5121b0a4845cc5cc27547f4f"
+
+[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6517,6 +6588,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "resvg"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6554f47c38eca56827eea7f285c2a3018b4e12e0e195cc105833c008be338f1"
+dependencies = [
+ "gif",
+ "jpeg-decoder",
+ "log",
+ "pico-args",
+ "png",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6549,6 +6637,15 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows 0.37.0",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20ec2d3e3fc7a92ced357df9cebd5a10b6fb2aa1ee797bf7e9ce2f17dffc8f59"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -6596,6 +6693,15 @@ checksum = "2e0e0214a4a2b444ecce41a4025792fc31f77c7bb89c46d253953ea8c65701ec"
 dependencies = [
  "num-traits",
  "rmp",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f595a457b6b8c6cda66a48503e92ee8d19342f905948f29c383200ec9eb1d8"
+dependencies = [
+ "xmlparser",
 ]
 
 [[package]]
@@ -6761,6 +6867,22 @@ name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
+name = "rustybuzz"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162bdf42e261bee271b3957691018634488084ef577dddeb6420a9684cab2a6a"
+dependencies = [
+ "bitflags 1.3.2",
+ "bytemuck",
+ "smallvec 1.11.0",
+ "ttf-parser 0.18.1",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-general-category",
+ "unicode-script",
+]
 
 [[package]]
 name = "rw-stream-sink"
@@ -7222,6 +7344,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sd-svg"
+version = "0.1.0"
+dependencies = [
+ "image",
+ "resvg",
+ "thiserror",
+ "tokio",
+ "tracing 0.1.37",
+]
+
+[[package]]
 name = "sd-sync"
 version = "0.1.0"
 dependencies = [
@@ -7662,6 +7795,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "simplecss"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a11be7c62927d9427e9f40f3444d5499d868648e2edbc4e2116de69e7ec0e89d"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7983,6 +8125,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
+
+[[package]]
 name = "string_cache"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8069,6 +8220,16 @@ name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
+name = "svgtypes"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed4b0611e7f3277f68c0fa18e385d9e2d26923691379690039548f867cef02a7"
+dependencies = [
+ "kurbo",
+ "siphasher",
+]
 
 [[package]]
 name = "swift-rs"
@@ -8620,6 +8781,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-skia"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db11798945fa5c3e5490c794ccca7c6de86d3afdd54b4eb324109939c6f37bc"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f60aa35c89ac2687ace1a2556eaaea68e8c0d47408a2e3e7f5c98a489e7281c"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9060,6 +9247,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
+name = "ttf-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0609f771ad9c6155384897e1df4d948e692667cc0588548b68eb44d052b27633"
+
+[[package]]
+name = "ttf-parser"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a464a4b34948a5f67fddd2b823c62d9d92e44be75058b99939eae6c5b6960b33"
+
+[[package]]
 name = "tungstenite"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9152,6 +9351,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
+name = "unicode-bidi-mirroring"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d12260fb92d52f9008be7e4bca09f584780eb2266dc8fecc6a192bec561694"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2520efa644f8268dce4dcd3050eaa7fc044fca03961e9998ac7e2e92b77cf1"
+
+[[package]]
+name = "unicode-general-category"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2281c8c1d221438e373249e065ca4989c4c36952c211ff21a0ee91c44a3869e7"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9167,10 +9384,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-script"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d817255e1bed6dfd4ca47258685d14d2bdcfbc64fdc9e3819bd5848057b8ecc"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "unicode-xid"
@@ -9264,6 +9493,67 @@ dependencies = [
  "serde_json",
  "tracing 0.1.37",
  "user-facing-error-macros",
+]
+
+[[package]]
+name = "usvg"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14d09ddfb0d93bf84824c09336d32e42f80961a9d1680832eb24fdf249ce11e6"
+dependencies = [
+ "base64 0.21.2",
+ "log",
+ "pico-args",
+ "usvg-parser",
+ "usvg-text-layout",
+ "usvg-tree",
+ "xmlwriter",
+]
+
+[[package]]
+name = "usvg-parser"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19bf93d230813599927d88557014e0908ecc3531666d47c634c6838bc8db408"
+dependencies = [
+ "data-url",
+ "flate2",
+ "imagesize",
+ "kurbo",
+ "log",
+ "roxmltree",
+ "simplecss",
+ "siphasher",
+ "svgtypes",
+ "usvg-tree",
+]
+
+[[package]]
+name = "usvg-text-layout"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "035044604e89652c0a2959b8b356946997a52649ba6cade45928c2842376feb4"
+dependencies = [
+ "fontdb",
+ "kurbo",
+ "log",
+ "rustybuzz",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "usvg-tree",
+]
+
+[[package]]
+name = "usvg-tree"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7939a7e4ed21cadb5d311d6339730681c3e24c3e81d60065be80e485d3fc8b92"
+dependencies = [
+ "rctree",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
 ]
 
 [[package]]
@@ -10370,6 +10660,18 @@ checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "yasna"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7235,6 +7235,7 @@ dependencies = [
  "image",
  "libheif-rs",
  "libheif-sys",
+ "once_cell",
  "thiserror",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7077,6 +7077,7 @@ dependencies = [
  "sd-media-metadata",
  "sd-p2p",
  "sd-prisma",
+ "sd-svg",
  "sd-sync",
  "sd-utils",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7236,6 +7236,7 @@ dependencies = [
  "libheif-rs",
  "libheif-sys",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -27,6 +27,7 @@ sd-crypto = { path = "../crates/crypto", features = [
 	"serde",
 	"keymanager",
 ] }
+sd-svg = { path = "../crates/svg" }
 sd-heif = { path = "../crates/heif", optional = true }
 sd-file-ext = { path = "../crates/file-ext" }
 sd-sync = { path = "../crates/sync" }

--- a/core/src/object/media/thumbnail/mod.rs
+++ b/core/src/object/media/thumbnail/mod.rs
@@ -136,6 +136,7 @@ pub async fn generate_image_thumbnail<P: AsRef<Path>>(
 	if metadata.len()
 		> (match ext {
 			"svg" => sd_svg::MAXIMUM_FILE_SIZE,
+			#[cfg(all(feature = "heif", not(target_os = "linux")))]
 			_ if HEIF_EXTENSIONS.contains(ext) => sd_heif::MAXIMUM_FILE_SIZE,
 			_ => MAXIMUM_FILE_SIZE,
 		}) {

--- a/core/src/object/media/thumbnail/mod.rs
+++ b/core/src/object/media/thumbnail/mod.rs
@@ -9,7 +9,8 @@ use crate::{
 };
 
 use sd_file_ext::extensions::{Extension, ImageExtension, ALL_IMAGE_EXTENSIONS};
-use sd_media_metadata::image::Orientation;
+use sd_media_metadata::image::{ExifReader, Orientation};
+use std::collections::HashSet;
 
 #[cfg(feature = "ffmpeg")]
 use sd_file_ext::extensions::{VideoExtension, ALL_VIDEO_EXTENSIONS};
@@ -19,14 +20,15 @@ use std::{
 	error::Error,
 	ops::Deref,
 	path::{Path, PathBuf},
+	sync::Arc,
 };
 
 use futures_concurrency::future::{Join, TryJoin};
-use image::{self, imageops, DynamicImage, GenericImageView};
+use image::{self, imageops, DynamicImage, GenericImageView, ImageFormat};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tokio::{fs, io, task::block_in_place};
+use tokio::{fs, io, task::spawn_blocking};
 use tracing::{error, trace, warn};
 use webp::Encoder;
 
@@ -86,6 +88,10 @@ pub enum ThumbnailerError {
 	FileIO(#[from] FileIOError),
 	#[error(transparent)]
 	VersionManager(#[from] VersionManagerError),
+	#[error("failed to encode webp")]
+	Encoding,
+	#[error("the image provided is too large")]
+	TooLarge,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
@@ -101,39 +107,65 @@ pub struct ThumbnailerMetadata {
 	pub skipped: u32,
 }
 
-// TOOD(brxken128): validate avci and avcs
-#[cfg(all(feature = "heif", not(target_os = "linux")))]
-const HEIF_EXTENSIONS: [&str; 7] = ["heif", "heifs", "heic", "heics", "avif", "avci", "avcs"];
+static HEIF_EXTENSIONS: Lazy<HashSet<String>> = Lazy::new(|| {
+	["heif", "heifs", "heic", "heics", "avif", "avci", "avcs"]
+		.into_iter()
+		.map(|s| s.to_string())
+		.collect()
+});
+
+// The maximum file size that an image can be in order to have a thumbnail generated.
+const MAXIMUM_FILE_SIZE: u64 = 50 * 1024 * 1024; // 50MB
 
 pub async fn generate_image_thumbnail<P: AsRef<Path>>(
 	file_path: P,
 	output_path: P,
 ) -> Result<(), Box<dyn Error>> {
-	// Webp creation has blocking code
-	let webp = block_in_place(|| -> Result<Vec<u8>, Box<dyn Error>> {
-		#[cfg(all(feature = "heif", not(target_os = "linux")))]
-		let img = {
-			let ext = file_path
-				.as_ref()
-				.extension()
-				.unwrap_or_default()
-				.to_ascii_lowercase();
-			if HEIF_EXTENSIONS
-				.iter()
-				.any(|e| ext == std::ffi::OsStr::new(e))
-			{
-				sd_heif::heif_to_dynamic_image(file_path.as_ref())?
-			} else {
-				image::open(file_path.as_ref())?
-			}
-		};
+	let file_path = file_path.as_ref();
 
-		#[cfg(not(all(feature = "heif", not(target_os = "linux"))))]
-		let img = image::open(file_path.as_ref())?;
+	let ext = file_path
+		.extension()
+		.and_then(|ext| ext.to_str())
+		.unwrap_or_default()
+		.to_ascii_lowercase();
+	let ext = ext.as_str();
 
-		let orientation = Orientation::source_orientation(&file_path);
+	let metadata = fs::metadata(file_path)
+		.await
+		.map_err(|e| FileIOError::from((file_path, e)))?;
 
+	if metadata.len()
+		> (match ext {
+			"svg" => sd_svg::MAXIMUM_FILE_SIZE,
+			_ if HEIF_EXTENSIONS.contains(ext) => sd_heif::MAXIMUM_FILE_SIZE,
+			_ => MAXIMUM_FILE_SIZE,
+		}) {
+		return Err(ThumbnailerError::TooLarge.into());
+	}
+
+	let data = Arc::new(
+		fs::read(file_path)
+			.await
+			.map_err(|e| FileIOError::from((file_path, e)))?,
+	);
+
+	let img = match ext {
+		"svg" => sd_svg::svg_to_dynamic_image(data.clone()).await?,
+		_ if HEIF_EXTENSIONS.contains(ext) => {
+			#[cfg(not(all(feature = "heif", not(target_os = "linux"))))]
+			return Err("HEIF not supported".into());
+			#[cfg(all(feature = "heif", not(target_os = "linux")))]
+			sd_heif::heif_to_dynamic_image(data.clone()).await?
+		}
+		_ => image::load_from_memory_with_format(
+			&fs::read(file_path).await?,
+			ImageFormat::from_path(file_path)?,
+		)?,
+	};
+
+	let webp = spawn_blocking(move || -> Result<_, ThumbnailerError> {
 		let (w, h) = img.dimensions();
+
 		// Optionally, resize the existing photo and convert back into DynamicImage
 		let mut img = DynamicImage::ImageRgba8(imageops::resize(
 			&img,
@@ -143,13 +175,20 @@ pub async fn generate_image_thumbnail<P: AsRef<Path>>(
 			imageops::FilterType::Triangle,
 		));
 
-		// this corrects the rotation/flip of the image based on the available exif data
-		if let Some(x) = orientation {
-			img = x.correct_thumbnail(img);
+		match ExifReader::from_slice(data.as_ref()) {
+			Ok(exif_reader) => {
+				// this corrects the rotation/flip of the image based on the available exif data
+				if let Some(orientation) = Orientation::from_reader(&exif_reader) {
+					img = orientation.correct_thumbnail(img);
+				}
+			}
+			Err(e) => warn!("Unable to extract EXIF: {:?}", e),
 		}
 
 		// Create the WebP encoder for the above image
-		let encoder = Encoder::from_image(&img)?;
+		let Ok(encoder) = Encoder::from_image(&img) else {
+			return Err(ThumbnailerError::Encoding);
+		};
 
 		// Encode the image at a specified quality 0-100
 
@@ -157,7 +196,8 @@ pub async fn generate_image_thumbnail<P: AsRef<Path>>(
 		// this make us `deref` to have a `&[u8]` and then `to_owned` to make a Vec<u8>
 		// which implies on a unwanted clone...
 		Ok(encoder.encode(THUMBNAIL_QUALITY).deref().to_owned())
-	})?;
+	})
+	.await??;
 
 	let output_path = output_path.as_ref();
 
@@ -204,11 +244,11 @@ pub const fn can_generate_thumbnail_for_image(image_extension: &ImageExtension) 
 	#[cfg(all(feature = "heif", not(target_os = "linux")))]
 	let res = matches!(
 		image_extension,
-		Jpg | Jpeg | Png | Webp | Gif | Heic | Heics | Heif | Heifs | Avif
+		Jpg | Jpeg | Png | Webp | Gif | Svg | Heic | Heics | Heif | Heifs | Avif
 	);
 
 	#[cfg(not(all(feature = "heif", not(target_os = "linux"))))]
-	let res = matches!(image_extension, Jpg | Jpeg | Png | Webp | Gif);
+	let res = matches!(image_extension, Jpg | Jpeg | Png | Webp | Gif | Svg);
 
 	res
 }

--- a/core/src/object/media/thumbnail/mod.rs
+++ b/core/src/object/media/thumbnail/mod.rs
@@ -10,13 +10,12 @@ use crate::{
 
 use sd_file_ext::extensions::{Extension, ImageExtension, ALL_IMAGE_EXTENSIONS};
 use sd_media_metadata::image::{ExifReader, Orientation};
-use std::collections::HashSet;
 
 #[cfg(feature = "ffmpeg")]
 use sd_file_ext::extensions::{VideoExtension, ALL_VIDEO_EXTENSIONS};
 
 use std::{
-	collections::HashMap,
+	collections::{HashMap, HashSet},
 	error::Error,
 	ops::Deref,
 	path::{Path, PathBuf},

--- a/crates/heif/Cargo.toml
+++ b/crates/heif/Cargo.toml
@@ -10,4 +10,5 @@ edition = { workspace = true }
 libheif-rs = "0.19.2"
 libheif-sys = "=1.14.2"
 image = "0.24.6"
+tokio = { workspace = true, features = ["fs", "io-util"] }
 thiserror = "1.0.40"

--- a/crates/heif/Cargo.toml
+++ b/crates/heif/Cargo.toml
@@ -10,5 +10,6 @@ edition = { workspace = true }
 libheif-rs = "0.19.2"
 libheif-sys = "=1.14.2"
 image = "0.24.6"
+once_cell = "1.17.2"
 tokio = { workspace = true, features = ["fs", "io-util"] }
 thiserror = "1.0.40"

--- a/crates/heif/src/lib.rs
+++ b/crates/heif/src/lib.rs
@@ -1,21 +1,21 @@
-use std::{io::SeekFrom, path::Path};
+use std::{
+	io::{Cursor, SeekFrom},
+	sync::Arc,
+};
 
 use image::DynamicImage;
 use libheif_rs::{ColorSpace, HeifContext, LibHeif, RgbChroma};
-use std::io::Cursor;
+use once_cell::sync::Lazy;
 use thiserror::Error;
 use tokio::{
-	fs,
 	io::{AsyncReadExt, AsyncSeekExt, BufReader},
 	task::{spawn_blocking, JoinError},
 };
 
 type HeifResult<T> = Result<T, HeifError>;
 
-/// The maximum file size that an image can be in order to have a thumbnail generated.
-///
-/// This value is in MiB.
-const HEIF_MAXIMUM_FILE_SIZE: u64 = 1048576 * 20;
+// The maximum file size that an image can be in order to have a thumbnail generated.
+pub const MAXIMUM_FILE_SIZE: u64 = 20 * 1024 * 1024; // 20MB
 
 #[derive(Error, Debug)]
 pub enum HeifError {
@@ -23,47 +23,25 @@ pub enum HeifError {
 	LibHeif(#[from] libheif_rs::HeifError),
 	#[error("error while loading the image (via the `image` crate): {0}")]
 	Image(#[from] image::ImageError),
-	#[error("io error: {0} at {}", .1.display())]
-	Io(std::io::Error, Box<Path>),
 	#[error("Blocking task failed to execute to completion.")]
 	Join(#[from] JoinError),
 	#[error("there was an error while converting the image to an `RgbImage`")]
 	RgbImageConversion,
 	#[error("the image provided is unsupported")]
 	Unsupported,
-	#[error("the image provided is too large (over 20MiB)")]
-	TooLarge,
 	#[error("the provided bit depth is invalid")]
 	InvalidBitDepth,
 	#[error("invalid path provided (non UTF-8)")]
 	InvalidPath,
 }
 
-thread_local! {
-	static HEIF: LibHeif = LibHeif::new();
-}
+static HEIF: Lazy<LibHeif> = Lazy::new(LibHeif::new);
 
-pub async fn heif_to_dynamic_image(path: impl AsRef<Path>) -> HeifResult<DynamicImage> {
-	let path = path.as_ref();
-
-	if fs::metadata(path)
-		.await
-		.map_err(|e| HeifError::Io(e, path.to_path_buf().into_boxed_path()))?
-		.len() > HEIF_MAXIMUM_FILE_SIZE
-	{
-		return Err(HeifError::TooLarge);
-	}
-
-	let data = fs::read(path)
-		.await
-		.map_err(|e| HeifError::Io(e, path.to_path_buf().into_boxed_path()))?;
-
+pub async fn heif_to_dynamic_image(data: Arc<Vec<u8>>) -> HeifResult<DynamicImage> {
 	let (img_data, stride, height, width) = spawn_blocking(move || -> Result<_, HeifError> {
-		// do this in a separate block so we drop the raw (potentially huge) image handle
 		let ctx = HeifContext::read_from_bytes(&data)?;
 		let handle = ctx.primary_image_handle()?;
-
-		let img = HEIF.with(|heif| heif.decode(&handle, ColorSpace::Rgb(RgbChroma::Rgb), None))?;
+		let img = HEIF.decode(&handle, ColorSpace::Rgb(RgbChroma::Rgb), None)?;
 
 		// TODO(brxken128): add support for images with individual r/g/b channels
 		// i'm unable to find a sample to test with, but it should follow the same principles as this one
@@ -94,13 +72,13 @@ pub async fn heif_to_dynamic_image(path: impl AsRef<Path>) -> HeifResult<Dynamic
 		reader
 			.seek(SeekFrom::Start((stride * y as usize) as u64))
 			.await
-			.map_err(|e| HeifError::Io(e, path.to_path_buf().into_boxed_path()))?;
+			.map_err(|_| HeifError::RgbImageConversion)?;
 
 		for _ in 0..width {
 			reader
 				.read_exact(&mut buffer)
 				.await
-				.map_err(|e| HeifError::Io(e, path.to_path_buf().into_boxed_path()))?;
+				.map_err(|_| HeifError::RgbImageConversion)?;
 			sequence.extend_from_slice(&buffer);
 		}
 	}

--- a/crates/svg/Cargo.toml
+++ b/crates/svg/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "sd-svg"
+version = "0.1.0"
+authors = ["Vítor Vasconcellos <vitor@spacedrive.com>"]
+license = { workspace = true }
+repository = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+image = "0.24.6"
+resvg = "0.35.0"
+thiserror = "1.0.40"
+tokio = { workspace = true, features = ["fs", "io-util"] }
+tracing = "0.1.37"

--- a/crates/svg/src/lib.rs
+++ b/crates/svg/src/lib.rs
@@ -1,8 +1,14 @@
 use image::DynamicImage;
-use resvg::{tiny_skia, usvg};
+use resvg::{
+	tiny_skia::{self, Pixmap},
+	usvg,
+};
 use std::path::Path;
 use thiserror::Error;
-use tokio::fs;
+use tokio::{
+	fs,
+	task::{spawn_blocking, JoinError},
+};
 use tracing::error;
 use usvg::{fontdb, TreeParsing, TreeTextToPath};
 
@@ -21,8 +27,10 @@ pub enum SvgError {
 	USvg(#[from] resvg::usvg::Error),
 	#[error("error while loading the image (via the `image` crate): {0}")]
 	Image(#[from] image::ImageError),
-	#[error("io error: {0}")]
-	Io(#[from] std::io::Error),
+	#[error("io error: {0} at {}", .1.display())]
+	Io(std::io::Error, Box<Path>),
+	#[error("Blocking task failed to execute to completion")]
+	Join(#[from] JoinError),
 	#[error("failed to allocate `Pixbuf`")]
 	Pixbuf,
 	#[error("there was an error while converting the image to an `RgbImage`")]
@@ -33,44 +41,57 @@ pub enum SvgError {
 	TooLarge,
 }
 
-pub async fn svg_to_dynamic_image(path: &Path) -> SvgResult<DynamicImage> {
-	if fs::metadata(path).await?.len() > SVG_MAXIMUM_FILE_SIZE {
+pub async fn svg_to_dynamic_image(path: impl AsRef<Path>) -> SvgResult<DynamicImage> {
+	let path = path.as_ref();
+
+	if fs::metadata(path)
+		.await
+		.map_err(|e| SvgError::Io(e, path.to_path_buf().into_boxed_path()))?
+		.len() > SVG_MAXIMUM_FILE_SIZE
+	{
 		return Err(SvgError::TooLarge);
 	}
 
-	let data = fs::read(path).await?;
+	let data = fs::read(path)
+		.await
+		.map_err(|e| SvgError::Io(e, path.to_path_buf().into_boxed_path()))?;
 
-	let opt = usvg::Options::default();
+	let mut pixmap = spawn_blocking(move || -> Result<Pixmap, SvgError> {
+		let mut fontdb = fontdb::Database::new();
 
-	let mut fontdb = fontdb::Database::new();
-	fontdb.load_system_fonts();
+		fontdb.load_system_fonts();
 
-	let mut tree = usvg::Tree::from_data(&data, &opt)?;
-	tree.convert_text(&fontdb);
+		let mut tree = usvg::Tree::from_data(&data, &usvg::Options::default())?;
+		tree.convert_text(&fontdb);
 
-	let rtree = resvg::Tree::from_usvg(&tree);
+		let rtree = resvg::Tree::from_usvg(&tree);
 
-	let size = if rtree.size.width() > rtree.size.height() {
-		rtree.size.to_int_size().scale_to_width(THUMB_SIZE)
-	} else {
-		rtree.size.to_int_size().scale_to_height(THUMB_SIZE)
-	}
-	.ok_or(SvgError::InvalidSize)?;
+		let size = if rtree.size.width() > rtree.size.height() {
+			rtree.size.to_int_size().scale_to_width(THUMB_SIZE)
+		} else {
+			rtree.size.to_int_size().scale_to_height(THUMB_SIZE)
+		}
+		.ok_or(SvgError::InvalidSize)?;
 
-	let transform = tiny_skia::Transform::from_scale(
-		size.width() as f32 / rtree.size.width(),
-		size.height() as f32 / rtree.size.height(),
-	);
+		let transform = tiny_skia::Transform::from_scale(
+			size.width() as f32 / rtree.size.width(),
+			size.height() as f32 / rtree.size.height(),
+		);
 
-	let Some(mut pixmap) = tiny_skia::Pixmap::new(size.width(), size.height()) else {
-		return Err(SvgError::Pixbuf)
-	};
-	rtree.render(transform, &mut pixmap.as_mut());
+		let Some(mut pixmap) = tiny_skia::Pixmap::new(size.width(), size.height()) else {
+			return Err(SvgError::Pixbuf);
+		};
 
-	let Some(rgb_img) = image::RgbaImage::from_raw(
-		pixmap.width(), pixmap.height(), pixmap.data_mut().into()
-	) else {
-		return Err(SvgError::RgbImageConversion)
+		rtree.render(transform, &mut pixmap.as_mut());
+
+		Ok(pixmap)
+	})
+	.await??;
+
+	let Some(rgb_img) =
+		image::RgbaImage::from_raw(pixmap.width(), pixmap.height(), pixmap.data_mut().into())
+	else {
+		return Err(SvgError::RgbImageConversion);
 	};
 
 	Ok(DynamicImage::ImageRgba8(rgb_img))

--- a/crates/svg/src/lib.rs
+++ b/crates/svg/src/lib.rs
@@ -8,6 +8,8 @@ use usvg::{fontdb, TreeParsing, TreeTextToPath};
 
 type SvgResult<T> = Result<T, SvgError>;
 
+const THUMB_SIZE: u32 = 512;
+
 /// The maximum file size that an image can be in order to have a thumbnail generated.
 ///
 /// This value is in MiB.
@@ -25,6 +27,8 @@ pub enum SvgError {
 	Pixbuf,
 	#[error("there was an error while converting the image to an `RgbImage`")]
 	RgbImageConversion,
+	#[error("failed to calculate thumbnail size")]
+	InvalidSize,
 	#[error("the image provided is too large (over 20MiB)")]
 	TooLarge,
 }
@@ -46,15 +50,28 @@ pub async fn svg_to_dynamic_image(path: &Path) -> SvgResult<DynamicImage> {
 
 	let rtree = resvg::Tree::from_usvg(&tree);
 
-	let Some(mut pixmap) = tiny_skia::Pixmap::new(rtree.size.width().ceil() as u32, rtree.size.height().ceil() as u32) else {
+	let size = if rtree.size.width() > rtree.size.height() {
+		rtree.size.to_int_size().scale_to_width(THUMB_SIZE)
+	} else {
+		rtree.size.to_int_size().scale_to_height(THUMB_SIZE)
+	}
+	.ok_or(SvgError::InvalidSize)?;
+
+	let transform = tiny_skia::Transform::from_scale(
+		size.width() as f32 / rtree.size.width() as f32,
+		size.height() as f32 / rtree.size.height() as f32,
+	);
+
+	let Some(mut pixmap) = tiny_skia::Pixmap::new(size.width(), size.height()) else {
 		return Err(SvgError::Pixbuf)
 	};
+	rtree.render(transform, &mut pixmap.as_mut());
 
-	rtree.render(tiny_skia::Transform::default(), &mut pixmap.as_mut());
-
-	let Some(rgb_img) = image::RgbImage::from_raw(pixmap.width(), pixmap.height(), pixmap.data_mut().into()) else {
+	let Some(rgb_img) = image::RgbaImage::from_raw(
+		pixmap.width(), pixmap.height(), pixmap.data_mut().into()
+	) else {
 		return Err(SvgError::RgbImageConversion)
 	};
 
-	Ok(DynamicImage::ImageRgb8(rgb_img))
+	Ok(DynamicImage::ImageRgba8(rgb_img))
 }

--- a/crates/svg/src/lib.rs
+++ b/crates/svg/src/lib.rs
@@ -1,14 +1,12 @@
+use std::sync::Arc;
+
 use image::DynamicImage;
 use resvg::{
 	tiny_skia::{self, Pixmap},
 	usvg,
 };
-use std::path::Path;
 use thiserror::Error;
-use tokio::{
-	fs,
-	task::{spawn_blocking, JoinError},
-};
+use tokio::task::{spawn_blocking, JoinError};
 use tracing::error;
 use usvg::{fontdb, TreeParsing, TreeTextToPath};
 
@@ -16,10 +14,8 @@ type SvgResult<T> = Result<T, SvgError>;
 
 const THUMB_SIZE: u32 = 512;
 
-/// The maximum file size that an image can be in order to have a thumbnail generated.
-///
-/// This value is in MiB.
-const SVG_MAXIMUM_FILE_SIZE: u64 = 1048576 * 20;
+// The maximum file size that an image can be in order to have a thumbnail generated.
+pub const MAXIMUM_FILE_SIZE: u64 = 20 * 1024 * 1024; // 20MB
 
 #[derive(Error, Debug)]
 pub enum SvgError {
@@ -27,8 +23,6 @@ pub enum SvgError {
 	USvg(#[from] resvg::usvg::Error),
 	#[error("error while loading the image (via the `image` crate): {0}")]
 	Image(#[from] image::ImageError),
-	#[error("io error: {0} at {}", .1.display())]
-	Io(std::io::Error, Box<Path>),
 	#[error("Blocking task failed to execute to completion")]
 	Join(#[from] JoinError),
 	#[error("failed to allocate `Pixbuf`")]
@@ -37,34 +31,18 @@ pub enum SvgError {
 	RgbImageConversion,
 	#[error("failed to calculate thumbnail size")]
 	InvalidSize,
-	#[error("the image provided is too large (over 20MiB)")]
-	TooLarge,
 }
 
-pub async fn svg_to_dynamic_image(path: impl AsRef<Path>) -> SvgResult<DynamicImage> {
-	let path = path.as_ref();
-
-	if fs::metadata(path)
-		.await
-		.map_err(|e| SvgError::Io(e, path.to_path_buf().into_boxed_path()))?
-		.len() > SVG_MAXIMUM_FILE_SIZE
-	{
-		return Err(SvgError::TooLarge);
-	}
-
-	let data = fs::read(path)
-		.await
-		.map_err(|e| SvgError::Io(e, path.to_path_buf().into_boxed_path()))?;
-
+pub async fn svg_to_dynamic_image(data: Arc<Vec<u8>>) -> SvgResult<DynamicImage> {
 	let mut pixmap = spawn_blocking(move || -> Result<Pixmap, SvgError> {
-		let mut fontdb = fontdb::Database::new();
+		let rtree = usvg::Tree::from_data(&data, &usvg::Options::default()).map(|mut tree| {
+			let mut fontdb = fontdb::Database::new();
+			fontdb.load_system_fonts();
 
-		fontdb.load_system_fonts();
+			tree.convert_text(&fontdb);
 
-		let mut tree = usvg::Tree::from_data(&data, &usvg::Options::default())?;
-		tree.convert_text(&fontdb);
-
-		let rtree = resvg::Tree::from_usvg(&tree);
+			resvg::Tree::from_usvg(&tree)
+		})?;
 
 		let size = if rtree.size.width() > rtree.size.height() {
 			rtree.size.to_int_size().scale_to_width(THUMB_SIZE)

--- a/crates/svg/src/lib.rs
+++ b/crates/svg/src/lib.rs
@@ -58,8 +58,8 @@ pub async fn svg_to_dynamic_image(path: &Path) -> SvgResult<DynamicImage> {
 	.ok_or(SvgError::InvalidSize)?;
 
 	let transform = tiny_skia::Transform::from_scale(
-		size.width() as f32 / rtree.size.width() as f32,
-		size.height() as f32 / rtree.size.height() as f32,
+		size.width() as f32 / rtree.size.width(),
+		size.height() as f32 / rtree.size.height(),
 	);
 
 	let Some(mut pixmap) = tiny_skia::Pixmap::new(size.width(), size.height()) else {

--- a/crates/svg/src/lib.rs
+++ b/crates/svg/src/lib.rs
@@ -1,0 +1,66 @@
+use image::DynamicImage;
+use resvg::{tiny_skia, usvg};
+use std::path::Path;
+use thiserror::Error;
+use tokio::fs;
+use tracing::error;
+use usvg::{fontdb, TreeParsing, TreeTextToPath};
+
+type SvgResult<T> = Result<T, SvgError>;
+
+/// The maximum file size that an image can be in order to have a thumbnail generated.
+///
+/// This value is in MiB.
+const SVG_MAXIMUM_FILE_SIZE: u64 = 1048576 * 20;
+
+#[derive(Error, Debug)]
+pub enum SvgError {
+	#[error("error with usvg: {0}")]
+	USvg(#[from] resvg::usvg::Error),
+	#[error("error while loading the image (via the `image` crate): {0}")]
+	Image(#[from] image::ImageError),
+	#[error("io error: {0}")]
+	Io(#[from] std::io::Error),
+	#[error("failed to allocate `Pixbuf`")]
+	Pixbuf,
+	#[error("there was an error while converting the image to an `RgbImage`")]
+	RgbImageConversion,
+	#[error("the image provided is unsupported")]
+	Unsupported,
+	#[error("the image provided is too large (over 20MiB)")]
+	TooLarge,
+	#[error("the provided bit depth is invalid")]
+	InvalidBitDepth,
+	#[error("invalid path provided (non UTF-8)")]
+	InvalidPath,
+}
+
+pub async fn svg_to_dynamic_image(path: &Path) -> SvgResult<DynamicImage> {
+	if fs::metadata(path).await?.len() > SVG_MAXIMUM_FILE_SIZE {
+		return Err(SvgError::TooLarge);
+	}
+
+	let opt = usvg::Options::default();
+
+	let mut fontdb = fontdb::Database::new();
+	fontdb.load_system_fonts();
+
+	let data = fs::read(path).await?;
+
+	let mut tree = usvg::Tree::from_data(&data, &opt)?;
+	tree.convert_text(&fontdb);
+
+	let rtree = resvg::Tree::from_usvg(&tree);
+
+	let Some(mut pixmap) = tiny_skia::Pixmap::new(rtree.size.width() as u32, rtree.size.height() as u32) else {
+		return Err(SvgError::Pixbuf)
+	};
+
+	rtree.render(tiny_skia::Transform::default(), &mut pixmap.as_mut());
+
+	let Some(rgb_img) = image::RgbImage::from_raw(pixmap.width(), pixmap.height(), pixmap.data_mut().into()) else {
+		return Err(SvgError::RgbImageConversion)
+	};
+
+	Ok(DynamicImage::ImageRgb8(rgb_img))
+}


### PR DESCRIPTION
Introduces a new `sd-svg` crate inspired by `sd-heif` to allow integrating our `Thumbnailer` to parse SVGs:
[resvg](https://github.com/RazrFalcon/resvg) and [tiny-skia](https://github.com/RazrFalcon/tiny-skia) are used to parse and render the SVG and the RGBA data is converted to a `DynamicImage` that will be handled by the `Thumbnailer`