### PR TITLE
Refactor explorer settings to use useExplorer and useExplorerSettings

### DIFF
--- a/apps/mobile/src/screens/p2p/index.tsx
+++ b/apps/mobile/src/screens/p2p/index.tsx
@@ -1,4 +1,4 @@
-import { useBridgeMutation, useFeatureFlag, useLibraryContext, useP2PEvents } from '@sd/client';
+import { useFeatureFlag, useP2PEvents } from '@sd/client';
 
 export function P2P() {
 	// const pairingResponse = useBridgeMutation('p2p.pairingResponse');

--- a/core/src/api/search.rs
+++ b/core/src/api/search.rs
@@ -52,7 +52,7 @@ impl From<SortOrder> for prisma::SortOrder {
 }
 
 #[derive(Serialize, Deserialize, Type, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", tag = "field", content = "value")]
 pub enum FilePathSearchOrdering {
 	Name(SortOrder),
 	SizeInBytes(SortOrder),
@@ -185,15 +185,17 @@ impl FilePathFilterArgs {
 }
 
 #[derive(Serialize, Deserialize, Type, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", tag = "field", content = "value")]
 pub enum ObjectSearchOrdering {
 	DateAccessed(SortOrder),
+	Kind(SortOrder),
 }
 
 impl ObjectSearchOrdering {
 	fn get_sort_order(&self) -> prisma::SortOrder {
 		(*match self {
 			Self::DateAccessed(v) => v,
+			Self::Kind(v) => v,
 		})
 		.into()
 	}
@@ -204,6 +206,7 @@ impl ObjectSearchOrdering {
 
 		match self {
 			Self::DateAccessed(_) => date_accessed::order(dir),
+			Self::Kind(_) => kind::order(dir),
 		}
 	}
 }

--- a/core/src/preferences/library.rs
+++ b/core/src/preferences/library.rs
@@ -45,12 +45,12 @@ impl LibraryPreferences {
 #[derive(Clone, Serialize, Deserialize, Type, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct LocationSettings {
-	explorer: ExplorerSettings,
+	explorer: ExplorerSettings<search::FilePathSearchOrdering>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Type, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct ExplorerSettings {
+pub struct ExplorerSettings<TOrder> {
 	layout_mode: Option<ExplorerLayout>,
 	grid_item_size: Option<i32>,
 	media_columns: Option<i32>,
@@ -59,7 +59,8 @@ pub struct ExplorerSettings {
 	show_bytes_in_grid_view: Option<bool>,
 	col_sizes: Option<BTreeMap<String, i32>>,
 	// temporary
-	order: Option<search::FilePathSearchOrdering>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	order: Option<Option<TOrder>>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Type, Debug)]

--- a/interface/app/$libraryId/Explorer/Context.tsx
+++ b/interface/app/$libraryId/Explorer/Context.tsx
@@ -1,11 +1,12 @@
-import { createContext, useContext } from 'react';
+import { PropsWithChildren, createContext, useContext } from 'react';
+import { Ordering } from './store';
 import { UseExplorer } from './useExplorer';
 
 /**
  * Context that must wrap anything to do with the explorer.
  * This includes explorer views, the inspector, and top bar items.
  */
-export const ExplorerContext = createContext<UseExplorer | null>(null);
+const ExplorerContext = createContext<UseExplorer<Ordering> | null>(null);
 
 export const useExplorerContext = () => {
 	const ctx = useContext(ExplorerContext);
@@ -14,3 +15,10 @@ export const useExplorerContext = () => {
 
 	return ctx;
 };
+
+export const ExplorerContextProvider = <TOrdering extends Ordering>({
+	explorer,
+	children
+}: PropsWithChildren<{
+	explorer: UseExplorer<TOrdering>;
+}>) => <ExplorerContext.Provider value={explorer as any}>{children}</ExplorerContext.Provider>;

--- a/interface/app/$libraryId/Explorer/ContextMenu/SharedItems.tsx
+++ b/interface/app/$libraryId/Explorer/ContextMenu/SharedItems.tsx
@@ -4,6 +4,7 @@ import { ContextMenu, ModifierKeys } from '@sd/ui';
 import { useKeybindFactory } from '~/hooks/useKeybindFactory';
 import { isNonEmpty } from '~/util';
 import { Platform } from '~/util/Platform';
+import { useExplorerContext } from '../Context';
 import { RevealInNativeExplorerBase } from '../RevealInNativeExplorer';
 import { useExplorerViewContext } from '../ViewContext';
 import { getExplorerStore, useExplorerStore } from '../store';
@@ -50,9 +51,10 @@ export const Details = new ConditionalItem({
 export const Rename = new ConditionalItem({
 	useCondition: () => {
 		const { selectedItems } = useContextMenuContext();
-		const explorerStore = useExplorerStore();
 
-		if (explorerStore.layoutMode === 'media' || selectedItems.length > 1) return null;
+		const settings = useExplorerContext().useSettingsSnapshot();
+
+		if (settings.layoutMode === 'media' || selectedItems.length > 1) return null;
 
 		return {};
 	},

--- a/interface/app/$libraryId/Explorer/DismissibleNotice.tsx
+++ b/interface/app/$libraryId/Explorer/DismissibleNotice.tsx
@@ -11,6 +11,7 @@ import { ExplorerLayout } from '@sd/client';
 import DismissibleNotice from '~/components/DismissibleNotice';
 import { useIsDark } from '~/hooks';
 import { dismissibleNoticeStore } from '~/hooks/useDismissibleNoticeStore';
+import { useExplorerContext } from './Context';
 import { useExplorerStore } from './store';
 
 const MediaViewIcon = () => {
@@ -73,9 +74,9 @@ const notices = {
 } satisfies Record<ExplorerLayout, Notice | undefined>;
 
 export default () => {
-	const { layoutMode } = useExplorerStore();
+	const settings = useExplorerContext().useSettingsSnapshot();
 
-	const notice = notices[layoutMode];
+	const notice = notices[settings.layoutMode];
 
 	if (!notice) return null;
 

--- a/interface/app/$libraryId/Explorer/OptionsPanel.tsx
+++ b/interface/app/$libraryId/Explorer/OptionsPanel.tsx
@@ -1,101 +1,53 @@
-import { useDebouncedCallback } from 'use-debounce';
-import { stringify } from 'uuid';
-import { useLibraryMutation } from '@sd/client';
-import { RadixCheckbox, Select, SelectOption, Slider, tw } from '@sd/ui';
+import { RadixCheckbox, Select, SelectOption, Slider, tw, z } from '@sd/ui';
 import { SortOrderSchema } from '~/app/route-schemas';
 import { useExplorerContext } from './Context';
 import {
-	FilePathSearchOrderingKeys,
-	defaultExplorerSettings,
-	getExplorerSettings,
+	createOrdering,
 	getExplorerStore,
+	getOrderingDirection,
+	orderingKey,
 	useExplorerStore
 } from './store';
 
 const Subheading = tw.div`text-ink-dull mb-1 text-xs font-medium`;
 
-export const sortOptions: Record<FilePathSearchOrderingKeys, string> = {
-	'none': 'None',
-	'name': 'Name',
-	'sizeInBytes': 'Size',
-	'dateCreated': 'Date created',
-	'dateModified': 'Date modified',
-	'dateIndexed': 'Date indexed',
-	'object.dateAccessed': 'Date accessed'
-};
-
 export default () => {
 	const explorerStore = useExplorerStore();
-	const explorerContext = useExplorerContext();
-	const locationUuid =
-		explorerContext.parent?.type === 'Location'
-			? stringify(explorerContext.parent.location.pub_id)
-			: '';
+	const explorer = useExplorerContext();
 
-	const updatePreferences = useLibraryMutation('preferences.update', {
-		onError: () => {
-			alert('An error has occurred while updating your preferences.');
-		}
-	});
-
-	const updatePreferencesHandler = useDebouncedCallback(
-		async (
-			settingToUpdate: keyof typeof defaultExplorerSettings,
-			value: (typeof defaultExplorerSettings)[keyof typeof defaultExplorerSettings]
-		) => {
-			const updatedExplorerSettings = {
-				...getExplorerSettings(),
-				[settingToUpdate]: value
-			};
-			await updatePreferences.mutateAsync({
-				location: {
-					[locationUuid]: {
-						explorer: updatedExplorerSettings
-					}
-				}
-			});
-		},
-		100
-	);
+	const settings = explorer.useSettingsSnapshot();
 
 	return (
-		<div className="flex flex-col gap-4 p-4 w-80">
-			{(explorerStore.layoutMode === 'grid' || explorerStore.layoutMode === 'media') && (
+		<div className="flex w-80 flex-col gap-4 p-4">
+			{(settings.layoutMode === 'grid' || settings.layoutMode === 'media') && (
 				<div>
 					<Subheading>Item size</Subheading>
-					{explorerStore.layoutMode === 'grid' ? (
+					{settings.layoutMode === 'grid' ? (
 						<Slider
 							onValueChange={(value) => {
-								if (!locationUuid)
-									return (getExplorerStore().gridItemSize = value[0] || 100);
-								updatePreferencesHandler('gridItemSize', value[0] || 100);
-								getExplorerStore().gridItemSize = value[0] || 100;
+								explorer.settingsStore.gridItemSize = value[0] || 100;
 							}}
-							defaultValue={[explorerStore.gridItemSize]}
+							defaultValue={[settings.gridItemSize]}
 							max={200}
 							step={10}
 							min={60}
 						/>
 					) : (
 						<Slider
-							defaultValue={[10 - explorerStore.mediaColumns]}
+							defaultValue={[10 - settings.mediaColumns]}
 							min={0}
 							max={6}
 							step={2}
 							onValueChange={([val]) => {
-								if (val !== undefined) {
-									if (!locationUuid)
-										return (getExplorerStore().mediaColumns = 10 - val);
-									updatePreferencesHandler('mediaColumns', 10 - val);
-									getExplorerStore().mediaColumns = 10 - val;
-								}
+								if (val !== undefined)
+									explorer.settingsStore.mediaColumns = 10 - val;
 							}}
 						/>
 					)}
 				</div>
 			)}
 
-			{explorerStore.layoutMode === 'grid' && (
+			{settings.layoutMode === 'grid' && (
 				<div>
 					<Subheading>Gap</Subheading>
 					<Slider
@@ -110,23 +62,29 @@ export default () => {
 				</div>
 			)}
 
-			{(explorerStore.layoutMode === 'grid' || explorerStore.layoutMode === 'media') && (
+			{(settings.layoutMode === 'grid' || settings.layoutMode === 'media') && (
 				<div className="grid grid-cols-2 gap-2">
 					<div className="flex flex-col">
 						<Subheading>Sort by</Subheading>
 						<Select
-							value={explorerStore.orderBy}
+							value={settings.order ? orderingKey(settings.order) : 'none'}
 							size="sm"
 							className="w-full"
-							onChange={(sortBy) => {
-								if (!locationUuid) return (getExplorerStore().orderBy = sortBy);
-								updatePreferencesHandler('orderBy', sortBy);
-								getExplorerStore().orderBy = sortBy;
+							onChange={(key) => {
+								if (key === 'none') explorer.settingsStore.order = null;
+								else
+									explorer.settingsStore.order = createOrdering(
+										key,
+										explorer.settingsStore.order
+											? getOrderingDirection(explorer.settingsStore.order)
+											: 'Asc'
+									);
 							}}
 						>
-							{Object.entries(sortOptions).map(([value, text]) => (
-								<SelectOption key={value} value={value}>
-									{text}
+							<SelectOption value="none">None</SelectOption>
+							{explorer.orderingKeys?.options.map((option) => (
+								<SelectOption key={option.value} value={option.value}>
+									{option.description}
 								</SelectOption>
 							))}
 						</Select>
@@ -135,14 +93,17 @@ export default () => {
 					<div className="flex flex-col">
 						<Subheading>Direction</Subheading>
 						<Select
-							value={explorerStore.orderByDirection}
+							value={settings.order ? getOrderingDirection(settings.order) : 'Asc'}
 							size="sm"
 							className="w-full"
-							onChange={(value) => {
-								if (!locationUuid)
-									return (getExplorerStore().orderByDirection = value);
-								updatePreferencesHandler('orderByDirection', value);
-								getExplorerStore().orderByDirection = value;
+							disabled={explorer.settingsStore.order === null}
+							onChange={(order) => {
+								if (explorer.settingsStore.order === null) return;
+
+								explorer.settingsStore.order = createOrdering(
+									orderingKey(explorer.settingsStore.order),
+									order
+								);
 							}}
 						>
 							{SortOrderSchema.options.map((o) => (
@@ -155,35 +116,29 @@ export default () => {
 				</div>
 			)}
 
-			{explorerStore.layoutMode === 'grid' && (
+			{settings.layoutMode === 'grid' && (
 				<RadixCheckbox
-					checked={explorerStore.showBytesInGridView}
+					checked={settings.showBytesInGridView}
 					label="Show Object size"
 					name="showBytesInGridView"
 					onCheckedChange={(value) => {
-						if (typeof value === 'boolean') {
-							if (!locationUuid)
-								return (getExplorerStore().showBytesInGridView = value);
-							updatePreferencesHandler('showBytesInGridView', value);
-							getExplorerStore().showBytesInGridView = value;
-						}
+						if (typeof value !== 'boolean') return;
+
+						explorer.settingsStore.showBytesInGridView = value;
 					}}
 					className="mt-1"
 				/>
 			)}
 
-			{explorerStore.layoutMode === 'media' && (
+			{settings.layoutMode === 'media' && (
 				<RadixCheckbox
-					checked={explorerStore.mediaAspectSquare}
+					checked={settings.mediaAspectSquare}
 					label="Show square thumbnails"
 					name="mediaAspectSquare"
 					onCheckedChange={(value) => {
-						if (typeof value === 'boolean') {
-							if (!locationUuid)
-								return (getExplorerStore().mediaAspectSquare = value);
-							updatePreferencesHandler('mediaAspectSquare', value);
-							getExplorerStore().mediaAspectSquare = value;
-						}
+						if (typeof value !== 'boolean') return;
+
+						explorer.settingsStore.mediaAspectSquare = value;
 					}}
 					className="mt-1"
 				/>
@@ -192,17 +147,23 @@ export default () => {
 				<Subheading>Double click action</Subheading>
 				<Select
 					className="w-full"
-					value={explorerStore.openOnDoubleClick}
+					value={settings.openOnDoubleClick}
 					onChange={(value) => {
-						if (!locationUuid) return (getExplorerStore().openOnDoubleClick = value);
-						updatePreferencesHandler('openOnDoubleClick', value);
-						getExplorerStore().openOnDoubleClick = value;
+						explorer.settingsStore.openOnDoubleClick = value;
 					}}
 				>
-					<SelectOption value="openFile">Open File</SelectOption>
-					<SelectOption value="quickPreview">Quick Preview</SelectOption>
+					{doubleClickActions.options.map((option) => (
+						<SelectOption key={option.value} value={option.value}>
+							{option.description}
+						</SelectOption>
+					))}
 				</Select>
 			</div>
 		</div>
 	);
 };
+
+const doubleClickActions = z.union([
+	z.literal('openFile').describe('Open File'),
+	z.literal('quickPreview').describe('Quick Preview')
+]);

--- a/interface/app/$libraryId/Explorer/TopBarOptions.tsx
+++ b/interface/app/$libraryId/Explorer/TopBarOptions.tsx
@@ -17,52 +17,28 @@ import { KeyManager } from '../KeyManager';
 import TopBarOptions, { TOP_BAR_ICON_STYLE, ToolOption } from '../TopBar/TopBarOptions';
 import { useExplorerContext } from './Context';
 import OptionsPanel from './OptionsPanel';
-import { getExplorerSettings, getExplorerStore, useExplorerStore } from './store';
+import { getExplorerStore, useExplorerStore } from './store';
 import { useExplorerSearchParams } from './util';
 
 export const useExplorerTopBarOptions = () => {
 	const explorerStore = useExplorerStore();
-	const explorerContext = useExplorerContext();
-	const locationUuid =
-		explorerContext.parent?.type === 'Location'
-			? stringify(explorerContext.parent.location.pub_id)
-			: '';
-	const updatePreferences = useLibraryMutation('preferences.update', {
-		onError: () => {
-			alert('An error has occurred while updating your preferences.');
-		}
-	});
-	const updateLayoutPreferredHandler = async (layout: ExplorerLayout) => {
-		if (!locationUuid) {
-			return (getExplorerStore().layoutMode = layout);
-		}
-		const updatedExplorerSettings = {
-			...getExplorerSettings(),
-			layoutMode: layout
-		};
-		await updatePreferences.mutateAsync({
-			location: {
-				[locationUuid]: {
-					explorer: updatedExplorerSettings
-				}
-			}
-		});
-		getExplorerStore().layoutMode = layout;
-	};
+	const explorer = useExplorerContext();
+
+	const settings = explorer.useSettingsSnapshot();
 
 	const viewOptions: ToolOption[] = [
 		{
 			toolTipLabel: 'Grid view',
 			icon: <SquaresFour className={TOP_BAR_ICON_STYLE} />,
-			topBarActive: explorerStore.layoutMode === 'grid',
-			onClick: () => updateLayoutPreferredHandler('grid'),
+			topBarActive: settings.layoutMode === 'grid',
+			onClick: () => (explorer.settingsStore.layoutMode = 'grid'),
 			showAtResolution: 'sm:flex'
 		},
 		{
 			toolTipLabel: 'List view',
 			icon: <Rows className={TOP_BAR_ICON_STYLE} />,
-			topBarActive: explorerStore.layoutMode === 'list',
-			onClick: () => updateLayoutPreferredHandler('list'),
+			topBarActive: settings.layoutMode === 'list',
+			onClick: () => (explorer.settingsStore.layoutMode = 'list'),
 			showAtResolution: 'sm:flex'
 		},
 		// {
@@ -75,8 +51,8 @@ export const useExplorerTopBarOptions = () => {
 		{
 			toolTipLabel: 'Media view',
 			icon: <MonitorPlay className={TOP_BAR_ICON_STYLE} />,
-			topBarActive: explorerStore.layoutMode === 'media',
-			onClick: () => updateLayoutPreferredHandler('media'),
+			topBarActive: settings.layoutMode === 'media',
+			onClick: () => (explorer.settingsStore.layoutMode = 'media'),
 			showAtResolution: 'sm:flex'
 		}
 	];

--- a/interface/app/$libraryId/Explorer/View/GridList.tsx
+++ b/interface/app/$libraryId/Explorer/View/GridList.tsx
@@ -98,6 +98,7 @@ export default ({ children }: { children: RenderItem }) => {
 	const isChrome = CHROME_REGEX.test(navigator.userAgent);
 
 	const explorer = useExplorerContext();
+	const settings = explorer.useSettingsSnapshot();
 	const explorerStore = useExplorerStore();
 	const explorerView = useExplorerViewContext();
 
@@ -108,9 +109,8 @@ export default ({ children }: { children: RenderItem }) => {
 
 	const [dragFromThumbnail, setDragFromThumbnail] = useState(false);
 
-	const itemDetailsHeight =
-		explorerStore.gridItemSize / 4 + (explorerStore.showBytesInGridView ? 20 : 0);
-	const itemHeight = explorerStore.gridItemSize + itemDetailsHeight;
+	const itemDetailsHeight = settings.gridItemSize / 4 + (settings.showBytesInGridView ? 20 : 0);
+	const itemHeight = settings.gridItemSize + itemDetailsHeight;
 
 	const grid = useGridList({
 		ref: explorerView.ref,
@@ -119,19 +119,19 @@ export default ({ children }: { children: RenderItem }) => {
 		onLoadMore: explorer.loadMore,
 		rowsBeforeLoadMore: explorer.rowsBeforeLoadMore,
 		size:
-			explorerStore.layoutMode === 'grid'
-				? { width: explorerStore.gridItemSize, height: itemHeight }
+			settings.layoutMode === 'grid'
+				? { width: settings.gridItemSize, height: itemHeight }
 				: undefined,
-		columns: explorerStore.layoutMode === 'media' ? explorerStore.mediaColumns : undefined,
+		columns: settings.layoutMode === 'media' ? settings.mediaColumns : undefined,
 		getItemId: (index) => {
 			const item = explorer.items?.[index];
 			return item ? explorerItemHash(item) : undefined;
 		},
 		getItemData: (index) => explorer.items?.[index],
-		padding: explorerView.padding || explorerStore.layoutMode === 'grid' ? 12 : undefined,
+		padding: explorerView.padding || settings.layoutMode === 'grid' ? 12 : undefined,
 		gap:
 			explorerView.gap ||
-			(explorerStore.layoutMode === 'grid' ? explorerStore.gridGap : undefined),
+			(settings.layoutMode === 'grid' ? explorerStore.gridGap : undefined),
 		top: explorerView.top
 	});
 

--- a/interface/app/$libraryId/Explorer/View/GridView.tsx
+++ b/interface/app/$libraryId/Explorer/View/GridView.tsx
@@ -18,9 +18,11 @@ interface GridViewItemProps {
 }
 
 const GridViewItem = memo(({ data, selected, cut, isRenaming, renamable }: GridViewItemProps) => {
+	const explorer = useExplorerContext();
+	const { showBytesInGridView, gridItemSize } = explorer.useSettingsSnapshot();
+
 	const filePathData = getItemFilePath(data);
 	const location = getItemLocation(data);
-	const { showBytesInGridView, gridItemSize } = useExplorerStore();
 
 	const showSize =
 		!filePathData?.is_dir &&

--- a/interface/app/$libraryId/Explorer/View/MediaView.tsx
+++ b/interface/app/$libraryId/Explorer/View/MediaView.tsx
@@ -4,6 +4,7 @@ import { memo } from 'react';
 import { ExplorerItem } from '@sd/client';
 import { Button } from '@sd/ui';
 import { ViewItem } from '.';
+import { useExplorerContext } from '../Context';
 import { FileThumb } from '../FilePath/Thumb';
 import { getExplorerStore, useExplorerStore } from '../store';
 import GridList from './GridList';
@@ -15,7 +16,7 @@ interface MediaViewItemProps {
 }
 
 const MediaViewItem = memo(({ data, selected, cut }: MediaViewItemProps) => {
-	const explorerStore = useExplorerStore();
+	const settings = useExplorerContext().useSettingsSnapshot();
 
 	return (
 		<ViewItem
@@ -33,11 +34,8 @@ const MediaViewItem = memo(({ data, selected, cut }: MediaViewItemProps) => {
 			>
 				<FileThumb
 					data={data}
-					cover={explorerStore.mediaAspectSquare}
-					className={clsx(
-						!explorerStore.mediaAspectSquare && 'px-1',
-						cut && 'opacity-60'
-					)}
+					cover={settings.mediaAspectSquare}
+					className={clsx(!settings.mediaAspectSquare && 'px-1', cut && 'opacity-60')}
 				/>
 
 				<Button

--- a/interface/app/$libraryId/Explorer/View/index.tsx
+++ b/interface/app/$libraryId/Explorer/View/index.tsx
@@ -176,7 +176,7 @@ export default memo(({ className, style, emptyNotice, ...contextProps }: Explore
 
 	const quickPreviewCtx = useQuickPreviewContext();
 
-	const { layoutMode } = useExplorerStore();
+	const { layoutMode } = explorer.useSettingsSnapshot();
 
 	const ref = useRef<HTMLDivElement>(null);
 
@@ -227,7 +227,7 @@ export default memo(({ className, style, emptyNotice, ...contextProps }: Explore
 });
 
 export const EmptyNotice = (props: { icon?: Icon | ReactNode; message?: ReactNode }) => {
-	const { layoutMode } = useExplorerStore();
+	const { layoutMode } = useExplorerContext().useSettingsSnapshot();
 
 	const emptyNoticeIcon = (icon?: Icon) => {
 		const Icon =

--- a/interface/app/$libraryId/Explorer/util.ts
+++ b/interface/app/$libraryId/Explorer/util.ts
@@ -1,30 +1,9 @@
 import { useMemo } from 'react';
-import { ExplorerItem, FilePathSearchOrdering, getExplorerItemData } from '@sd/client';
+import { ExplorerItem, getExplorerItemData } from '@sd/client';
 import { ExplorerParamsSchema } from '~/app/route-schemas';
 import { useZodSearchParams } from '~/hooks';
 import { flattenThumbnailKey, useExplorerStore } from './store';
 import { ExplorerItemHash } from './useExplorer';
-
-export function useExplorerOrder(): FilePathSearchOrdering | undefined {
-	const explorerStore = useExplorerStore();
-
-	const ordering = useMemo(() => {
-		if (explorerStore.orderBy === 'none') return undefined;
-
-		const obj = {};
-
-		explorerStore.orderBy.split('.').reduce((acc, next, i, all) => {
-			if (all.length - 1 === i) acc[next] = explorerStore.orderByDirection;
-			else acc[next] = {};
-
-			return acc[next];
-		}, obj as any);
-
-		return obj as FilePathSearchOrdering;
-	}, [explorerStore.orderBy, explorerStore.orderByDirection]);
-
-	return ordering;
-}
 
 export function useExplorerSearchParams() {
 	return useZodSearchParams(ExplorerParamsSchema);

--- a/interface/app/$libraryId/location/$id.tsx
+++ b/interface/app/$libraryId/location/$id.tsx
@@ -1,9 +1,12 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo } from 'react';
+import { useDebouncedCallback } from 'use-debounce';
 import { stringify } from 'uuid';
 import {
 	ExplorerSettings,
+	FilePathSearchOrdering,
 	useLibraryContext,
+	useLibraryMutation,
 	useLibraryQuery,
 	useLibrarySubscription,
 	useRspcLibraryContext
@@ -12,11 +15,15 @@ import { LocationIdParamsSchema } from '~/app/route-schemas';
 import { Folder } from '~/components';
 import { useKeyDeleteFile, useZodRouteParams } from '~/hooks';
 import Explorer from '../Explorer';
-import { ExplorerContext } from '../Explorer/Context';
+import { ExplorerContextProvider } from '../Explorer/Context';
 import { DefaultTopBarOptions } from '../Explorer/TopBarOptions';
-import { getExplorerStore, nullValuesHandler, useExplorerStore } from '../Explorer/store';
-import { useExplorer } from '../Explorer/useExplorer';
-import { useExplorerOrder, useExplorerSearchParams } from '../Explorer/util';
+import {
+	createDefaultExplorerSettings,
+	filePathOrderingKeysSchema,
+	getExplorerStore
+} from '../Explorer/store';
+import { UseExplorerSettings, useExplorer, useExplorerSettings } from '../Explorer/useExplorer';
+import { useExplorerSearchParams } from '../Explorer/util';
 import { TopBarPortal } from '../TopBar/Portal';
 import LocationOptions from './LocationOptions';
 
@@ -25,26 +32,74 @@ export const Component = () => {
 
 	const { id: locationId } = useZodRouteParams(LocationIdParamsSchema);
 	const location = useLibraryQuery(['locations.get', locationId]);
-	const explorerStore = useExplorerStore();
-	const locationUuid = location.data && stringify(location.data?.pub_id);
+
 	const preferences = useLibraryQuery(['preferences.get']);
+	const updatePreferences = useLibraryMutation('preferences.update');
 
-	useEffect(() => {
-		if (locationUuid) {
-			const explorerData = preferences.data?.location?.[locationUuid]?.explorer;
-			if (!explorerData) return;
-			const updatedSettings = {
-				...explorerStore,
-				...nullValuesHandler(explorerData as ExplorerSettings),
-				orderByDirection: 'Desc' //temp till types are fixed - for testing
-			};
-			explorerStore.reset(updatedSettings);
+	const settings = useMemo(() => {
+		const defaults = createDefaultExplorerSettings<FilePathSearchOrdering>({
+			order: {
+				field: 'name',
+				value: 'Asc'
+			}
+		});
+
+		if (!location.data) return defaults;
+
+		const pubId = stringify(location.data.pub_id);
+
+		const settings = preferences.data?.location?.[pubId]?.explorer;
+
+		if (!settings) return defaults;
+
+		for (const [key, value] of Object.entries(settings)) {
+			if (value !== null) Object.assign(defaults, { [key]: value });
 		}
-	}, [locationUuid]);
 
-	useEffect(() => {
-		preferences.refetch.call(undefined);
-	}, [locationUuid, path, preferences.refetch]);
+		return defaults;
+	}, [location.data, preferences.data?.location]);
+
+	const onSettingsChanged = useDebouncedCallback(
+		async (settings: ExplorerSettings<FilePathSearchOrdering>) => {
+			if (!location.data) return;
+
+			const pubId = stringify(location.data.pub_id);
+
+			try {
+				console.log(settings);
+				await updatePreferences.mutateAsync({
+					location: {
+						[pubId]: {
+							explorer: settings
+						}
+					}
+				});
+			} catch (e) {
+				alert('An error has occurred while updating your preferences.');
+			}
+		},
+		500
+	);
+
+	const explorerSettings = useExplorerSettings<FilePathSearchOrdering>({
+		settings,
+		onSettingsChanged,
+		orderingKeys: filePathOrderingKeysSchema
+	});
+
+	const { items, loadMore } = useItems({ locationId, settings: explorerSettings });
+
+	const explorer = useExplorer({
+		items,
+		loadMore,
+		parent: location.data
+			? {
+					type: 'Location',
+					location: location.data
+			  }
+			: undefined,
+		settings: explorerSettings
+	});
 
 	useLibrarySubscription(
 		[
@@ -57,19 +112,6 @@ export const Component = () => {
 		{ onData() {} }
 	);
 
-	const { items, loadMore } = useItems({ locationId });
-
-	const explorer = useExplorer({
-		items,
-		loadMore,
-		parent: location.data
-			? {
-					type: 'Location',
-					location: location.data
-			  }
-			: undefined
-	});
-
 	useEffect(() => {
 		// Using .call to silence eslint exhaustive deps warning.
 		// If clearSelectedItems referenced 'this' then this wouldn't work
@@ -79,7 +121,7 @@ export const Component = () => {
 	useKeyDeleteFile(explorer.selectedItems, location.data?.id);
 
 	return (
-		<ExplorerContext.Provider value={explorer}>
+		<ExplorerContextProvider explorer={explorer}>
 			<TopBarPortal
 				left={
 					<div className="group flex flex-row items-center space-x-2">
@@ -100,17 +142,23 @@ export const Component = () => {
 			/>
 
 			<Explorer />
-		</ExplorerContext.Provider>
+		</ExplorerContextProvider>
 	);
 };
 
-const useItems = ({ locationId }: { locationId: number }) => {
+const useItems = ({
+	locationId,
+	settings
+}: {
+	locationId: number;
+	settings: UseExplorerSettings<FilePathSearchOrdering>;
+}) => {
 	const [{ path, take }] = useExplorerSearchParams();
 
 	const ctx = useRspcLibraryContext();
 	const { library } = useLibraryContext();
 
-	const explorerState = useExplorerStore();
+	const explorerSettings = settings.useSettingsSnapshot();
 
 	const query = useInfiniteQuery({
 		queryKey: [
@@ -118,10 +166,10 @@ const useItems = ({ locationId }: { locationId: number }) => {
 			{
 				library_id: library.uuid,
 				arg: {
-					order: useExplorerOrder(),
+					order: explorerSettings.order,
 					filter: {
 						locationId,
-						...(explorerState.layoutMode === 'media'
+						...(explorerSettings.layoutMode === 'media'
 							? { object: { kind: [5, 7] } }
 							: { path: path ?? '' })
 					},

--- a/interface/app/$libraryId/node/$id.tsx
+++ b/interface/app/$libraryId/node/$id.tsx
@@ -1,11 +1,13 @@
 import { Laptop } from '@sd/assets/icons';
+import { useMemo } from 'react';
 import { useBridgeQuery, useLibraryQuery } from '@sd/client';
 import { NodeIdParamsSchema } from '~/app/route-schemas';
 import { useZodRouteParams } from '~/hooks';
 import Explorer from '../Explorer';
-import { ExplorerContext } from '../Explorer/Context';
+import { ExplorerContextProvider } from '../Explorer/Context';
 import { DefaultTopBarOptions } from '../Explorer/TopBarOptions';
-import { useExplorer } from '../Explorer/useExplorer';
+import { createDefaultExplorerSettings } from '../Explorer/store';
+import { useExplorer, useExplorerSettings } from '../Explorer/useExplorer';
 import { TopBarPortal } from '../TopBar/Portal';
 
 export const Component = () => {
@@ -15,6 +17,17 @@ export const Component = () => {
 
 	const nodeState = useBridgeQuery(['nodeState']);
 
+	const explorerSettings = useExplorerSettings({
+		settings: useMemo(
+			() =>
+				createDefaultExplorerSettings<never>({
+					order: null
+				}),
+			[]
+		),
+		onSettingsChanged: () => {}
+	});
+
 	const explorer = useExplorer({
 		items: query.data || null,
 		parent: nodeState.data
@@ -22,11 +35,12 @@ export const Component = () => {
 					type: 'Node',
 					node: nodeState.data
 			  }
-			: undefined
+			: undefined,
+		settings: explorerSettings
 	});
 
 	return (
-		<ExplorerContext.Provider value={explorer}>
+		<ExplorerContextProvider explorer={explorer}>
 			<TopBarPortal
 				left={
 					<div className="group flex flex-row items-center space-x-2">
@@ -45,6 +59,6 @@ export const Component = () => {
 			/>
 
 			<Explorer />
-		</ExplorerContext.Provider>
+		</ExplorerContextProvider>
 	);
 };

--- a/interface/app/$libraryId/overview/data.ts
+++ b/interface/app/$libraryId/overview/data.ts
@@ -1,8 +1,15 @@
 import { iconNames } from '@sd/assets/util';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
-import { Category, useLibraryContext, useRspcLibraryContext } from '@sd/client';
+import {
+	Category,
+	ObjectSearchOrdering,
+	useLibraryContext,
+	useRspcLibraryContext
+} from '@sd/client';
+import { useExplorerContext } from '../Explorer/Context';
 import { getExplorerStore, useExplorerStore } from '../Explorer/store';
+import { UseExplorerSettings } from '../Explorer/useExplorer';
 
 export const IconForCategory: Partial<Record<Category, string>> = {
 	Recents: iconNames.Collection,
@@ -23,15 +30,39 @@ export const IconForCategory: Partial<Record<Category, string>> = {
 	Trash: iconNames.Trash
 };
 
+export const IconToDescription = {
+	Recents: "See files you've recently opened or created",
+	Favorites: 'See files you have marked as favorites',
+	Albums: 'Organize your photos and videos into albums',
+	Photos: 'View all photos in your library',
+	Videos: 'View all videos in your library',
+	Movies: 'View all movies in your library',
+	Music: 'View all music in your library',
+	Documents: 'View all documents in your library',
+	Downloads: 'View all downloads in your library',
+	Encrypted: 'View all encrypted files in your library',
+	Projects: 'View all projects in your library',
+	Applications: 'View all applications in your library',
+	Archives: 'View all archives in your library',
+	Databases: 'View all databases in your library',
+	Games: 'View all games in your library',
+	Books: 'View all books in your library',
+	Contacts: 'View all contacts in your library',
+	Trash: 'View all files in your trash'
+};
+
 const OBJECT_CATEGORIES: Category[] = ['Recents', 'Favorites'];
 
 // this is a gross function so it's in a separate hook :)
-export function useItems(category: Category) {
-	const explorerStore = useExplorerStore();
+export function useItems(
+	category: Category,
+	explorerSettings: UseExplorerSettings<ObjectSearchOrdering>
+) {
+	const settings = explorerSettings.useSettingsSnapshot();
 	const rspc = useRspcLibraryContext();
 	const { library } = useLibraryContext();
 
-	const kind = explorerStore.layoutMode === 'media' ? [5, 7] : undefined;
+	const kind = settings.layoutMode === 'media' ? [5, 7] : undefined;
 
 	const isObjectQuery = OBJECT_CATEGORIES.includes(category);
 

--- a/interface/app/$libraryId/overview/index.tsx
+++ b/interface/app/$libraryId/overview/index.tsx
@@ -1,56 +1,53 @@
 import { getIcon } from '@sd/assets/util';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import 'react-loading-skeleton/dist/skeleton.css';
-import { Category } from '@sd/client';
+import { useSnapshot } from 'valtio';
+import { Category, ObjectSearchOrdering } from '@sd/client';
 import { useIsDark } from '../../../hooks';
-import { ExplorerContext } from '../Explorer/Context';
+import { ExplorerContextProvider } from '../Explorer/Context';
 import ContextMenu, { ObjectItems } from '../Explorer/ContextMenu';
 import { Conditional } from '../Explorer/ContextMenu/ConditionalItem';
 import { Inspector } from '../Explorer/Inspector';
 import { DefaultTopBarOptions } from '../Explorer/TopBarOptions';
 import View from '../Explorer/View';
-import { useExplorerStore } from '../Explorer/store';
-import { useExplorer } from '../Explorer/useExplorer';
+import {
+	createDefaultExplorerSettings,
+	objectOrderingKeysSchema,
+	useExplorerStore
+} from '../Explorer/store';
+import { useExplorer, useExplorerSettings } from '../Explorer/useExplorer';
 import { usePageLayoutContext } from '../PageLayout/Context';
 import { TopBarPortal } from '../TopBar/Portal';
 import Statistics from '../overview/Statistics';
-import { Categories, CategoryList } from './Categories';
-import { IconForCategory, useItems } from './data';
-
-const IconToDescription = {
-	Recents: "See files you've recently opened or created",
-	Favorites: 'See files you have marked as favorites',
-	Albums: 'Organize your photos and videos into albums',
-	Photos: 'View all photos in your library',
-	Videos: 'View all videos in your library',
-	Movies: 'View all movies in your library',
-	Music: 'View all music in your library',
-	Documents: 'View all documents in your library',
-	Downloads: 'View all downloads in your library',
-	Encrypted: 'View all encrypted files in your library',
-	Projects: 'View all projects in your library',
-	Applications: 'View all applications in your library',
-	Archives: 'View all archives in your library',
-	Databases: 'View all databases in your library',
-	Games: 'View all games in your library',
-	Books: 'View all books in your library',
-	Contacts: 'View all contacts in your library',
-	Trash: 'View all files in your trash'
-};
+import { Categories } from './Categories';
+import { IconForCategory, IconToDescription, useItems } from './data';
 
 export const Component = () => {
 	const explorerStore = useExplorerStore();
 	const isDark = useIsDark();
 	const page = usePageLayoutContext();
 
+	const explorerSettings = useExplorerSettings({
+		settings: useMemo(
+			() =>
+				createDefaultExplorerSettings<ObjectSearchOrdering>({
+					order: null
+				}),
+			[]
+		),
+		onSettingsChanged: () => {},
+		orderingKeys: objectOrderingKeysSchema
+	});
+
 	const [selectedCategory, setSelectedCategory] = useState<Category>('Recents');
 
-	const { items, loadMore } = useItems(selectedCategory);
+	const { items, loadMore } = useItems(selectedCategory, explorerSettings);
 
 	const explorer = useExplorer({
 		items,
 		loadMore,
-		scrollRef: page.ref
+		scrollRef: page.ref,
+		settings: explorerSettings
 	});
 
 	useEffect(() => {
@@ -60,8 +57,10 @@ export const Component = () => {
 		if (scrollTop > 100) page.ref.current.scrollTo({ top: 100 });
 	}, [selectedCategory, page.ref]);
 
+	const settings = useSnapshot(explorer.settingsStore);
+
 	return (
-		<ExplorerContext.Provider value={explorer}>
+		<ExplorerContextProvider explorer={explorer}>
 			<TopBarPortal right={<DefaultTopBarOptions />} />
 
 			<Statistics />
@@ -71,7 +70,7 @@ export const Component = () => {
 			<div className="flex flex-1">
 				<View
 					top={68}
-					className={explorerStore.layoutMode === 'list' ? 'min-w-0' : undefined}
+					className={settings.layoutMode === 'list' ? 'min-w-0' : undefined}
 					contextMenu={
 						<ContextMenu>
 							{() => <Conditional items={[ObjectItems.RemoveFromRecents]} />}
@@ -96,11 +95,11 @@ export const Component = () => {
 
 				{explorerStore.showInspector && (
 					<Inspector
-						showThumbnail={explorerStore.layoutMode !== 'media'}
+						showThumbnail={settings.layoutMode !== 'media'}
 						className="custom-scroll inspector-scroll sticky top-[68px] h-full w-[260px] shrink-0 bg-app pb-4 pl-1.5 pr-1"
 					/>
 				)}
 			</div>
-		</ExplorerContext.Provider>
+		</ExplorerContextProvider>
 	);
 };

--- a/interface/app/$libraryId/tag/$id.tsx
+++ b/interface/app/$libraryId/tag/$id.tsx
@@ -1,12 +1,14 @@
 import { getIcon, iconNames } from '@sd/assets/util';
-import { useLibraryQuery } from '@sd/client';
+import { useMemo } from 'react';
+import { ObjectSearchOrdering, useLibraryQuery } from '@sd/client';
 import { LocationIdParamsSchema } from '~/app/route-schemas';
 import { useZodRouteParams } from '~/hooks';
 import Explorer from '../Explorer';
-import { ExplorerContext } from '../Explorer/Context';
+import { ExplorerContextProvider } from '../Explorer/Context';
 import { DefaultTopBarOptions } from '../Explorer/TopBarOptions';
 import { EmptyNotice } from '../Explorer/View';
-import { useExplorer } from '../Explorer/useExplorer';
+import { createDefaultExplorerSettings, objectOrderingKeysSchema } from '../Explorer/store';
+import { useExplorer, useExplorerSettings } from '../Explorer/useExplorer';
 import { TopBarPortal } from '../TopBar/Portal';
 
 export const Component = () => {
@@ -23,6 +25,18 @@ export const Component = () => {
 
 	const tag = useLibraryQuery(['tags.get', tagId], { suspense: true });
 
+	const explorerSettings = useExplorerSettings({
+		settings: useMemo(
+			() =>
+				createDefaultExplorerSettings<ObjectSearchOrdering>({
+					order: null
+				}),
+			[]
+		),
+		onSettingsChanged: () => {},
+		orderingKeys: objectOrderingKeysSchema
+	});
+
 	const explorer = useExplorer({
 		items: explorerData.data?.items || null,
 		parent: tag.data
@@ -30,11 +44,12 @@ export const Component = () => {
 					type: 'Tag',
 					tag: tag.data
 			  }
-			: undefined
+			: undefined,
+		settings: explorerSettings
 	});
 
 	return (
-		<ExplorerContext.Provider value={explorer}>
+		<ExplorerContextProvider explorer={explorer}>
 			<TopBarPortal right={<DefaultTopBarOptions />} />
 			<Explorer
 				emptyNotice={
@@ -44,6 +59,6 @@ export const Component = () => {
 					/>
 				}
 			/>
-		</ExplorerContext.Provider>
+		</ExplorerContextProvider>
 	);
 };

--- a/interface/app/route-schemas.ts
+++ b/interface/app/route-schemas.ts
@@ -23,7 +23,10 @@ export type PathParams = z.infer<typeof PathParamsSchema>;
 export const SearchParamsSchema = PathParamsSchema.extend({
 	take: z.coerce.number().optional(),
 	order: z
-		.union([z.object({ name: SortOrderSchema }), z.object({ name: SortOrderSchema })])
+		.union([
+			z.object({ field: z.literal('name'), value: SortOrderSchema }),
+			z.object({ field: z.literal('sizeInBytes'), value: SortOrderSchema })
+		])
 		.optional(),
 	search: z.string().optional()
 });

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -113,7 +113,7 @@ export type ExplorerItem = { type: "Path"; has_local_thumbnail: boolean; thumbna
 
 export type ExplorerLayout = "grid" | "list" | "media"
 
-export type ExplorerSettings = { layoutMode: ExplorerLayout | null; gridItemSize: number | null; mediaColumns: number | null; mediaAspectSquare: boolean | null; openOnDoubleClick: DoubleClickAction | null; showBytesInGridView: boolean | null; colSizes: { [key: string]: number } | null; order: FilePathSearchOrdering | null }
+export type ExplorerSettings<TOrder> = { layoutMode: ExplorerLayout | null; gridItemSize: number | null; mediaColumns: number | null; mediaAspectSquare: boolean | null; openOnDoubleClick: DoubleClickAction | null; showBytesInGridView: boolean | null; colSizes: { [key: string]: number } | null; order?: TOrder | null }
 
 export type FileCopierJobInit = { source_location_id: number; target_location_id: number; sources_file_path_ids: number[]; target_location_relative_directory_path: string; target_file_name_suffix: string | null }
 
@@ -129,7 +129,7 @@ export type FilePathFilterArgs = { locationId?: number | null; search?: string |
 
 export type FilePathSearchArgs = { take?: number | null; order?: FilePathSearchOrdering | null; cursor?: number[] | null; filter?: FilePathFilterArgs }
 
-export type FilePathSearchOrdering = { name: SortOrder } | { sizeInBytes: SortOrder } | { dateCreated: SortOrder } | { dateModified: SortOrder } | { dateIndexed: SortOrder } | { object: ObjectSearchOrdering }
+export type FilePathSearchOrdering = { field: "name"; value: SortOrder } | { field: "sizeInBytes"; value: SortOrder } | { field: "dateCreated"; value: SortOrder } | { field: "dateModified"; value: SortOrder } | { field: "dateIndexed"; value: SortOrder } | { field: "object"; value: ObjectSearchOrdering }
 
 export type FilePathWithObject = { id: number; pub_id: number[]; is_dir: boolean | null; cas_id: string | null; integrity_checksum: string | null; location_id: number | null; materialized_path: string | null; name: string | null; extension: string | null; size_in_bytes: string | null; size_in_bytes_bytes: number[] | null; inode: number[] | null; device: number[] | null; object_id: number | null; key_id: number | null; date_created: string | null; date_modified: string | null; date_indexed: string | null; object: Object | null }
 
@@ -194,7 +194,7 @@ export type Location = { id: number; pub_id: number[]; name: string | null; path
  */
 export type LocationCreateArgs = { path: string; dry_run: boolean; indexer_rules_ids: number[] }
 
-export type LocationSettings = { explorer: ExplorerSettings }
+export type LocationSettings = { explorer: ExplorerSettings<FilePathSearchOrdering> }
 
 /**
  * `LocationUpdateArgs` is the argument received from the client using `rspc` to update a location.
@@ -237,7 +237,7 @@ export type ObjectHiddenFilter = "exclude" | "include"
 
 export type ObjectSearchArgs = { take?: number | null; order?: ObjectSearchOrdering | null; cursor?: number[] | null; filter?: ObjectFilterArgs }
 
-export type ObjectSearchOrdering = { dateAccessed: SortOrder }
+export type ObjectSearchOrdering = { field: "dateAccessed"; value: SortOrder } | { field: "kind"; value: SortOrder }
 
 export type ObjectValidatorArgs = { id: number; path: string }
 


### PR DESCRIPTION
This PR isn't targeted at `main`.

A lot of `explorerStore` is now gone and replaced with a settings store that can be created using `useExplorerSettings`, which is then passed into `useExplorer` (the hooks are separate bc `items` of `useExplorer` can be dependent on settings).

This will probably introduce some bugs that we'll need to tackle later (one being properly handling default ordering settings), but pleases both rust + ts and is a design i'm comfortable with for now.