### PR TITLE
[ENG-976] Fixed Missing scrollbar in the Explorer

### DIFF
--- a/interface/app/$libraryId/Explorer/index.tsx
+++ b/interface/app/$libraryId/Explorer/index.tsx
@@ -44,7 +44,7 @@ export default function Explorer(props: PropsWithChildren<Props>) {
 				<div className="flex-1 overflow-hidden">
 					<div
 						ref={explorer.scrollRef}
-						className="custom-scroll explorer-scroll relative h-screen overflow-x-hidden"
+						className="explorer-scroll relative h-screen overflow-x-hidden overflow-y-auto"
 						style={{
 							paddingTop: TOP_BAR_HEIGHT,
 							paddingRight: explorerStore.showInspector ? INSPECTOR_WIDTH : 0

--- a/interface/app/style.scss
+++ b/interface/app/style.scss
@@ -57,21 +57,16 @@ body {
 .explorer-scroll {
 	&::-webkit-scrollbar {
 		height: 6px;
-		width: 6px;
+		width: 8px;
 	}
 	&::-webkit-scrollbar-track {
-		@apply mt-[46px] rounded-[6px] bg-[#00000000];
+		@apply mt-[46px] rounded-[6px] bg-transparent;
 	}
 	&::-webkit-scrollbar-thumb {
-		@apply rounded-[6px] bg-transparent;
+		@apply rounded-[8px] bg-app-box;
 	}
 	&::-webkit-scrollbar-corner {
 		background-color: transparent;
-	}
-	&:hover {
-		&::-webkit-scrollbar-thumb {
-			@apply bg-app-divider/20;
-		}
 	}
 }
 .default-scroll {

--- a/interface/app/style.scss
+++ b/interface/app/style.scss
@@ -57,13 +57,13 @@ body {
 .explorer-scroll {
 	&::-webkit-scrollbar {
 		height: 6px;
-		width: 8px;
+		width: 6px;
 	}
 	&::-webkit-scrollbar-track {
 		@apply mt-[46px] rounded-[6px] bg-transparent;
 	}
 	&::-webkit-scrollbar-thumb {
-		@apply rounded-[8px] bg-app-box;
+		@apply rounded-[6px] bg-app-box;
 	}
 	&::-webkit-scrollbar-corner {
 		background-color: transparent;


### PR DESCRIPTION
Hey @brxken128,

I appreciate your observation regarding the missing scrollbar on the Explorer. I've looked into this, and it turns out that the scrollbar is actually present but not easily visible due to its color being the same as the background of the Explorer. However, you can still interact with it by hovering over it and dragging from the right edge to initiate scrolling.

Here are some screenshots - Before Fix:
![Screenshot (140)](https://github.com/spacedriveapp/spacedrive/assets/77260113/d3db34b5-c78b-40b6-9ac7-3f1fcc25161c)

Screenshot After Fix:
![Screenshot (141)](https://github.com/spacedriveapp/spacedrive/assets/77260113/c5604d0c-ef0b-4525-9318-6ca99e986f2f)

To address this issue, I removed the `custom-scroll` Class that was causing the scrollbar to be constantly visible. Instead, I've added the `overflow-y-auto` Class, which ensures that the scrollbar appears only when needed.
Additionally, I've made some modifications to the CSS file (`.scss`) to ensure that the scrollbar is visible. Previously, it was transparent.

Best regards,
Aditya

Closes #1219 