### PR TITLE
[ENG-992] Add `search.pathsCount` route

### DIFF
--- a/interface/app/$libraryId/Explorer/store.ts
+++ b/interface/app/$libraryId/Explorer/store.ts
@@ -159,3 +159,10 @@ export const objectOrderingKeysSchema = z.union([
 	z.literal('dateAccessed').describe('Date Accessed'),
 	z.literal('kind').describe('Kind')
 ]);
+
+export const nonIndexedPathOrderingSchema = z.union([
+	z.literal('name').describe('Name'),
+	z.literal('sizeInBytes').describe('Size'),
+	z.literal('dateCreated').describe('Date Created'),
+	z.literal('dateModified').describe('Date Modified')
+]);

--- a/interface/app/$libraryId/ephemeral.tsx
+++ b/interface/app/$libraryId/ephemeral.tsx
@@ -1,5 +1,5 @@
 import { Suspense, memo, useDeferredValue, useMemo } from 'react';
-import { type FilePathSearchOrdering, getExplorerItemData, useLibraryQuery } from '@sd/client';
+import { type NonIndexedPathOrdering, getExplorerItemData, useLibraryQuery } from '@sd/client';
 import { Tooltip } from '@sd/ui';
 import { type PathParams, PathParamsSchema } from '~/app/route-schemas';
 import { useOperatingSystem, useZodSearchParams } from '~/hooks';
@@ -8,8 +8,8 @@ import { ExplorerContextProvider } from './Explorer/Context';
 import { DefaultTopBarOptions } from './Explorer/TopBarOptions';
 import {
 	createDefaultExplorerSettings,
-	filePathOrderingKeysSchema,
-	getExplorerStore
+	getExplorerStore,
+	nonIndexedPathOrderingSchema
 } from './Explorer/store';
 import { useExplorer, useExplorerSettings } from './Explorer/useExplorer';
 import { TopBarPortal } from './TopBar/Portal';
@@ -22,7 +22,7 @@ const EphemeralExplorer = memo((props: { args: PathParams }) => {
 	const explorerSettings = useExplorerSettings({
 		settings: useMemo(
 			() =>
-				createDefaultExplorerSettings<FilePathSearchOrdering>({
+				createDefaultExplorerSettings<NonIndexedPathOrdering>({
 					order: {
 						field: 'name',
 						value: 'Asc'
@@ -30,14 +30,14 @@ const EphemeralExplorer = memo((props: { args: PathParams }) => {
 				}),
 			[]
 		),
-		orderingKeys: filePathOrderingKeysSchema
+		orderingKeys: nonIndexedPathOrderingSchema
 	});
 
 	const settingsSnapshot = explorerSettings.useSettingsSnapshot();
 
 	const query = useLibraryQuery(
 		[
-			'search.ephemeral-paths',
+			'search.ephemeralPaths',
 			{
 				path: path ?? (os === 'windows' ? 'C:\\' : '/'),
 				withHiddenFiles: true,

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -25,9 +25,10 @@ export type Procedures = {
         { key: "notifications.dismissAll", input: never, result: null } | 
         { key: "notifications.get", input: never, result: Notification[] } | 
         { key: "preferences.get", input: LibraryArgs<null>, result: LibraryPreferences } | 
-        { key: "search.ephemeral-paths", input: LibraryArgs<NonIndexedPath>, result: NonIndexedFileSystemEntries } | 
+        { key: "search.ephemeralPaths", input: LibraryArgs<NonIndexedPath>, result: NonIndexedFileSystemEntries } | 
         { key: "search.objects", input: LibraryArgs<ObjectSearchArgs>, result: SearchData<ExplorerItem> } | 
         { key: "search.paths", input: LibraryArgs<FilePathSearchArgs>, result: SearchData<ExplorerItem> } | 
+        { key: "search.pathsCount", input: LibraryArgs<{ filter?: FilePathFilterArgs }>, result: number } | 
         { key: "sync.messages", input: LibraryArgs<null>, result: CRDTOperation[] } | 
         { key: "tags.get", input: LibraryArgs<number>, result: Tag | null } | 
         { key: "tags.getForObject", input: LibraryArgs<number>, result: Tag[] } | 
@@ -236,9 +237,11 @@ export type NodeState = ({ id: string; name: string; p2p_port: number | null; p2
 
 export type NonIndexedFileSystemEntries = { entries: ExplorerItem[]; errors: Error[] }
 
-export type NonIndexedPath = { path: string; withHiddenFiles: boolean; order?: FilePathSearchOrdering | null }
+export type NonIndexedPath = { path: string; withHiddenFiles: boolean; order?: NonIndexedPathOrdering | null }
 
 export type NonIndexedPathItem = { path: string; name: string; extension: string; kind: number; is_dir: boolean; date_created: string; date_modified: string; size_in_bytes_bytes: number[] }
+
+export type NonIndexedPathOrdering = { field: "name"; value: SortOrder } | { field: "sizeInBytes"; value: SortOrder } | { field: "dateCreated"; value: SortOrder } | { field: "dateModified"; value: SortOrder }
 
 /**
  * Represents a single notification.


### PR DESCRIPTION
This doesn't actually utilise the query, but just makes it exist.
Whether this will help with making scroll navigation work properly is tbd, but I'm not sure what the best approach is so for now we'll implement whatever the UI needs.