### PR TITLE
[ENG-1027] Fix build on Windows

### DIFF
--- a/.github/scripts/setup-system.ps1
+++ b/.github/scripts/setup-system.ps1
@@ -147,10 +147,11 @@ To set up your machine for Spacedrive development, this script will do the follo
 2) Install Edge Webview 2
 3) Install Rust and Cargo
 4) Install Rust tools
-5) Install Node.js, npm and pnpm
-6) Install LLVM $llvmVersion (compiler for ffmpeg-rust)
-7) Download the protbuf compiler
-8) Download a compatible ffmpeg build
+5) Install Strawberry perl (used by to build the openssl-sys crate)
+6) Install Node.js, npm and pnpm
+7) Install LLVM $llvmVersion (compiler for ffmpeg-rust)
+8) Download the protbuf compiler
+9) Download a compatible ffmpeg build
 "@
 
 # Install System dependencies (GitHub Actions already has all of those installed)
@@ -214,7 +215,14 @@ https://learn.microsoft.com/windows/package-manager/winget/
         $LASTEXITCODE = 0
     }
 
-    # TODO: Install Strawberry perl, required by debug build of openssl-sys
+    Write-Host
+    Write-Host 'Installing Strawberry perl...' -ForegroundColor Yellow
+    winget install -e --accept-source-agreements --disable-interactivity --id StrawberryPerl.StrawberryPerl
+    if (-not ($wingetValidExit -contains $LASTEXITCODE)) {
+        Exit-WithError 'Failed to install Strawberry perl'
+    } else {
+        $LASTEXITCODE = 0
+    }
 
     Write-Host
     Write-Host 'Installing NodeJS...' -ForegroundColor Yellow

--- a/apps/desktop/crates/windows/src/lib.rs
+++ b/apps/desktop/crates/windows/src/lib.rs
@@ -2,22 +2,21 @@
 
 use std::{
 	ffi::{OsStr, OsString},
-	os::windows::{ffi::OsStrExt, prelude::OsStringExt},
-	path::{Path, PathBuf},
+	os::windows::ffi::OsStrExt,
+	path::Path,
 };
 
 use normpath::PathExt;
 use windows::{
-	core::{GUID, HSTRING, PCWSTR},
+	core::{HSTRING, PCWSTR},
 	Win32::{
-		Foundation::HANDLE,
 		System::Com::{
 			CoInitializeEx, CoUninitialize, IDataObject, COINIT_APARTMENTTHREADED,
 			COINIT_DISABLE_OLE1DDE,
 		},
 		UI::Shell::{
-			BHID_DataObject, FOLDERID_Profile, IAssocHandler, IShellItem, SHAssocEnumHandlers,
-			SHCreateItemFromParsingName, SHGetKnownFolderPath, ASSOC_FILTER_RECOMMENDED,
+			BHID_DataObject, IAssocHandler, IShellItem, SHAssocEnumHandlers,
+			SHCreateItemFromParsingName, ASSOC_FILTER_RECOMMENDED,
 		},
 	},
 };

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -20,5 +20,5 @@ export default mergeConfig(baseConfig, {
 	server: {
 		port: 8001
 	},
-	plugins: [devtoolsPlugin],
+	plugins: [devtoolsPlugin]
 });

--- a/core/crates/sync/tests/lib.rs
+++ b/core/crates/sync/tests/lib.rs
@@ -156,6 +156,7 @@ async fn bruh() -> Result<(), Box<dyn std::error::Error>> {
 					ingest::Request::Ingested => {
 						instance2.sync.tx.send(SyncMessage::Ingested).ok();
 					}
+					_ => todo!(),
 				}
 			}
 		}

--- a/packages/config/vite/relativeAliasResolver.ts
+++ b/packages/config/vite/relativeAliasResolver.ts
@@ -11,25 +11,28 @@ const resolver: Alias = {
 	async customResolver(source, importer) {
 		let root: null | string = null;
 
+		if (importer) importer = path.normalize(importer);
+
+		// source is the path imported on typescript, which always use / as path separator
 		const [_, sourcePath] = source.split('~/');
 
-		const relativeImporter = importer!.replace(projectPath, '');
+		const relativeImporter = importer?.replace(projectPath, '');
+		if (relativeImporter && relativeImporter.includes(`${path.sep}src${path.sep}`)) {
+			const [pkg] = relativeImporter.split(`${path.sep}src${path.sep}`);
 
-		if (relativeImporter.includes('/src/')) {
-			const [pkg] = relativeImporter.split('/src/');
+			root = `${projectPath}${pkg}${path.sep}src`;
+		} else if (importer) {
+			const pathObj = path.parse(importer);
 
-			root = `${projectPath}${pkg}/src`;
-		} else {
-			let parent = importer!;
-
-			while (parent !== '/') {
+			let parent = pathObj.dir;
+			while (parent !== pathObj.root) {
 				parent = path.dirname(parent);
 
 				let hasPkgJson = pkgJsonCache.get(parent);
 
 				if (hasPkgJson === undefined)
 					try {
-						await fs.stat(`${parent}/package.json`);
+						await fs.stat(`${parent}${path.sep}package.json`);
 						pkgJsonCache.set(parent, (hasPkgJson = true));
 					} catch {
 						pkgJsonCache.set(parent, (hasPkgJson = false));
@@ -43,12 +46,15 @@ const resolver: Alias = {
 
 			if (root === null)
 				throw new Error(`Failed to resolve import path ${source} in file ${importer}`);
+		} else {
+			throw new Error(`Failed to resolve import path ${source} in file ${importer}`);
 		}
 
-		const absolutePath = `${root}/${sourcePath}`;
+		const absolutePath = `${root}${path.sep}${sourcePath}`;
 
-		const folderItems = await fs.readdir(path.join(absolutePath, '../'));
+		const folderItems = await fs.readdir(path.join(absolutePath, '..'));
 
+		// sourcePath is derived from the path imported on typescript, which always use / as path separator
 		const item = folderItems.find((i) => i.startsWith(sourcePath.split('/').at(-1)!))!;
 
 		const fullPath = absolutePath + path.extname(item);
@@ -60,7 +66,7 @@ const resolver: Alias = {
 
 			const indexFile = directoryItems.find((i) => i.startsWith('index'));
 
-			return `${absolutePath}/${indexFile}`;
+			return `${absolutePath}${path.sep}${indexFile}`;
 		} else {
 			return fullPath;
 		}


### PR DESCRIPTION
 - Fix Vite `relativeAliasResolver` on Windows
 - Add Strawberry Perl installation to setup-system.ps1 (stop rust-analyzer from crashing on Windows)
 - Remove unused imports from desktop windows crate
 - Add todo for missing sync test match cases
