### PR TITLE
[ENG-1017] Job name tooltip center

### DIFF
--- a/interface/app/$libraryId/Layout/Sidebar/JobManager/JobContainer.tsx
+++ b/interface/app/$libraryId/Layout/Sidebar/JobManager/JobContainer.tsx
@@ -44,7 +44,7 @@ const JobContainer = forwardRef<HTMLLIElement, JobContainerProps>((props, ref) =
 			)}
 			<MetaContainer>
 				<Tooltip asChild tooltipClassName="bg-black max-w-[400px]" position="top" label={name}>
-					<p className="truncate max-w-[83%] pl-1.5 font-semibold">{name}</p>
+					<p className="truncate w-fit max-w-[83%] pl-1.5 font-semibold">{name}</p>
 				</Tooltip>
 				{textItems?.map((item, index) => {
 					// filter out undefined text so we don't render empty TextItems


### PR DESCRIPTION
Quick fix - addresses overflowing and centering tooltip.

<img width="442" alt="Screenshot 2023-08-30 at 12 38 45 PM" src="https://github.com/spacedriveapp/spacedrive/assets/33054370/841de66c-f703-4020-8686-8995c529bad2">
