### PR TITLE
Fix dialog entry

### DIFF
--- a/packages/ui/src/Dialog.tsx
+++ b/packages/ui/src/Dialog.tsx
@@ -210,9 +210,7 @@ export function Dialog<S extends FieldValues>({
 									e?.preventDefault();
 									await onSubmit?.(e);
 									dialog.onSubmit?.();
-									if (form.formState.isValid) {
-										setOpen(false);
-									}
+									setOpen(false);
 								}}
 								className="!pointer-events-auto my-8 min-w-[300px] max-w-[400px] rounded-md border border-app-line bg-app-box text-ink shadow-app-shade"
 							>


### PR DESCRIPTION
A bug was introduced in PR #1279 where a dialog would only close if the form state was valid, however this is not available everywhere so dialogs weren't closing in the vast majority of cases. This fixes that bug.