### PR TITLE
[ENG-1063] Actually regenerate thumbnails on `Regen Thumbnails` button

### DIFF
--- a/core/src/api/jobs.rs
+++ b/core/src/api/jobs.rs
@@ -227,17 +227,25 @@ pub(crate) fn mount() -> AlphaRouter<Ctx> {
 			pub struct GenerateThumbsForLocationArgs {
 				pub id: location::id::Type,
 				pub path: PathBuf,
+				#[serde(default)]
+				pub regenerate: bool,
 			}
 
 			R.with2(library()).mutation(
-				|(node, library), args: GenerateThumbsForLocationArgs| async move {
-					let Some(location) = find_location(&library, args.id).exec().await? else {
-						return Err(LocationError::IdNotFound(args.id).into());
+				|(node, library),
+				 GenerateThumbsForLocationArgs {
+				     id,
+				     path,
+				     regenerate,
+				 }: GenerateThumbsForLocationArgs| async move {
+					let Some(location) = find_location(&library, id).exec().await? else {
+						return Err(LocationError::IdNotFound(id).into());
 					};
 
 					Job::new(MediaProcessorJobInit {
 						location,
-						sub_path: Some(args.path),
+						sub_path: Some(path),
+						regenerate_thumbnails: regenerate,
 					})
 					.spawn(&node, &library)
 					.await

--- a/core/src/location/mod.rs
+++ b/core/src/location/mod.rs
@@ -412,6 +412,7 @@ pub async fn scan_location(
 	.queue_next(MediaProcessorJobInit {
 		location: location_base_data,
 		sub_path: None,
+		regenerate_thumbnails: false,
 	})
 	.spawn(node, library)
 	.await
@@ -450,6 +451,7 @@ pub async fn scan_location_sub_path(
 	.queue_next(MediaProcessorJobInit {
 		location: location_base_data,
 		sub_path: Some(sub_path),
+		regenerate_thumbnails: false,
 	})
 	.spawn(node, library)
 	.await

--- a/core/src/object/media/media_data_extractor.rs
+++ b/core/src/object/media/media_data_extractor.rs
@@ -88,7 +88,15 @@ pub async fn process(
 		)])
 		.select(media_data::select!({ object_id }))
 		.exec()
-		.await?
+		.await?;
+
+	if files_paths.len() == objects_already_with_media_data.len() {
+		// All files already have media data, skipping
+		run_metadata.skipped = files_paths.len() as u32;
+		return Ok((run_metadata, JobRunErrors::default()));
+	}
+
+	let objects_already_with_media_data = objects_already_with_media_data
 		.into_iter()
 		.map(|media_data| media_data.object_id)
 		.collect::<HashSet<_>>();

--- a/core/src/object/media/media_processor/job.rs
+++ b/core/src/object/media/media_processor/job.rs
@@ -37,6 +37,7 @@ const BATCH_SIZE: usize = 10;
 pub struct MediaProcessorJobInit {
 	pub location: location::Data,
 	pub sub_path: Option<PathBuf>,
+	pub regenerate_thumbnails: bool,
 }
 
 impl Hash for MediaProcessorJobInit {
@@ -181,6 +182,7 @@ impl StatefulJob for MediaProcessorJobInit {
 			self.location.id,
 			&data.location_path,
 			&data.thumbnails_base_dir,
+			self.regenerate_thumbnails,
 			&ctx.library,
 			|completed_count| {
 				ctx.progress(vec![JobReportUpdate::CompletedTaskCount(

--- a/core/src/object/media/media_processor/mod.rs
+++ b/core/src/object/media/media_processor/mod.rs
@@ -120,6 +120,7 @@ async fn process(
 	location_id: location::id::Type,
 	location_path: impl AsRef<Path>,
 	thumbnails_base_dir: impl AsRef<Path>,
+	regenerate_thumbnails: bool,
 	library: &Library,
 	ctx_update_fn: impl Fn(usize),
 ) -> Result<(MediaProcessorMetadata, JobRunErrors), MediaProcessorError> {
@@ -168,6 +169,7 @@ async fn process(
 					location_id,
 					location_path,
 					thumbnails_base_dir,
+					regenerate_thumbnails,
 					library,
 					ctx_update_fn,
 				)

--- a/core/src/object/media/media_processor/shallow.rs
+++ b/core/src/object/media/media_processor/shallow.rs
@@ -124,6 +124,7 @@ pub async fn shallow(
 			location.id,
 			&location_path,
 			&thumbnails_base_dir,
+			false,
 			library,
 			|_| {},
 		)
@@ -135,7 +136,7 @@ pub async fn shallow(
 		}
 	}
 
-	debug!("Media shallow processor run metadata: {run_metadata:#?}");
+	debug!("Media shallow processor run metadata: {run_metadata:?}");
 
 	if run_metadata.media_data.extracted > 0 || run_metadata.thumbnailer.created > 0 {
 		invalidate_query!(library, "search.paths");

--- a/interface/app/$libraryId/Explorer/ContextMenu/FilePath/Items.tsx
+++ b/interface/app/$libraryId/Explorer/ContextMenu/FilePath/Items.tsx
@@ -209,7 +209,8 @@ export const ParentFolderActions = new ConditionalItem({
 						try {
 							await generateThumbnails.mutateAsync({
 								id: parent.location.id,
-								path: selectedFilePaths[0]?.materialized_path ?? '/'
+								path: selectedFilePaths[0]?.materialized_path ?? '/',
+								regenerate: true,
 							});
 						} catch (error) {
 							showAlertDialog({

--- a/interface/app/$libraryId/Explorer/ParentContextMenu.tsx
+++ b/interface/app/$libraryId/Explorer/ParentContextMenu.tsx
@@ -133,7 +133,8 @@ export default (props: PropsWithChildren) => {
 								try {
 									await generateThumbsForLocation.mutateAsync({
 										id: parent.location.id,
-										path: currentPath ?? '/'
+										path: currentPath ?? '/',
+										regenerate: true,
 									});
 								} catch (error) {
 									showAlertDialog({

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -177,7 +177,7 @@ export type FromPattern = { pattern: string; replace_all: boolean }
 
 export type FullRescanArgs = { location_id: number; reidentify_objects: boolean }
 
-export type GenerateThumbsForLocationArgs = { id: number; path: string }
+export type GenerateThumbsForLocationArgs = { id: number; path: string; regenerate?: boolean }
 
 export type GetAll = { backups: Backup[]; directory: string }
 


### PR DESCRIPTION
Introducing a new `renegerate` param to `MediaProcessorJob` asking for regenerating thumbnails already existing instead of skipping.