### PR TITLE
Hotfix: Disable orphan object remover

### DIFF
--- a/core/src/object/orphan_remover.rs
+++ b/core/src/object/orphan_remover.rs
@@ -80,17 +80,17 @@ impl OrphanRemoverActor {
 
 			trace!("Removing {} orphaned objects", objects_ids.len());
 
-			if let Err(e) = db
-				._batch((
-					db.tag_on_object()
-						.delete_many(vec![tag_on_object::object_id::in_vec(objects_ids.clone())]),
-					db.object()
-						.delete_many(vec![object::id::in_vec(objects_ids)]),
-				))
-				.await
-			{
-				error!("Failed to remove orphaned objects: {e:#?}");
-			}
+			// if let Err(e) = db
+			// 	._batch((
+			// 		db.tag_on_object()
+			// 			.delete_many(vec![tag_on_object::object_id::in_vec(objects_ids.clone())]),
+			// 		db.object()
+			// 			.delete_many(vec![object::id::in_vec(objects_ids)]),
+			// 	))
+			// 	.await
+			// {
+			// 	error!("Failed to remove orphaned objects: {e:#?}");
+			// }
 		}
 	}
 }


### PR DESCRIPTION
The orphan remover is a nessesary part of Spacedrive as it ensures metadata is removed from the library once all file paths have been removed. Our approch is not working well at all, she's trigger happy. Objects vanish out of no where, the streets are not safe. This is the solution we need.