### PR TITLE
[ENG-198] Cleaning up after removing a location

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -97,7 +97,7 @@ async fn main() -> tauri::Result<()> {
 				move || node.clone()
 			}))
 			.plugin(sd_server_plugin(node.clone()).unwrap()) // TODO: Handle `unwrap`
-			.manage(node.clone()),
+			.manage(node),
 		Err(err) => {
 			error!("Error starting up the node: {err}");
 			app.plugin(sd_error_plugin(err))

--- a/core/src/library/library.rs
+++ b/core/src/library/library.rs
@@ -88,7 +88,7 @@ impl Library {
 			sync,
 			db: db.clone(),
 			// key_manager,
-			identity: identity.clone(),
+			identity,
 			orphan_remover: OrphanRemoverActor::spawn(db),
 			notifications: node.notifications.clone(),
 			instance_uuid,

--- a/core/src/location/metadata.rs
+++ b/core/src/location/metadata.rs
@@ -1,5 +1,5 @@
 use std::{
-	collections::HashMap,
+	collections::{HashMap, HashSet},
 	path::{Path, PathBuf},
 };
 
@@ -190,6 +190,10 @@ impl SpacedriveLocationMetadataFile {
 			.map(|l| l.path.as_path())
 	}
 
+	pub(super) fn is_empty(&self) -> bool {
+		self.metadata.libraries.is_empty()
+	}
+
 	pub(super) async fn remove_library(
 		&mut self,
 		library_id: LibraryId,
@@ -207,6 +211,30 @@ impl SpacedriveLocationMetadataFile {
 			fs::remove_file(&self.path)
 				.await
 				.map_err(|e| LocationMetadataError::Delete(e, self.path.clone()))
+		}
+	}
+
+	pub(super) async fn clean_stale_libraries(
+		&mut self,
+		existing_libraries_ids: &HashSet<LibraryId>,
+	) -> Result<(), LocationMetadataError> {
+		let previous_libraries_count = self.metadata.libraries.len();
+		self.metadata
+			.libraries
+			.retain(|library_id, _| existing_libraries_ids.contains(library_id));
+
+		if self.metadata.libraries.len() != previous_libraries_count {
+			self.metadata.updated_at = Utc::now();
+
+			if !self.metadata.libraries.is_empty() {
+				self.write_metadata().await
+			} else {
+				fs::remove_file(&self.path)
+					.await
+					.map_err(|e| LocationMetadataError::Delete(e, self.path.clone()))
+			}
+		} else {
+			Ok(())
 		}
 	}
 

--- a/core/src/location/mod.rs
+++ b/core/src/location/mod.rs
@@ -16,7 +16,7 @@ use crate::{
 		},
 	},
 	prisma::{file_path, indexer_rules_in_location, location, PrismaClient},
-	util::error::FileIOError,
+	util::{db::maybe_missing, error::FileIOError},
 	Node,
 };
 
@@ -94,19 +94,33 @@ impl LocationCreateArgs {
 			return Err(LocationError::NotDirectory(self.path));
 		}
 
-		if let Some(metadata) = SpacedriveLocationMetadataFile::try_load(&self.path).await? {
-			return if let Some(old_path) = metadata.location_path(library.id) {
-				if old_path == self.path {
-					Err(LocationError::LocationAlreadyExists(self.path))
+		if let Some(mut metadata) = SpacedriveLocationMetadataFile::try_load(&self.path).await? {
+			metadata
+				.clean_stale_libraries(
+					&node
+						.libraries
+						.get_all()
+						.await
+						.into_iter()
+						.map(|library| library.id)
+						.collect(),
+				)
+				.await?;
+
+			if !metadata.is_empty() {
+				return if let Some(old_path) = metadata.location_path(library.id) {
+					if old_path == self.path {
+						Err(LocationError::LocationAlreadyExists(self.path))
+					} else {
+						Err(LocationError::NeedRelink {
+							old_path: old_path.to_path_buf(),
+							new_path: self.path,
+						})
+					}
 				} else {
-					Err(LocationError::NeedRelink {
-						old_path: old_path.to_path_buf(),
-						new_path: self.path,
-					})
-				}
-			} else {
-				Err(LocationError::AddLibraryToMetadata(self.path))
-			};
+					Err(LocationError::AddLibraryToMetadata(self.path))
+				};
+			}
 		}
 
 		debug!(
@@ -167,6 +181,18 @@ impl LocationCreateArgs {
 		let mut metadata = SpacedriveLocationMetadataFile::try_load(&self.path)
 			.await?
 			.ok_or_else(|| LocationError::MetadataNotFound(self.path.clone()))?;
+
+		metadata
+			.clean_stale_libraries(
+				&node
+					.libraries
+					.get_all()
+					.await
+					.into_iter()
+					.map(|library| library.id)
+					.collect(),
+			)
+			.await?;
 
 		if metadata.has_library(library.id) {
 			return Err(LocationError::NeedRelink {
@@ -310,7 +336,7 @@ impl LocationUpdateArgs {
 						SpacedriveLocationMetadataFile::try_load(path).await?
 					{
 						metadata
-							.update(library.id, self.name.expect("TODO"))
+							.update(library.id, maybe_missing(self.name, "location.name")?)
 							.await?;
 					}
 				}
@@ -701,6 +727,18 @@ pub async fn delete_location(
 	if location.instance_id == Some(library.config.instance_id) {
 		if let Some(path) = &location.path {
 			if let Ok(Some(mut metadata)) = SpacedriveLocationMetadataFile::try_load(path).await {
+				metadata
+					.clean_stale_libraries(
+						&node
+							.libraries
+							.get_all()
+							.await
+							.into_iter()
+							.map(|library| library.id)
+							.collect(),
+					)
+					.await?;
+
 				metadata.remove_library(library.id).await?;
 			}
 		}

--- a/core/src/p2p/p2p_manager.rs
+++ b/core/src/p2p/p2p_manager.rs
@@ -146,7 +146,6 @@ impl P2PManager {
 			let spacedrop_cancelations = self.spacedrop_cancelations.clone();
 
 			let pairing = self.pairing.clone();
-			let node = node.clone();
 
 			async move {
 				let mut shutdown = false;


### PR DESCRIPTION
Removing stale libraries data from libraries that doesn't exist anymore from `.spacedrive` file.

Also minor clippy warnings.
