### PR TITLE
fix: remove the git submodule for test-files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "packages/test-files"]
-	path = "packages/test-files"
-	url = "https://github.com/spacedriveapp/test-files"
-	branch = "main"


### PR DESCRIPTION
Feel free to close this, but multiple people have mentioned that the git submodule for `test-files` has just been messing absolutely everything up - I've experienced it too.

We will sort out a correct test-files setup, either via a CDN, cloning the repo itself or maybe even a quick Google Drive download.