### PR TITLE
[ENG-814] Explorer shortcuts: Escape de-selects all selected items

### DIFF
--- a/interface/app/$libraryId/Explorer/View/GridList.tsx
+++ b/interface/app/$libraryId/Explorer/View/GridList.tsx
@@ -221,7 +221,8 @@ export default ({ children }: { children: RenderItem }) => {
 		if (!explorerView.selectable) return;
 
 		if (e.key === 'Escape') {
-			return explorer.resetSelectedItems([]);
+			explorer.resetSelectedItems([]);
+			return;
 		}
 
 		if (explorer.selectedItems.size > 0) e.preventDefault();

--- a/interface/app/$libraryId/Explorer/View/GridList.tsx
+++ b/interface/app/$libraryId/Explorer/View/GridList.tsx
@@ -220,6 +220,10 @@ export default ({ children }: { children: RenderItem }) => {
 	useKey(['ArrowUp', 'ArrowDown', 'ArrowRight', 'ArrowLeft', 'Escape'], (e) => {
 		if (!explorerView.selectable) return;
 
+		if (e.key === 'Escape') {
+			return explorer.resetSelectedItems([]);
+		}
+
 		if (explorer.selectedItems.size > 0) e.preventDefault();
 
 		const lastItem = activeItem.current;
@@ -270,9 +274,6 @@ export default ({ children }: { children: RenderItem }) => {
 						selectedItemDom as HTMLElement
 					]);
 				}
-			} else if (e.key === 'Escape' && explorer.selectedItems.has(newSelectedItem.data)) {
-				explorer.resetSelectedItems([]);
-				selecto.current?.setSelectedTargets([]);
 			} else {
 				explorer.resetSelectedItems([newSelectedItem.data]);
 				selecto.current?.setSelectedTargets([selectedItemDom as HTMLElement]);

--- a/interface/app/$libraryId/Explorer/View/GridList.tsx
+++ b/interface/app/$libraryId/Explorer/View/GridList.tsx
@@ -222,6 +222,7 @@ export default ({ children }: { children: RenderItem }) => {
 
 		if (e.key === 'Escape') {
 			explorer.resetSelectedItems([]);
+			selecto.current?.setSelectedTargets([]);
 			return;
 		}
 

--- a/interface/app/$libraryId/Explorer/View/GridList.tsx
+++ b/interface/app/$libraryId/Explorer/View/GridList.tsx
@@ -11,9 +11,9 @@ import {
 import Selecto from 'react-selecto';
 import { useKey } from 'rooks';
 import { type ExplorerItem } from '@sd/client';
-
 import { GridList, useGridList } from '~/components';
 import { useOperatingSystem } from '~/hooks';
+
 import { useExplorerContext } from '../Context';
 import { getExplorerStore, isCut, useExplorerStore } from '../store';
 import { uniqueId } from '../util';
@@ -217,7 +217,7 @@ export default ({ children }: { children: RenderItem }) => {
 		activeItem.current = null;
 	}, [explorer.selectedItems]);
 
-	useKey(['ArrowUp', 'ArrowDown', 'ArrowRight', 'ArrowLeft'], (e) => {
+	useKey(['ArrowUp', 'ArrowDown', 'ArrowRight', 'ArrowLeft', 'Escape'], (e) => {
 		if (!explorerView.selectable) return;
 
 		if (explorer.selectedItems.size > 0) e.preventDefault();
@@ -270,6 +270,9 @@ export default ({ children }: { children: RenderItem }) => {
 						selectedItemDom as HTMLElement
 					]);
 				}
+			} else if (e.key === 'Escape' && explorer.selectedItems.has(newSelectedItem.data)) {
+				explorer.resetSelectedItems([]);
+				selecto.current?.setSelectedTargets([]);
 			} else {
 				explorer.resetSelectedItems([newSelectedItem.data]);
 				selecto.current?.setSelectedTargets([selectedItemDom as HTMLElement]);

--- a/interface/app/$libraryId/Explorer/View/ListView.tsx
+++ b/interface/app/$libraryId/Explorer/View/ListView.tsx
@@ -784,7 +784,8 @@ export default () => {
 		if (!explorerView.selectable) return;
 
 		if (e.key === 'Escape') {
-			return explorer.resetSelectedItems([]);
+			explorer.resetSelectedItems([]);
+			return;
 		}
 
 		e.preventDefault();

--- a/interface/app/$libraryId/Explorer/View/ListView.tsx
+++ b/interface/app/$libraryId/Explorer/View/ListView.tsx
@@ -1,3 +1,4 @@
+import { CaretDown, CaretUp } from '@phosphor-icons/react';
 import {
 	flexRender,
 	getCoreRowModel,
@@ -9,7 +10,6 @@ import {
 import { useVirtualizer } from '@tanstack/react-virtual';
 import clsx from 'clsx';
 import dayjs from 'dayjs';
-import { CaretDown, CaretUp } from '@phosphor-icons/react';
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { ScrollSync, ScrollSyncPane } from 'react-scroll-sync';
 import { useKey, useMutationObserver, useWindowEventListener } from 'rooks';
@@ -25,9 +25,9 @@ import {
 	type NonIndexedPathItem
 } from '@sd/client';
 import { Tooltip } from '@sd/ui';
-
 import { useIsTextTruncated, useScrolled } from '~/hooks';
 import { stringify } from '~/util/uuid';
+
 import { ViewItem } from '.';
 import { useLayoutContext } from '../../Layout/Context';
 import { useExplorerContext } from '../Context';
@@ -780,8 +780,12 @@ export default () => {
 		if (lastRow.index >= loadMoreFromRow - 1) explorer.loadMore.call(undefined);
 	}, [virtualRows, rows.length, explorer.loadMore]);
 
-	useKey(['ArrowUp', 'ArrowDown'], (e) => {
+	useKey(['ArrowUp', 'ArrowDown', 'Escape'], (e) => {
 		if (!explorerView.selectable) return;
+
+		if (e.key === 'Escape') {
+			return explorer.resetSelectedItems([]);
+		}
 
 		e.preventDefault();
 

--- a/interface/app/$libraryId/Explorer/View/ListView.tsx
+++ b/interface/app/$libraryId/Explorer/View/ListView.tsx
@@ -783,16 +783,17 @@ export default () => {
 	useKey(['ArrowUp', 'ArrowDown', 'Escape'], (e) => {
 		if (!explorerView.selectable) return;
 
-		if (e.key === 'Escape') {
-			explorer.resetSelectedItems([]);
-			return;
-		}
-
 		e.preventDefault();
 
 		const range = getRangeByIndex(ranges.length - 1);
 
 		if (!range) return;
+
+		if (e.key === 'Escape') {
+			explorer.resetSelectedItems([]);
+			setRanges([]);
+			return;
+		}
 
 		const keyDirection = e.key === 'ArrowDown' ? 'down' : 'up';
 

--- a/interface/app/$libraryId/TopBar/SearchBar.tsx
+++ b/interface/app/$libraryId/TopBar/SearchBar.tsx
@@ -4,7 +4,6 @@ import { useLocation, useNavigate, useResolvedPath } from 'react-router';
 import { createSearchParams } from 'react-router-dom';
 import { useDebouncedCallback } from 'use-debounce';
 import { Input, ModifierKeys, Shortcut } from '@sd/ui';
-
 import { SearchParamsSchema } from '~/app/route-schemas';
 import { getSearchStore, useOperatingSystem, useZodSearchParams } from '~/hooks';
 import { keybindForOs } from '~/util/keybinds';
@@ -58,7 +57,6 @@ export default () => {
 	);
 
 	const blurHandler = useCallback((event: KeyboardEvent) => {
-		console.log(event.key, document.activeElement === searchRef.current);
 		if (event.key === 'Escape' && document.activeElement === searchRef.current) {
 			// Check if element is in focus, then remove it
 			event.preventDefault();
@@ -118,7 +116,7 @@ export default () => {
 						}
 					</div>
 					{/* This indicates whether the search is loading, a spinner could be put here */}
-					{/* {_isPending && <div className="h-8 w-8 bg-red-500" />} */}
+					{/* {_isPending && <div className="w-8 h-8 bg-red-500" />} */}
 				</>
 			}
 		/>


### PR DESCRIPTION
After an evaluation, most shortcuts required are all in place. 

But I also added the idea of being able to press 'Esc' to deselect all selected items. This makes using other shortcuts more accessible, instead of having the user to de-select manually first.

