### PR TITLE
Fix typo server.yml

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -41,7 +41,7 @@ jobs:
             IMAGE_TAG=$(git rev-parse --short "$GITHUB_SHA")
           fi
           GITHUB_REPOSITORY_LOWER=$(echo $GITHUB_REPOSITORY | awk '{print tolower($0)}')
-          IMAGE_NAME="ghcr.io/$GITHUB_REPOSITORY_LOWER/server"
+          IMAGE_NAME="$GITHUB_REPOSITORY_LOWER/server"
 
           echo "Building $IMAGE_NAME:$IMAGE_TAG"
           echo "tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Remove `ghcr.io` from the server's docker image name, as the registry is already being appended by `buidah`