### PR TITLE
[ENG-812] Folder size calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,5 +77,6 @@ dev.db-journal
 /core/migration_test
 sd_init.json
 
+spacedrive
 .cargo/config
 .github/scripts/deps

--- a/core/src/location/file_path_helper/mod.rs
+++ b/core/src/location/file_path_helper/mod.rs
@@ -80,6 +80,7 @@ file_path::select!(file_path_walker {
 	date_modified
 	inode
 	device
+	size_in_bytes_bytes
 });
 file_path::select!(file_path_to_handle_custom_uri {
 	pub_id

--- a/core/src/location/indexer/indexer_job.rs
+++ b/core/src/location/indexer/indexer_job.rs
@@ -499,7 +499,8 @@ impl StatefulJob for IndexerJobInit {
 					&data.location_path,
 					&ctx.library.db,
 				)
-				.await?;
+				.await
+				.map_err(IndexerError::from)?;
 			}
 		}
 

--- a/core/src/location/indexer/mod.rs
+++ b/core/src/location/indexer/mod.rs
@@ -387,12 +387,12 @@ macro_rules! to_remove_db_fetcher_fn {
 	}};
 }
 
-async fn reverse_update_directories_sizes(
+pub async fn reverse_update_directories_sizes(
 	base_path: impl AsRef<Path>,
 	location_id: location::id::Type,
 	location_path: impl AsRef<Path>,
 	db: &PrismaClient,
-) -> Result<(), IndexerError> {
+) -> Result<(), FilePathError> {
 	let base_path = base_path.as_ref();
 	let location_path = location_path.as_ref();
 

--- a/core/src/location/indexer/shallow.rs
+++ b/core/src/location/indexer/shallow.rs
@@ -71,7 +71,7 @@ pub async fn shallow(
 		(false, location_path.to_path_buf())
 	};
 
-	let (walked, to_update, to_remove, errors) = {
+	let (walked, to_update, to_remove, errors, _s) = {
 		walk_single_dir(
 			&to_walk_path,
 			&indexer_rules,

--- a/core/src/location/indexer/shallow.rs
+++ b/core/src/location/indexer/shallow.rs
@@ -7,19 +7,25 @@ use crate::{
 			check_file_path_exists, ensure_sub_path_is_directory, ensure_sub_path_is_in_location,
 			IsolatedFilePathData,
 		},
-		indexer::{execute_indexer_update_step, IndexerJobUpdateStep},
-		LocationError,
+		indexer::{
+			execute_indexer_update_step, reverse_update_directories_sizes, IndexerJobUpdateStep,
+		},
+		scan_location_sub_path,
 	},
-	to_remove_db_fetcher_fn, Node,
+	to_remove_db_fetcher_fn,
+	util::db::maybe_missing,
+	Node,
 };
-use tracing::error;
 
 use std::{
+	collections::HashSet,
 	path::{Path, PathBuf},
 	sync::Arc,
 };
 
+use futures::future::join_all;
 use itertools::Itertools;
+use tracing::error;
 
 use super::{
 	execute_indexer_save_step, iso_file_path_factory, location_with_indexer_rules,
@@ -34,12 +40,10 @@ pub async fn shallow(
 	location: &location_with_indexer_rules::Data,
 	sub_path: &PathBuf,
 	node: &Arc<Node>,
-	library: &Library,
+	library: &Arc<Library>,
 ) -> Result<(), JobError> {
 	let location_id = location.id;
-	let Some(location_path) = location.path.as_ref().map(PathBuf::from) else {
-		return Err(JobError::Location(LocationError::MissingPath(location_id)));
-	};
+	let location_path = maybe_missing(&location.path, "location.path").map(Path::new)?;
 
 	let db = library.db.clone();
 
@@ -60,7 +64,7 @@ pub async fn shallow(
 
 		(
 			!check_file_path_exists::<IndexerError>(
-				&IsolatedFilePathData::new(location_id, &location_path, &full_path, true)
+				&IsolatedFilePathData::new(location_id, location_path, &full_path, true)
 					.map_err(IndexerError::from)?,
 				&db,
 			)
@@ -78,7 +82,7 @@ pub async fn shallow(
 			|_, _| {},
 			file_paths_db_fetcher_fn!(&db),
 			to_remove_db_fetcher_fn!(location_id, &db),
-			iso_file_path_factory(location_id, &location_path),
+			iso_file_path_factory(location_id, location_path),
 			add_root,
 		)
 		.await?
@@ -98,18 +102,45 @@ pub async fn shallow(
 	// TODO pass these uuids to sync system
 	remove_non_existing_file_paths(to_remove, &db).await?;
 
+	let mut new_directories_to_scan = HashSet::new();
+
 	let save_steps = walked
 		.chunks(BATCH_SIZE)
 		.into_iter()
 		.enumerate()
-		.map(|(i, chunk)| IndexerJobSaveStep {
-			chunk_idx: i,
-			walked: chunk.collect::<Vec<_>>(),
+		.map(|(i, chunk)| {
+			let walked = chunk.collect::<Vec<_>>();
+
+			walked
+				.iter()
+				.filter_map(|walked_entry| {
+					walked_entry.iso_file_path.materialized_path_for_children()
+				})
+				.for_each(|new_dir| {
+					new_directories_to_scan.insert(new_dir);
+				});
+
+			IndexerJobSaveStep {
+				chunk_idx: i,
+				walked,
+			}
 		})
 		.collect::<Vec<_>>();
 
 	for step in save_steps {
 		execute_indexer_save_step(location, &step, library).await?;
+	}
+
+	for scan in join_all(
+		new_directories_to_scan
+			.into_iter()
+			.map(|sub_path| scan_location_sub_path(node, library, location.clone(), sub_path)),
+	)
+	.await
+	{
+		if let Err(e) = scan {
+			error!("{e}");
+		}
 	}
 
 	let update_steps = to_update
@@ -124,6 +155,11 @@ pub async fn shallow(
 
 	for step in update_steps {
 		execute_indexer_update_step(&step, library).await?;
+	}
+
+	if to_walk_path != location_path {
+		reverse_update_directories_sizes(to_walk_path, location_id, location_path, &library.db)
+			.await?;
 	}
 
 	invalidate_query!(library, "search.paths");

--- a/core/src/location/indexer/shallow.rs
+++ b/core/src/location/indexer/shallow.rs
@@ -159,7 +159,8 @@ pub async fn shallow(
 
 	if to_walk_path != location_path {
 		reverse_update_directories_sizes(to_walk_path, location_id, location_path, &library.db)
-			.await?;
+			.await
+			.map_err(IndexerError::from)?;
 	}
 
 	invalidate_query!(library, "search.paths");

--- a/core/src/location/indexer/walk.rs
+++ b/core/src/location/indexer/walk.rs
@@ -404,6 +404,8 @@ where
 										])
 									})
 									.unwrap_or_default())
+						// We ignore the size of directories because it is not reliable, we need to
+						// calculate it ourselves later
 						{
 							to_update.push(
 								(sd_utils::from_bytes_to_uuid(&file_path.pub_id), entry).into(),

--- a/core/src/location/indexer/walk.rs
+++ b/core/src/location/indexer/walk.rs
@@ -382,11 +382,28 @@ where
 
 						// Datetimes stored in DB loses a bit of precision, so we need to check against a delta
 						// instead of using != operator
-						if inode != metadata.inode
+						if (inode != metadata.inode
 							|| device != metadata.device || DateTime::<FixedOffset>::from(
 							metadata.modified_at,
 						) - *date_modified
-							> Duration::milliseconds(1)
+							> Duration::milliseconds(1)) && !(entry.iso_file_path.is_dir
+							&& metadata.size_in_bytes
+								!= file_path
+									.size_in_bytes_bytes
+									.as_ref()
+									.map(|size_in_bytes_bytes| {
+										u64::from_be_bytes([
+											size_in_bytes_bytes[0],
+											size_in_bytes_bytes[1],
+											size_in_bytes_bytes[2],
+											size_in_bytes_bytes[3],
+											size_in_bytes_bytes[4],
+											size_in_bytes_bytes[5],
+											size_in_bytes_bytes[6],
+											size_in_bytes_bytes[7],
+										])
+									})
+									.unwrap_or_default())
 						{
 							to_update.push(
 								(sd_utils::from_bytes_to_uuid(&file_path.pub_id), entry).into(),

--- a/core/src/location/manager/watcher/utils.rs
+++ b/core/src/location/manager/watcher/utils.rs
@@ -10,7 +10,9 @@ use crate::{
 			loose_find_existing_file_path_params, FilePathError, FilePathMetadata,
 			IsolatedFilePathData, MetadataExt,
 		},
-		find_location, generate_thumbnail, location_with_indexer_rules,
+		find_location, generate_thumbnail,
+		indexer::reverse_update_directories_sizes,
+		location_with_indexer_rules,
 		manager::LocationManagerError,
 		scan_location_sub_path,
 	},
@@ -38,7 +40,7 @@ use crate::location::file_path_helper::get_inode_and_device;
 use crate::location::file_path_helper::get_inode_and_device_from_path;
 
 use std::{
-	collections::HashSet,
+	collections::{HashMap, HashSet},
 	ffi::OsStr,
 	fs::Metadata,
 	path::{Path, PathBuf},
@@ -57,11 +59,12 @@ use serde_json::json;
 use tokio::{
 	fs,
 	io::{self, ErrorKind},
+	time::Instant,
 };
 use tracing::{debug, error, trace, warn};
 use uuid::Uuid;
 
-use super::INodeAndDevice;
+use super::{INodeAndDevice, HUNDRED_MILLIS};
 
 pub(super) fn check_event(event: &Event, ignore_paths: &HashSet<PathBuf>) -> bool {
 	// if path includes .DS_Store, .spacedrive file creation or is in the `ignore_paths` set, we ignore
@@ -314,25 +317,6 @@ async fn inner_create_file(
 	invalidate_query!(library, "search.paths");
 
 	Ok(())
-}
-
-pub(super) async fn create_dir_or_file(
-	location_id: location::id::Type,
-	path: impl AsRef<Path>,
-	node: &Arc<Node>,
-	library: &Arc<Library>,
-) -> Result<Metadata, LocationManagerError> {
-	let path = path.as_ref();
-	let metadata = fs::metadata(path)
-		.await
-		.map_err(|e| FileIOError::from((path, e)))?;
-
-	if metadata.is_dir() {
-		create_dir(location_id, path, &metadata, node, library).await
-	} else {
-		create_file(location_id, path, &metadata, node, library).await
-	}
-	.map(|_| metadata)
 }
 
 pub(super) async fn update_file(
@@ -824,4 +808,53 @@ pub(super) async fn extract_location_path(
 			// NOTE: The following usage of `PathBuf` doesn't incur a new allocation so it's fine
 			|location| Ok(maybe_missing(location.path, "location.path")?.into()),
 		)
+}
+
+pub(super) async fn recalculate_directories_size(
+	candidates: &mut HashMap<PathBuf, Instant>,
+	buffer: &mut Vec<(PathBuf, Instant)>,
+	location_id: location::id::Type,
+	library: &Library,
+) -> Result<(), LocationManagerError> {
+	let mut location_path_cache = None;
+	let mut should_invalidate = false;
+	buffer.clear();
+
+	for (path, instant) in candidates.drain() {
+		if instant.elapsed() > HUNDRED_MILLIS * 5 {
+			if location_path_cache.is_none() {
+				location_path_cache = Some(maybe_missing(
+					find_location(library, location_id)
+						.select(location::select!({ path }))
+						.exec()
+						.await?
+						.ok_or(LocationManagerError::MissingLocation(location_id))?
+						.path,
+					"location.path",
+				)?)
+			}
+
+			if let Some(location_path) = &location_path_cache {
+				if path != Path::new(location_path) {
+					trace!(
+						"Reverse calculating directory sizes starting at {} until {location_path}",
+						path.display()
+					);
+					reverse_update_directories_sizes(path, location_id, location_path, &library.db)
+						.await?;
+					should_invalidate = true;
+				}
+			}
+		} else {
+			buffer.push((path, instant));
+		}
+	}
+
+	if should_invalidate {
+		invalidate_query!(library, "search.paths");
+	}
+
+	candidates.extend(buffer.drain(..));
+
+	Ok(())
 }

--- a/core/src/location/manager/watcher/utils.rs
+++ b/core/src/location/manager/watcher/utils.rs
@@ -840,7 +840,7 @@ pub(super) async fn recalculate_directories_size(
 						"Reverse calculating directory sizes starting at {} until {location_path}",
 						path.display()
 					);
-					reverse_update_directories_sizes(path, location_id, location_path, &library.db)
+					reverse_update_directories_sizes(path, location_id, location_path, library)
 						.await?;
 					should_invalidate = true;
 				}

--- a/core/src/location/non_indexed.rs
+++ b/core/src/location/non_indexed.rs
@@ -25,7 +25,7 @@ use tokio::{fs, io};
 use tracing::{error, warn};
 
 use super::{
-	file_path_helper::{path_is_hidden, FilePathMetadata, MetadataExt},
+	file_path_helper::{path_is_hidden, MetadataExt},
 	generate_thumbnail,
 	indexer::rules::{
 		seed::{no_hidden, no_os_protected},
@@ -188,7 +188,7 @@ pub async fn walk(
 				has_local_thumbnail: thumbnail_key.is_some(),
 				thumbnail_key,
 				item: NonIndexedPathItem {
-					hidden: path_is_hidden(&Path::new(&entry_path), &metadata),
+					hidden: path_is_hidden(Path::new(&entry_path), &metadata),
 					path: entry_path,
 					name,
 					extension,
@@ -234,7 +234,7 @@ pub async fn walk(
 				has_local_thumbnail: false,
 				thumbnail_key: None,
 				item: NonIndexedPathItem {
-					hidden: path_is_hidden(&Path::new(&directory), &metadata),
+					hidden: path_is_hidden(Path::new(&directory), &metadata),
 					path: directory,
 					name,
 					extension: "".to_string(),


### PR DESCRIPTION
This PR presents a way to calculate directory sizes for all directories in an indexed location in a really lightweight manner, using data about each file size already extracted in the walker for indexer job and shallow indexer. It also takes into account size updates in a directory for files being added through the watcher. 

In case of new or updated files found through indexer jobs or shallow indexers that were using a sub path in a given location, we back propagate the updated size calculations back to ancestor directories.

Now we also dispatch sub path scans for new directories found through the shallow indexer.

Closes #1149
