### PR TITLE
[ENG-1139] Walker wrongly marking files for update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2165,9 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "futures-concurrency"
-version = "7.4.2"
+version = "7.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cf7759a91582f72d30e68a2507feecac3dbcf6314ae91fa7046d6173d502e7"
+checksum = "ef6712e11cdeed5c8cf21ea0b90fec40fbe64afc9bbf2339356197eeca829fc3"
 dependencies = [
  "bitvec",
  "futures-core",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -95,7 +95,7 @@ regex = "1.9.5"
 hex = "0.4.3"
 int-enum = "0.5.0"
 tokio-stream = "0.1.14"
-futures-concurrency = "7.4"
+futures-concurrency = "7.4.3"
 async-channel = "1.9"
 tokio-util = { version = "0.7.8", features = ["io"] }
 slotmap = "1.0.6"

--- a/core/src/location/file_path_helper/mod.rs
+++ b/core/src/location/file_path_helper/mod.rs
@@ -134,6 +134,7 @@ pub struct FilePathMetadata {
 pub fn path_is_hidden(path: &Path, metadata: &Metadata) -> bool {
 	#[cfg(target_family = "unix")]
 	{
+		let _ = metadata; // just to avoid warnings on Linux
 		if path
 			.file_name()
 			.and_then(OsStr::to_str)

--- a/core/src/location/indexer/shallow.rs
+++ b/core/src/location/indexer/shallow.rs
@@ -183,9 +183,11 @@ pub async fn shallow(
 		update_location_size(location.id, library)
 			.await
 			.map_err(IndexerError::from)?;
+
+		invalidate_query!(library, "search.paths");
 	}
 
-	invalidate_query!(library, "search.paths");
+
 
 	library.orphan_remover.invoke().await;
 

--- a/core/src/location/indexer/shallow.rs
+++ b/core/src/location/indexer/shallow.rs
@@ -187,8 +187,6 @@ pub async fn shallow(
 		invalidate_query!(library, "search.paths");
 	}
 
-
-
 	library.orphan_remover.invoke().await;
 
 	Ok(())

--- a/core/src/location/indexer/walk.rs
+++ b/core/src/location/indexer/walk.rs
@@ -422,6 +422,46 @@ where
 								update_conditions[2],
 								update_conditions[3],
 							);
+
+							if update_conditions[0] {
+								debug!("inode: {} != {}", inode, metadata.inode);
+							}
+
+							if update_conditions[1] {
+								debug!("device: {} != {}", device, metadata.device);
+							}
+
+							if update_conditions[2] {
+								debug!(
+									"modified_at: {} != {}",
+									DateTime::<FixedOffset>::from(metadata.modified_at),
+									*date_modified
+								);
+							}
+
+							if update_conditions[3] {
+								debug!(
+									"size_in_bytes: {} != {}",
+									metadata.size_in_bytes,
+									file_path
+										.size_in_bytes_bytes
+										.as_ref()
+										.map(|size_in_bytes_bytes| {
+											u64::from_be_bytes([
+												size_in_bytes_bytes[0],
+												size_in_bytes_bytes[1],
+												size_in_bytes_bytes[2],
+												size_in_bytes_bytes[3],
+												size_in_bytes_bytes[4],
+												size_in_bytes_bytes[5],
+												size_in_bytes_bytes[6],
+												size_in_bytes_bytes[7],
+											])
+										})
+										.unwrap_or_default()
+								);
+							}
+
 							to_update.push(
 								(sd_utils::from_bytes_to_uuid(&file_path.pub_id), entry).into(),
 							);

--- a/core/src/location/indexer/walk.rs
+++ b/core/src/location/indexer/walk.rs
@@ -19,7 +19,7 @@ use std::{
 use chrono::{DateTime, Duration, FixedOffset};
 use serde::{Deserialize, Serialize};
 use tokio::fs;
-use tracing::trace;
+use tracing::{debug, trace};
 use uuid::Uuid;
 
 use super::{
@@ -380,33 +380,48 @@ where
 						let (inode, device) =
 							(inode_from_db(&inode[0..8]), device_from_db(&device[0..8]));
 
-						// Datetimes stored in DB loses a bit of precision, so we need to check against a delta
-						// instead of using != operator
-						if (inode != metadata.inode
-							|| device != metadata.device || DateTime::<FixedOffset>::from(
-							metadata.modified_at,
-						) - *date_modified
-							> Duration::milliseconds(1)) && !(entry.iso_file_path.is_dir
-							&& metadata.size_in_bytes
-								!= file_path
-									.size_in_bytes_bytes
-									.as_ref()
-									.map(|size_in_bytes_bytes| {
-										u64::from_be_bytes([
-											size_in_bytes_bytes[0],
-											size_in_bytes_bytes[1],
-											size_in_bytes_bytes[2],
-											size_in_bytes_bytes[3],
-											size_in_bytes_bytes[4],
-											size_in_bytes_bytes[5],
-											size_in_bytes_bytes[6],
-											size_in_bytes_bytes[7],
-										])
-									})
-									.unwrap_or_default())
-						// We ignore the size of directories because it is not reliable, we need to
-						// calculate it ourselves later
+						let update_conditions = [
+							inode != metadata.inode,
+							device != metadata.device,
+							// Datetimes stored in DB loses a bit of precision, so we need to check against a delta
+							// instead of using != operator
+							DateTime::<FixedOffset>::from(metadata.modified_at) - *date_modified
+								> Duration::milliseconds(1),
+							// We ignore the size of directories because it is not reliable, we need to
+							// calculate it ourselves later
+							!(entry.iso_file_path.is_dir
+								&& metadata.size_in_bytes
+									!= file_path
+										.size_in_bytes_bytes
+										.as_ref()
+										.map(|size_in_bytes_bytes| {
+											u64::from_be_bytes([
+												size_in_bytes_bytes[0],
+												size_in_bytes_bytes[1],
+												size_in_bytes_bytes[2],
+												size_in_bytes_bytes[3],
+												size_in_bytes_bytes[4],
+												size_in_bytes_bytes[5],
+												size_in_bytes_bytes[6],
+												size_in_bytes_bytes[7],
+											])
+										})
+										.unwrap_or_default()),
+						];
+
+						if (update_conditions[0] || update_conditions[1] || update_conditions[2])
+							&& update_conditions[3]
 						{
+							debug!(
+								"File {} is already in DB, update conditions: \
+								((Different inode: {} || Different device: {} || \
+								Different modified_at: {}) && Not a directory with different size: {})",
+								entry.iso_file_path,
+								update_conditions[0],
+								update_conditions[1],
+								update_conditions[2],
+								update_conditions[3],
+							);
 							to_update.push(
 								(sd_utils::from_bytes_to_uuid(&file_path.pub_id), entry).into(),
 							);

--- a/core/src/object/media/thumbnail/mod.rs
+++ b/core/src/object/media/thumbnail/mod.rs
@@ -17,7 +17,6 @@ use sd_file_ext::extensions::{VideoExtension, ALL_VIDEO_EXTENSIONS};
 
 use std::{
 	collections::HashMap,
-	error::Error,
 	ops::Deref,
 	path::{Path, PathBuf},
 };
@@ -177,7 +176,7 @@ pub async fn generate_image_thumbnail<P: AsRef<Path>>(
 pub async fn generate_video_thumbnail<P: AsRef<Path> + Send>(
 	file_path: P,
 	output_path: P,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<(), Box<dyn std::error::Error>> {
 	use sd_ffmpeg::to_thumbnail;
 
 	to_thumbnail(file_path, output_path, 256, TARGET_QUALITY).await?;


### PR DESCRIPTION
Could't replicate the desired bug, but found a different one. Introduced more aggressive logging of when a file is marked to be updated, explaining why.