### PR TITLE
Fix mobile core not building on non-darwin machines

### DIFF
--- a/apps/mobile/modules/sd-core/android/build.gradle
+++ b/apps/mobile/modules/sd-core/android/build.gradle
@@ -112,7 +112,7 @@ cargo {
     targetDirectory = "../../../../../target" // Monorepo moment
 		exec { spec, toolchain ->
 
-			def dir = "${android.ndkDirectory}/toolchains/llvm/prebuilt/${osName}-x86_64/bin/llvm-ranlib"
+			def dir = "${android.ndkDirectory}/toolchains/llvm/prebuilt/${osName.contains("mac") ? "darwin" : osName}-x86_64/bin/llvm-ranlib"
 
 			spec.environment("RANLIB_armv7-linux-androideabi", "${dir}")
 			spec.environment("RANLIB_aarch64-linux-android", "${dir}")

--- a/apps/mobile/modules/sd-core/android/build.gradle
+++ b/apps/mobile/modules/sd-core/android/build.gradle
@@ -110,36 +110,14 @@ cargo {
     profile = 'release' // 'debug'
     targets = cargoTargets
     targetDirectory = "../../../../../target" // Monorepo moment
-		if (osName.contains("linux")) {
-			exec { spec, toolchain ->
+		exec { spec, toolchain ->
 
-				def dir = "${android.ndkDirectory}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ranlib"
+			def dir = "${android.ndkDirectory}/toolchains/llvm/prebuilt/${osName}-x86_64/bin/llvm-ranlib"
 
-		    spec.environment("RANLIB_armv7-linux-androideabi", "${dir}")
-				spec.environment("RANLIB_aarch64-linux-android", "${dir}")
-				spec.environment("RANLIB_i686-linux-android", "${dir}")
-				spec.environment("RANLIB_x86_64-linux-android", "${dir}")
-    	}
-		} else if (osName.contains("windows")) {
-			exec { spec, toolchain ->
-
-				def dir = "${android.ndkDirectory}/toolchains/llvm/prebuilt/windows-x86_64/bin/llvm-ranlib"
-
-		    spec.environment("RANLIB_armv7-linux-androideabi", "${dir}")
-				spec.environment("RANLIB_aarch64-linux-android", "${dir}")
-				spec.environment("RANLIB_i686-linux-android", "${dir}")
-				spec.environment("RANLIB_x86_64-linux-android", "${dir}")
-    	}
-		} else {
-						exec { spec, toolchain ->
-
-				def dir = "${android.ndkDirectory}/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ranlib"
-
-		    spec.environment("RANLIB_armv7-linux-androideabi", "${dir}")
-				spec.environment("RANLIB_aarch64-linux-android", "${dir}")
-				spec.environment("RANLIB_i686-linux-android", "${dir}")
-				spec.environment("RANLIB_x86_64-linux-android", "${dir}")
-    	}
+			spec.environment("RANLIB_armv7-linux-androideabi", "${dir}")
+			spec.environment("RANLIB_aarch64-linux-android", "${dir}")
+			spec.environment("RANLIB_i686-linux-android", "${dir}")
+			spec.environment("RANLIB_x86_64-linux-android", "${dir}")
 		}
 }
 

--- a/apps/mobile/modules/sd-core/android/build.gradle
+++ b/apps/mobile/modules/sd-core/android/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'maven-publish'
 
+
 group = 'com.spacedrive.core'
 version = '0.0.1'
 
@@ -101,21 +102,45 @@ if (System.getenv('SPACEDRIVE_CI') != "1") {
 }
 
 cargo {
+	  final String osName = System.getProperty("os.name").toLowerCase();
+
     module  = "./crate"
     libname = "sd_mobile_android"
     pythonCommand = 'python3'
     profile = 'release' // 'debug'
     targets = cargoTargets
     targetDirectory = "../../../../../target" // Monorepo moment
+		if (osName.contains("linux")) {
+			exec { spec, toolchain ->
 
-		exec { spec, toolchain ->
+				def dir = "${android.ndkDirectory}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ranlib"
+
+		    spec.environment("RANLIB_armv7-linux-androideabi", "${dir}")
+				spec.environment("RANLIB_aarch64-linux-android", "${dir}")
+				spec.environment("RANLIB_i686-linux-android", "${dir}")
+				spec.environment("RANLIB_x86_64-linux-android", "${dir}")
+    	}
+		} else if (osName.contains("windows")) {
+			exec { spec, toolchain ->
+
+				def dir = "${android.ndkDirectory}/toolchains/llvm/prebuilt/windows-x86_64/bin/llvm-ranlib"
+
+		    spec.environment("RANLIB_armv7-linux-androideabi", "${dir}")
+				spec.environment("RANLIB_aarch64-linux-android", "${dir}")
+				spec.environment("RANLIB_i686-linux-android", "${dir}")
+				spec.environment("RANLIB_x86_64-linux-android", "${dir}")
+    	}
+		} else {
+						exec { spec, toolchain ->
+
 				def dir = "${android.ndkDirectory}/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ranlib"
 
 		    spec.environment("RANLIB_armv7-linux-androideabi", "${dir}")
 				spec.environment("RANLIB_aarch64-linux-android", "${dir}")
 				spec.environment("RANLIB_i686-linux-android", "${dir}")
 				spec.environment("RANLIB_x86_64-linux-android", "${dir}")
-    }
+    	}
+		}
 }
 
 tasks.whenTaskAdded { task ->


### PR DESCRIPTION
<!-- Put any information about this PR up here -->
Changed `build.gradle` in the android folder to properly find `llvm-ranlib` for Linux and Windows machines. Windows has not been tested yet. 

<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->

Closes #1387 
