### PR TITLE
[ENG-1165] Add a security policy and notices to the appropriate READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ View a list of our planned features here: [spacedrive.com/roadmap](https://space
 
 Please refer to the [contributing guide](CONTRIBUTING.md) for how to install Spacedrive from sources.
 
+# Security Policy
+
+Please refer to the [security policy](SECURITY.md) for details and information on how to responsibly report a security vulnerability or issue.
+
 # Architecture
 
 This project is using what I'm calling the **"PRRTT"** stack (Prisma, Rust, React, TypeScript, Tauri).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Spacedrive Security Policy
+
+## Reporting a vulnerability
+
+If you find a vulnerability within the app, please report it to us. You may do so anonymously, or we can credit you for it if you wish.
+
+The best way to report any vulnerability or security issue is to email us at [security@spacedrive.com](mailto:security@spacedrive.com).
+
+You may find more details in our [security.txt](https://spacedrive.com/.well-known/security.txt) file, and a copy of our PGP key can be found [spacedrive.com/pgp-key.txt](https://spacedrive.com/pgp-key.txt), or below this message.
+
+<details>
+<summary>PGP Key</summary>
+
+```
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mDMEY5io8BYJKwYBBAHaRw8BAQdACK2o65kjGTShJ5JbpRZ+j1UifYxdGrs5VnJn
+/psHv0e0InNlY3VyaXR5IDxzZWN1cml0eUBzcGFjZWRyaXZlLmNvbT6ImQQTFgoA
+QRYhBAyPfu3J8YRaZx7C0cJwzcnw9t/KBQJjmKjwAhsDBQkD3IVQBQsJCAcCAiIC
+BhUKCQgLAgQWAgMBAh4HAheAAAoJEMJwzcnw9t/KwPwBAN1llaO61SmP4QeQNebg
+KS6/spqArAa/bNS49ihtdCBZAP9QaTgEs42D/qnu4QTeos1vmCaHX5lDpdgtMgaJ
+00Y0BLg4BGOYqPASCisGAQQBl1UBBQEBB0Cnzds/TL9KdUWc+yVepvqm9knob+Na
+euXnVGkLk/TQKQMBCAeIfgQYFgoAJhYhBAyPfu3J8YRaZx7C0cJwzcnw9t/KBQJj
+mKjwAhsMBQkD3IVQAAoJEMJwzcnw9t/KJZIA/iAtQm+3aJlaFG+G5/zJvEAg0qdc
+FElFSz5Kqeyd0BU/AQCOACKdLwNZ3exVR3S1ON1wM3qgaLPZoEmyfDE2/kmyBg==
+=+LNM
+-----END PGP PUBLIC KEY BLOCK-----
+```
+
+</details>

--- a/crates/crypto/README.md
+++ b/crates/crypto/README.md
@@ -38,3 +38,7 @@ You may find them below:
 - AES-GCM and XChaCha20-Poly1305 audit by NCC group ([link](https://research.nccgroup.com/wp-content/uploads/2020/02/NCC_Group_MobileCoin_RustCrypto_AESGCM_ChaCha20Poly1305_Implementation_Review_2020-02-12_v1.0.pdf))
 
 Breaking changes are very likely! Use at your own risk - no stability or security is guaranteed.
+
+## Security Policy
+
+Please refer to the [security policy](../../SECURITY.md) for details and information on how to responsibly report a security vulnerability or issue.


### PR DESCRIPTION
Self explanatory. We could probably sign these, but the `security.txt` file is signed which should validate all of the information displayed anyway.