### PR TITLE
Add pnpm tauri root command

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -6,9 +6,9 @@
 	"private": true,
 	"scripts": {
 		"vite": "vite",
-		"dev": "node ./src-tauri/scripts/tauri.js dev",
-		"dev-vite": "vite --clearScreen=false --mode development",
-		"build": "node ./src-tauri/scripts/tauri.js build",
+		"dev": "vite dev",
+		"build": "vite build",
+		"tauri": "node ./src-tauri/scripts/tauri.js",
 		"dmg": "open ../../target/release/bundle/dmg/",
 		"typecheck": "tsc -b",
 		"lint": "eslint src --cache"

--- a/apps/desktop/src-tauri/scripts/tauri.js
+++ b/apps/desktop/src-tauri/scripts/tauri.js
@@ -6,7 +6,7 @@ const semver = require('semver');
 
 const { spawn } = require('./spawn.js');
 
-const workspace = path.resolve(__dirname, '../../../../')
+const workspace = path.resolve(__dirname, '../../../../');
 const cargoConfig = toml.parse(
 	fs.readFileSync(path.resolve(workspace, '.cargo/config.toml'), { encoding: 'binary' })
 );
@@ -29,8 +29,13 @@ switch (args[0]) {
 		break;
 	}
 	case 'build': {
-		if (!process.env.NODE_OPTIONS || !process.env.NODE_OPTIONS.includes('--max_old_space_size')) {
-			process.env.NODE_OPTIONS = `--max_old_space_size=4096 ${process.env.NODE_OPTIONS ?? ''}`;
+		if (
+			!process.env.NODE_OPTIONS ||
+			!process.env.NODE_OPTIONS.includes('--max_old_space_size')
+		) {
+			process.env.NODE_OPTIONS = `--max_old_space_size=4096 ${
+				process.env.NODE_OPTIONS ?? ''
+			}`;
 		}
 
 		if (args.findIndex((e) => e === '-c' || e === '--config') !== -1) {
@@ -140,7 +145,7 @@ switch (args[0]) {
 }
 
 let code = 0;
-spawn('pnpm', ['tauri', ...args])
+spawn('pnpm', ['exec', 'tauri', ...args])
 	.catch((exitCode) => {
 		code = exitCode;
 		console.error(`tauri ${args[0]} failed with exit code ${exitCode}`);

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -6,8 +6,8 @@
 	"build": {
 		"distDir": "../dist",
 		"devPath": "http://localhost:8001",
-		"beforeDevCommand": "pnpm dev-vite",
-		"beforeBuildCommand": "pnpm vite build"
+		"beforeDevCommand": "pnpm dev",
+		"beforeBuildCommand": "pnpm turbo run build --filter @sd/desktop"
 	},
 	"tauri": {
 		"macOSPrivateApi": true,

--- a/interface/package.json
+++ b/interface/package.json
@@ -13,8 +13,7 @@
 	},
 	"scripts": {
 		"lint": "eslint . --cache",
-		"typecheck": "tsc -b",
-		"build": "tsc"
+		"typecheck": "tsc -b"
 	},
 	"dependencies": {
 		"@fontsource/inter": "^4.5.13",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"gen:prisma": "cd core && cargo prisma generate",
 		"format": "prettier --write .",
 		"desktop": "pnpm --filter @sd/desktop --",
+		"tauri": "pnpm desktop tauri",
 		"web": "pnpm --filter @sd/web -- ",
 		"mobile": "pnpm --filter @sd/mobile --",
 		"core": "pnpm --filter @sd/server -- ",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -10,8 +10,7 @@
 		"test": "jest",
 		"lint": "eslint src --cache",
 		"clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
-		"typecheck": "tsc -b",
-		"build": "tsc"
+		"typecheck": "tsc -b"
 	},
 	"dependencies": {
 		"@rspc/client": "=0.0.0-main-799eec5d",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -15,8 +15,7 @@
 	},
 	"scripts": {
 		"lint": "eslint src --cache",
-		"typecheck": "tsc -b",
-		"build": "tsc"
+		"typecheck": "tsc -b"
 	},
 	"dependencies": {
 		"@headlessui/react": "^1.7.3",

--- a/turbo.json
+++ b/turbo.json
@@ -2,6 +2,7 @@
 	"$schema": "https://turborepo.org/schema.json",
 	"pipeline": {
 		"build": {
+			"inputs": ["!src-tauri/**"],
 			"dependsOn": ["^build"],
 			"outputs": ["dist/**"]
 		},


### PR DESCRIPTION
Makes `pnpm desktop dev/build` run `vite dev/build`, and adds `pnpm tauri` root command that runs `pnpm desktop tauri`.
This allows `tauri.conf.json` to call `vite build` via turborepo and take advantage of caching.