### PR TITLE
Use actual oauth clients + ship ids and secrets

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -12,9 +12,9 @@ edition = { workspace = true }
 tauri = { version = "=1.3.0", features = ["dialog-all", "linux-protocol-headers", "macos-private-api", "os-all", "path-all", "protocol-all", "shell-all", "window-all"] }
 rspc = { workspace = true, features = ["tauri"] }
 sd-core = { path = "../../../core", features = [
-	"ffmpeg",
+	# "ffmpeg",
 	"location-watcher",
-	"heif",
+	# "heif",
 ] }
 tokio = { workspace = true, features = ["sync"] }
 window-shadows = "0.2.1"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -12,9 +12,9 @@ edition = { workspace = true }
 tauri = { version = "=1.3.0", features = ["dialog-all", "linux-protocol-headers", "macos-private-api", "os-all", "path-all", "protocol-all", "shell-all", "window-all"] }
 rspc = { workspace = true, features = ["tauri"] }
 sd-core = { path = "../../../core", features = [
-	# "ffmpeg",
+	"ffmpeg",
 	"location-watcher",
-	# "heif",
+	"heif",
 ] }
 tokio = { workspace = true, features = ["sync"] }
 window-shadows = "0.2.1"

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -96,7 +96,7 @@ async fn main() -> tauri::Result<()> {
 			Node::new(
 				data_dir,
 				sd_core::Env {
-					api_url: "http://localhost:3000".to_string(),
+					api_url: "https://app.spacedrive.com".to_string(),
 					client_id: CLIENT_ID.to_string(),
 					client_secret: CLIENT_SECRET.to_string(),
 				},

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -71,6 +71,9 @@ macro_rules! tauri_handlers {
 	}};
 }
 
+const CLIENT_ID: &str = "2abb241e-40b8-4517-a3e3-5594375c8fbb";
+const CLIENT_SECRET: &str = "eb4554cb-c08d-4e82-b4cc-0aa29c07e934";
+
 #[tokio::main]
 async fn main() -> tauri::Result<()> {
 	#[cfg(debug_assertions)]
@@ -88,7 +91,18 @@ async fn main() -> tauri::Result<()> {
 
 	// The `_guard` must be assigned to variable for flushing remaining logs on main exit through Drop
 	let (_guard, result) = match Node::init_logger(&data_dir) {
-		Ok(guard) => (Some(guard), Node::new(data_dir).await),
+		Ok(guard) => (
+			Some(guard),
+			Node::new(
+				data_dir,
+				sd_core::Env {
+					api_url: "http://localhost:3000".to_string(),
+					client_id: CLIENT_ID.to_string(),
+					client_secret: CLIENT_SECRET.to_string(),
+				},
+			)
+			.await,
+		),
 		Err(err) => (None, Err(NodeError::Logger(err))),
 	};
 

--- a/apps/mobile/modules/sd-core/core/src/lib.rs
+++ b/apps/mobile/modules/sd-core/core/src/lib.rs
@@ -29,6 +29,9 @@ pub static SUBSCRIPTIONS: Lazy<Arc<futures_locks::Mutex<HashMap<RequestId, onesh
 
 pub static EVENT_SENDER: OnceCell<mpsc::Sender<Response>> = OnceCell::new();
 
+pub const CLIENT_ID: &str = "d068776a-05b6-4aaa-9001-4d01734e1944";
+pub const CLIENT_SECRET: &str = "961cdf5c-9eb1-43dc-b921-5b1dd8bbf6a5";
+
 pub struct MobileSender<'a> {
 	resp: &'a mut Option<Response>,
 }
@@ -70,7 +73,16 @@ pub fn handle_core_msg(
 					let _guard = Node::init_logger(&data_dir);
 
 					// TODO: probably don't unwrap
-					let new_node = Node::new(data_dir).await.unwrap();
+					let new_node = Node::new(
+						data_dir,
+						sd_core::Env {
+							api_url: "https://app.spacedrive.com".to_string(),
+							client_id: CLIENT_ID.to_string(),
+							client_secret: CLIENT_SECRET.to_string(),
+						},
+					)
+					.await
+					.unwrap();
 					node.replace(new_node.clone());
 					new_node
 				}

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -39,7 +39,19 @@ async fn main() {
 		}
 	};
 
-	let (node, router) = match Node::new(data_dir).await {
+	let (node, router) = match Node::new(
+		data_dir,
+		sd_core::Env {
+			api_url: std::env::var("SD_API_URL")
+				.unwrap_or_else(|_| "https://app.spacedrive.com".to_string()),
+			client_id: std::env::var("SD_CLIENT_ID")
+				.unwrap_or_else(|_| "04701823-a498-406e-aef9-22081c1dae34".to_string()),
+			client_secret: std::env::var("SD_CLIENT_ID")
+				.unwrap_or_else(|_| "8c0e4f85-d1d3-4a0c-9445-65003ffc581d".to_string()),
+		},
+	)
+	.await
+	{
 		Ok(d) => d,
 		Err(e) => {
 			panic!("{}", e.to_string())

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -1,18 +1,5 @@
 pub struct Env {
 	pub api_url: String,
-}
-
-impl Default for Env {
-	fn default() -> Self {
-		Self::new()
-	}
-}
-
-impl Env {
-	pub fn new() -> Self {
-		Self {
-			api_url: std::env::var("SD_API_URL")
-				.unwrap_or_else(|_| "https://app.spacedrive.com".to_string()),
-		}
-	}
+	pub client_id: String,
+	pub client_secret: String,
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -49,6 +49,8 @@ pub(crate) mod preferences;
 pub mod util;
 pub(crate) mod volume;
 
+pub use env::Env;
+
 pub(crate) use sd_core_sync as sync;
 
 /// Represents a single running instance of the Spacedrive core.
@@ -78,7 +80,10 @@ impl fmt::Debug for Node {
 }
 
 impl Node {
-	pub async fn new(data_dir: impl AsRef<Path>) -> Result<(Arc<Node>, Arc<Router>), NodeError> {
+	pub async fn new(
+		data_dir: impl AsRef<Path>,
+		env: env::Env,
+	) -> Result<(Arc<Node>, Arc<Router>), NodeError> {
 		let data_dir = data_dir.as_ref();
 
 		info!("Starting core with data directory '{}'", data_dir.display());
@@ -114,8 +119,8 @@ impl Node {
 			),
 			libraries,
 			files_over_p2p_flag: Arc::new(AtomicBool::new(false)),
-			env: Default::default(),
 			http: reqwest::Client::new(),
+			env,
 		});
 
 		// Restore backend feature flags


### PR DESCRIPTION
Backend now requires adhering to the actual OAuth spec, with client ids and secrets and everything.
Shipping client secrets may seem insecure but GitHub do it and from what I can tell it's secure - GitHub do it for their CLI.

The main security vuln I want to protect us from is open redirects. Since we're only using device flow this isn't an issue atm, but in future if we allow external OAuth clients we'll want to either restrict our first-party apps to allow device flow only, or use more custom auth methods like forcing redirecting to a localhost server or using a deeplink (mobile) if a particular client ID is provided.
I think we'll keep using device flow for server deployments no matter what since preventing open redirects on them seems really hard.