### PR TITLE
[ENG-1170] - Prevent sidebar scrolling with keyboard

### DIFF
--- a/interface/app/$libraryId/Layout/Sidebar/index.tsx
+++ b/interface/app/$libraryId/Layout/Sidebar/index.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import { useEffect, useRef } from 'react';
 import { MacTrafficLights } from '~/components';
 import { useOperatingSystem } from '~/hooks';
 
@@ -11,10 +12,22 @@ export default () => {
 	const os = useOperatingSystem();
 	const showControls = window.location.search.includes('showControls');
 
+	//prevent sidebar scrolling with keyboard
+	useEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			const arrows = ['ArrowUp', 'ArrowDown'];
+			if (arrows.includes(e.key)) {
+				e.preventDefault();
+			}
+		};
+		document.addEventListener('keydown', handleKeyDown);
+		return () => document.removeEventListener('keydown', handleKeyDown);
+	}, []);
+
 	return (
 		<div
 			className={clsx(
-				'relative flex min-h-full w-44 shrink-0 grow-0 flex-col gap-2.5 border-r border-sidebar-divider bg-sidebar px-2.5 pb-2 pt-2.5',
+				'relative flex min-h-full w-44 shrink-0 grow-0 flex-col gap-2.5  border-r border-sidebar-divider bg-sidebar px-2.5 pb-2 pt-2.5',
 				macOnly(os, 'bg-opacity-[0.65]')
 			)}
 		>

--- a/interface/app/$libraryId/Layout/Sidebar/index.tsx
+++ b/interface/app/$libraryId/Layout/Sidebar/index.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { MacTrafficLights } from '~/components';
 import { useOperatingSystem } from '~/hooks';
 


### PR DESCRIPTION
When navigating with keyboard, this prevents sidebar scrolling from happening. **This has been tested to ensure that it doesn't affect other functionalities.**

- By default all overflowing elements have scrolling support with keyboard by the browsers, we need to prevent that by targeting the up and down arrow keys.