### PR TITLE
[ENG-1172] - Update navigation keys

### DIFF
--- a/interface/app/$libraryId/TopBar/NavigationButtons.tsx
+++ b/interface/app/$libraryId/TopBar/NavigationButtons.tsx
@@ -2,7 +2,7 @@ import { ArrowLeft, ArrowRight } from '@phosphor-icons/react';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router';
 import { Tooltip } from '@sd/ui';
-import { useKeyMatcher, useOperatingSystem, useSearchStore } from '~/hooks';
+import { useKeybind, useKeyMatcher, useOperatingSystem, useSearchStore } from '~/hooks';
 
 import TopBarButton from './TopBarButton';
 
@@ -11,7 +11,16 @@ export const NavigationButtons = () => {
 	const { isFocused } = useSearchStore();
 	const os = useOperatingSystem();
 	const idx = history.state.idx as number;
-	const controlIcon = useKeyMatcher('Meta').icon;
+	const { icon, key } = useKeyMatcher('Meta');
+
+	useKeybind([key, '['], () => {
+		if (idx === 0 || isFocused) return;
+		navigate(-1);
+	});
+	useKeybind([key, ']'], () => {
+		if (idx === history.length - 1 || isFocused) return;
+		navigate(1);
+	});
 
 	useEffect(() => {
 		const onMouseDown = (e: MouseEvent) => {
@@ -30,7 +39,7 @@ export const NavigationButtons = () => {
 
 	return (
 		<div data-tauri-drag-region={os === 'macOS'} className="flex">
-			<Tooltip keybinds={[controlIcon, '←']} label="Navigate back">
+			<Tooltip keybinds={[icon, '[']} label="Navigate back">
 				<TopBarButton
 					rounding="left"
 					// className="text-[14px] text-ink-dull"
@@ -40,7 +49,7 @@ export const NavigationButtons = () => {
 					<ArrowLeft size={14} className="m-[4px]" weight="bold" />
 				</TopBarButton>
 			</Tooltip>
-			<Tooltip keybinds={[controlIcon, '→']} label="Navigate forward">
+			<Tooltip keybinds={[icon, ']']} label="Navigate forward">
 				<TopBarButton
 					rounding="right"
 					// className="text-[14px] text-ink-dull"

--- a/interface/app/$libraryId/settings/client/keybindings.tsx
+++ b/interface/app/$libraryId/settings/client/keybindings.tsx
@@ -51,11 +51,11 @@ const shortcutCategories: Record<string, Shortcut[]> = {
 		},
 		{
 			action: 'Navigate forward in folder history',
-			key: [[[ModifierKeys.Control], ['ArrowRight']]]
+			key: [[[ModifierKeys.Control], [']']]]
 		},
 		{
 			action: 'Navigate backward in folder history',
-			key: [[[ModifierKeys.Control], ['ArrowLeft']]]
+			key: [[[ModifierKeys.Control], ['[']]]
 		},
 		{
 			action: 'Switch explorer layout',


### PR DESCRIPTION
This makes you able to navigate backwards and forwards using Meta + [ and Meta + ] - at the sametime we also have support with arrow keys, as most apps **(seems to be native)**.