### PR TITLE
Enabling frontend dev tools

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,8 @@
 				"problemMatcher": "$rustc"
 			},
 			"env": {
-				"RUST_BACKTRACE": "short"
+				"RUST_BACKTRACE": "short",
+				"SD_DEVTOOLS": "true"
 				// "RUST_LOG": "sd_core::invalidate-query=trace"
 			},
 			"sourceLanguages": ["rust"],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -52,7 +52,8 @@
 				"--no-default-features"
 			],
 			"env": {
-				"RUST_BACKTRACE": "short"
+				"RUST_BACKTRACE": "short",
+				"SD_DEVTOOLS": "true"
 				// "RUST_LOG": "sd_core::invalidate-query=trace"
 			},
 			"problemMatcher": ["$rustc"],

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -155,6 +155,13 @@ async fn main() -> tauri::Result<()> {
 					}
 				});
 
+				#[cfg(debug_assertions)]
+				{
+					if std::env::var("SD_DEVTOOLS").is_ok() {
+						window.open_devtools();
+					}
+				}
+
 				#[cfg(target_os = "windows")]
 				window.set_decorations(true).unwrap();
 


### PR DESCRIPTION
This PR enables Frontend's dev tools when Spacedrive is compiled in dev mode and a `SD_DEVTOOLS` environment variable in set. Making the dev tools open alongside the app. Very useful for frontend debugging.