### PR TITLE
[ENG-871] - Rename shortcut

### DIFF
--- a/interface/app/$libraryId/Explorer/FilePath/RenameTextBox.tsx
+++ b/interface/app/$libraryId/Explorer/FilePath/RenameTextBox.tsx
@@ -8,10 +8,10 @@ import {
 	useState,
 	type ComponentProps
 } from 'react';
-import { useKey } from 'rooks';
+import { useKey, useKeys } from 'rooks';
 import { useLibraryMutation, useRspcLibraryContext } from '@sd/client';
 import { toast, Tooltip } from '@sd/ui';
-import { useIsTextTruncated, useKeybind, useOperatingSystem } from '~/hooks';
+import { useIsTextTruncated, useOperatingSystem } from '~/hooks';
 
 import { useExplorerViewContext } from '../ViewContext';
 
@@ -115,8 +115,9 @@ export const RenameTextBoxBase = forwardRef<HTMLDivElement | null, Props>(
 			}
 		};
 
-		useKey('F2', (e) => {
+		useKey(['F2', 'Enter'], (e) => {
 			e.preventDefault();
+			if (os === 'windows' && e.key === 'Enter') return;
 			if (allowRename) blur();
 			else if (!disabled) setAllowRename(true);
 		});

--- a/interface/app/$libraryId/Explorer/FilePath/RenameTextBox.tsx
+++ b/interface/app/$libraryId/Explorer/FilePath/RenameTextBox.tsx
@@ -11,7 +11,7 @@ import {
 import { useKey } from 'rooks';
 import { useLibraryMutation, useRspcLibraryContext } from '@sd/client';
 import { toast, Tooltip } from '@sd/ui';
-import { useIsTextTruncated, useOperatingSystem } from '~/hooks';
+import { useIsTextTruncated, useKeybind, useOperatingSystem } from '~/hooks';
 
 import { useExplorerViewContext } from '../ViewContext';
 
@@ -115,9 +115,8 @@ export const RenameTextBoxBase = forwardRef<HTMLDivElement | null, Props>(
 			}
 		};
 
-		useKey('Enter', (e) => {
+		useKey('F2', (e) => {
 			e.preventDefault();
-
 			if (allowRename) blur();
 			else if (!disabled) setAllowRename(true);
 		});


### PR DESCRIPTION
- For windows, you can now press F2 to rename, this also includes on Mac (FN + F2) and also Enter for Mac.
- Keybindings slightly refactored to accomodate our needs, you can now specificy what OS to target for a specific shortcut or keys for 'all' regardless of the OS.

**Notes**: 

- Enter will be re-routed to open a folder while on Mac CMD + O on a separate PR.