### PR TITLE
Remove client secret from apps

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -95,7 +95,7 @@ async fn main() -> tauri::Result<()> {
 			Node::new(
 				data_dir,
 				sd_core::Env {
-					api_url: "http://localhost:3000".to_string(),
+					api_url: "https://app.spacedrive.com".to_string(),
 					client_id: CLIENT_ID.to_string(),
 				},
 			)

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -72,7 +72,6 @@ macro_rules! tauri_handlers {
 }
 
 const CLIENT_ID: &str = "2abb241e-40b8-4517-a3e3-5594375c8fbb";
-const CLIENT_SECRET: &str = "eb4554cb-c08d-4e82-b4cc-0aa29c07e934";
 
 #[tokio::main]
 async fn main() -> tauri::Result<()> {
@@ -96,9 +95,8 @@ async fn main() -> tauri::Result<()> {
 			Node::new(
 				data_dir,
 				sd_core::Env {
-					api_url: "https://app.spacedrive.com".to_string(),
+					api_url: "http://localhost:3000".to_string(),
 					client_id: CLIENT_ID.to_string(),
-					client_secret: CLIENT_SECRET.to_string(),
 				},
 			)
 			.await,

--- a/apps/mobile/modules/sd-core/core/src/lib.rs
+++ b/apps/mobile/modules/sd-core/core/src/lib.rs
@@ -30,7 +30,6 @@ pub static SUBSCRIPTIONS: Lazy<Arc<futures_locks::Mutex<HashMap<RequestId, onesh
 pub static EVENT_SENDER: OnceCell<mpsc::Sender<Response>> = OnceCell::new();
 
 pub const CLIENT_ID: &str = "d068776a-05b6-4aaa-9001-4d01734e1944";
-pub const CLIENT_SECRET: &str = "961cdf5c-9eb1-43dc-b921-5b1dd8bbf6a5";
 
 pub struct MobileSender<'a> {
 	resp: &'a mut Option<Response>,
@@ -78,7 +77,6 @@ pub fn handle_core_msg(
 						sd_core::Env {
 							api_url: "https://app.spacedrive.com".to_string(),
 							client_id: CLIENT_ID.to_string(),
-							client_secret: CLIENT_SECRET.to_string(),
 						},
 					)
 					.await

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -46,8 +46,6 @@ async fn main() {
 				.unwrap_or_else(|_| "https://app.spacedrive.com".to_string()),
 			client_id: std::env::var("SD_CLIENT_ID")
 				.unwrap_or_else(|_| "04701823-a498-406e-aef9-22081c1dae34".to_string()),
-			client_secret: std::env::var("SD_CLIENT_ID")
-				.unwrap_or_else(|_| "8c0e4f85-d1d3-4a0c-9445-65003ffc581d".to_string()),
 		},
 	)
 	.await

--- a/core/src/env.rs
+++ b/core/src/env.rs
@@ -1,5 +1,4 @@
 pub struct Env {
 	pub api_url: String,
 	pub client_id: String,
-	pub client_secret: String,
 }


### PR DESCRIPTION
Our apps will use a special token refreshing strategy employing JWTs that other apps won't be allowed to use, removing the need to ship client secrets with the apps. Client secrets have already been rotated.