### PR TITLE
[ENG-872, ENG-1177] - Windows enter key opens & Open context menu correction

### DIFF
--- a/interface/app/$libraryId/Explorer/ContextMenu/FilePath/Items.tsx
+++ b/interface/app/$libraryId/Explorer/ContextMenu/FilePath/Items.tsx
@@ -1,5 +1,5 @@
 import { Image, Package, Trash, TrashSimple } from '@phosphor-icons/react';
-import { libraryClient, useLibraryContext, useLibraryMutation } from '@sd/client';
+import { libraryClient, useLibraryMutation } from '@sd/client';
 import { ContextMenu, dialogManager, ModifierKeys, toast } from '@sd/ui';
 import { Menu } from '~/components/Menu';
 import { useKeybindFactory } from '~/hooks/useKeybindFactory';
@@ -238,10 +238,9 @@ export const OpenOrDownload = new ConditionalItem({
 
 		return { openFilePaths, selectedFilePaths };
 	},
-	Component: ({ selectedFilePaths }) => {
+	Component: () => {
 		const keybind = useKeybindFactory();
 		const { platform } = usePlatform();
-		const updateAccessTime = useLibraryMutation('files.updateAccessTime');
 		const { doubleClick } = useViewItemDoubleClick();
 
 		if (platform === 'web') return <Menu.Item label="Download" />;
@@ -251,15 +250,7 @@ export const OpenOrDownload = new ConditionalItem({
 					<Menu.Item
 						label="Open"
 						keybind={keybind([ModifierKeys.Control], ['O'])}
-						onClick={async () => {
-							if (selectedFilePaths.length < 1) return;
-							await updateAccessTime
-								.mutateAsync(
-									selectedFilePaths.map((p) => p.object_id!).filter(Boolean)
-								)
-								.catch(console.error);
-							doubleClick();
-						}}
+						onClick={() => doubleClick()}
 					/>
 					<Conditional items={[OpenWith]} />
 				</>

--- a/interface/app/$libraryId/Explorer/ContextMenu/FilePath/Items.tsx
+++ b/interface/app/$libraryId/Explorer/ContextMenu/FilePath/Items.tsx
@@ -10,6 +10,7 @@ import { useExplorerContext } from '../../Context';
 import { CopyAsPathBase } from '../../CopyAsPath';
 import DeleteDialog from '../../FilePath/DeleteDialog';
 import EraseDialog from '../../FilePath/EraseDialog';
+import { useViewItemDoubleClick } from '../../View/ViewItem';
 import { Conditional, ConditionalItem } from '../ConditionalItem';
 import { useContextMenuContext } from '../context';
 import OpenWith from './OpenWith';
@@ -237,12 +238,11 @@ export const OpenOrDownload = new ConditionalItem({
 
 		return { openFilePaths, selectedFilePaths };
 	},
-	Component: ({ openFilePaths, selectedFilePaths }) => {
+	Component: ({ selectedFilePaths }) => {
 		const keybind = useKeybindFactory();
 		const { platform } = usePlatform();
 		const updateAccessTime = useLibraryMutation('files.updateAccessTime');
-
-		const { library } = useLibraryContext();
+		const { doubleClick } = useViewItemDoubleClick();
 
 		if (platform === 'web') return <Menu.Item label="Download" />;
 		else
@@ -253,24 +253,12 @@ export const OpenOrDownload = new ConditionalItem({
 						keybind={keybind([ModifierKeys.Control], ['O'])}
 						onClick={async () => {
 							if (selectedFilePaths.length < 1) return;
-
-							updateAccessTime
+							await updateAccessTime
 								.mutateAsync(
 									selectedFilePaths.map((p) => p.object_id!).filter(Boolean)
 								)
 								.catch(console.error);
-
-							try {
-								await openFilePaths(
-									library.uuid,
-									selectedFilePaths.map((p) => p.id)
-								);
-							} catch (error) {
-								toast.error({
-									title: `Failed to open file`,
-									body: `Error: ${error}.`
-								});
-							}
+							doubleClick();
 						}}
 					/>
 					<Conditional items={[OpenWith]} />

--- a/interface/app/$libraryId/settings/client/keybindings.tsx
+++ b/interface/app/$libraryId/settings/client/keybindings.tsx
@@ -87,7 +87,7 @@ const shortcutCategories: Record<string, Shortcut[]> = {
 			action: 'Open selected item',
 			keys: {
 				all: {
-					value: [ModifierKeys.Control, 'ArrowUp']
+					value: [ModifierKeys.Control, 'O']
 				}
 			}
 		},


### PR DESCRIPTION
- For windows, Enter key now opens the selected folder/item.
- CMD + O to open folder on mac, this was already implemented, but the prev func was no longer needed anymore.
- Open in context menu was opening the item in Finder, but this has now been corrected to open in Spacedrive.