### PR TITLE
[ENG-1176] Append `(x)` to the end of files instead of overwriting

### DIFF
--- a/core/src/api/files.rs
+++ b/core/src/api/files.rs
@@ -11,8 +11,8 @@ use crate::{
 	},
 	object::{
 		fs::{
-			append_digit_to_filename, copy::FileCopierJobInit, cut::FileCutterJobInit,
-			delete::FileDeleterJobInit, erase::FileEraserJobInit,
+			copy::FileCopierJobInit, cut::FileCutterJobInit, delete::FileDeleterJobInit,
+			erase::FileEraserJobInit,
 		},
 		media::{
 			media_data_extractor::{

--- a/core/src/api/files.rs
+++ b/core/src/api/files.rs
@@ -428,12 +428,12 @@ pub(crate) fn mount() -> AlphaRouter<Ctx> {
 
 					match fs::metadata(&new_file_full_path).await {
 						Ok(_) => {
-							return Err(rspc::Error::with_cause(
-									ErrorCode::InternalServerError,
-									"Renaming would overwrite a file".to_string(),
-									e,
-								));
+							return Err(rspc::Error::new(
+								ErrorCode::InternalServerError,
+								"Renaming would overwrite a file".to_string(),
+							));
 						}
+
 						Err(e) => {
 							if e.kind() != std::io::ErrorKind::NotFound {
 								return Err(rspc::Error::with_cause(
@@ -442,8 +442,8 @@ pub(crate) fn mount() -> AlphaRouter<Ctx> {
 									e,
 								));
 							}
-							
-fs::rename(location_path.join(&iso_file_path), new_file_full_path)
+
+							fs::rename(location_path.join(&iso_file_path), new_file_full_path)
 								.await
 								.map_err(|e| {
 									rspc::Error::with_cause(
@@ -452,11 +452,8 @@ fs::rename(location_path.join(&iso_file_path), new_file_full_path)
 										e,
 									)
 								})?;
-						
 						}
 					}
-
-						
 
 					Ok(())
 				}

--- a/core/src/api/files.rs
+++ b/core/src/api/files.rs
@@ -417,9 +417,7 @@ pub(crate) fn mount() -> AlphaRouter<Ctx> {
 						IsolatedFilePathData::separate_name_and_extension_from_str(&to)
 							.map_err(LocationError::FilePath)?;
 
-					let root_path = location_path.join(iso_file_path.parent());
-
-					let mut new_file_full_path = root_path.clone();
+					let mut new_file_full_path = location_path.join(iso_file_path.parent());
 					if !new_extension.is_empty() {
 						new_file_full_path.push(format!("{}.{}", new_file_name, new_extension));
 					} else {
@@ -429,7 +427,7 @@ pub(crate) fn mount() -> AlphaRouter<Ctx> {
 					match fs::metadata(&new_file_full_path).await {
 						Ok(_) => {
 							return Err(rspc::Error::new(
-								ErrorCode::InternalServerError,
+								ErrorCode::Conflict,
 								"Renaming would overwrite a file".to_string(),
 							));
 						}
@@ -447,7 +445,7 @@ pub(crate) fn mount() -> AlphaRouter<Ctx> {
 								.await
 								.map_err(|e| {
 									rspc::Error::with_cause(
-										ErrorCode::Conflict,
+										ErrorCode::InternalServerError,
 										"Failed to rename file".to_string(),
 										e,
 									)

--- a/core/src/api/files.rs
+++ b/core/src/api/files.rs
@@ -428,35 +428,11 @@ pub(crate) fn mount() -> AlphaRouter<Ctx> {
 
 					match fs::metadata(&new_file_full_path).await {
 						Ok(_) => {
-							for i in 1..u32::MAX {
-								let mut new_file_full_path = root_path.clone();
-
-								append_digit_to_filename(
-									&mut new_file_full_path,
-									new_file_name,
-									(!new_extension.is_empty())
-										.then_some(new_extension)
-										.or(None),
-									i,
-								);
-
-								if fs::metadata(&new_file_full_path).await.is_err() {
-									fs::rename(
-										location_path.join(&iso_file_path),
-										new_file_full_path,
-									)
-									.await
-									.map_err(|e| {
-										rspc::Error::with_cause(
-											ErrorCode::Conflict,
-											"Failed to rename file".to_string(),
-											e,
-										)
-									})?;
-
-									break;
-								}
-							}
+							return Err(rspc::Error::with_cause(
+									ErrorCode::InternalServerError,
+									"Renaming would overwrite a file".to_string(),
+									e,
+								));
 						}
 						Err(e) => {
 							if e.kind() != std::io::ErrorKind::NotFound {
@@ -466,8 +442,8 @@ pub(crate) fn mount() -> AlphaRouter<Ctx> {
 									e,
 								));
 							}
-
-							fs::rename(location_path.join(&iso_file_path), new_file_full_path)
+							
+fs::rename(location_path.join(&iso_file_path), new_file_full_path)
 								.await
 								.map_err(|e| {
 									rspc::Error::with_cause(
@@ -476,8 +452,11 @@ pub(crate) fn mount() -> AlphaRouter<Ctx> {
 										e,
 									)
 								})?;
+						
 						}
 					}
+
+						
 
 					Ok(())
 				}

--- a/core/src/object/fs/copy.rs
+++ b/core/src/object/fs/copy.rs
@@ -13,7 +13,7 @@ use crate::{
 	},
 };
 
-use std::{hash::Hash, path::PathBuf};
+use std::{ffi::OsStr, hash::Hash, path::PathBuf};
 
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -22,8 +22,9 @@ use tokio::{fs, io};
 use tracing::{trace, warn};
 
 use super::{
-	construct_target_filename, error::FileSystemJobsError, fetch_source_and_target_location_paths,
-	get_file_data_from_isolated_file_path, get_many_files_datas, FileData,
+	append_digit_to_filename, construct_target_filename, error::FileSystemJobsError,
+	fetch_source_and_target_location_paths, get_file_data_from_isolated_file_path,
+	get_many_files_datas, FileData,
 };
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -37,7 +38,7 @@ pub struct FileCopierJobInit {
 	pub target_location_id: location::id::Type,
 	pub sources_file_path_ids: Vec<file_path::id::Type>,
 	pub target_location_relative_directory_path: PathBuf,
-	pub target_file_name_suffix: Option<String>,
+	// pub target_file_name_suffix: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -80,10 +81,7 @@ impl StatefulJob for FileCopierJobInit {
 					&init.target_location_relative_directory_path,
 				);
 
-				full_target_path.push(construct_target_filename(
-					&file_data,
-					&init.target_file_name_suffix,
-				)?);
+				full_target_path.push(construct_target_filename(&file_data, &None)?);
 
 				Ok::<_, MissingFieldError>(FileCopierJobStep {
 					source_file_data: file_data,
@@ -173,17 +171,46 @@ impl StatefulJob for FileCopierJobInit {
 			}
 
 			Ok(more_steps.into())
-		} else if &source_file_data.full_path == target_full_path {
-			// File is already here, do nothing
-			Ok(().into())
 		} else {
-			match fs::metadata(target_full_path).await {
+			match fs::metadata(&target_full_path).await {
 				Ok(_) => {
-					// only skip as it could be half way through a huge directory copy and run into an issue
-					warn!(
-						"Skipping {} as it would be overwritten",
-						target_full_path.display()
-					);
+					let new_file_name =
+						target_full_path
+							.file_stem()
+							.ok_or(JobError::JobDataNotFound(
+								"No stem on file path, but it's supposed to be a file".to_string(),
+							))?;
+
+					for i in 1..u32::MAX {
+						let mut new_file_full_path = target_full_path.parent().map_or_else(
+							|| {
+								Err(JobError::JobDataNotFound(
+									"No parent for file path, which is supposed to be a file"
+										.to_string(),
+								))
+							},
+							|x| Ok(x.to_path_buf()),
+						)?;
+
+						append_digit_to_filename(
+							&mut new_file_full_path,
+							new_file_name.to_str().ok_or(JobError::JobDataNotFound(
+								"Unable to convert file name to &str".to_string(),
+							))?,
+							target_full_path.extension().and_then(OsStr::to_str),
+							i,
+						);
+
+						if fs::metadata(&new_file_full_path).await.is_err() {
+							fs::copy(&source_file_data.full_path, &new_file_full_path)
+								.await
+								// Using the ? here because we don't want to increase the completed task
+								// count in case of file system errors
+								.map_err(|e| FileIOError::from((new_file_full_path, e)))?;
+
+							break;
+						}
+					}
 
 					Ok(JobRunErrors(vec![FileSystemJobsError::WouldOverwrite(
 						target_full_path.clone().into_boxed_path(),

--- a/core/src/object/fs/copy.rs
+++ b/core/src/object/fs/copy.rs
@@ -38,7 +38,6 @@ pub struct FileCopierJobInit {
 	pub target_location_id: location::id::Type,
 	pub sources_file_path_ids: Vec<file_path::id::Type>,
 	pub target_location_relative_directory_path: PathBuf,
-	// pub target_file_name_suffix: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/core/src/object/fs/cut.rs
+++ b/core/src/object/fs/cut.rs
@@ -84,7 +84,7 @@ impl StatefulJob for FileCutterJobInit {
 	) -> Result<JobStepOutput<Self::Step, Self::RunMetadata>, JobError> {
 		let full_output = data
 			.full_target_directory_path
-			.join(construct_target_filename(file_data, &None)?);
+			.join(construct_target_filename(file_data)?);
 
 		if file_data.full_path == full_output {
 			// File is already here, do nothing

--- a/core/src/object/fs/mod.rs
+++ b/core/src/object/fs/mod.rs
@@ -175,3 +175,29 @@ fn construct_target_filename(
 		)
 	})
 }
+
+pub fn append_digit_to_filename(
+	final_path: &mut PathBuf,
+	file_name: &str,
+	ext: Option<&str>,
+	current_int: u32,
+) {
+	let is_already_copied = if file_name.len() > 3 {
+		let ending = file_name[file_name.len() - 3..].to_string();
+		ending.chars().enumerate().all(|(i, c)| {
+			(i == 1 && u32::try_from(c).is_ok()) || (i == 0 && c == '(') || (i == 2 && c == ')')
+		})
+	} else {
+		false
+	};
+
+	let new_file_name = is_already_copied
+		.then(|| &file_name[..file_name.len() - 3])
+		.map_or_else(|| file_name.to_string(), str::to_string);
+
+	if let Some(ext) = ext {
+		final_path.push(format!("{} ({current_int}).{}", new_file_name, ext));
+	} else {
+		final_path.push(format!("{new_file_name} ({current_int})"));
+	}
+}

--- a/core/src/object/fs/mod.rs
+++ b/core/src/object/fs/mod.rs
@@ -139,30 +139,13 @@ pub async fn fetch_source_and_target_location_paths(
 
 fn construct_target_filename(
 	source_file_data: &FileData,
-	target_file_name_suffix: &Option<String>,
 ) -> Result<String, MissingFieldError> {
 	// extension wizardry for cloning and such
 	// if no suffix has been selected, just use the file name
 	// if a suffix is provided and it's a directory, use the directory name + suffix
 	// if a suffix is provided and it's a file, use the (file name + suffix).extension
 
-	Ok(if let Some(ref suffix) = target_file_name_suffix {
-		if maybe_missing(source_file_data.file_path.is_dir, "file_path.is_dir")?
-			|| source_file_data.file_path.extension.is_none()
-			|| source_file_data.file_path.extension == Some(String::new())
-		{
-			format!(
-				"{}{suffix}",
-				maybe_missing(&source_file_data.file_path.name, "file_path.name")?
-			)
-		} else {
-			format!(
-				"{}{suffix}.{}",
-				maybe_missing(&source_file_data.file_path.name, "file_path.name")?,
-				maybe_missing(&source_file_data.file_path.extension, "file_path.extension")?,
-			)
-		}
-	} else if *maybe_missing(&source_file_data.file_path.is_dir, "file_path.is_dir")?
+	Ok(if *maybe_missing(&source_file_data.file_path.is_dir, "file_path.is_dir")?
 		|| source_file_data.file_path.extension.is_none()
 		|| source_file_data.file_path.extension == Some(String::new())
 	{

--- a/core/src/object/fs/mod.rs
+++ b/core/src/object/fs/mod.rs
@@ -170,7 +170,7 @@ pub fn append_digit_to_filename(
 	ext: Option<&str>,
 	current_int: u32,
 ) {
-	let new_file_name = if let Some(found) = DUPLICATE_PATTERN.find(file_name) {
+	let new_file_name = if let Some(found) = DUPLICATE_PATTERN.find_iter(file_name).last() {
 		&file_name[..found.start()]
 	} else {
 		file_name

--- a/interface/app/$libraryId/Explorer/ContextMenu/FilePath/CutCopyItems.tsx
+++ b/interface/app/$libraryId/Explorer/ContextMenu/FilePath/CutCopyItems.tsx
@@ -64,8 +64,7 @@ export const CutCopyItems = new ConditionalItem({
 								source_location_id: locationId,
 								sources_file_path_ids: selectedFilePaths.map((p) => p.id),
 								target_location_id: locationId,
-								target_location_relative_directory_path: path ?? '/',
-								target_file_name_suffix: ' copy'
+								target_location_relative_directory_path: path ?? '/'
 							});
 						} catch (error) {
 							toast.error({

--- a/interface/app/$libraryId/Explorer/ParentContextMenu.tsx
+++ b/interface/app/$libraryId/Explorer/ParentContextMenu.tsx
@@ -47,8 +47,7 @@ export default (props: PropsWithChildren) => {
 										source_location_id: sourceLocationId,
 										sources_file_path_ids: [...sourcePathIds],
 										target_location_id: parent.location.id,
-										target_location_relative_directory_path: path,
-										target_file_name_suffix: sameLocation ? ' copy' : null
+										target_location_relative_directory_path: path
 									});
 								} else if (sameLocation) {
 									toast.error('File already exists in this location');

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -159,7 +159,7 @@ export type ExplorerLayout = "grid" | "list" | "media"
 
 export type ExplorerSettings<TOrder> = { layoutMode: ExplorerLayout | null; gridItemSize: number | null; mediaColumns: number | null; mediaAspectSquare: boolean | null; openOnDoubleClick: DoubleClickAction | null; showBytesInGridView: boolean | null; colVisibility: { [key: string]: boolean } | null; colSizes: { [key: string]: number } | null; order?: TOrder | null; showHiddenFiles?: boolean }
 
-export type FileCopierJobInit = { source_location_id: number; target_location_id: number; sources_file_path_ids: number[]; target_location_relative_directory_path: string; target_file_name_suffix: string | null }
+export type FileCopierJobInit = { source_location_id: number; target_location_id: number; sources_file_path_ids: number[]; target_location_relative_directory_path: string }
 
 export type FileCutterJobInit = { source_location_id: number; target_location_id: number; sources_file_path_ids: number[]; target_location_relative_directory_path: string }
 


### PR DESCRIPTION
During: copying, cutting, duplicating and renaming we now will append the lowest available digit to the file name if it would overwrite the source file.

The only "bug" I have ran into is when renaming say `File (2).jpg` to `File.jpg`, it will increment the name to `File (3).jpg` when it should in fact remain as `File (2).jpg` (as that's the largest available number, but it already exists so it gets incremented.

A preview:
![an image showing how the new names look including the `(x)`](https://github.com/spacedriveapp/spacedrive/assets/77554505/1a9876e9-131d-4b1a-89ca-6fa4571f1978)

This may need some pretty heavy battle-testing before merge, as it could end up truncating files if it goes wrong (it shouldn't, as the action should only ever happen if the `fs::metadata` call is an `Err` (the file doesn't exist).