### PR TITLE
[ENG-1189] Overview shortcut + Settings shortcut adjusted

### DIFF
--- a/interface/app/$libraryId/Layout/Sidebar/Contents.tsx
+++ b/interface/app/$libraryId/Layout/Sidebar/Contents.tsx
@@ -6,8 +6,12 @@ import {
 	FilmStrip,
 	Planet
 } from '@phosphor-icons/react';
+import { useNavigate } from 'react-router';
+import { useKeys } from 'rooks';
 import { LibraryContextProvider, useClientContext, useFeatureFlag } from '@sd/client';
+import { modifierSymbols, Tooltip } from '@sd/ui';
 import { SubtleButton } from '~/components/SubtleButton';
+import { useKeyMatcher } from '~/hooks';
 
 import { EphemeralSection } from './EphemeralSection';
 import Icon from './Icon';
@@ -17,14 +21,27 @@ import Section from './Section';
 
 export default () => {
 	const { library } = useClientContext();
+	const navigate = useNavigate();
+	const { key, icon } = useKeyMatcher('Meta');
+
+	useKeys([key, 'Shift', 'KeyO'], (e) => {
+		e.stopPropagation();
+		navigate('overview');
+	});
 
 	return (
 		<div className="no-scrollbar mask-fade-out flex grow flex-col overflow-x-hidden overflow-y-scroll pb-10">
 			<div className="space-y-0.5">
-				<SidebarLink to="overview">
-					<Icon component={Planet} />
-					Overview
-				</SidebarLink>
+				<Tooltip
+					position="right"
+					label="Overview"
+					keybinds={[modifierSymbols.Shift.Other, icon, 'O']}
+				>
+					<SidebarLink to="overview">
+						<Icon component={Planet} />
+						Overview
+					</SidebarLink>
+				</Tooltip>
 				{/* <SidebarLink to="spacedrop">
 					<Icon component={Broadcast} />
 					Spacedrop

--- a/interface/app/$libraryId/Layout/Sidebar/Footer.tsx
+++ b/interface/app/$libraryId/Layout/Sidebar/Footer.tsx
@@ -1,8 +1,9 @@
 import { Gear } from '@phosphor-icons/react';
 import { useNavigate } from 'react-router';
+import { useKeys } from 'rooks';
 import { JobManagerContextProvider, useClientContext, useDebugState } from '@sd/client';
-import { Button, ButtonLink, dialogManager, ModifierKeys, Popover, Tooltip } from '@sd/ui';
-import { useKeybind, useKeyMatcher, useOperatingSystem } from '~/hooks';
+import { Button, ButtonLink, dialogManager, modifierSymbols, Popover, Tooltip } from '@sd/ui';
+import { useKeyMatcher } from '~/hooks';
 
 import DebugPopover from './DebugPopover';
 import FeedbackDialog from './FeedbackDialog';
@@ -11,11 +12,10 @@ import { IsRunningJob, JobManager } from './JobManager';
 export default () => {
 	const { library } = useClientContext();
 	const debugState = useDebugState();
-	const os = useOperatingSystem();
 	const navigate = useNavigate();
-	const jobManagerKeys = [os === 'macOS' ? ModifierKeys.Meta : ModifierKeys.Control, 'j'];
+	const { key, icon } = useKeyMatcher('Meta');
 
-	useKeybind(['g', 's'], (e) => {
+	useKeys([key, 'Shift', 'KeyS'], (e) => {
 		e.stopPropagation();
 		navigate('settings/client/general');
 	});
@@ -30,13 +30,17 @@ export default () => {
 						variant="subtle"
 						className="text-sidebar-inkFaint ring-offset-sidebar"
 					>
-						<Tooltip label="Settings" keybinds={['G', 'S']}>
+						<Tooltip
+							position="top"
+							label="Settings"
+							keybinds={[modifierSymbols.Shift.Other, icon, 'S']}
+						>
 							<Gear className="h-5 w-5" />
 						</Tooltip>
 					</ButtonLink>
 					<JobManagerContextProvider>
 						<Popover
-							keybind={jobManagerKeys}
+							keybind={[key, 'j']}
 							trigger={
 								<Button
 									size="icon"
@@ -47,7 +51,8 @@ export default () => {
 									{library && (
 										<Tooltip
 											label="Recent Jobs"
-											keybinds={[useKeyMatcher('Meta').icon, 'J']}
+											position="top"
+											keybinds={[icon, 'J']}
 										>
 											<IsRunningJob />
 										</Tooltip>

--- a/interface/app/$libraryId/settings/client/keybindings.tsx
+++ b/interface/app/$libraryId/settings/client/keybindings.tsx
@@ -6,7 +6,7 @@ import {
 } from '@tanstack/react-table';
 import clsx from 'clsx';
 import { useState } from 'react';
-import { Divider, ModifierKeys, Switch } from '@sd/ui';
+import { Divider, ModifierKeys, modifierSymbols, Switch } from '@sd/ui';
 import { useOperatingSystem } from '~/hooks';
 import { keybindForOs } from '~/util/keybinds';
 import { OperatingSystem } from '~/util/Platform';
@@ -20,8 +20,8 @@ type Shortcut = {
 	keys: {
 		//the operating system the shortcut is for
 		[K in OperatingSystem | 'all']?: {
-			value: string | ModifierKeys | (string | ModifierKeys)[]; //if the shortcut is a single key, use a string, if it's a combination of keys, make it an array
-			split?: boolean; //if the 'length' of the shortcut is 2, should it be split into 2 keys?
+			value: string | undefined | ModifierKeys | (string | undefined | ModifierKeys)[]; //if the shortcut is a single key, use a string, if it's a combination of keys, make it an array
+			split?: boolean; //if the 'length' of the shortcut is >= 2, should it be split into 2 keys?
 		};
 	};
 };
@@ -32,8 +32,22 @@ const shortcutCategories: Record<string, Shortcut[]> = {
 			description: 'Different pages in the app',
 			action: 'Navigate to Settings page',
 			keys: {
+				macOS: {
+					value: ['Shift', modifierSymbols.Meta.macOS, 'S']
+				},
 				all: {
-					value: ['G', 'S']
+					value: ['Shift', modifierSymbols.Control.Other, 'S']
+				}
+			}
+		},
+		{
+			action: 'Navigate to Overview page',
+			keys: {
+				macOS: {
+					value: ['Shift', modifierSymbols.Meta.macOS, 'O']
+				},
+				all: {
+					value: ['Shift', modifierSymbols.Control.Other, 'O']
 				}
 			}
 		}
@@ -43,8 +57,11 @@ const shortcutCategories: Record<string, Shortcut[]> = {
 			description: 'To perform actions and operations',
 			action: 'Toggle Job Manager',
 			keys: {
+				macOS: {
+					value: [modifierSymbols.Meta.macOS, 'J']
+				},
 				all: {
-					value: [ModifierKeys.Control, 'J']
+					value: [modifierSymbols.Control.Other, 'J']
 				}
 			}
 		}
@@ -62,48 +79,66 @@ const shortcutCategories: Record<string, Shortcut[]> = {
 		{
 			action: 'Navigate forward in folder history',
 			keys: {
+				macOS: {
+					value: [modifierSymbols.Meta.macOS, ']']
+				},
 				all: {
-					value: [ModifierKeys.Control, ']']
+					value: [modifierSymbols.Control.Other, ']']
 				}
 			}
 		},
 		{
 			action: 'Navigate backward in folder history',
 			keys: {
+				macOS: {
+					value: [modifierSymbols.Meta.macOS, '[']
+				},
 				all: {
-					value: [ModifierKeys.Control, '[']
+					value: [modifierSymbols.Control.Other, '[']
 				}
 			}
 		},
 		{
 			action: 'Switch explorer layout',
 			keys: {
+				macOS: {
+					value: [modifierSymbols.Meta.macOS, 'b']
+				},
 				all: {
-					value: [ModifierKeys.Control, 'b']
+					value: [modifierSymbols.Control.Other, 'b']
 				}
 			}
 		},
 		{
 			action: 'Open selected item',
 			keys: {
+				macOS: {
+					value: [modifierSymbols.Meta.macOS, 'O']
+				},
 				all: {
-					value: [ModifierKeys.Control, 'O']
+					value: [modifierSymbols.Control.Other, 'O']
 				}
 			}
 		},
 		{
 			action: 'Show inspector',
 			keys: {
+				macOS: {
+					value: [modifierSymbols.Meta.macOS, 'i']
+				},
 				all: {
-					value: [ModifierKeys.Control, 'i']
+					value: [modifierSymbols.Control.Other, 'i']
 				}
 			}
 		},
 		{
 			action: 'Show path bar',
 			keys: {
+				macOS: {
+					value: [modifierSymbols.Meta.macOS, 'p']
+				},
 				all: {
-					value: [ModifierKeys.Control, 'p']
+					value: [modifierSymbols.Control.Other, 'p']
 				}
 			}
 		},
@@ -244,7 +279,7 @@ function createKeybindColumns(os: OperatingSystem) {
 				});
 				return shortcuts.map((shortcut, idx) => {
 					if (shortcut) {
-						if (shortcut.length === 2) {
+						if (shortcut.length <= 5) {
 							return (
 								<div key={idx.toString()} className="inline-flex items-center">
 									<kbd
@@ -256,7 +291,7 @@ function createKeybindColumns(os: OperatingSystem) {
 								</div>
 							);
 						} else {
-							return shortcut?.split(' ').map(([key]) => {
+							return shortcut?.split(' ').map(([key], idx) => {
 								const controlSymbolCheck =
 									key === '⌘' ? (os === 'macOS' ? '⌘' : 'Ctrl') : key;
 								return (

--- a/interface/app/style.scss
+++ b/interface/app/style.scss
@@ -63,6 +63,21 @@ body {
 	animation-name: slideDown;
 }
 
+.TooltipContent[data-side='right'] {
+	animation-name: slideRight;
+}
+
+@keyframes slideRight {
+	from {
+		opacity: 0;
+		transform: translateX(-10px);
+	}
+	to {
+		opacity: 1;
+		transform: translateX(0);
+	}
+}
+
 @keyframes slideDown {
 	from {
 		opacity: 0;

--- a/packages/ui/src/Tooltip.tsx
+++ b/packages/ui/src/Tooltip.tsx
@@ -19,6 +19,10 @@ const separateKeybinds = (keybinds: TooltipProps['keybinds']): TooltipProps['key
 	if (!keybinds) return;
 	const arr = [];
 	for (const i of keybinds) {
+		if (i.length >= 2) {
+			arr.push(i);
+			continue;
+		}
 		for (const j of i) {
 			arr.push(j);
 		}


### PR DESCRIPTION
**This PR does the following:**

- New overview shortcut:  **Shift, Meta/Ctrl,  O**
- Settings page shortcut changed to: **Shift, Meta/Ctrl,  S**

**More will be added in future after the new shortcuts system**

<img width="332" alt="Screenshot 2023-10-05 at 1 44 09 PM" src="https://github.com/spacedriveapp/spacedrive/assets/33054370/5e597838-3a12-49d6-9ecb-6308a2781244">
<img width="168" alt="Screenshot 2023-10-05 at 1 44 33 PM" src="https://github.com/spacedriveapp/spacedrive/assets/33054370/8c686cd9-1c54-482b-be1c-b1127ace064c">





**Fixes**:

- Incorrect symbols were being display for other OSs, i corrected this. This is also for tooltips.
- The keybind page needs 1 more refactor, this will be done in future.

<img width="845" alt="Screenshot 2023-10-05 at 3 11 03 PM" src="https://github.com/spacedriveapp/spacedrive/assets/33054370/ea3b3c07-635b-40ab-aee4-f21eace3e3da">
