### PR TITLE
[ENG-1163] Data import/export

### DIFF
--- a/.cspell/project_words.txt
+++ b/.cspell/project_words.txt
@@ -5,6 +5,7 @@ augusto
 automount
 benja
 brendonovich
+bufread
 chacha
 codegen
 Condvar

--- a/.cspell/project_words.txt
+++ b/.cspell/project_words.txt
@@ -14,6 +14,7 @@ deel
 elon
 encryptor
 Flac
+flate
 graps
 haden
 haoyuan

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb42b2197bf15ccb092b62c74515dbd8b86d0effd934795f6687c93b6e679a2c"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-io"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6532,6 +6545,7 @@ version = "0.1.0"
 dependencies = [
  "aovec",
  "async-channel",
+ "async-compression",
  "async-stream",
  "async-trait",
  "axum",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -108,6 +108,7 @@ http-body = "0.4.5"
 pin-project-lite = "0.2.13"
 bytes = "1.5.0"
 reqwest = { version = "0.11.20", features = ["json"] }
+async-compression = { version = "0.4.3", features = ["tokio", "gzip"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 plist = "1"

--- a/core/src/object/tag/import_export.rs
+++ b/core/src/object/tag/import_export.rs
@@ -1,0 +1,98 @@
+use crate::util::import_export_manager::{ImportExport, ImportExportError};
+use crate::{library::Library, prisma::tag};
+use async_trait::async_trait;
+use futures::stream::{self, StreamExt};
+use sd_prisma::prisma::{file_path, tag_on_object};
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct JsonTag {
+	pub_id: String,
+	name: Option<String>,
+	color: Option<String>,
+	objects: Vec<JsonTagObject>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+struct JsonTagObject {
+	pub_id: String,
+	cas_ids: Vec<String>,
+}
+
+#[derive(Deserialize, Clone, Type)]
+pub struct TagImportExport {
+	pub tag_id: i32,
+}
+
+#[async_trait]
+impl ImportExport<JsonTag> for TagImportExport {
+	async fn export(&self, Library { db, .. }: &Library) -> Result<JsonTag, ImportExportError> {
+		let tag = db
+			.tag()
+			.find_unique(tag::id::equals(self.tag_id))
+			.exec()
+			.await?
+			.ok_or(ImportExportError::NotFound)?;
+
+		let tags_on_object = db
+			.tag_on_object()
+			.find_many(vec![tag_on_object::tag_id::equals(tag.id)])
+			.select(tag_on_object::select!({
+				object: select {
+					id
+					pub_id
+				}
+				tag: select {
+					id
+					pub_id
+					name
+					color
+				}
+			}))
+			.exec()
+			.await?;
+
+		let combined_results: Vec<_> = stream::iter(tags_on_object.into_iter())
+			.filter_map(|to| {
+				let db = db.clone();
+				async move {
+					let file_paths = db
+						.file_path()
+						.find_many(vec![file_path::object_id::equals(Some(to.object.id))])
+						.select(file_path::select!({ cas_id }))
+						.exec()
+						.await
+						.ok()?;
+
+					let mut cas_ids: Vec<_> =
+						file_paths.into_iter().filter_map(|fp| fp.cas_id).collect();
+
+					cas_ids.sort();
+					cas_ids.dedup();
+					Some((to, cas_ids))
+				}
+			})
+			.collect()
+			.await;
+
+		// Create JsonTag objects from the fetched and processed data
+		let json_tags = combined_results
+			.into_iter()
+			.map(|(to, cas_ids)| JsonTagObject {
+				pub_id: hex::encode(to.object.pub_id),
+				cas_ids,
+			})
+			.collect::<Vec<JsonTagObject>>();
+
+		Ok(JsonTag {
+			pub_id: hex::encode(tag.pub_id),
+			name: tag.name,
+			color: tag.color,
+			objects: json_tags,
+		})
+	}
+	async fn import(&self, lib: &Library) -> Result<JsonTag, ImportExportError> {
+		unimplemented!()
+	}
+}

--- a/core/src/object/tag/mod.rs
+++ b/core/src/object/tag/mod.rs
@@ -1,3 +1,5 @@
+// pub mod export;
+pub mod import_export;
 pub mod seed;
 
 use chrono::{DateTime, FixedOffset, Utc};

--- a/core/src/util/import_export_manager.rs
+++ b/core/src/util/import_export_manager.rs
@@ -1,0 +1,224 @@
+use crate::library::Library;
+use crate::{DateTime, Utc};
+use async_compression::tokio::bufread::GzipDecoder;
+use async_compression::tokio::write::GzipEncoder;
+use async_trait::async_trait;
+use flate2::write::GzEncoder;
+use serde::{Deserialize, Serialize};
+use std::io::Read;
+use std::path::PathBuf;
+use strum_macros::Display;
+use thiserror::Error;
+use tokio::fs::File;
+use tokio::io::AsyncReadExt;
+use tokio::io::{AsyncWriteExt, BufReader};
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct ImportExportOptions {
+	pub output_path: PathBuf,
+	pub kind: ExportKind,
+	pub format: ExportFormat,
+	pub compress: bool,
+}
+
+#[derive(Debug, Deserialize, Clone, Display)]
+pub enum ExportFormat {
+	JSON,
+	CSV,
+}
+
+#[async_trait]
+pub trait ImportExport<T>: Sync + Send {
+	async fn export(&self, lib: &Library) -> Result<T, ImportExportError>;
+	async fn import(&self, lib: &Library) -> Result<T, ImportExportError>;
+}
+
+#[derive(Debug, Deserialize, Clone, Display)]
+pub enum ExportKind {
+	Tags,
+	TagWithAssociations,
+	Location,
+	LocationWithObjects,
+	Album,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct ExportMetadata<T> {
+	export_date: DateTime<Utc>,
+	version: u8,
+	kind: String,
+	data: Option<T>,
+}
+
+#[derive(Error, Debug)]
+pub enum ImportExportError {
+	#[error("database error: {0}")]
+	Database(#[from] prisma_client_rust::QueryError),
+	#[error("compression error")]
+	CompressionError,
+	#[error("encryption error")]
+	EncryptionError,
+	#[error("item not found error")]
+	NotFound,
+	#[error("JSON conversion error: {0}")]
+	JsonError(#[from] serde_json::Error),
+	#[error("IO error: {0}")]
+	IOError(#[from] std::io::Error),
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub enum ExportData<T, U = T> {
+	Single(T),
+	Multiple(Vec<U>),
+}
+pub struct ImportExportManager<T, U = T> {
+	options: ImportExportOptions,
+	data: ExportData<T, U>,
+}
+
+impl<T, U> ImportExportManager<T, U>
+where
+	T: Serialize + for<'de> Deserialize<'de> + Send + Sync,
+	U: Serialize + for<'de> Deserialize<'de> + Send + Sync,
+{
+	pub fn new(options: ImportExportOptions, data: ExportData<T, U>) -> Self {
+		Self { options, data }
+	}
+
+	fn name(&self) -> String {
+		format!(
+			"SpacedriveExport-{}-{}",
+			self.options.kind.to_string(),
+			Utc::now().timestamp()
+		)
+	}
+
+	pub fn get_data(&self) -> &ExportData<T, U> {
+		&self.data
+	}
+
+	pub async fn save(&self) -> Result<(), ImportExportError> {
+		let mut output_path = self.options.output_path.join(self.name());
+
+		match &self.data {
+			ExportData::Single(data) => {
+				let raw_export_data = self.prepare_data(data).await?;
+
+				if self.options.compress {
+					output_path.set_extension("gz");
+
+					let file = File::create(&output_path).await?;
+
+					let mut encoder = GzipEncoder::new(file);
+
+					encoder.write_all(raw_export_data.as_bytes()).await?;
+					encoder
+						.shutdown()
+						.await
+						.map_err(|_| ImportExportError::CompressionError)?;
+				} else {
+					output_path.set_extension(self.options.format.to_string().to_lowercase());
+					let mut file = File::create(&output_path).await?;
+					file.write_all(raw_export_data.as_bytes()).await?;
+				}
+			}
+			ExportData::Multiple(items) => {
+				output_path.set_extension("tar.gz");
+				let tar_gz_file = std::fs::File::create(&output_path)?;
+
+				let enc = GzEncoder::new(tar_gz_file, flate2::Compression::default());
+				let mut tar = tar::Builder::new(enc);
+
+				for (index, item) in items.iter().enumerate() {
+					let raw_export_data = self.prepare_data(item).await?;
+					let data = raw_export_data.as_bytes();
+
+					let mut header = tar::Header::new_gnu();
+
+					header.set_size(data.len() as u64);
+					header.set_mode(0o755);
+
+					// TODO: handle CSV case
+					let file_name = format!("{}-{}.json", self.name(), index);
+
+					tar.append_data(&mut header, file_name, data)?;
+				}
+
+				let enc = tar.into_inner()?;
+				enc.finish()?;
+			}
+		};
+
+		Ok(())
+	}
+
+	async fn prepare_data<V>(&self, data: &V) -> Result<String, ImportExportError>
+	where
+		V: Serialize,
+	{
+		let raw_export_data = match self.options.format {
+			ExportFormat::JSON => serde_json::to_string(data)?,
+			ExportFormat::CSV => {
+				unimplemented!();
+			}
+		};
+
+		Ok(raw_export_data)
+	}
+
+	pub async fn new_from_path(path: PathBuf) -> Result<Self, ImportExportError> {
+		let file_extension = path
+			.extension()
+			.and_then(|s| s.to_str())
+			.ok_or(ImportExportError::CompressionError)?;
+
+		let content = if file_extension.ends_with("gz") {
+			// Read and decompress the .gz or .tar.gz file
+			let file = File::open(&path)
+				.await
+				.map_err(ImportExportError::IOError)?;
+
+			let buf_reader = BufReader::new(file);
+			let mut decoder = GzipDecoder::new(buf_reader);
+			let mut buffer = Vec::new();
+
+			decoder.read_to_end(&mut buffer).await?;
+			buffer
+		} else {
+			// For non-gz files, read them directly
+			tokio::fs::read(&path)
+				.await
+				.map_err(ImportExportError::IOError)?
+		};
+
+		// If it's a tar.gz file, extract JSON content from the tar archive
+		let content_str = if file_extension == "tar.gz" {
+			let mut archive = tar::Archive::new(&*content);
+			let mut content_str = String::new();
+			for file in archive
+				.entries()
+				.map_err(|_| ImportExportError::CompressionError)?
+			{
+				let mut file = file.map_err(|_| ImportExportError::CompressionError)?;
+				file.read_to_string(&mut content_str)
+					.map_err(ImportExportError::IOError)?;
+			}
+			content_str
+		} else {
+			String::from_utf8(content).map_err(|_| ImportExportError::CompressionError)?
+		};
+
+		let data: ExportData<T, U> = ExportData::Single(
+			serde_json::from_str(&content_str).map_err(ImportExportError::JsonError)?,
+		);
+
+		let options = ImportExportOptions {
+			output_path: path.parent().unwrap().to_path_buf(),
+			kind: ExportKind::Tags,
+			format: ExportFormat::JSON,
+			compress: file_extension.ends_with("gz"),
+		};
+
+		Ok(Self { options, data })
+	}
+}

--- a/core/src/util/mod.rs
+++ b/core/src/util/mod.rs
@@ -3,6 +3,7 @@ pub mod db;
 #[cfg(debug_assertions)]
 pub mod debug_initializer;
 pub mod error;
+pub mod import_export_manager;
 mod infallible_request;
 mod maybe_undefined;
 pub mod migrator;

--- a/interface/app/$libraryId/settings/library/tags/EditForm.tsx
+++ b/interface/app/$libraryId/settings/library/tags/EditForm.tsx
@@ -3,6 +3,7 @@ import { Tag, useLibraryMutation, useZodForm } from '@sd/client';
 import { Button, dialogManager, Form, InputField, Switch, Tooltip, z } from '@sd/ui';
 import { ColorPicker } from '~/components';
 import { useDebouncedFormWatch } from '~/hooks';
+import { usePlatform } from '~/util/Platform';
 
 import Setting from '../../Setting';
 import DeleteDialog from './DeleteDialog';
@@ -24,7 +25,10 @@ interface Props {
 }
 
 export default ({ tag, onDelete }: Props) => {
+	const platform = usePlatform();
 	const updateTag = useLibraryMutation('tags.update');
+	const exportTag = useLibraryMutation('tags.export');
+	const importTag = useLibraryMutation('tags.import');
 
 	const form = useZodForm({
 		schema,
@@ -43,7 +47,7 @@ export default ({ tag, onDelete }: Props) => {
 
 	return (
 		<Form form={form}>
-			<div className="flex justify-between">
+			<div className="flex items-center justify-between">
 				<div className="mb-10 flex flex-row space-x-3">
 					<InputField
 						label="Color"
@@ -52,22 +56,24 @@ export default ({ tag, onDelete }: Props) => {
 						icon={<ColorPicker control={form.control} name="color" />}
 						{...form.register('color')}
 					/>
-
 					<InputField maxLength={24} label="Name" {...form.register('name')} />
 				</div>
-				<Button
-					variant="gray"
-					className="mt-[22px] h-[38px]"
-					onClick={() =>
-						dialogManager.create((dp) => (
-							<DeleteDialog {...dp} tagId={tag.id} onSuccess={onDelete} />
-						))
-					}
-				>
-					<Tooltip label="Delete Tag">
-						<Trash className="h-4 w-4" />
-					</Tooltip>
-				</Button>
+
+				<div>
+					<Button
+						variant="gray"
+						// className="mt-[22px] h-[38px]"
+						onClick={() =>
+							dialogManager.create((dp) => (
+								<DeleteDialog {...dp} tagId={tag.id} onSuccess={onDelete} />
+							))
+						}
+					>
+						<Tooltip label="Delete Tag">
+							<Trash className="h-4 w-4" />
+						</Tooltip>
+					</Button>
+				</div>
 			</div>
 			<div className="flex flex-col gap-2">
 				<Setting
@@ -83,6 +89,42 @@ export default ({ tag, onDelete }: Props) => {
 					description="Prevent this tag from showing in the sidebar of the app."
 				>
 					<Switch />
+				</Setting>
+				<Setting
+					mini
+					title="Export Tag"
+					description="Create a zip file containing this tag's metadata and file associations."
+				>
+					<div>
+						<Button
+							variant="accent"
+							className=""
+							onClick={() => exportTag.mutate({ tag_id: tag.id })}
+						>
+							Export
+						</Button>
+					</div>
+				</Setting>
+				<Setting
+					mini
+					title="Import Tag"
+					description="Create a zip file containing this tag's metadata and file associations."
+				>
+					<div>
+						<Button
+							variant="gray"
+							className=""
+							onClick={() => {
+								platform?.openFilePickerDialog?.().then((file) => {
+									if (typeof file !== 'string') return;
+
+									importTag.mutate({ path: file });
+								});
+							}}
+						>
+							Import
+						</Button>
+					</div>
 				</Setting>
 			</div>
 		</Form>

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -88,6 +88,8 @@ export type Procedures = {
         { key: "tags.assign", input: LibraryArgs<TagAssignArgs>, result: null } | 
         { key: "tags.create", input: LibraryArgs<TagCreateArgs>, result: Tag } | 
         { key: "tags.delete", input: LibraryArgs<number>, result: null } | 
+        { key: "tags.export", input: LibraryArgs<TagImportExport>, result: null } | 
+        { key: "tags.import", input: LibraryArgs<TagImportArgs>, result: null } | 
         { key: "tags.update", input: LibraryArgs<TagUpdateArgs>, result: null } | 
         { key: "toggleFeatureFlag", input: BackendFeature, result: null },
     subscriptions: 
@@ -394,6 +396,10 @@ export type Tag = { id: number; pub_id: number[]; name: string | null; color: st
 export type TagAssignArgs = { object_ids: number[]; tag_id: number; unassign: boolean }
 
 export type TagCreateArgs = { name: string; color: string }
+
+export type TagImportArgs = { path: string }
+
+export type TagImportExport = { tag_id: number }
 
 export type TagUpdateArgs = { id: number; name: string | null; color: string | null }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true
@@ -5812,7 +5812,7 @@ packages:
       magic-string: 0.27.0
       react-docgen-typescript: 2.2.2(typescript@5.0.4)
       typescript: 5.0.4
-      vite: 4.3.9(@types/node@18.15.1)
+      vite: 4.3.9(less@4.2.0)
 
   /@jridgewell/gen-mapping@0.3.3:
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
@@ -8862,7 +8862,7 @@ packages:
       remark-slug: 6.1.0
       rollup: 3.28.1
       typescript: 5.0.4
-      vite: 4.3.9(@types/node@18.15.1)
+      vite: 4.3.9(less@4.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -9462,7 +9462,7 @@ packages:
       react: 18.2.0
       react-docgen: 6.0.0-alpha.3
       react-dom: 18.2.0(react@18.2.0)
-      vite: 4.3.9(@types/node@18.15.1)
+      vite: 4.3.9(less@4.2.0)
     transitivePeerDependencies:
       - '@preact/preset-vite'
       - supports-color
@@ -23523,6 +23523,7 @@ packages:
       rollup: 3.28.1
     optionalDependencies:
       fsevents: 2.3.3
+    dev: true
 
   /vite@4.3.9(less@4.2.0):
     resolution: {integrity: sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==}


### PR DESCRIPTION
Import export tags and locations

Optionally compress (.gz and .tar.gz)

Building this now because I need to move a few tags from one library to another, and I also wish to create location backups to preserve the filesystem structures before I begin organizing entire drives.

Supports single file and multi-file output.

```rust
pub struct JsonTag {
    pub_id: String,
    name: Option<String>,
    color: Option<String>,
    objects: Vec<JsonTagObject>,
}

struct JsonTagObject {
    pub_id: String,
    cas_ids: Vec<String>,
}

struct TagExportArgs {
    tag_id: i32,
}
 
impl ImportExport for JsonTag {
    type ExportContext = TagExportArgs;
    type ImportData = JsonTag;
}
 
async fn export(ctx: Self::ExportContext, library: &Library) {
   // grab data from db
}

async fn import(data: Self::ImportData, library: &Library) {
   // put data back into db
}
```
Usage: 
```rust

let exported_data = JsonTag::export(args, &library).await?;

let manager = ImportExportManager::<JsonTag>::new(
   ImportExportOptions {
      output_path: args.output_path,
      kind: ExportKind::TagWithAssociations,
      format: ExportFormat::JSON,
      compress: true,
   },
   ExportFile::Single(exported_data),
 );

manager.save().await?;
```
