### PR TITLE
[ENG-1195] Hide folder size in Ephemeral locations

### DIFF
--- a/interface/app/$libraryId/Explorer/View/GridView.tsx
+++ b/interface/app/$libraryId/Explorer/View/GridView.tsx
@@ -26,13 +26,14 @@ const GridViewItem = memo(({ data, selected, cut, isRenaming, renamable }: GridV
 	const filePathData = getItemFilePath(data);
 	const location = getItemLocation(data);
 	const isEphemeralLocation = useMatch('/:libraryId/ephemeral/:ephemeralId');
+	const isFolder = 'is_dir' in data.item ? data.item.is_dir || data.type === 'Location' : false;
 
 	const showSize =
-		!isEphemeralLocation &&
-		!filePathData?.is_dir &&
-		!location &&
-		showBytesInGridView &&
-		(!isRenaming || (isRenaming && !selected));
+		(!isEphemeralLocation && !isFolder) ||
+		(!filePathData?.is_dir &&
+			!location &&
+			showBytesInGridView &&
+			(!isRenaming || (isRenaming && !selected)));
 
 	return (
 		<ViewItem data={data} className="w-full h-full">

--- a/interface/app/$libraryId/Explorer/View/GridView.tsx
+++ b/interface/app/$libraryId/Explorer/View/GridView.tsx
@@ -28,12 +28,18 @@ const GridViewItem = memo(({ data, selected, cut, isRenaming, renamable }: GridV
 	const isEphemeralLocation = useMatch('/:libraryId/ephemeral/:ephemeralId');
 	const isFolder = 'is_dir' in data.item ? data.item.is_dir || data.type === 'Location' : false;
 
-	const showSize =
-		(!isEphemeralLocation && !isFolder) ||
-		(!filePathData?.is_dir &&
-			!location &&
-			showBytesInGridView &&
-			(!isRenaming || (isRenaming && !selected)));
+	//do not refactor please - this has been done for readability
+
+	const shouldShowSize = () => {
+		if (isEphemeralLocation) return false;
+		if (isFolder) return false;
+		if (!filePathData?.is_dir && !location) return false;
+		if (showBytesInGridView) return true;
+		if (isRenaming) return false;
+		if (!selected) return false;
+
+		return true;
+	};
 
 	return (
 		<ViewItem data={data} className="w-full h-full">
@@ -56,7 +62,7 @@ const GridViewItem = memo(({ data, selected, cut, isRenaming, renamable }: GridV
 					style={{ maxHeight: gridItemSize / 3 }}
 					disabled={!renamable}
 				/>
-				{showSize && filePathData?.size_in_bytes_bytes && (
+				{shouldShowSize() && filePathData?.size_in_bytes_bytes && (
 					<span
 						className={clsx(
 							'cursor-default truncate rounded-md px-1.5 py-[1px] text-center text-tiny text-ink-dull '

--- a/interface/app/$libraryId/Explorer/View/GridView.tsx
+++ b/interface/app/$libraryId/Explorer/View/GridView.tsx
@@ -8,7 +8,7 @@ import { FileThumb } from '../FilePath/Thumb';
 import { useQuickPreviewStore } from '../QuickPreview/store';
 import { useExplorerViewContext } from '../ViewContext';
 import GridList from './GridList';
-import RenamableItemText from './RenamableItemText';
+import { RenamableItemText } from './RenamableItemText';
 import { ViewItem } from './ViewItem';
 
 interface GridViewItemProps {
@@ -56,12 +56,7 @@ const GridViewItem = memo(({ data, selected, cut, isRenaming, renamable }: GridV
 			</div>
 
 			<div className="flex flex-col justify-center">
-				<RenamableItemText
-					item={data}
-					selected={selected}
-					style={{ maxHeight: gridItemSize / 3 }}
-					disabled={!renamable}
-				/>
+				<RenamableItemText item={data} style={{ maxHeight: gridItemSize / 3 }} />
 				{shouldShowSize() && filePathData?.size_in_bytes_bytes && (
 					<span
 						className={clsx(

--- a/interface/app/$libraryId/Explorer/View/GridView.tsx
+++ b/interface/app/$libraryId/Explorer/View/GridView.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import { memo } from 'react';
+import { useMatch } from 'react-router';
 import { byteSize, getItemFilePath, getItemLocation, type ExplorerItem } from '@sd/client';
 
 import { useExplorerContext } from '../Context';
@@ -24,15 +25,17 @@ const GridViewItem = memo(({ data, selected, cut, isRenaming, renamable }: GridV
 
 	const filePathData = getItemFilePath(data);
 	const location = getItemLocation(data);
+	const isEphemeralLocation = useMatch('/:libraryId/ephemeral/:ephemeralId');
 
 	const showSize =
+		!isEphemeralLocation &&
 		!filePathData?.is_dir &&
 		!location &&
 		showBytesInGridView &&
 		(!isRenaming || (isRenaming && !selected));
 
 	return (
-		<ViewItem data={data} className="h-full w-full">
+		<ViewItem data={data} className="w-full h-full">
 			<div
 				className={clsx('mb-1 aspect-square rounded-lg', selected && 'bg-app-selectedItem')}
 			>

--- a/interface/app/$libraryId/Explorer/View/GridView.tsx
+++ b/interface/app/$libraryId/Explorer/View/GridView.tsx
@@ -5,7 +5,6 @@ import { byteSize, getItemFilePath, getItemLocation, type ExplorerItem } from '@
 
 import { useExplorerContext } from '../Context';
 import { FileThumb } from '../FilePath/Thumb';
-import { useQuickPreviewStore } from '../QuickPreview/store';
 import { useExplorerViewContext } from '../ViewContext';
 import GridList from './GridList';
 import { RenamableItemText } from './RenamableItemText';
@@ -16,10 +15,9 @@ interface GridViewItemProps {
 	selected: boolean;
 	isRenaming: boolean;
 	cut: boolean;
-	renamable: boolean;
 }
 
-const GridViewItem = memo(({ data, selected, cut, isRenaming, renamable }: GridViewItemProps) => {
+const GridViewItem = memo(({ data, selected, cut, isRenaming }: GridViewItemProps) => {
 	const explorer = useExplorerContext();
 	const { showBytesInGridView, gridItemSize } = explorer.useSettingsSnapshot();
 
@@ -72,9 +70,7 @@ const GridViewItem = memo(({ data, selected, cut, isRenaming, renamable }: GridV
 });
 
 export default () => {
-	const explorer = useExplorerContext();
 	const explorerView = useExplorerViewContext();
-	const quickPreviewStore = useQuickPreviewStore();
 
 	return (
 		<GridList>
@@ -84,9 +80,6 @@ export default () => {
 					selected={selected}
 					cut={cut}
 					isRenaming={explorerView.isRenaming}
-					renamable={
-						selected && explorer.selectedItems.size === 1 && !quickPreviewStore.open
-					}
 				/>
 			)}
 		</GridList>

--- a/interface/app/$libraryId/Explorer/View/ListView/util/table.tsx
+++ b/interface/app/$libraryId/Explorer/View/ListView/util/table.tsx
@@ -8,6 +8,7 @@ import {
 import clsx from 'clsx';
 import dayjs from 'dayjs';
 import { useEffect, useMemo, useState } from 'react';
+import { useMatch } from 'react-router';
 import { stringify } from 'uuid';
 import {
 	byteSize,
@@ -33,6 +34,7 @@ export const useTable = () => {
 
 	const [columnSizing, setColumnSizing] = useState<ColumnSizingState>({});
 	const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
+	const isEphemeralLocation = useMatch('/:libraryId/ephemeral/:ephemeralId');
 
 	const columns = useMemo<ColumnDef<ExplorerItem>[]>(
 		() => [
@@ -87,10 +89,14 @@ export const useTable = () => {
 				id: 'sizeInBytes',
 				header: 'Size',
 				accessorFn: (file) => {
+					const isFolder =
+						isEphemeralLocation && 'is_dir' in file.item
+							? file.item.is_dir || file.type === 'Location'
+							: false;
 					const file_path = getItemFilePath(file);
 					if (!file_path || !file_path.size_in_bytes_bytes) return;
 
-					return byteSize(file_path.size_in_bytes_bytes);
+					return isFolder ? '-' : byteSize(file_path.size_in_bytes_bytes);
 				}
 			},
 			{


### PR DESCRIPTION
This hides folder size in Ephemeral locations, grid and list view are handled.

- We currently don't have support to measure sizes of folders in Ephemeral locations.

**Image**:

<img width="1184" alt="Screenshot 2023-10-09 at 4 03 34 PM" src="https://github.com/spacedriveapp/spacedrive/assets/33054370/012bec20-87d5-4bce-a25a-052b4d7af6fc">
