### PR TITLE
fix: dev tools shortcut

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ To quickly run only the desktop app after `prep`, you can use:
 
 - `pnpm tauri dev`
 
-  If necessary, the webview devtools can be opened by pressing Ctrl + Shift + I in the desktop app.
+  If necessary, the webview devtools can be opened by pressing Cmd + Alt + I (Mac) or Ctrl + Alt + I in the desktop app.
 
   Also, the react-devtools can be launched using `pnpm dlx react-devtools`.
   However, it must be executed before starting the desktop app for it qto connect.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ To quickly run only the desktop app after `prep`, you can use:
 
 - `pnpm tauri dev`
 
-  If necessary, the webview devtools can be opened by pressing Cmd + Alt + I (Mac) or Ctrl + Alt + I in the desktop app.
+  If necessary, the [webview devtools](https://tauri.app/v1/guides/debugging/application/#webview-console) can be opened by pressing `Ctrl + Shift + I` (Linux and Windows) and `Command + Option + I` (Mac) in the desktop app.
 
   Also, the react-devtools can be launched using `pnpm dlx react-devtools`.
   However, it must be executed before starting the desktop app for it qto connect.


### PR DESCRIPTION
The dev tools are opened using `CmdOrCrtl+Alt+I` so I updated the `CONTRIBUTING.md` to reflect this.