### PR TITLE
Add version to updater endpoint

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -59,7 +59,7 @@
 			"dialog": false,
 			"pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEZBMURCMkU5NEU3NDAyOEMKUldTTUFuUk82YklkK296dlkxUGkrTXhCT3ZMNFFVOWROcXNaS0RqWU1kMUdRV2tDdFdIS0Y3YUsK",
 			"endpoints": [
-				"https://spacedrive-landing-git-eng-927-fix-updater-spacedrive.vercel.app/api/releases/tauri/{{target}}/{{arch}}"
+				"https://spacedrive-landing-git-eng-927-fix-updater-spacedrive.vercel.app/api/releases/tauri/{{version}}/{{target}}/{{arch}}"
 			]
 		},
 		"allowlist": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -59,7 +59,7 @@
 			"dialog": false,
 			"pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEZBMURCMkU5NEU3NDAyOEMKUldTTUFuUk82YklkK296dlkxUGkrTXhCT3ZMNFFVOWROcXNaS0RqWU1kMUdRV2tDdFdIS0Y3YUsK",
 			"endpoints": [
-				"https://spacedrive-landing-git-eng-927-fix-updater-spacedrive.vercel.app/api/releases/tauri/{{version}}/{{target}}/{{arch}}"
+				"https://spacedrive.com/api/releases/tauri/{{version}}/{{target}}/{{arch}}"
 			]
 		},
 		"allowlist": {

--- a/apps/landing/src/app/api/releases/tauri/[version]/[target]/[arch]/route.ts
+++ b/apps/landing/src/app/api/releases/tauri/[version]/[target]/[arch]/route.ts
@@ -23,12 +23,23 @@ type TauriResponse = {
 
 export const runtime = 'edge';
 
-export async function GET(req: Request, extra: { params: Record<string, unknown> }) {
-	const version = req.headers.get('X-Spacedrive-Version');
-
-	if (version === null) return NextResponse.json({ error: 'No version header' }, { status: 400 });
-
-	const params = await paramsSchema.parseAsync({ ...extra.params, version });
+export async function GET(
+	req: Request,
+	{
+		params: rawParams
+	}: {
+		params: {
+			version: string;
+			target: string;
+			arch: string;
+		};
+	}
+) {
+	const params = await paramsSchema.parseAsync({
+		...rawParams,
+		// prefer header override to support release channels
+		version: req.headers.get('X-Spacedrive-Version') ?? rawParams.version
+	});
 
 	const release = await getRelease(params);
 


### PR DESCRIPTION
Just wanted to do this before release so that we can support release channels without the custom header at some point.