### PR TITLE
[ENG-1214] Disable updater for `.deb` distrubutions

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -133,6 +133,7 @@ async fn main() -> tauri::Result<()> {
 	});
 
 	let app = app
+		.plugin(updater::plugin())
 		.setup(|app| {
 			let app = app.handle();
 
@@ -189,6 +190,7 @@ async fn main() -> tauri::Result<()> {
 			file::open_ephemeral_file_with,
 			file::reveal_items,
 			theme::lock_app_theme,
+			// TODO: move to plugin w/tauri-specta
 			updater::check_for_update,
 			updater::install_update
 		])

--- a/apps/desktop/src-tauri/src/updater.rs
+++ b/apps/desktop/src-tauri/src/updater.rs
@@ -1,6 +1,5 @@
 use tauri::{plugin::TauriPlugin, Manager, Runtime};
 use tokio::sync::Mutex;
-use tracing::{error, warn};
 
 #[derive(Debug, Clone, specta::Type, serde::Serialize)]
 pub struct Update {
@@ -108,10 +107,10 @@ pub fn plugin<R: Runtime>() -> TauriPlugin<R> {
 
 			if updater_available {
 				window
-					.eval(&format!("window.__SD_UPDATER__ = true"))
+					.eval("window.__SD_UPDATER__ = true")
 					.expect("Failed to inject updater JS");
 			}
 		})
-		.js_init_script(format!(""))
+		.js_init_script(String::new())
 		.build()
 }

--- a/apps/desktop/src/commands.ts
+++ b/apps/desktop/src/commands.ts
@@ -62,9 +62,9 @@ export function installUpdate() {
     return invoke()<null>("install_update")
 }
 
-export type Update = { version: string; body: string | null }
 export type OpenWithApplication = { url: string; name: string }
 export type AppThemeType = "Auto" | "Light" | "Dark"
 export type EphemeralFileOpenResult = { t: "Ok"; c: string } | { t: "Err"; c: string }
+export type Update = { version: string; body: string | null }
 export type OpenFilePathResult = { t: "NoLibrary" } | { t: "NoFile"; c: number } | { t: "OpenError"; c: [number, string] } | { t: "AllGood"; c: number } | { t: "Internal"; c: string }
 export type RevealItem = { Location: { id: number } } | { FilePath: { id: number } } | { Ephemeral: { path: string } }


### PR DESCRIPTION
Updater now has to be enabled by the backend else it won't be available in `usePlatform`.
`.deb` detection logic taken from [Tauri's implementation](https://github.com/tauri-apps/tauri/blob/tauri-v1.3.0/core/tauri/src/app.rs#L944).