### PR TITLE
[ENG-1220] Fix pdf thumb crashing app

### DIFF
--- a/crates/images/Cargo.toml
+++ b/crates/images/Cargo.toml
@@ -2,8 +2,8 @@
 name = "sd-images"
 version = "0.0.0"
 authors = [
-  "Jake Robinson <jake@spacedrive.com>",
-  "Vítor Vasconcellos <vitor@spacedrive.com>",
+	"Jake Robinson <jake@spacedrive.com>",
+	"Vítor Vasconcellos <vitor@spacedrive.com>",
 ]
 license = { workspace = true }
 repository = { workspace = true }
@@ -21,8 +21,8 @@ rspc = { workspace = true, optional = true } # error conversion
 specta = { workspace = true, optional = true }
 serde = { workspace = true, optional = true, features = ["derive"] }
 bincode = { version = "2.0.0-rc.3", features = [
-  "derive",
-  "alloc",
+	"derive",
+	"alloc",
 ], optional = true }
 once_cell = "1.18.0"
 tracing = { workspace = true }
@@ -31,8 +31,4 @@ tracing = { workspace = true }
 # this broke builds as we build our own liibheif, so i disabled their default features
 libheif-rs = { version = "0.22.0", default-features = false, optional = true }
 libheif-sys = { version = "2.0.0", default-features = false, optional = true }
-pdfium-render = { version = "0.8.8", features = [
-  "sync",
-  "image",
-  "thread_safe",
-] }
+pdfium-render = { version = "0.8.8", features = ["image"] }

--- a/crates/images/src/pdf.rs
+++ b/crates/images/src/pdf.rs
@@ -6,7 +6,6 @@ use std::{
 
 use crate::{consts::PDF_RENDER_WIDTH, Error::PdfiumBinding, ImageHandler, Result};
 use image::DynamicImage;
-use once_cell::sync::Lazy;
 use pdfium_render::prelude::{PdfPageRenderRotation, PdfRenderConfig, Pdfium};
 use tracing::error;
 
@@ -20,59 +19,64 @@ const BINDING_LOCATION: &str = if cfg!(target_os = "macos") {
 	"../lib/spacedrive"
 };
 
-static PDFIUM: Lazy<Option<Pdfium>> = Lazy::new(|| {
-	let lib_name = Pdfium::pdfium_platform_library_name();
-	let lib_path = current_exe()
-		.ok()
-		.and_then(|exe_path| {
-			exe_path.parent().and_then(|parent_path| {
-				match parent_path
-					.join(BINDING_LOCATION)
-					.join(&lib_name)
-					.canonicalize()
-				{
-					Ok(lib_path) => lib_path.to_str().map(ToOwned::to_owned),
-					Err(err) => {
-						error!("{err:#?}");
-						None
+// FIX-ME: This is slow, but using Lazy with thread_safe was causing concurrency bugs that crashed the app
+thread_local! {
+	static PDFIUM: Option<Pdfium> = {
+		let lib_name = Pdfium::pdfium_platform_library_name();
+		let lib_path = current_exe()
+			.ok()
+			.and_then(|exe_path| {
+				exe_path.parent().and_then(|parent_path| {
+					match parent_path
+						.join(BINDING_LOCATION)
+						.join(&lib_name)
+						.canonicalize()
+					{
+						Ok(lib_path) => lib_path.to_str().map(ToOwned::to_owned),
+						Err(err) => {
+							error!("{err:#?}");
+							None
+						}
 					}
-				}
+				})
 			})
-		})
-		.unwrap_or_else(|| {
-			#[allow(clippy::expect_used)]
-			PathBuf::from(BINDING_LOCATION)
-				.join(&lib_name)
-				.to_str()
-				.expect("We are converting valid strs to PathBuf then back, it should not fail")
-				.to_owned()
-		});
+			.unwrap_or_else(|| {
+				#[allow(clippy::expect_used)]
+				PathBuf::from(BINDING_LOCATION)
+					.join(&lib_name)
+					.to_str()
+					.expect("We are converting valid strs to PathBuf then back, it should not fail")
+					.to_owned()
+			});
 
-	Pdfium::bind_to_library(lib_path)
-		.or_else(|err| {
-			error!("{err:#?}");
-			Pdfium::bind_to_system_library()
-		})
-		.map(Pdfium::new)
-		.map_err(|err| error!("{err:#?}"))
-		.ok()
-});
+		Pdfium::bind_to_library(lib_path)
+			.or_else(|err| {
+				error!("{err:#?}");
+				Pdfium::bind_to_system_library()
+			})
+			.map(Pdfium::new)
+			.map_err(|err| error!("{err:#?}"))
+			.ok()
+	};
+}
 
 pub struct PdfHandler {}
 
 impl ImageHandler for PdfHandler {
 	fn handle_image(&self, path: &Path) -> Result<DynamicImage> {
-		let pdfium = PDFIUM.as_ref().ok_or(PdfiumBinding)?;
+		PDFIUM.with(|maybe_pdfium| {
+			let pdfium = maybe_pdfium.as_ref().ok_or(PdfiumBinding)?;
 
-		let render_config = PdfRenderConfig::new()
-			.set_target_width(PDF_RENDER_WIDTH)
-			.rotate_if_landscape(PdfPageRenderRotation::Degrees90, true);
+			let render_config = PdfRenderConfig::new()
+				.set_target_width(PDF_RENDER_WIDTH)
+				.rotate_if_landscape(PdfPageRenderRotation::Degrees90, true);
 
-		Ok(pdfium
-			.load_pdf_from_file(path, None)?
-			.pages()
-			.first()?
-			.render_with_config(&render_config)?
-			.as_image())
+			Ok(pdfium
+				.load_pdf_from_file(path, None)?
+				.pages()
+				.first()?
+				.render_with_config(&render_config)?
+				.as_image())
+		})
 	}
 }


### PR DESCRIPTION
Use a separate instance of Pdfium lib for each thread to avoid concurrency bugs when processing multiple PDF's at the same time