### PR TITLE
[ENG-1222] `udevadm` doesn't exist in Docker container

### DIFF
--- a/core/src/api/files.rs
+++ b/core/src/api/files.rs
@@ -5,8 +5,7 @@ use crate::{
 	library::Library,
 	location::{
 		file_path_helper::{
-			file_path_to_full_path, file_path_to_isolate, file_path_to_isolate_with_id,
-			FilePathError, IsolatedFilePathData,
+			file_path_to_isolate, file_path_to_isolate_with_id, FilePathError, IsolatedFilePathData,
 		},
 		get_location_path_from_location_id, LocationError,
 	},
@@ -33,7 +32,7 @@ use sd_media_metadata::MediaMetadata;
 
 use std::{
 	ffi::OsString,
-	path::{Path, PathBuf, MAIN_SEPARATOR, MAIN_SEPARATOR_STR},
+	path::{Path, PathBuf},
 	str::FromStr,
 	sync::Arc,
 };

--- a/core/src/api/utils/invalidate.rs
+++ b/core/src/api/utils/invalidate.rs
@@ -197,10 +197,16 @@ macro_rules! invalidate_query {
 					.queries
 					.push($crate::api::utils::InvalidationRequest {
 						key: $key,
-						arg_ty: Some(<$arg_ty as rspc::internal::specta::Type>::reference(rspc::internal::specta::DefOpts {
+						arg_ty: <$arg_ty as specta::Type>::reference(specta::DefOpts {
                             parent_inline: false,
-                            type_map: &mut rspc::internal::specta::TypeDefs::new(),
-                        }, &[])),
+                            type_map: &mut specta::TypeDefs::new(),
+                        }, &[]).map_err(|e| {
+								::tracing::error!(
+									"Failed to get type reference for invalidate query '{}': {:?}",
+									$key,
+									e
+								)
+							}).ok(),
 						result_ty: None,
                         macro_src: concat!(file!(), ":", line!()),
 					})

--- a/core/src/volume/mod.rs
+++ b/core/src/volume/mod.rs
@@ -1,9 +1,15 @@
 // Adapted from: https://github.com/kimlimjustin/xplorer/blob/f4f3590d06783d64949766cc2975205a3b689a56/src-tauri/src/drives.rs
 
+use std::{
+	fmt::Display,
+	hash::{Hash, Hasher},
+	path::PathBuf,
+	sync::OnceLock,
+};
+
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 use specta::Type;
-use std::{fmt::Display, path::PathBuf, sync::OnceLock};
 use sysinfo::{DiskExt, System, SystemExt};
 use thiserror::Error;
 use tokio::sync::Mutex;
@@ -16,7 +22,7 @@ fn sys_guard() -> &'static Mutex<System> {
 	SYS.get_or_init(|| Mutex::new(System::new_all()))
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Type)]
+#[derive(Serialize, Deserialize, Debug, Clone, Type, Hash, PartialEq, Eq)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum DiskType {
 	SSD,
@@ -49,6 +55,33 @@ pub struct Volume {
 	pub file_system: Option<String>,
 	pub is_root_filesystem: bool,
 }
+
+impl Hash for Volume {
+	fn hash<H: Hasher>(&self, state: &mut H) {
+		self.name.hash(state);
+		self.mount_points.iter().for_each(|mount_point| {
+			// Hashing like this to ignore ordering between mount points
+			mount_point.hash(state);
+		});
+		self.disk_type.hash(state);
+		self.file_system.hash(state);
+	}
+}
+
+impl PartialEq for Volume {
+	fn eq(&self, other: &Self) -> bool {
+		self.name == other.name
+			&& self.disk_type == other.disk_type
+			&& self.file_system == other.file_system
+			// Leaving mount points for last because O(n * m)
+			&& self
+				.mount_points
+				.iter()
+				.all(|mount_point| other.mount_points.contains(mount_point))
+	}
+}
+
+impl Eq for Volume {}
 
 #[derive(Error, Debug)]
 pub enum VolumeError {

--- a/core/src/volume/watcher.rs
+++ b/core/src/volume/watcher.rs
@@ -2,13 +2,16 @@ use crate::{invalidate_query, library::Library};
 
 use std::{collections::HashSet, sync::Arc};
 
-use tokio::{spawn, time::Duration};
+use tokio::{
+	spawn,
+	time::{interval, Duration},
+};
 
 use super::{get_volumes, Volume};
 
 pub fn spawn_volume_watcher(library: Arc<Library>) {
 	spawn(async move {
-		let mut interval = tokio::time::interval(Duration::from_secs(1));
+		let mut interval = interval(Duration::from_secs(1));
 		let mut existing_volumes = get_volumes().await.into_iter().collect::<HashSet<_>>();
 
 		loop {


### PR DESCRIPTION
This fixes the issue of not having udevadm inside the docker image, reusing the same code we already have for getting volumes. Tried my hand at fixing the invalidate query macro to return new data.