### PR TITLE
Dynamic OS/version string and toggle-able download links for multi-download platforms

### DIFF
--- a/apps/landing/src/pages/index.tsx
+++ b/apps/landing/src/pages/index.tsx
@@ -10,7 +10,7 @@ import { motion } from 'framer-motion';
 import dynamic from 'next/dynamic';
 import Head from 'next/head';
 import Image from 'next/image';
-import { ComponentProps, useEffect, useState } from 'react';
+import { ComponentProps, useEffect, useMemo, useState } from 'react';
 import { Tooltip, TooltipProvider, tw } from '@sd/ui';
 import NewBanner from '~/components/NewBanner';
 import PageWrapper from '~/components/PageWrapper';
@@ -25,6 +25,8 @@ const HomeCTA = dynamic(() => import('~/components/HomeCTA'), {
 const AppFrameOuter = tw.div`relative m-auto flex w-full max-w-7xl rounded-lg transition-opacity`;
 const AppFrameInner = tw.div`z-30 flex w-full rounded-lg border-t border-app-line/50 backdrop-blur`;
 
+const RELEASE_VERSION = 'Alpha v0.1.0';
+
 const BASE_DL_LINK = '/api/releases/desktop/stable';
 const downloadEntries = {
 	linux: {
@@ -33,7 +35,7 @@ const downloadEntries = {
 		links: 'linux/x86_64'
 	},
 	macOS: {
-		name: 'Mac',
+		name: 'MacOS',
 		icon: <Apple />,
 		links: {
 			'Intel': 'darwin/x86_64',
@@ -48,14 +50,20 @@ const downloadEntries = {
 } as const;
 
 const platforms = [
-	{ name: 'iOS and macOS', icon: Apple, clickable: true },
+	{ name: 'MacOS', icon: Apple, clickable: true, version: '12+' },
 	{
 		name: 'Windows',
 		icon: WindowsLogo,
-		href: `${BASE_DL_LINK}/${downloadEntries.windows.links}`
+		href: `${BASE_DL_LINK}/${downloadEntries.windows.links}`,
+		version: '10+'
 	},
-	{ name: 'Linux', icon: LinuxLogo, href: `${BASE_DL_LINK}/${downloadEntries.linux.links}` },
-	{ name: 'Android', icon: AndroidLogo },
+	{
+		name: 'Linux',
+		icon: LinuxLogo,
+		href: `${BASE_DL_LINK}/${downloadEntries.linux.links}`,
+		version: 'AppImage'
+	},
+	{ name: 'Android', icon: AndroidLogo, version: '10+' },
 	{ name: 'Web', icon: Globe }
 ] as const;
 
@@ -118,6 +126,19 @@ export default function HomePage() {
 			}
 		})();
 	}, [background]);
+
+	const currentPlatform =
+		downloadEntry !== undefined
+			? platforms.find((e) => e.name === downloadEntry.name)
+			: undefined;
+
+	const supportedVersion =
+		currentPlatform && 'version' in currentPlatform ? currentPlatform.version : undefined;
+
+	const formattedVersion =
+		downloadEntry && supportedVersion && downloadEntry.name !== 'Linux'
+			? `${downloadEntry.name} ${supportedVersion}`
+			: supportedVersion;
 
 	return (
 		<TooltipProvider>
@@ -193,7 +214,7 @@ export default function HomePage() {
 							/>
 						)}
 
-						{multipleDownloads == null && (
+						{downloadEntry === undefined && (
 							<a
 								target="_blank"
 								href="https://www.github.com/spacedriveapp/spacedrive"
@@ -220,13 +241,18 @@ export default function HomePage() {
 							))}
 						</div>
 					)}
-
 					<p
 						className={clsx(
 							'animation-delay-3 z-30 mt-3 px-6 text-center text-sm text-gray-400 fade-in'
 						)}
 					>
-						Alpha v0.1.0 <span className="mx-2 opacity-50">|</span> macOS 12+
+						{RELEASE_VERSION}
+						{formattedVersion && (
+							<>
+								<span className="mx-2 opacity-50">|</span>
+								{formattedVersion}
+							</>
+						)}
 					</p>
 					<div className="relative z-10 mt-5 flex gap-3">
 						{platforms.map((platform, i) => (
@@ -240,12 +266,21 @@ export default function HomePage() {
 									icon={platform.icon}
 									label={platform.name}
 									href={'href' in platform ? platform.href : undefined}
+									iconDisabled={
+										platform.name === 'Android' || platform.name === 'Web'
+											? true
+											: undefined
+									}
 									clickable={
 										'clickable' in platform ? platform.clickable : undefined
 									}
 									onClick={() => {
-										if (platform.name === 'iOS and macOS') {
-											setMultipleDownloads(downloadEntries.macOS.links);
+										if (platform.name === 'MacOS') {
+											setMultipleDownloads(
+												multipleDownloads
+													? undefined
+													: downloadEntries.macOS.links
+											);
 										}
 									}}
 								/>
@@ -316,6 +351,7 @@ export default function HomePage() {
 interface Props {
 	label: string;
 	icon: any;
+	iconDisabled?: true;
 	clickable?: true;
 }
 
@@ -329,7 +365,14 @@ const Platform = ({ icon: Icon, label, ...props }: ComponentProps<'a'> & Props) 
 	return (
 		<Tooltip label={label}>
 			<Outer {...props}>
-				<Icon size={25} className="h-[25px] opacity-80" weight="fill" />
+				<Icon
+					size={25}
+					className={clsx('h-[25px]', {
+						['opacity-20']: props.iconDisabled,
+						['opacity-80']: props.iconDisabled === undefined
+					})}
+					weight="fill"
+				/>
 			</Outer>
 		</Tooltip>
 	);


### PR DESCRIPTION
Linux now just says "AppImage", and the final image is when no platform/a currently unsupported platform is detected. The icons are all clickable, except for Android and Web which have been disabled.

The tooltip for the Apple logo was altered to just say MacOS, as that could ultimately lead to some confusion (as the icon is active). I considered possibly using an iMac icon, but decided against it. Another issue with having iOS on this tooltip is accessibility - a screen reader would've read out "iOS and MacOS" and could've been misleading.

The OS autodetect system is far from perfect - many privacy-centric extensions often spoof your user agent to a more common, less unique one, which is the one of the few reasons I made the icons clickable (and it's just intuitive). 

If I didn't know any better, I wouldn't have actually been able to download a build for my Mac as my UA was set to Windows, and the rest of the download links are all the way at the bottom of the landing page.

<img width="1020" alt="Screenshot 2023-10-11 at 14 18 27" src="https://github.com/spacedriveapp/spacedrive/assets/77554505/e02fa3f5-3d6f-4b63-a3ce-d325c8404eb9">
