### PR TITLE
[ENG-870] Fix wording for delete dialog

### DIFF
--- a/interface/app/$libraryId/Explorer/ContextMenu/FilePath/Items.tsx
+++ b/interface/app/$libraryId/Explorer/ContextMenu/FilePath/Items.tsx
@@ -30,8 +30,8 @@ export const Delete = new ConditionalItem({
 
 		const rescan = useQuickRescan();
 
-		const atLeastOneDirectory = selectedFilePaths.some((p) => p.is_dir);
-		const atLeastOneFile = selectedFilePaths.some((p) => !p.is_dir);
+		const dirCount = selectedFilePaths.filter((p) => p.is_dir).length;
+		const fileCount = selectedFilePaths.filter((p) => !p.is_dir).length;
 
 		return (
 			<Menu.Item
@@ -46,8 +46,8 @@ export const Delete = new ConditionalItem({
 							rescan={rescan}
 							locationId={locationId}
 							pathIds={selectedFilePaths.map((p) => p.id)}
-							includesDirectorys={atLeastOneDirectory}
-							includesFiles={atLeastOneFile}
+							dirCount={dirCount}
+							fileCount={fileCount}
 						/>
 					))
 				}

--- a/interface/app/$libraryId/Explorer/ContextMenu/FilePath/Items.tsx
+++ b/interface/app/$libraryId/Explorer/ContextMenu/FilePath/Items.tsx
@@ -30,6 +30,9 @@ export const Delete = new ConditionalItem({
 
 		const rescan = useQuickRescan();
 
+		const atLeastOneDirectory = selectedFilePaths.some((p) => p.is_dir);
+		const atLeastOneFile = selectedFilePaths.some((p) => !p.is_dir);
+
 		return (
 			<Menu.Item
 				icon={Trash}
@@ -43,6 +46,8 @@ export const Delete = new ConditionalItem({
 							rescan={rescan}
 							locationId={locationId}
 							pathIds={selectedFilePaths.map((p) => p.id)}
+							includesDirectorys={atLeastOneDirectory}
+							includesFiles={atLeastOneFile}
 						/>
 					))
 				}

--- a/interface/app/$libraryId/Explorer/FilePath/DeleteDialog.tsx
+++ b/interface/app/$libraryId/Explorer/FilePath/DeleteDialog.tsx
@@ -5,12 +5,25 @@ interface Props extends UseDialogProps {
 	locationId: number;
 	rescan?: () => void;
 	pathIds: number[];
+	includesDirectorys?: boolean;
+	includesFiles?: boolean;
 }
 
 export default (props: Props) => {
 	const deleteFile = useLibraryMutation('files.deleteFiles');
 
 	const form = useZodForm();
+
+	let type = "file";
+
+	if(props.includesDirectorys){
+		type = "directory";
+		if(props.includesFiles){
+			type = "item";
+		}
+	}
+
+	const description = `Warning: This will delete your ${type} forever, we don't have a trash can yet...`;
 
 	return (
 		<Dialog
@@ -24,8 +37,8 @@ export default (props: Props) => {
 				props.rescan?.();
 			})}
 			dialog={useDialog(props)}
-			title="Delete a file"
-			description="Warning: This will delete your file forever, we don't have a trash can yet..."
+			title={"Delete a " + type}
+			description={description}
 			loading={deleteFile.isLoading}
 			ctaLabel="Delete"
 			ctaDanger
@@ -34,7 +47,7 @@ export default (props: Props) => {
 			<Tooltip label="Coming soon">
 				<div className="flex items-center pt-2 opacity-50">
 					<CheckBox disabled className="!mt-0" />
-					<p className="text-sm text-ink-dull">Delete all matching files</p>
+					<p className="text-sm text-ink-dull">Delete all matching {type}s</p>
 				</div>
 			</Tooltip>
 		</Dialog>

--- a/interface/app/$libraryId/Explorer/FilePath/DeleteDialog.tsx
+++ b/interface/app/$libraryId/Explorer/FilePath/DeleteDialog.tsx
@@ -5,23 +5,45 @@ interface Props extends UseDialogProps {
 	locationId: number;
 	rescan?: () => void;
 	pathIds: number[];
-	includesDirectorys?: boolean;
-	includesFiles?: boolean;
+	dirCount?: number;
+	fileCount?: number;
+}
+
+function getWording(dirCount: number, fileCount: number) {
+	let type = "file";
+	let prefix = "a";
+
+	if(dirCount == 1 && fileCount == 0){
+		type = "directory";
+		prefix = "a";
+	}
+
+	if(dirCount > 1 && fileCount == 0){
+		type = "directories";
+		prefix = dirCount.toString();
+	}
+
+	if(fileCount> 1 && dirCount == 0){
+		type = "files";
+		prefix = fileCount.toString();
+	}
+
+	if(fileCount > 0 && dirCount > 0){
+		type = "items";
+		prefix = (fileCount + dirCount).toString();
+	}
+
+	return { type, prefix };
 }
 
 export default (props: Props) => {
 	const deleteFile = useLibraryMutation('files.deleteFiles');
+	props.dirCount ??= 0;
+	props.fileCount ??= 0;
 
 	const form = useZodForm();
 
-	let type = "file";
-
-	if(props.includesDirectorys){
-		type = "directory";
-		if(props.includesFiles){
-			type = "item";
-		}
-	}
+	const { type, prefix } = getWording(props.dirCount, props.fileCount);
 
 	const description = `Warning: This will delete your ${type} forever, we don't have a trash can yet...`;
 
@@ -37,7 +59,7 @@ export default (props: Props) => {
 				props.rescan?.();
 			})}
 			dialog={useDialog(props)}
-			title={"Delete a " + type}
+			title={"Delete " + prefix + " " + type}
 			description={description}
 			loading={deleteFile.isLoading}
 			ctaLabel="Delete"
@@ -47,7 +69,7 @@ export default (props: Props) => {
 			<Tooltip label="Coming soon">
 				<div className="flex items-center pt-2 opacity-50">
 					<CheckBox disabled className="!mt-0" />
-					<p className="text-sm text-ink-dull">Delete all matching {type}s</p>
+					<p className="text-sm text-ink-dull">Delete all matching {type.endsWith("s") ? type : type + "s"}</p>
 				</div>
 			</Tooltip>
 		</Dialog>

--- a/interface/app/$libraryId/Explorer/FilePath/DeleteDialog.tsx
+++ b/interface/app/$libraryId/Explorer/FilePath/DeleteDialog.tsx
@@ -5,8 +5,8 @@ interface Props extends UseDialogProps {
 	locationId: number;
 	rescan?: () => void;
 	pathIds: number[];
-	dirCount: number;
-	fileCount: number;
+	dirCount?: number;
+	fileCount?: number;
 }
 
 function getWording(dirCount: number, fileCount: number) {
@@ -36,12 +36,13 @@ function getWording(dirCount: number, fileCount: number) {
 	return { type, prefix };
 }
 
-const deleteDialog = (props: Props) => {
+export default (props: Props) => {
 	const deleteFile = useLibraryMutation('files.deleteFiles');
 
 	const form = useZodForm();
+	const { dirCount = 0, fileCount = 0 } = props;
 
-	const { type, prefix } = getWording(props.dirCount, props.fileCount);
+	const { type, prefix } = getWording(dirCount, fileCount);
 
 	const description = `Warning: This will delete your ${type} forever, we don't have a trash can yet...`;
 
@@ -73,10 +74,3 @@ const deleteDialog = (props: Props) => {
 		</Dialog>
 	);
 };
-
-deleteDialog.defaultProps = {
-	dirCount: 0,
-	fileCount: 0
-}
-
-export default deleteDialog;

--- a/interface/app/$libraryId/Explorer/FilePath/DeleteDialog.tsx
+++ b/interface/app/$libraryId/Explorer/FilePath/DeleteDialog.tsx
@@ -5,8 +5,8 @@ interface Props extends UseDialogProps {
 	locationId: number;
 	rescan?: () => void;
 	pathIds: number[];
-	dirCount?: number;
-	fileCount?: number;
+	dirCount: number;
+	fileCount: number;
 }
 
 function getWording(dirCount: number, fileCount: number) {
@@ -36,10 +36,8 @@ function getWording(dirCount: number, fileCount: number) {
 	return { type, prefix };
 }
 
-export default (props: Props) => {
+const deleteDialog = (props: Props) => {
 	const deleteFile = useLibraryMutation('files.deleteFiles');
-	props.dirCount ??= 0;
-	props.fileCount ??= 0;
 
 	const form = useZodForm();
 
@@ -75,3 +73,10 @@ export default (props: Props) => {
 		</Dialog>
 	);
 };
+
+deleteDialog.defaultProps = {
+	dirCount: 0,
+	fileCount: 0
+}
+
+export default deleteDialog;

--- a/interface/app/$libraryId/Explorer/QuickPreview/index.tsx
+++ b/interface/app/$libraryId/Explorer/QuickPreview/index.tsx
@@ -211,8 +211,8 @@ export const QuickPreview = () => {
 				{...dp}
 				locationId={path.location_id!}
 				pathIds={[path.id]}
-				includesDirectorys={path.is_dir ?? false}
-				includesFiles={!path.is_dir}
+				dirCount={path.is_dir ? 1 : 0}
+				fileCount={path.is_dir ? 0 : 1}
 			/>
 		));
 	});

--- a/interface/app/$libraryId/Explorer/QuickPreview/index.tsx
+++ b/interface/app/$libraryId/Explorer/QuickPreview/index.tsx
@@ -207,7 +207,13 @@ export const QuickPreview = () => {
 		if (!path || path.location_id === null) return;
 
 		dialogManager.create((dp) => (
-			<DeleteDialog {...dp} locationId={path.location_id!} pathIds={[path.id]} />
+			<DeleteDialog
+				{...dp}
+				locationId={path.location_id!}
+				pathIds={[path.id]}
+				includesDirectorys={path.is_dir ?? false}
+				includesFiles={!path.is_dir}
+			/>
 		));
 	});
 

--- a/interface/hooks/useKeyDeleteFile.tsx
+++ b/interface/hooks/useKeyDeleteFile.tsx
@@ -2,6 +2,7 @@ import { useKey } from 'rooks';
 import type { ExplorerItem } from '@sd/client';
 import { dialogManager } from '@sd/ui';
 import DeleteDialog from '~/app/$libraryId/Explorer/FilePath/DeleteDialog';
+import { dir } from 'console';
 
 export const useKeyDeleteFile = (selectedItems: Set<ExplorerItem>, locationId?: number | null) => {
 	return useKey('Delete', (e) => {
@@ -10,13 +11,20 @@ export const useKeyDeleteFile = (selectedItems: Set<ExplorerItem>, locationId?: 
 		if (!locationId) return;
 
 		const pathIds: number[] = [];
+		let dirCount = 0;
+		let fileCount = 0;
 
 		for (const item of selectedItems) {
-			if (item.type === 'Path') pathIds.push(item.item.id);
+			if (item.type === 'Path'){
+				 pathIds.push(item.item.id);
+
+				 dirCount += item.item.is_dir ? 1 : 0;
+				 fileCount += item.item.is_dir ? 0 : 1;
+			}
 		}
 
 		dialogManager.create((dp) => (
-			<DeleteDialog {...dp} locationId={locationId} pathIds={pathIds} />
+			<DeleteDialog {...dp} locationId={locationId} pathIds={pathIds} dirCount={dirCount} fileCount={fileCount}/>
 		));
 	});
 };


### PR DESCRIPTION
*Prefix: I'm really new to the project but wanted to try to tackle an issue, I'm not familiar with the Codebase, so if this is totally wrong or there is need to change something please let me know. I would really appreciate it if someone would take the time to give some feedback on this.*

Currently, the delete dialog always says that you are deleting a file, even if it is a directory or a mix of items.

To fix this:
The DeleteDialog now accepts two props, which specify the type of files to be deleted.
Based on this information, the wording is adjusted.

![Example of directory deletion](https://github.com/spacedriveapp/spacedrive/assets/17810881/13e9e0ab-1ced-495d-b6bc-2cda1079c960)
![Example of mix deletion](https://github.com/spacedriveapp/spacedrive/assets/17810881/9f4c4ad4-3f1c-410e-9c83-a5e49754f81c)


Closes #1384
