### PR TITLE
[ENG-1225] Put brakes on thumbnail generation for ephemeral locations

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,7 +3,7 @@
 use crate::{
 	api::{CoreEvent, Router},
 	location::LocationManagerError,
-	object::thumbnail_remover,
+	object::media::thumbnail::actor::Thumbnailer,
 	p2p::sync::NetworkedLibraries,
 };
 
@@ -65,7 +65,7 @@ pub struct Node {
 	pub event_bus: (broadcast::Sender<CoreEvent>, broadcast::Receiver<CoreEvent>),
 	pub notifications: Notifications,
 	pub nlm: Arc<NetworkedLibraries>,
-	pub thumbnail_remover: thumbnail_remover::Actor,
+	pub thumbnailer: Thumbnailer,
 	pub files_over_p2p_flag: Arc<AtomicBool>,
 	pub env: env::Env,
 	pub http: reqwest::Client,
@@ -113,10 +113,7 @@ impl Node {
 			p2p,
 			config,
 			event_bus,
-			thumbnail_remover: thumbnail_remover::Actor::new(
-				data_dir.to_path_buf(),
-				libraries.clone(),
-			),
+			thumbnailer: Thumbnailer::new(data_dir.to_path_buf(), libraries.clone()),
 			libraries,
 			files_over_p2p_flag: Arc::new(AtomicBool::new(false)),
 			http: reqwest::Client::new(),

--- a/core/src/location/indexer/indexer_job.rs
+++ b/core/src/location/indexer/indexer_job.rs
@@ -220,7 +220,7 @@ impl StatefulJob for IndexerJobInit {
 		);
 
 		ctx.node
-			.thumbnail_remover
+			.thumbnailer
 			.remove_cas_ids(
 				to_remove
 					.iter()

--- a/core/src/location/indexer/shallow.rs
+++ b/core/src/location/indexer/shallow.rs
@@ -92,7 +92,7 @@ pub async fn shallow(
 
 	debug!("Walker at shallow indexer found {to_remove_count} file_paths to be removed");
 
-	node.thumbnail_remover
+	node.thumbnailer
 		.remove_cas_ids(
 			to_remove
 				.iter()

--- a/core/src/object/media/thumbnail/actor.rs
+++ b/core/src/object/media/thumbnail/actor.rs
@@ -1,35 +1,42 @@
 use crate::{
 	library::{Libraries, LibraryManagerEvent},
+	object::media::thumbnail::ThumbnailerError,
 	prisma::{file_path, PrismaClient},
 	util::error::{FileIOError, NonUtf8PathError},
 };
 
 use std::{
-	collections::{HashMap, HashSet},
+	collections::{HashMap, HashSet, VecDeque},
 	ffi::OsStr,
 	path::{Path, PathBuf},
 	pin::pin,
 	sync::Arc,
-	time::Duration,
+	time::{Duration, SystemTime},
 };
 
 use async_channel as chan;
 use futures::{future::try_join_all, stream::FuturesUnordered, FutureExt};
-use futures_concurrency::stream::Merge;
+use futures_concurrency::{
+	future::{Join, Race},
+	stream::Merge,
+};
 use thiserror::Error;
 use tokio::{
-	fs, io,
-	time::{interval_at, Instant, MissedTickBehavior},
+	fs, io, spawn,
+	sync::oneshot,
+	time::{interval, interval_at, timeout, Instant, MissedTickBehavior},
 };
 use tokio_stream::{wrappers::IntervalStream, StreamExt};
 use tokio_util::sync::{CancellationToken, DropGuard};
 use tracing::{debug, error, trace};
 use uuid::Uuid;
 
-use super::media::thumbnail::THUMBNAIL_CACHE_DIR_NAME;
+use super::{generate_thumbnail, GenerateThumbnailArgs, THUMBNAIL_CACHE_DIR_NAME};
 
+const ONE_SEC: Duration = Duration::from_secs(1);
 const THIRTY_SECS: Duration = Duration::from_secs(30);
 const HALF_HOUR: Duration = Duration::from_secs(30 * 60);
+const ONE_WEEK: Duration = Duration::from_secs(7 * 24 * 60 * 60);
 
 #[derive(Error, Debug)]
 enum Error {
@@ -49,19 +56,24 @@ enum DatabaseMessage {
 	Remove(Uuid),
 }
 
-pub struct Actor {
+// Thumbnails directory have the following structure:
+// thumbnails/
+// ├── version.txt
+//└── <cas_id>[0..2]/ # sharding
+//    └── <cas_id>.webp
+pub struct Thumbnailer {
 	cas_ids_to_delete_tx: chan::Sender<Vec<String>>,
-	non_indexed_thumbnails_cas_ids_tx: chan::Sender<String>,
+	ephemeral_thumbnails_to_generate_tx: chan::Sender<Vec<GenerateThumbnailArgs>>,
 	_cancel_loop: DropGuard,
 }
 
-impl Actor {
+impl Thumbnailer {
 	pub fn new(data_dir: PathBuf, lm: Arc<Libraries>) -> Self {
 		let mut thumbnails_directory = data_dir;
 		thumbnails_directory.push(THUMBNAIL_CACHE_DIR_NAME);
 
 		let (databases_tx, databases_rx) = chan::bounded(4);
-		let (non_indexed_thumbnails_cas_ids_tx, non_indexed_thumbnails_cas_ids_rx) =
+		let (ephemeral_thumbnails_to_generate_tx, ephemeral_thumbnails_to_generate_rx) =
 			chan::unbounded();
 		let (cas_ids_to_delete_tx, cas_ids_to_delete_rx) = chan::bounded(16);
 		let cancel_token = CancellationToken::new();
@@ -73,7 +85,7 @@ impl Actor {
 					thumbnails_directory.clone(),
 					databases_rx.clone(),
 					cas_ids_to_delete_rx.clone(),
-					non_indexed_thumbnails_cas_ids_rx.clone(),
+					ephemeral_thumbnails_to_generate_rx.clone(),
 					inner_cancel_token.child_token(),
 				))
 				.await
@@ -131,7 +143,7 @@ impl Actor {
 
 		Self {
 			cas_ids_to_delete_tx,
-			non_indexed_thumbnails_cas_ids_tx,
+			ephemeral_thumbnails_to_generate_tx,
 			_cancel_loop: cancel_token.drop_guard(),
 		}
 	}
@@ -140,44 +152,107 @@ impl Actor {
 		thumbnails_directory: PathBuf,
 		databases_rx: chan::Receiver<DatabaseMessage>,
 		cas_ids_to_delete_rx: chan::Receiver<Vec<String>>,
-		non_indexed_thumbnails_cas_ids_rx: chan::Receiver<String>,
+		ephemeral_thumbnails_to_generate_rx: chan::Receiver<Vec<GenerateThumbnailArgs>>,
 		cancel_token: CancellationToken,
 	) {
-		let mut check_interval = interval_at(Instant::now() + THIRTY_SECS, HALF_HOUR);
-		check_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+		let mut to_remove_interval = interval_at(Instant::now() + THIRTY_SECS, HALF_HOUR);
+		to_remove_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+		let mut idle_interval = interval(ONE_SEC);
+		idle_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
 		let mut databases = HashMap::new();
-		let mut non_indexed_thumbnails_cas_ids = HashSet::new();
+		let mut ephemeral_thumbnails_cas_ids = HashSet::new();
 
 		#[derive(Debug)]
 		enum StreamMessage {
-			Run,
+			RemovalTick,
 			ToDelete(Vec<String>),
 			Database(DatabaseMessage),
-			NonIndexedThumbnail(String),
+			EphemeralThumbnailNewBatch(Vec<GenerateThumbnailArgs>),
+			Leftovers(Vec<GenerateThumbnailArgs>),
+			NewEphemeralThumbnailCasIds(Vec<String>),
 			Stop,
+			IdleTick,
 		}
 
 		let cancel = pin!(cancel_token.cancelled());
 
+		// This is a LIFO queue, so we can process the most recent thumbnails first
+		let mut ephemeral_thumbnails_queue = Vec::with_capacity(8);
+
+		// This one is a FIFO queue, so we can process leftovers from the previous batch first
+		let mut ephemeral_thumbnails_leftovers_queue = VecDeque::with_capacity(8);
+
+		let (ephemeral_thumbnails_cas_ids_tx, ephemeral_thumbnails_cas_ids_rx) = chan::bounded(32);
+		let (leftovers_tx, leftovers_rx) = chan::bounded(8);
+
+		let (stop_older_processing_tx, stop_older_processing_rx) = chan::bounded(1);
+
+		let mut current_batch_processing_rx: Option<oneshot::Receiver<()>> = None;
+
 		let mut msg_stream = (
 			databases_rx.map(StreamMessage::Database),
 			cas_ids_to_delete_rx.map(StreamMessage::ToDelete),
-			non_indexed_thumbnails_cas_ids_rx.map(StreamMessage::NonIndexedThumbnail),
-			IntervalStream::new(check_interval).map(|_| StreamMessage::Run),
+			ephemeral_thumbnails_to_generate_rx.map(StreamMessage::EphemeralThumbnailNewBatch),
+			leftovers_rx.map(StreamMessage::Leftovers),
+			ephemeral_thumbnails_cas_ids_rx.map(StreamMessage::NewEphemeralThumbnailCasIds),
+			IntervalStream::new(to_remove_interval).map(|_| StreamMessage::RemovalTick),
+			IntervalStream::new(idle_interval).map(|_| StreamMessage::IdleTick),
 			cancel.into_stream().map(|()| StreamMessage::Stop),
 		)
 			.merge();
 
 		while let Some(msg) = msg_stream.next().await {
 			match msg {
-				StreamMessage::Run => {
+				StreamMessage::IdleTick => {
+					if let Some(done_rx) = current_batch_processing_rx.as_mut() {
+						// Checking if the previous run finished or was aborted to clean state
+						if matches!(
+							done_rx.try_recv(),
+							Ok(()) | Err(oneshot::error::TryRecvError::Closed)
+						) {
+							current_batch_processing_rx = None;
+						}
+					}
+
+					if current_batch_processing_rx.is_none()
+						&& (!ephemeral_thumbnails_queue.is_empty()
+							|| !ephemeral_thumbnails_leftovers_queue.is_empty())
+					{
+						let (done_tx, done_rx) = oneshot::channel();
+						current_batch_processing_rx = Some(done_rx);
+
+						if let Some(batch) = ephemeral_thumbnails_queue.pop() {
+							spawn(batch_processor(
+								batch,
+								ephemeral_thumbnails_cas_ids_tx.clone(),
+								stop_older_processing_rx.clone(),
+								done_tx,
+								leftovers_tx.clone(),
+								false,
+							));
+						} else if let Some(batch) = ephemeral_thumbnails_leftovers_queue.pop_front()
+						{
+							spawn(batch_processor(
+								batch,
+								ephemeral_thumbnails_cas_ids_tx.clone(),
+								stop_older_processing_rx.clone(),
+								done_tx,
+								leftovers_tx.clone(),
+								true,
+							));
+						}
+					}
+				}
+
+				StreamMessage::RemovalTick => {
 					// For any of them we process a clean up if a time since the last one already passed
 					if !databases.is_empty() {
 						if let Err(e) = Self::process_clean_up(
 							&thumbnails_directory,
 							databases.values(),
-							&non_indexed_thumbnails_cas_ids,
+							&ephemeral_thumbnails_cas_ids,
 						)
 						.await
 						{
@@ -195,14 +270,27 @@ impl Actor {
 					}
 				}
 
+				StreamMessage::EphemeralThumbnailNewBatch(batch) => {
+					ephemeral_thumbnails_queue.push(batch);
+					if current_batch_processing_rx.is_some() // Only sends stop signal if there is a batch being processed
+						&& stop_older_processing_tx.send(()).await.is_err()
+					{
+						error!("Thumbnail remover actor died when trying to stop older processing");
+					}
+				}
+
+				StreamMessage::Leftovers(batch) => {
+					ephemeral_thumbnails_leftovers_queue.push_back(batch);
+				}
+
 				StreamMessage::Database(DatabaseMessage::Add(id, db)) => {
 					databases.insert(id, db);
 				}
 				StreamMessage::Database(DatabaseMessage::Remove(id)) => {
 					databases.remove(&id);
 				}
-				StreamMessage::NonIndexedThumbnail(cas_id) => {
-					non_indexed_thumbnails_cas_ids.insert(cas_id);
+				StreamMessage::NewEphemeralThumbnailCasIds(cas_ids) => {
+					ephemeral_thumbnails_cas_ids.extend(cas_ids);
 				}
 				StreamMessage::Stop => {
 					debug!("Thumbnail remover actor is stopping");
@@ -218,7 +306,7 @@ impl Actor {
 	) -> Result<(), Error> {
 		try_join_all(cas_ids.into_iter().map(|cas_id| async move {
 			let thumbnail_path =
-				thumbnails_directory.join(format!("{}/{}.webp", &cas_id[0..2], &cas_id[2..]));
+				thumbnails_directory.join(format!("{}/{cas_id}.webp", &cas_id[0..2]));
 
 			trace!("Removing thumbnail: {}", thumbnail_path.display());
 
@@ -239,12 +327,6 @@ impl Actor {
 		non_indexed_thumbnails_cas_ids: &HashSet<String>,
 	) -> Result<(), Error> {
 		let databases = databases.collect::<Vec<_>>();
-
-		// Thumbnails directory have the following structure:
-		// thumbnails/
-		// ├── version.txt
-		//└── <cas_id>[0..2]/ # sharding
-		//    └── <cas_id>.webp
 
 		fs::create_dir_all(&thumbnails_directory)
 			.await
@@ -336,22 +418,40 @@ impl Actor {
 			thumbnails_paths_by_cas_id
 				.retain(|cas_id, _| !non_indexed_thumbnails_cas_ids.contains(cas_id));
 
-			let thumbs_to_remove = thumbnails_paths_by_cas_id.len();
+			let now = SystemTime::now();
 
-			try_join_all(
-				thumbnails_paths_by_cas_id
-					.into_values()
-					.map(|path| async move {
-						trace!("Removing stale thumbnail: {}", path.display());
-						fs::remove_file(&path)
-							.await
-							.map_err(|e| FileIOError::from((path, e)))
-					}),
-			)
-			.await?;
+			let removed_count = try_join_all(thumbnails_paths_by_cas_id.into_values().map(
+				|path| async move {
+					if let Ok(metadata) = fs::metadata(&path).await {
+						if metadata
+							.accessed()
+							.map(|when| {
+								now.duration_since(when)
+									.map(|duration| duration < ONE_WEEK)
+									.unwrap_or(false)
+							})
+							.unwrap_or(false)
+						{
+							// If the thumbnail was accessed in the last week, we don't remove it yet
+							// as the file is probably still in use
+							return Ok(false);
+						}
+					}
 
-			if thumbs_to_remove == thumbs_found {
-				// if we removed all the thumnails we foumd, it means that the directory is empty
+					tracing::warn!("Removing stale thumbnail: {}", path.display());
+					fs::remove_file(&path)
+						.await
+						.map(|()| true)
+						.map_err(|e| FileIOError::from((path, e)))
+				},
+			))
+			.await?
+			.into_iter()
+			.filter(|r| *r)
+			.count();
+
+			if thumbs_found == removed_count {
+				// if we removed all the thumnails we found, it means that the directory is empty
 				// and can be removed...
 				trace!(
 					"Removing empty thumbnails sharding directory: {}",
@@ -366,20 +466,121 @@ impl Actor {
 		Ok(())
 	}
 
-	pub async fn new_non_indexed_thumbnail(&self, cas_id: String) {
+	pub async fn new_non_indexed_thumbnails_batch(&self, batch: Vec<GenerateThumbnailArgs>) {
 		if self
-			.non_indexed_thumbnails_cas_ids_tx
-			.send(cas_id)
+			.ephemeral_thumbnails_to_generate_tx
+			.send(batch)
 			.await
 			.is_err()
 		{
-			error!("Thumbnail remover actor is dead");
+			error!("Thumbnail remover actor is dead: Failed to send new batch");
 		}
 	}
 
 	pub async fn remove_cas_ids(&self, cas_ids: Vec<String>) {
 		if self.cas_ids_to_delete_tx.send(cas_ids).await.is_err() {
-			error!("Thumbnail remover actor is dead");
+			error!("Thumbnail remover actor is dead: Failed to send cas ids to delete");
 		}
 	}
+}
+
+async fn batch_processor(
+	batch: Vec<GenerateThumbnailArgs>,
+	generated_cas_ids_tx: chan::Sender<Vec<String>>,
+	stop_rx: chan::Receiver<()>,
+	done_tx: oneshot::Sender<()>,
+	leftovers_tx: chan::Sender<Vec<GenerateThumbnailArgs>>,
+	in_background: bool,
+) {
+	let mut queue = VecDeque::from(batch);
+
+	enum RaceOutputs {
+		CasIds(Vec<String>),
+		Stop,
+	}
+
+	while !queue.is_empty() {
+		let chunk = (0..4)
+			.filter_map(|_| queue.pop_front())
+			.map(
+				|GenerateThumbnailArgs {
+				     extension,
+				     cas_id,
+				     path,
+				     node,
+				 }| {
+					spawn(async move {
+						timeout(
+							THIRTY_SECS,
+							generate_thumbnail(&extension, cas_id, &path, node, in_background),
+						)
+						.await
+						.unwrap_or_else(|_| Err(ThumbnailerError::TimedOut(path.into_boxed_path())))
+					})
+				},
+			)
+			.collect::<Vec<_>>();
+
+		match (
+			async move {
+				let cas_ids = chunk
+					.join()
+					.await
+					.into_iter()
+					.filter_map(|join_result| {
+						join_result
+							.map_err(|e| error!("Failed to join thumbnail generation task: {e:#?}"))
+							.ok()
+					})
+					.filter_map(|result| {
+						result
+							.map_err(|e| {
+								error!(
+									"Failed to generate thumbnail for ephemeral location: {e:#?}"
+								)
+							})
+							.ok()
+					})
+					.collect();
+
+				trace!("Processed chunk of thumbnails");
+				RaceOutputs::CasIds(cas_ids)
+			},
+			async {
+				stop_rx
+					.recv()
+					.await
+					.expect("Critical error on thumbnails actor");
+				trace!("Received a stop signal");
+				RaceOutputs::Stop
+			},
+		)
+			.race()
+			.await
+		{
+			RaceOutputs::CasIds(cas_ids) => {
+				if generated_cas_ids_tx.send(cas_ids).await.is_err() {
+					error!("Thumbnail remover actor is dead: Failed to send generated cas ids")
+				}
+			}
+			RaceOutputs::Stop => {
+				// Our queue is always contiguous, so this `from`` is free
+				let leftovers = Vec::from(queue);
+
+				trace!(
+					"Stopped with {} thumbnails left to process",
+					leftovers.len()
+				);
+				if !leftovers.is_empty() && leftovers_tx.send(leftovers).await.is_err() {
+					error!("Thumbnail remover actor is dead: Failed to send leftovers")
+				}
+
+				done_tx.send(()).ok();
+
+				return;
+			}
+		}
+	}
+
+	done_tx.send(()).ok();
 }

--- a/core/src/object/mod.rs
+++ b/core/src/object/mod.rs
@@ -9,7 +9,6 @@ pub mod fs;
 pub mod media;
 pub mod orphan_remover;
 pub mod tag;
-pub mod thumbnail_remover;
 pub mod validation;
 
 // Objects are primarily created by the identifier from Paths

--- a/core/src/volume/watcher.rs
+++ b/core/src/volume/watcher.rs
@@ -7,7 +7,7 @@ use tokio::{
 	time::{interval, Duration},
 };
 
-use super::{get_volumes, Volume};
+use super::get_volumes;
 
 pub fn spawn_volume_watcher(library: Arc<Library>) {
 	spawn(async move {
@@ -21,11 +21,7 @@ pub fn spawn_volume_watcher(library: Arc<Library>) {
 
 			if existing_volumes != current_volumes {
 				existing_volumes = current_volumes;
-				invalidate_query!(
-					&library,
-					"volumes.list": (),
-					()
-				);
+				invalidate_query!(&library, "volumes.list");
 			}
 		}
 	});

--- a/crates/ffmpeg/src/lib.rs
+++ b/crates/ffmpeg/src/lib.rs
@@ -18,8 +18,8 @@ pub use thumbnailer::{Thumbnailer, ThumbnailerBuilder};
 
 /// Helper function to generate a thumbnail file from a video file with reasonable defaults
 pub async fn to_thumbnail(
-	video_file_path: impl AsRef<Path> + Send,
-	output_thumbnail_path: impl AsRef<Path> + Send,
+	video_file_path: impl AsRef<Path>,
+	output_thumbnail_path: impl AsRef<Path>,
 	size: u32,
 	quality: f32,
 ) -> Result<(), ThumbnailerError> {
@@ -34,7 +34,7 @@ pub async fn to_thumbnail(
 
 /// Helper function to generate a thumbnail bytes from a video file with reasonable defaults
 pub async fn to_webp_bytes(
-	video_file_path: impl AsRef<Path> + Send,
+	video_file_path: impl AsRef<Path>,
 	size: u32,
 	quality: f32,
 ) -> Result<Vec<u8>, ThumbnailerError> {

--- a/crates/ffmpeg/src/thumbnailer.rs
+++ b/crates/ffmpeg/src/thumbnailer.rs
@@ -16,8 +16,8 @@ impl Thumbnailer {
 	/// Processes an video input file and write to file system a thumbnail with webp format
 	pub async fn process(
 		&self,
-		video_file_path: impl AsRef<Path> + Send,
-		output_thumbnail_path: impl AsRef<Path> + Send,
+		video_file_path: impl AsRef<Path>,
+		output_thumbnail_path: impl AsRef<Path>,
 	) -> Result<(), ThumbnailerError> {
 		let path = output_thumbnail_path.as_ref().parent().ok_or_else(|| {
 			io::Error::new(
@@ -39,7 +39,7 @@ impl Thumbnailer {
 	/// Processes an video input file and returns a webp encoded thumbnail as bytes
 	pub async fn process_to_webp_bytes(
 		&self,
-		video_file_path: impl AsRef<Path> + Send,
+		video_file_path: impl AsRef<Path>,
 	) -> Result<Vec<u8>, ThumbnailerError> {
 		let video_file_path = video_file_path.as_ref().to_path_buf();
 		let prefer_embedded_metadata = self.builder.prefer_embedded_metadata;


### PR DESCRIPTION
This PR introduces new capabilities to our thumbnailer actor, procing thumbnails in batches and with background processing for ephemeral locations, prioritizing the directory the user has opened in the explorer.