### PR TITLE
[ENG-1250] Fix windows mouse navigation

### DIFF
--- a/interface/app/$libraryId/TopBar/NavigationButtons.tsx
+++ b/interface/app/$libraryId/TopBar/NavigationButtons.tsx
@@ -23,6 +23,7 @@ export const NavigationButtons = () => {
 	});
 
 	useEffect(() => {
+		if (os === 'windows') return; //windows already navigates back and forth with mouse buttons
 		const onMouseDown = (e: MouseEvent) => {
 			e.stopPropagation();
 			if (e.buttons === 8) {
@@ -35,7 +36,7 @@ export const NavigationButtons = () => {
 		};
 		window.addEventListener('mousedown', onMouseDown);
 		return () => window.removeEventListener('mousedown', onMouseDown);
-	}, [navigate, idx, isFocused]);
+	}, [navigate, idx, isFocused, os]);
 
 	return (
 		<div data-tauri-drag-region={os === 'macOS'} className="flex">


### PR DESCRIPTION
- Users reported that the navigation on windows using mouse was navigating 2 routes back and forth. This is due to the useEffect, however, after testing, it seems by default Tauri offers this by default for windows.

Tested on Windows and can confirm it's all good.