### PR TITLE
fix text viewer duplicate content on rerender & shrink font

### DIFF
--- a/interface/components/TextViewer/index.tsx
+++ b/interface/components/TextViewer/index.tsx
@@ -24,12 +24,13 @@ export const TextViewer = memo(
 		const rowVirtualizer = useVirtualizer({
 			count: lines.length,
 			getScrollElement: () => parentRef.current,
-			estimateSize: () => 25
+			estimateSize: () => 22
 		});
 
 		useEffect(() => {
 			// Ignore empty urls
 			if (!src || src === '#') return;
+			if (lines.length) return;
 
 			const controller = new AbortController();
 			fetch(src, {
@@ -68,7 +69,7 @@ export const TextViewer = memo(
 				<div
 					tabIndex={0}
 					className={clsx(
-						'relative w-full whitespace-pre text-ink',
+						'relative w-full whitespace-pre text-sm text-ink',
 						codeExtension &&
 							`language-${prism.languageMapping.get(codeExtension) ?? codeExtension}`
 					)}


### PR DESCRIPTION
Fixes the text viewer duplicating file content on rerender

issue spotted by [Tim on the Discord](https://discord.com/channels/949090953497567312/1121730047993200640/1161808831647584407)

### Before
https://github.com/spacedriveapp/spacedrive/assets/65303441/70c1e8d1-ab65-4c19-a2dc-7bea7b8f0e80

### After
https://github.com/spacedriveapp/spacedrive/assets/65303441/b8eae6bc-ab21-442b-b96b-e3851b597385

Also shrinks the size of the text to fit more content on screen:

<img width="400" alt="Screenshot 2023-10-12 at 11 02 30 AM" src="https://github.com/spacedriveapp/spacedrive/assets/65303441/27767ff2-433c-4289-b9e8-531c23f46473">
<img width="400" alt="Screenshot 2023-10-12 at 11 03 40 AM" src="https://github.com/spacedriveapp/spacedrive/assets/65303441/4f7a3ad3-22e3-48e2-9022-e678a527d293">

