### PR TITLE
[ENG-1160] Opening a location while indexing causes a lot of jobs to be spawned

### DIFF
--- a/core/src/location/indexer/indexer_job.rs
+++ b/core/src/location/indexer/indexer_job.rs
@@ -150,6 +150,10 @@ impl StatefulJob for IndexerJobInit {
 	const NAME: &'static str = "indexer";
 	const IS_BATCHED: bool = true;
 
+	fn target_location(&self) -> location::id::Type {
+		self.location.id
+	}
+
 	/// Creates a vector of valid path buffers from a directory, chunked into batches of `BATCH_SIZE`.
 	async fn init(
 		&self,

--- a/core/src/location/indexer/shallow.rs
+++ b/core/src/location/indexer/shallow.rs
@@ -90,8 +90,6 @@ pub async fn shallow(
 
 	let to_remove_count = to_remove.len();
 
-	debug!("Walker at shallow indexer found {to_remove_count} file_paths to be removed");
-
 	node.thumbnailer
 		.remove_cas_ids(
 			to_remove
@@ -167,11 +165,14 @@ pub async fn shallow(
 		})
 		.collect::<Vec<_>>();
 
-	debug!("Walker at shallow indexer found {to_update_count} file_paths to be updated");
-
 	for step in update_steps {
 		execute_indexer_update_step(&step, library).await?;
 	}
+
+	debug!(
+		"Walker at shallow indexer found: \
+		To create: {to_create_count}; To update: {to_update_count}; To remove: {to_remove_count};"
+	);
 
 	if to_create_count > 0 || to_update_count > 0 || to_remove_count > 0 {
 		if to_walk_path != location_path {

--- a/core/src/object/file_identifier/file_identifier_job.rs
+++ b/core/src/object/file_identifier/file_identifier_job.rs
@@ -77,6 +77,10 @@ impl StatefulJob for FileIdentifierJobInit {
 	const NAME: &'static str = "file_identifier";
 	const IS_BATCHED: bool = true;
 
+	fn target_location(&self) -> location::id::Type {
+		self.location.id
+	}
+
 	async fn init(
 		&self,
 		ctx: &WorkerContext,

--- a/core/src/object/fs/copy.rs
+++ b/core/src/object/fs/copy.rs
@@ -54,6 +54,10 @@ impl StatefulJob for FileCopierJobInit {
 
 	const NAME: &'static str = "file_copier";
 
+	fn target_location(&self) -> location::id::Type {
+		self.target_location_id
+	}
+
 	async fn init(
 		&self,
 		ctx: &WorkerContext,

--- a/core/src/object/fs/cut.rs
+++ b/core/src/object/fs/cut.rs
@@ -42,6 +42,10 @@ impl StatefulJob for FileCutterJobInit {
 
 	const NAME: &'static str = "file_cutter";
 
+	fn target_location(&self) -> location::id::Type {
+		self.target_location_id
+	}
+
 	async fn init(
 		&self,
 		ctx: &WorkerContext,

--- a/core/src/object/fs/delete.rs
+++ b/core/src/object/fs/delete.rs
@@ -33,6 +33,10 @@ impl StatefulJob for FileDeleterJobInit {
 
 	const NAME: &'static str = "file_deleter";
 
+	fn target_location(&self) -> location::id::Type {
+		self.location_id
+	}
+
 	async fn init(
 		&self,
 		ctx: &WorkerContext,

--- a/core/src/object/fs/erase.rs
+++ b/core/src/object/fs/erase.rs
@@ -62,6 +62,10 @@ impl StatefulJob for FileEraserJobInit {
 
 	const NAME: &'static str = "file_eraser";
 
+	fn target_location(&self) -> location::id::Type {
+		self.location_id
+	}
+
 	async fn init(
 		&self,
 		ctx: &WorkerContext,

--- a/core/src/object/media/media_processor/job.rs
+++ b/core/src/object/media/media_processor/job.rs
@@ -67,6 +67,10 @@ impl StatefulJob for MediaProcessorJobInit {
 	const NAME: &'static str = "media_processor";
 	const IS_BATCHED: bool = true;
 
+	fn target_location(&self) -> location::id::Type {
+		self.location.id
+	}
+
 	async fn init(
 		&self,
 		ctx: &WorkerContext,

--- a/core/src/object/media/thumbnail/actor.rs
+++ b/core/src/object/media/thumbnail/actor.rs
@@ -59,7 +59,7 @@ enum DatabaseMessage {
 // Thumbnails directory have the following structure:
 // thumbnails/
 // ├── version.txt
-//└── <cas_id>[0..2]/ # sharding
+// └── <cas_id>[0..2]/ # sharding
 //    └── <cas_id>.webp
 pub struct Thumbnailer {
 	cas_ids_to_delete_tx: chan::Sender<Vec<String>>,

--- a/core/src/object/media/thumbnail/mod.rs
+++ b/core/src/object/media/thumbnail/mod.rs
@@ -102,6 +102,7 @@ pub enum ThumbnailerError {
 	SdImages(#[from] sd_images::Error),
 	#[error("failed to execute converting task: {0}")]
 	Task(#[from] task::JoinError),
+	#[cfg(feature = "ffmpeg")]
 	#[error(transparent)]
 	FFmpeg(#[from] sd_ffmpeg::ThumbnailerError),
 	#[error("thumbnail generation timed out for {}", .0.display())]

--- a/core/src/object/validation/validator_job.rs
+++ b/core/src/object/validation/validator_job.rs
@@ -58,6 +58,10 @@ impl StatefulJob for ObjectValidatorJobInit {
 
 	const NAME: &'static str = "object_validator";
 
+	fn target_location(&self) -> location::id::Type {
+		self.location.id
+	}
+
 	async fn init(
 		&self,
 		ctx: &WorkerContext,


### PR DESCRIPTION
This PR solves a race condition between the indexer job and the shallow indexer. When you're trying to index a big location and then open it up in the explorer, it dispatches a shallow indexer, that will find a bunch of directories in the location root directory and then as these directories are "brand new" according to the shallow indexer, it will dispatches a bunch of new scan locations with sub_path actions, with a bunch of new indexer jobs. 

I introduced a way to query the job manager to see if there are running jobs that matches a given predicate. With that I forbid quickRescan rspc route to run while there are running indexer and file identifier jobs running for a given location.

I tried to emit an error toast to the frontend warning the user, but failed hard. Can use some help from front-end guys in this regard.