### PR TITLE
Reduce production logs + button on error page for logs

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -168,12 +168,12 @@ impl Node {
 			.with(
 				tracing_fmt::Subscriber::new()
 					.with_ansi(false)
+					.with_writer(logfile)
 					.with_filter(
 						EnvFilter::builder()
 							.from_env()?
 							.add_directive("info".parse()?),
-					)
-					.with_writer(logfile),
+					),
 			)
 			.with(
 				tracing_fmt::Subscriber::new()

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -168,6 +168,11 @@ impl Node {
 			.with(
 				tracing_fmt::Subscriber::new()
 					.with_ansi(false)
+					.with_filter(
+						EnvFilter::builder()
+							.from_env()?
+							.add_directive("info".parse()?),
+					)
 					.with_writer(logfile),
 			)
 			.with(

--- a/interface/ErrorFallback.tsx
+++ b/interface/ErrorFallback.tsx
@@ -6,6 +6,7 @@ import { Button, Dialogs } from '@sd/ui';
 
 import { showAlertDialog } from './components';
 import { useOperatingSystem, useTheme } from './hooks';
+import { usePlatform } from './util/Platform';
 
 export function RouterErrorBoundary() {
 	const error = useRouteError();
@@ -56,6 +57,7 @@ export function ErrorPage({
 	useTheme();
 	const debug = useDebugState();
 	const os = useOperatingSystem();
+	const platform = usePlatform();
 	const isMacOS = os === 'macOS';
 
 	const resetHandler = () => {
@@ -97,11 +99,19 @@ export function ErrorPage({
 						Reload
 					</Button>
 				)}
-				{sendReportBtn && (
-					<Button variant="gray" className="mt-2" onClick={sendReportBtn}>
-						Send report
+				<Button
+					variant="gray"
+					className="mt-2"
+					onClick={() => (sendReportBtn ? sendReportBtn() : captureException(message))}
+				>
+					Send report
+				</Button>
+				{platform.openLogsDir && (
+					<Button variant="gray" className="mt-2" onClick={platform.openLogsDir}>
+						Open Logs
 					</Button>
 				)}
+
 				{(errorsThatRequireACoreReset.includes(message) ||
 					message.startsWith('NodeError::FailedToInitializeConfig') ||
 					message.startsWith('failed to initialize library manager')) && (


### PR DESCRIPTION
Tried to make the logging configurable from settings but our tracing config is painful cause `tracing-appender`'s crates.io version is sooooo old.