### PR TITLE
[ENG-1272] Tag color picker switches back to first tag when releasing the mouse

### DIFF
--- a/interface/app/$libraryId/settings/library/tags/index.tsx
+++ b/interface/app/$libraryId/settings/library/tags/index.tsx
@@ -26,7 +26,7 @@ export const Component = () => {
 	useEffect(() => {
 		if (tags?.data?.length || (0 > 1 && !selectedTag)) setSelectedTag(tags.data?.[0] ?? null);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [tags?.data]);
+	}, []);
 
 	return (
 		<>


### PR DESCRIPTION
useEffect was triggering a re-render when updating the tag, therefore re-selecting the first tag. Dependancy is not needed for initial selection on page load. Tested and confirmed.
