### PR TITLE
[ENG-1274] Update explorer path bar shortcut + keybindings

### DIFF
--- a/interface/app/$libraryId/Explorer/index.tsx
+++ b/interface/app/$libraryId/Explorer/index.tsx
@@ -27,6 +27,7 @@ export default function Explorer(props: PropsWithChildren<Props>) {
 	const explorer = useExplorerContext();
 	const layoutStore = useExplorerLayoutStore();
 	const metaCtrlKey = useKeyMatcher('Meta').key;
+	const optionAltKey = useKeyMatcher('Alt').key;
 
 	const showPathBar = explorer.showPathBar && layoutStore.showPathBar;
 
@@ -43,7 +44,7 @@ export default function Explorer(props: PropsWithChildren<Props>) {
 		}
 	});
 
-	useKeybind([metaCtrlKey, 'p'], (e) => {
+	useKeybind([optionAltKey, metaCtrlKey, 'p'], (e) => {
 		e.stopPropagation();
 		getExplorerLayoutStore().showPathBar = !layoutStore.showPathBar;
 	});
@@ -54,7 +55,7 @@ export default function Explorer(props: PropsWithChildren<Props>) {
 				<div className="flex-1 overflow-hidden">
 					<div
 						ref={explorer.scrollRef}
-						className="custom-scroll explorer-scroll h-screen overflow-x-hidden"
+						className="h-screen overflow-x-hidden custom-scroll explorer-scroll"
 						style={
 							{
 								'--scrollbar-margin-top': `${TOP_BAR_HEIGHT}px`,

--- a/interface/app/$libraryId/settings/client/keybindings.tsx
+++ b/interface/app/$libraryId/settings/client/keybindings.tsx
@@ -135,10 +135,10 @@ const shortcutCategories: Record<string, Shortcut[]> = {
 			action: 'Show path bar',
 			keys: {
 				macOS: {
-					value: [modifierSymbols.Meta.macOS, 'p']
+					value: [modifierSymbols.Alt.macOS, modifierSymbols.Meta.macOS, 'p']
 				},
 				all: {
-					value: [modifierSymbols.Control.Other, 'p']
+					value: [modifierSymbols.Alt.Other, modifierSymbols.Control.Other, 'p']
 				}
 			}
 		},
@@ -279,7 +279,7 @@ function createKeybindColumns(os: OperatingSystem) {
 				});
 				return shortcuts.map((shortcut, idx) => {
 					if (shortcut) {
-						if (shortcut.length <= 5) {
+						if (shortcut.length > 2) {
 							return (
 								<div key={idx.toString()} className="inline-flex items-center">
 									<kbd
@@ -292,15 +292,13 @@ function createKeybindColumns(os: OperatingSystem) {
 							);
 						} else {
 							return shortcut?.split(' ').map(([key], idx) => {
-								const controlSymbolCheck =
-									key === '⌘' ? (os === 'macOS' ? '⌘' : 'Ctrl') : key;
 								return (
 									<div key={idx.toString()} className="inline-flex items-center">
 										<kbd
 											className="ml-2 rounded-lg border border-app-line bg-app-box px-2 py-1 text-[10.5px] tracking-widest shadow"
 											key={idx.toString()}
 										>
-											{controlSymbolCheck}
+											{key}
 										</kbd>
 									</div>
 								);

--- a/interface/util/keybinds.ts
+++ b/interface/util/keybinds.ts
@@ -30,7 +30,12 @@ export function keybind<T extends string>(
 		return symbol[os] ?? symbol.Other;
 	});
 
-	return [...modifierSymbol, ...keySymbol].join(os === 'macOS' ? '' : '+');
+	const value = [...modifierSymbol, ...keySymbol].join(os === 'macOS' ? '' : '+');
+
+	//we don't want modifer symbols and key symbols to be duplicated if they are the same value
+	const noDuplicates = [...new Set(value.split('+'))].join('+');
+
+	return noDuplicates;
 }
 
 export function keybindForOs(

--- a/packages/ui/src/keys.ts
+++ b/packages/ui/src/keys.ts
@@ -1,6 +1,7 @@
 // https://www.w3.org/TR/uievents-key/#keys-modifier
 export enum ModifierKeys {
 	Alt = 'Alt',
+	Shift = 'Shift',
 	AltGraph = 'AltGraph',
 	CapsLock = 'CapsLock',
 	Control = 'Control',
@@ -9,7 +10,6 @@ export enum ModifierKeys {
 	Meta = 'Meta',
 	NumLock = 'NumLock',
 	ScrollLock = 'ScrollLock',
-	Shift = 'Shift',
 	Symbol = 'Symbol',
 	SymbolLock = 'SymbolLock'
 }
@@ -20,8 +20,8 @@ export const modifierSymbols: Record<
 	ModifierKeys,
 	{ macOS?: string; Windows?: string; Other: string }
 > = {
-	Alt: { macOS: '⌥', Other: '⎇' },
-	AltGraph: { macOS: '⌥', Other: '⎇' },
+	Alt: { macOS: '⌥', Other: 'Alt' },
+	AltGraph: { macOS: '⌥', Other: 'Alt' },
 	CapsLock: { Other: '⇪' },
 	Control: { macOS: '⌃', Other: 'Ctrl' },
 	Fn: { macOS: 'fn', Other: 'Fn' },
@@ -29,7 +29,7 @@ export const modifierSymbols: Record<
 	Meta: { macOS: '⌘', Windows: '⊞ Win', Other: 'Meta' },
 	NumLock: { macOS: '⇭', Other: 'Num' },
 	ScrollLock: { macOS: '⤓', Other: 'ScrLk' },
-	Shift: { Other: '⇧' },
+	Shift: { Other: 'Shift', macOS: '⇧' },
 	Symbol: { macOS: '⎄', Other: 'Sym' },
 	SymbolLock: { macOS: '⎄', Other: 'Sym' }
 };
@@ -50,6 +50,7 @@ export const keySymbols: Record<string, { macOS?: string; Windows?: string; Othe
 	'End': { macOS: '↘', Other: 'End' },
 	'PageUp': { macOS: '⇞', Other: 'PgUp' },
 	'PageDown': { macOS: '⇟', Other: 'PgDn' },
+	'Shift': { macOS: '⇧', Other: 'Shift'},
 	'PrintScreen': { Other: 'PrtSc' },
 	'ScrollLock': { macOS: '⤓', Other: 'ScrLk' },
 	'Pause': { macOS: '⎉', Other: 'Pause' }


### PR DESCRIPTION
The current shortcut isn't like Finder, ctrl + p on windows toggles it, but also triggers printing on windows.

**Now it's**:

MacOS: option, cmd, p
Windows: Alt, Ctrl, p

Tested both platforms.