### PR TITLE
[ENG-1268] Fix custom indexer rule crashing location scanning

### DIFF
--- a/core/src/location/indexer/rules/mod.rs
+++ b/core/src/location/indexer/rules/mod.rs
@@ -496,7 +496,7 @@ impl TryFrom<&indexer_rule::Data> for IndexerRule {
 		Ok(Self {
 			id: Some(data.id),
 			name: maybe_missing(data.name.clone(), "indexer_rule.name")?,
-			default: maybe_missing(data.default, "indexer_rule.default")?,
+			default: data.default.unwrap_or_default(),
 			rules: rmp_serde::from_slice(maybe_missing(
 				&data.rules_per_kind,
 				"indexer_rule.rules_per_kind",


### PR DESCRIPTION
Fix an optional db property being mistakenly required

Closes: #1093 