### PR TITLE
Remove cargo config templating

### DIFF
--- a/.cargo/config.toml.mustache
+++ b/.cargo/config.toml.mustache
@@ -1,4 +1,5 @@
 [env]
+DEPS_PATH = { relative = true, value = "apps/.deps" }
 {{#protoc}}
 PROTOC = "{{{protoc}}}"
 {{/protoc}}
@@ -6,46 +7,16 @@ PROTOC = "{{{protoc}}}"
 FFMPEG_DIR = "{{{nativeDeps}}}"
 {{/isLinux}}
 
-{{#isMacOS}}
-[target.x86_64-apple-darwin]
-rustflags = ["-L", "{{{nativeDeps}}}/lib"]
-
 [target.x86_64-apple-darwin.heif]
-rustc-link-search = ["{{{nativeDeps}}}/lib"]
 rustc-link-lib = ["heif"]
-
-[target.aarch64-apple-darwin]
-rustflags = ["-L", "{{{nativeDeps}}}/lib"]
-
 [target.aarch64-apple-darwin.heif]
-rustc-link-search = ["{{{nativeDeps}}}/lib"]
 rustc-link-lib = ["heif"]
-{{/isMacOS}}
-
-{{#isWin}}
-[target.x86_64-pc-windows-msvc]
-rustflags = ["-L", "{{{nativeDeps}}}\\lib"]
-
 [target.x86_64-pc-windows-msvc.heif]
-rustc-link-search = ["{{{nativeDeps}}}\\lib"]
 rustc-link-lib = ["heif"]
-{{/isWin}}
-
-{{#isLinux}}
-[target.x86_64-unknown-linux-gnu]
-rustflags = ["-L", "{{{nativeDeps}}}/lib", "-C", "link-arg=-Wl,-rpath=${ORIGIN}/../lib/spacedrive"]
-
 [target.x86_64-unknown-linux-gnu.heif]
-rustc-link-search = ["{{{nativeDeps}}}/lib"]
 rustc-link-lib = ["heif"]
-
-[target.aarch64-unknown-linux-gnu]
-rustflags = ["-L", "{{{nativeDeps}}}/lib", "-C", "link-arg=-Wl,-rpath=${ORIGIN}/../lib/spacedrive"]
-
 [target.aarch64-unknown-linux-gnu.heif]
-rustc-link-search = ["{{{nativeDeps}}}/lib"]
 rustc-link-lib = ["heif"]
-{{/isLinux}}
 
 [alias]
 prisma = "run -p prisma-cli --bin prisma --"

--- a/core/build.rs
+++ b/core/build.rs
@@ -8,4 +8,7 @@ fn main() {
 	let git_hash = String::from_utf8(output.stdout)
 		.expect("Error passing output of `git rev-parse --short HEAD`");
 	println!("cargo:rustc-env=GIT_HASH={git_hash}");
+
+	#[cfg(target_os = "linux")]
+	println!("cargo:rustc-link-arg=-Wl,-rpath=$ORIGIN/../lib/spacedrive");
 }

--- a/crates/ffmpeg/build.rs
+++ b/crates/ffmpeg/build.rs
@@ -1,0 +1,8 @@
+use std::path::Path;
+
+fn main() {
+	println!(
+		"cargo:rustc-link-search={}",
+		Path::new(env!("DEPS_PATH")).join("lib").display()
+	);
+}

--- a/crates/images/build.rs
+++ b/crates/images/build.rs
@@ -1,0 +1,8 @@
+use std::path::Path;
+
+fn main() {
+	println!(
+		"cargo:rustc-link-search={}",
+		Path::new(env!("DEPS_PATH")).join("lib").display()
+	)
+}


### PR DESCRIPTION
Uses relative envs and build scripts instead of absolute urls generated by the mustache template.

Needs testing on Windows and Linux!