### PR TITLE
[ENG-1289] Reload webview support for Windows and Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6787,7 +6787,6 @@ name = "sd-desktop"
 version = "0.1.1"
 dependencies = [
  "axum",
- "dotenv",
  "futures",
  "http",
  "opener",
@@ -6808,6 +6807,8 @@ dependencies = [
  "tokio",
  "tracing 0.2.0",
  "uuid",
+ "webkit2gtk",
+ "webview2-com",
  "window-shadows",
 ]
 

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -9,13 +9,23 @@ repository = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-tauri = { version = "1.5.1", features = ["dialog-all", "linux-protocol-headers", "macos-private-api", "os-all", "path-all", "protocol-all", "shell-all", "updater", "window-all"] }
+tauri = { version = "1.5.1", features = [
+  "dialog-all",
+  "linux-protocol-headers",
+  "macos-private-api",
+  "os-all",
+  "path-all",
+  "protocol-all",
+  "shell-all",
+  "updater",
+  "window-all",
+] }
 
 rspc = { workspace = true, features = ["tauri"] }
 sd-core = { path = "../../../core", features = [
-	"ffmpeg",
-	"location-watcher",
-	"heif",
+  "ffmpeg",
+  "location-watcher",
+  "heif",
 ] }
 tokio = { workspace = true, features = ["sync"] }
 window-shadows = "0.2.1"
@@ -33,16 +43,17 @@ rand = "0.8.5"
 
 prisma-client-rust = { workspace = true }
 sd-prisma = { path = "../../../crates/prisma" }
-dotenv = "0.15.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 sd-desktop-linux = { path = "../crates/linux" }
+webkit2gtk = { version = "0.18.2", features = ["v2_2"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 sd-desktop-macos = { path = "../crates/macos" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 sd-desktop-windows = { path = "../crates/windows" }
+webview2-com = "0.19.1"
 
 [build-dependencies]
 tauri-build = { version = "1.5.0", features = [] }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -41,13 +41,15 @@ async fn reload_webview(app_handle: AppHandle) {
 fn reload_webview_inner(webview: PlatformWebview) {
 	#[cfg(target_os = "macos")]
 	{
-		unsafe { sd_desktop_macos::reload_webview(&(webview.inner() as _)) }
+		unsafe {
+			sd_desktop_macos::reload_webview(&(webview.inner() as _));
+		}
 	}
 	#[cfg(target_os = "linux")]
 	{
 		use webkit2gtk::traits::WebViewExt;
 
-		webview.inner().reload()
+		webview.inner().reload();
 	}
 	#[cfg(target_os = "windows")]
 	unsafe {
@@ -56,6 +58,7 @@ fn reload_webview_inner(webview: PlatformWebview) {
 			.CoreWebView2()
 			.expect("Unable to get handle on inner webview")
 			.Reload()
+			.expect("Unable to reload webview");
 	}
 }
 

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -7,7 +7,7 @@ use std::{fs, path::PathBuf, sync::Arc, time::Duration};
 
 use sd_core::{Node, NodeError};
 
-use tauri::{api::path, ipc::RemoteDomainAccessScope, AppHandle, Manager};
+use tauri::{api::path, ipc::RemoteDomainAccessScope, window::PlatformWebview, AppHandle, Manager};
 use tauri_plugins::{sd_error_plugin, sd_server_plugin};
 use tokio::time::sleep;
 use tracing::error;
@@ -26,6 +26,37 @@ async fn app_ready(app_handle: AppHandle) {
 	let window = app_handle.get_window("main").unwrap();
 
 	window.show().unwrap();
+}
+
+#[tauri::command(async)]
+#[specta::specta]
+async fn reload_webview(app_handle: AppHandle) {
+	app_handle
+		.get_window("main")
+		.expect("Error getting window handle")
+		.with_webview(reload_webview_inner)
+		.expect("Error while reloading webview");
+}
+
+fn reload_webview_inner(webview: PlatformWebview) {
+	#[cfg(target_os = "macos")]
+	{
+		unsafe { sd_desktop_macos::reload_webview(&(webview.inner() as _)) }
+	}
+	#[cfg(target_os = "linux")]
+	{
+		use webkit2gtk::traits::WebViewExt;
+
+		webview.inner().reload()
+	}
+	#[cfg(target_os = "windows")]
+	unsafe {
+		webview
+			.controller()
+			.CoreWebView2()
+			.expect("Unable to get handle on inner webview")
+			.Reload()
+	}
 }
 
 #[tauri::command(async)]
@@ -179,6 +210,7 @@ async fn main() -> tauri::Result<()> {
 			app_ready,
 			reset_spacedrive,
 			open_logs_dir,
+			reload_webview,
 			file::open_file_paths,
 			file::open_ephemeral_files,
 			file::get_file_path_open_with_apps,

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -57,8 +57,7 @@ fn reload_webview_inner(webview: PlatformWebview) {
 			.controller()
 			.CoreWebView2()
 			.expect("Unable to get handle on inner webview")
-			.Reload()
-			.expect("Unable to reload webview");
+			.Reload();
 	}
 }
 

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -76,9 +76,6 @@ const CLIENT_ID: &str = "2abb241e-40b8-4517-a3e3-5594375c8fbb";
 
 #[tokio::main]
 async fn main() -> tauri::Result<()> {
-	#[cfg(debug_assertions)]
-	dotenv::dotenv().ok();
-
 	#[cfg(target_os = "linux")]
 	sd_desktop_linux::normalize_environment();
 

--- a/apps/desktop/src-tauri/src/menu.rs
+++ b/apps/desktop/src-tauri/src/menu.rs
@@ -110,12 +110,29 @@ pub(crate) fn handle_menu_event(event: WindowMenuEvent<Wry>) {
 					.with_webview(|webview| {
 						unsafe { sd_desktop_macos::reload_webview(&(webview.inner() as _)) };
 					})
-					.unwrap();
+					.expect("Error while reloading webview");
 			}
 
-			#[cfg(not(target_os = "macos"))]
+			#[cfg(target_os = "linux")]
 			{
-				unimplemented!();
+				use webkit2gtk::traits::WebViewExt;
+
+				event
+					.window()
+					.with_webview(|webview| webview.inner().reload())
+					.expect("Error while reloading webview");
+			}
+
+			#[cfg(target_os = "windows")]
+			unsafe {
+				event.window().with_webview(|webview| {
+					webview
+						.controller()
+						.CoreWebView2()
+						.expect("Unable to get handle on inner webview")
+						.Reload()
+						.expect("Error while reloading webview")
+				});
 			}
 		}
 		#[cfg(debug_assertions)]

--- a/apps/desktop/src-tauri/src/menu.rs
+++ b/apps/desktop/src-tauri/src/menu.rs
@@ -105,26 +105,7 @@ pub(crate) fn handle_menu_event(event: WindowMenuEvent<Wry>) {
 		"reload_app" => {
 			event
 				.window()
-				.with_webview(|webview| {
-					#[cfg(target_os = "macos")]
-					{
-						unsafe { sd_desktop_macos::reload_webview(&(webview.inner() as _)) }
-					}
-					#[cfg(target_os = "linux")]
-					{
-						use webkit2gtk::traits::WebViewExt;
-
-						webview.inner().reload()
-					}
-					#[cfg(target_os = "windows")]
-					unsafe {
-						webview
-							.controller()
-							.CoreWebView2()
-							.expect("Unable to get handle on inner webview")
-							.Reload()
-					}
-				})
+				.with_webview(crate::reload_webview_inner)
 				.expect("Error while reloading webview");
 		}
 		#[cfg(debug_assertions)]

--- a/apps/desktop/src-tauri/src/menu.rs
+++ b/apps/desktop/src-tauri/src/menu.rs
@@ -103,37 +103,29 @@ pub(crate) fn handle_menu_event(event: WindowMenuEvent<Wry>) {
 			.emit("keybind", "open_search".to_string())
 			.unwrap(),
 		"reload_app" => {
-			#[cfg(target_os = "macos")]
-			{
-				event
-					.window()
-					.with_webview(|webview| {
-						unsafe { sd_desktop_macos::reload_webview(&(webview.inner() as _)) };
-					})
-					.expect("Error while reloading webview");
-			}
+			event
+				.window()
+				.with_webview(|webview| {
+					#[cfg(target_os = "macos")]
+					{
+						unsafe { sd_desktop_macos::reload_webview(&(webview.inner() as _)) }
+					}
+					#[cfg(target_os = "linux")]
+					{
+						use webkit2gtk::traits::WebViewExt;
 
-			#[cfg(target_os = "linux")]
-			{
-				use webkit2gtk::traits::WebViewExt;
-
-				event
-					.window()
-					.with_webview(|webview| webview.inner().reload())
-					.expect("Error while reloading webview");
-			}
-
-			#[cfg(target_os = "windows")]
-			unsafe {
-				event.window().with_webview(|webview| {
-					webview
-						.controller()
-						.CoreWebView2()
-						.expect("Unable to get handle on inner webview")
-						.Reload()
-						.expect("Error while reloading webview")
-				});
-			}
+						webview.inner().reload()
+					}
+					#[cfg(target_os = "windows")]
+					unsafe {
+						webview
+							.controller()
+							.CoreWebView2()
+							.expect("Unable to get handle on inner webview")
+							.Reload()
+					}
+				})
+				.expect("Error while reloading webview");
 		}
 		#[cfg(debug_assertions)]
 		"toggle_devtools" => {

--- a/apps/desktop/src/commands.ts
+++ b/apps/desktop/src/commands.ts
@@ -22,6 +22,10 @@ export function openLogsDir() {
     return invoke()<null>("open_logs_dir")
 }
 
+export function reloadWebview() {
+    return invoke()<null>("reload_webview")
+}
+
 export function openFilePaths(library: string, ids: number[]) {
     return invoke()<OpenFilePathResult[]>("open_file_paths", { library,ids })
 }

--- a/interface/app/$libraryId/Layout/Sidebar/DebugPopover.tsx
+++ b/interface/app/$libraryId/Layout/Sidebar/DebugPopover.tsx
@@ -111,6 +111,21 @@ export default () => {
 						</div>
 					</Setting>
 				)}
+				{platform.reloadWebview && (
+					<Setting mini title="Reload webview" description="Reload the window's webview">
+						<div className="mt-2">
+							<Button
+								size="sm"
+								variant="gray"
+								onClick={() => {
+									platform.reloadWebview && platform.reloadWebview();
+								}}
+							>
+								Reload
+							</Button>
+						</div>
+					</Setting>
+				)}
 				<Setting
 					mini
 					title="React Query Devtools"

--- a/interface/util/Platform.tsx
+++ b/interface/util/Platform.tsx
@@ -33,6 +33,7 @@ export type Platform = {
 		)[]
 	): Promise<unknown>;
 	getFilePathOpenWithApps?(library: string, ids: number[]): Promise<unknown>;
+	reloadWebview?(): Promise<unknown>;
 	getEphemeralFilesOpenWithApps?(paths: string[]): Promise<unknown>;
 	openFilePathWith?(library: string, fileIdsAndAppUrls: [number, string][]): Promise<unknown>;
 	openEphemeralFileWith?(pathsAndUrls: [string, string][]): Promise<unknown>;


### PR DESCRIPTION
This button adds a "Reload webview" button to the debug popover, which can be used on any platform - beforehand, only MacOS was supported and the action for that was controlled by the menu bar (which is also only usable on MacOS).

This needs:

- [x] Testing on Windows
- [x] Testing on Linux

I followed the Tauri example on how to access/handle the webview for each appropriate platform, and from there used the respective crates and versions required by Tauri to (hopefully) make this feature cross-platform.

Video showing it working on Windows (thank you @ameer2468!) - please excuse the terrible quality and visual artifacts, `kdenlive` wasn't playing nicely:

https://github.com/spacedriveapp/spacedrive/assets/77554505/3cdf05c4-34f2-441c-9bad-6b9b75bbc8ca

