### PR TITLE
Popover keybind state fix

### DIFF
--- a/packages/ui/src/Popover.tsx
+++ b/packages/ui/src/Popover.tsx
@@ -28,7 +28,7 @@ export const Popover = ({ popover, trigger, children, disabled, className, ...pr
 	useKeys(props.keybind ?? [], (e) => {
 		if (!props.keybind) return;
 		e.stopPropagation();
-		popover.setOpen(!open);
+		popover.setOpen((o) => !o);
 	});
 
 	useEffect(() => {


### PR DESCRIPTION
This fixes the state toggle for popover keybinds. Now it works.