### PR TITLE
[ENG-1294] Mac - Delete shortcut

### DIFF
--- a/interface/app/$libraryId/Layout/Sidebar/Contents.tsx
+++ b/interface/app/$libraryId/Layout/Sidebar/Contents.tsx
@@ -1,9 +1,9 @@
-import { ArrowsClockwise, Broadcast, Planet } from '@phosphor-icons/react';
+import { ArrowsClockwise, Planet } from '@phosphor-icons/react';
 import { useNavigate } from 'react-router';
 import { useKeys } from 'rooks';
 import { LibraryContextProvider, useClientContext, useFeatureFlag } from '@sd/client';
-import { modifierSymbols, Tooltip } from '@sd/ui';
-import { useKeyMatcher } from '~/hooks';
+import { Tooltip } from '@sd/ui';
+import { useKeysMatcher } from '~/hooks';
 
 import { EphemeralSection } from './EphemeralSection';
 import Icon from './Icon';
@@ -13,9 +13,9 @@ import SidebarLink from './Link';
 export default () => {
 	const { library } = useClientContext();
 	const navigate = useNavigate();
-	const { key, icon } = useKeyMatcher('Meta');
+	const shortcuts = useKeysMatcher(['Meta', 'Shift']);
 
-	useKeys([key, 'Shift', 'KeyO'], (e) => {
+	useKeys([shortcuts.Meta.key, 'Shift', 'KeyO'], (e) => {
 		e.stopPropagation();
 		navigate('overview');
 	});
@@ -26,7 +26,7 @@ export default () => {
 				<Tooltip
 					position="right"
 					label="Overview"
-					keybinds={[modifierSymbols.Shift.Other, icon, 'O']}
+					keybinds={[shortcuts.Shift.icon, shortcuts.Meta.icon, 'O']}
 				>
 					<SidebarLink to="overview">
 						<Icon component={Planet} />

--- a/interface/app/$libraryId/Layout/Sidebar/Footer.tsx
+++ b/interface/app/$libraryId/Layout/Sidebar/Footer.tsx
@@ -2,16 +2,8 @@ import { Gear } from '@phosphor-icons/react';
 import { useNavigate } from 'react-router';
 import { useKeys } from 'rooks';
 import { JobManagerContextProvider, useClientContext, useDebugState } from '@sd/client';
-import {
-	Button,
-	ButtonLink,
-	dialogManager,
-	modifierSymbols,
-	Popover,
-	Tooltip,
-	usePopover
-} from '@sd/ui';
-import { useKeyMatcher } from '~/hooks';
+import { Button, ButtonLink, Popover, Tooltip, usePopover } from '@sd/ui';
+import { useKeysMatcher } from '~/hooks';
 import { usePlatform } from '~/util/Platform';
 
 import DebugPopover from './DebugPopover';
@@ -22,9 +14,9 @@ export default () => {
 	const { library } = useClientContext();
 	const debugState = useDebugState();
 	const navigate = useNavigate();
-	const { key, icon } = useKeyMatcher('Meta');
+	const shortcuts = useKeysMatcher(['Meta', 'Shift']);
 
-	useKeys([key, 'Shift', 'KeyT'], (e) => {
+	useKeys([shortcuts.Meta.key, 'Shift', 'KeyT'], (e) => {
 		e.stopPropagation();
 		navigate('settings/client/general');
 	});
@@ -58,7 +50,7 @@ export default () => {
 						<Tooltip
 							position="top"
 							label="Settings"
-							keybinds={[modifierSymbols.Shift.Other, icon, 'T']}
+							keybinds={[shortcuts.Shift.icon, shortcuts.Meta.icon, 'T']}
 						>
 							<Gear className="h-5 w-5" />
 						</Tooltip>
@@ -66,7 +58,7 @@ export default () => {
 					<JobManagerContextProvider>
 						<Popover
 							popover={usePopover()}
-							keybind={[key, 'j']}
+							keybind={[shortcuts.Meta.key, 'j']}
 							trigger={
 								<Button
 									size="icon"
@@ -78,7 +70,7 @@ export default () => {
 										<Tooltip
 											label="Recent Jobs"
 											position="top"
-											keybinds={[icon, 'J']}
+											keybinds={[shortcuts.Meta.icon, 'J']}
 										>
 											<IsRunningJob />
 										</Tooltip>

--- a/interface/hooks/useKeyDeleteFile.tsx
+++ b/interface/hooks/useKeyDeleteFile.tsx
@@ -1,12 +1,14 @@
-import { useKey } from 'rooks';
+import { useKey, useKeys } from 'rooks';
 import type { ExplorerItem } from '@sd/client';
 import { dialogManager } from '@sd/ui';
 import DeleteDialog from '~/app/$libraryId/Explorer/FilePath/DeleteDialog';
 
-export const useKeyDeleteFile = (selectedItems: Set<ExplorerItem>, locationId?: number | null) => {
-	return useKey('Delete', (e) => {
-		e.preventDefault();
+import { useOperatingSystem } from './useOperatingSystem';
 
+export const useKeyDeleteFile = (selectedItems: Set<ExplorerItem>, locationId?: number | null) => {
+	const os = useOperatingSystem();
+
+	const deleteHandler = () => {
 		if (!locationId) return;
 
 		const pathIds: number[] = [];
@@ -18,5 +20,17 @@ export const useKeyDeleteFile = (selectedItems: Set<ExplorerItem>, locationId?: 
 		dialogManager.create((dp) => (
 			<DeleteDialog {...dp} locationId={locationId} pathIds={pathIds} />
 		));
+	};
+
+	useKeys(['Meta', 'Backspace'], (e) => {
+		if (os !== 'macOS') return;
+		e.preventDefault();
+		deleteHandler();
+	});
+
+	useKey('Delete', (e) => {
+		if (os === 'macOS') return;
+		e.preventDefault();
+		deleteHandler();
 	});
 };

--- a/interface/hooks/useKeyDeleteFile.tsx
+++ b/interface/hooks/useKeyDeleteFile.tsx
@@ -8,8 +8,9 @@ import { useOperatingSystem } from './useOperatingSystem';
 export const useKeyDeleteFile = (selectedItems: Set<ExplorerItem>, locationId?: number | null) => {
 	const os = useOperatingSystem();
 
-	const deleteHandler = () => {
-		if (!locationId) return;
+	const deleteHandler = (e: KeyboardEvent) => {
+		e.preventDefault();
+		if (!locationId || selectedItems.size === 0) return;
 
 		const pathIds: number[] = [];
 
@@ -24,13 +25,11 @@ export const useKeyDeleteFile = (selectedItems: Set<ExplorerItem>, locationId?: 
 
 	useKeys(['Meta', 'Backspace'], (e) => {
 		if (os !== 'macOS') return;
-		e.preventDefault();
-		deleteHandler();
+		deleteHandler(e);
 	});
 
 	useKey('Delete', (e) => {
 		if (os === 'macOS') return;
-		e.preventDefault();
-		deleteHandler();
+		deleteHandler(e);
 	});
 };

--- a/interface/hooks/useKeyMatcher.ts
+++ b/interface/hooks/useKeyMatcher.ts
@@ -3,7 +3,7 @@ import { ModifierKeys, modifierSymbols } from '@sd/ui';
 import { OperatingSystem } from '..';
 import { useOperatingSystem } from './useOperatingSystem';
 
-type keysToMatch = 'Meta' | 'Alt';
+type keysToMatch = 'Meta' | 'Alt' | 'Shift';
 type keysOsMap = Record<keysToMatch, osKeys>;
 type osKeys = Record<OperatingSystem, { key: Partial<keyof typeof ModifierKeys>; icon: string }>;
 
@@ -13,13 +13,20 @@ const modifierKey = (key: keyof typeof ModifierKeys, os: 'Windows' | 'macOS' | '
 };
 
 //Match macOS keys to Windows keys and others
-const keysOsMap: keysOsMap = {
+const keysOsMap = {
 	Meta: {
 		macOS: { key: 'Meta', icon: modifierKey(ModifierKeys.Meta, 'macOS') },
 		windows: { key: 'Control', icon: modifierKey(ModifierKeys.Control, 'Windows') },
 		browser: { key: 'Control', icon: modifierKey(ModifierKeys.Control, 'Windows') },
 		linux: { key: 'Control', icon: modifierKey(ModifierKeys.Control, 'Windows') },
 		unknown: { key: 'Control', icon: modifierKey(ModifierKeys.Control, 'Windows') }
+	},
+	Shift: {
+		macOS: { key: 'Shift', icon: modifierKey(ModifierKeys.Shift, 'macOS') },
+		windows: { key: 'Shift', icon: modifierKey(ModifierKeys.Shift, 'Other') },
+		browser: { key: 'Shift', icon: modifierKey(ModifierKeys.Shift, 'Other') },
+		linux: { key: 'Shift', icon: modifierKey(ModifierKeys.Shift, 'Other') },
+		unknown: { key: 'Shift', icon: modifierKey(ModifierKeys.Shift, 'Other') }
 	},
 	Alt: {
 		macOS: { key: 'Alt', icon: modifierKey(ModifierKeys.Alt, 'macOS') },
@@ -28,10 +35,25 @@ const keysOsMap: keysOsMap = {
 		linux: { key: 'Alt', icon: modifierKey(ModifierKeys.Alt, 'Other') },
 		unknown: { key: 'Alt', icon: modifierKey(ModifierKeys.Alt, 'Other') }
 	}
-} as const;
+};
 
-export function useKeyMatcher(arg: keyof typeof keysOsMap): osKeys[OperatingSystem] {
+export function useKeyMatcher<T extends keysToMatch>(arg: T): { key: string; icon: string } {
 	const os = useOperatingSystem();
 	const key = keysOsMap[arg][os];
 	return key;
+}
+
+//This is another hook to pass an array for multiple keys rather than one at a time
+export function useKeysMatcher<T extends keysToMatch>(
+	arg: T[]
+): Record<T, { key: string; icon: string }> {
+	const os = useOperatingSystem();
+	const object = {} as Record<T, { key: string; icon: string }>;
+	for (const key of arg) {
+		object[key] = {
+			key: keysOsMap[key][os].key,
+			icon: keysOsMap[key][os].icon
+		};
+	}
+	return object;
 }


### PR DESCRIPTION
**This PR focuses on the following**:

- Delete shortcut for Mac. **It is the Del key on windows.**

**Other notes**:

- Improved TS typing of the useKeyMatcher hook to use generics.
- Fixed icons of 2 shortcuts in sidebar.
- useKeyMatchers to get multiple values back instead of one.

**Tested on Windows & Mac**