### PR TITLE
[END-1309] Fix explorer query invalidation

### DIFF
--- a/core/src/api/files.rs
+++ b/core/src/api/files.rs
@@ -258,6 +258,7 @@ pub(crate) fn mount() -> AlphaRouter<Ctx> {
 						.await?;
 
 					invalidate_query!(library, "search.paths");
+					invalidate_query!(library, "search.objects");
 					Ok(())
 				})
 		})
@@ -274,6 +275,7 @@ pub(crate) fn mount() -> AlphaRouter<Ctx> {
 						.exec()
 						.await?;
 
+					invalidate_query!(library, "search.objects");
 					invalidate_query!(library, "search.paths");
 					Ok(())
 				})
@@ -479,6 +481,7 @@ pub(crate) fn mount() -> AlphaRouter<Ctx> {
 						fs::remove_file(path.as_ref()).await.map_err(|e| {
 							// Let's also invalidate the query here, because we succeeded in converting the file
 							invalidate_query!(library, "search.paths");
+							invalidate_query!(library, "search.objects");
 
 							FileIOError::from((
 								path.as_ref(),
@@ -489,6 +492,7 @@ pub(crate) fn mount() -> AlphaRouter<Ctx> {
 					}
 
 					invalidate_query!(library, "search.paths");
+					invalidate_query!(library, "search.objects");
 
 					Ok(())
 				})

--- a/core/src/location/indexer/shallow.rs
+++ b/core/src/location/indexer/shallow.rs
@@ -186,6 +186,7 @@ pub async fn shallow(
 			.map_err(IndexerError::from)?;
 
 		invalidate_query!(library, "search.paths");
+		invalidate_query!(library, "search.objects");
 	}
 
 	library.orphan_remover.invoke().await;

--- a/core/src/location/manager/watcher/utils.rs
+++ b/core/src/location/manager/watcher/utils.rs
@@ -131,6 +131,7 @@ pub(super) async fn create_dir(
 	scan_location_sub_path(node, library, location, &children_materialized_path).await?;
 
 	invalidate_query!(library, "search.paths");
+	invalidate_query!(library, "search.objects");
 
 	Ok(())
 }
@@ -319,6 +320,7 @@ async fn inner_create_file(
 	}
 
 	invalidate_query!(library, "search.paths");
+	invalidate_query!(library, "search.objects");
 
 	Ok(())
 }
@@ -365,7 +367,10 @@ pub(super) async fn update_file(
 		)
 		.await
 	}
-	.map(|_| invalidate_query!(library, "search.paths"))
+	.map(|_| {
+		invalidate_query!(library, "search.paths");
+		invalidate_query!(library, "search.objects");
+	})
 }
 
 async fn inner_update_file(
@@ -572,6 +577,7 @@ async fn inner_update_file(
 		}
 
 		invalidate_query!(library, "search.paths");
+		invalidate_query!(library, "search.objects");
 	}
 
 	Ok(())
@@ -664,6 +670,7 @@ pub(super) async fn rename(
 			.await?;
 
 		invalidate_query!(library, "search.paths");
+		invalidate_query!(library, "search.objects");
 	}
 
 	Ok(())
@@ -741,6 +748,7 @@ pub(super) async fn remove_by_file_path(
 	}
 
 	invalidate_query!(library, "search.paths");
+	invalidate_query!(library, "search.objects");
 
 	Ok(())
 }
@@ -845,6 +853,7 @@ pub(super) async fn recalculate_directories_size(
 
 	if should_invalidate {
 		invalidate_query!(library, "search.paths");
+		invalidate_query!(library, "search.objects");
 	}
 
 	candidates.extend(buffer.drain(..));

--- a/core/src/location/mod.rs
+++ b/core/src/location/mod.rs
@@ -781,6 +781,7 @@ pub async fn delete_directory(
 	library.orphan_remover.invoke().await;
 
 	invalidate_query!(library, "search.paths");
+	invalidate_query!(library, "search.objects");
 
 	Ok(())
 }

--- a/core/src/object/file_identifier/shallow.rs
+++ b/core/src/object/file_identifier/shallow.rs
@@ -114,6 +114,7 @@ pub async fn shallow(
 	}
 
 	invalidate_query!(library, "search.paths");
+	invalidate_query!(library, "search.objects");
 
 	Ok(())
 }

--- a/core/src/object/media/media_processor/shallow.rs
+++ b/core/src/object/media/media_processor/shallow.rs
@@ -113,6 +113,7 @@ pub async fn shallow(
 
 	if run_metadata.media_data.extracted > 0 {
 		invalidate_query!(library, "search.paths");
+		invalidate_query!(library, "search.objects");
 	}
 
 	Ok(())


### PR DESCRIPTION
In most cases we invalidate search.paths and not search.objects, this change makes sure both are always invalided. Our invalidation system is terrible, but that's another PR.