### PR TITLE
[ENG-1310] Spacedrop better testing

### DIFF
--- a/core/src/p2p/p2p_manager.rs
+++ b/core/src/p2p/p2p_manager.rs
@@ -234,7 +234,7 @@ impl P2PManager {
 										debug!("Received ping from peer '{}'", event.peer_id);
 									}
 									Header::Spacedrop(req) => {
-										let id = Uuid::new_v4(); // TODO: Get ID from the remote
+										let id = req.id.clone();
 										let (tx, rx) = oneshot::channel();
 
 										info!(
@@ -254,7 +254,6 @@ impl P2PManager {
 													.find(|p| p.peer_id == event.peer_id)
 													.map(|p| p.metadata.name)
 													.unwrap_or_else(|| "Unknown".to_string()),
-												// TODO: If multiple files in request ask user to select a whole directory instead!
 												files: req
 													.requests
 													.iter()
@@ -270,7 +269,7 @@ impl P2PManager {
 
 										tokio::select! {
 											_ = sleep(SPACEDROP_TIMEOUT) => {
-												info!("spacedrop({id}): timeout, rejecting!");
+												info!("({id}): timeout, rejecting!");
 
 												stream.write_all(&[0]).await.unwrap();
 												stream.flush().await.unwrap();

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -43,3 +43,4 @@ hex = "0.4.3"
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+uuid = { version = "1.4.1", features = ["v4"] }

--- a/crates/p2p/src/spaceblock/block_size.rs
+++ b/crates/p2p/src/spaceblock/block_size.rs
@@ -32,3 +32,20 @@ impl BlockSize {
 		self.0
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use std::io::Cursor;
+
+	use super::*;
+
+	#[tokio::test]
+	async fn test_block_size() {
+		let req = BlockSize::dangerously_new(5);
+		let bytes = req.to_bytes();
+		let req2 = BlockSize::from_stream(&mut Cursor::new(bytes))
+			.await
+			.unwrap();
+		assert_eq!(req, req2);
+	}
+}

--- a/crates/p2p/src/spaceblock/mod.rs
+++ b/crates/p2p/src/spaceblock/mod.rs
@@ -176,6 +176,12 @@ where
 
 		// TODO: Prevent loop being a DOS vector
 		loop {
+			if self.cancelled.load(Ordering::Relaxed) {
+				stream.write_u8(1).await.unwrap(); // TODO: Error handling
+				stream.flush().await.unwrap(); // TODO: Error handling
+				return;
+			}
+
 			// TODO: Timeout if nothing is being received
 			let msg = Msg::from_stream(stream, &mut data_buf).await.unwrap(); // TODO: Error handling
 			match msg {
@@ -221,140 +227,205 @@ where
 	}
 }
 
-// #[cfg(test)]
-// mod tests {
-// 	use std::io::Cursor;
+#[cfg(test)]
+mod tests {
+	use std::{io::Cursor, mem};
 
-// 	use tokio::sync::oneshot;
+	use tokio::sync::oneshot;
+	use uuid::Uuid;
 
-// 	use super::*;
+	use super::*;
 
-// 	#[tokio::test]
-// 	async fn test_spaceblock_request() {
-// 		let req = SpaceblockRequest {
-// 			name: "Demo".to_string(),
-// 			size: 42069,
-// 			block_size: BlockSize::from_size(42069),
-// 			range: Range::Full,
-// 		};
+	#[tokio::test]
+	async fn test_spaceblock_single_block() {
+		let (mut client, mut server) = tokio::io::duplex(64);
 
-// 		let bytes = req.to_bytes();
-// 		let req2 = SpaceblockRequest::from_stream(&mut Cursor::new(bytes))
-// 			.await
-// 			.unwrap();
-// 		assert_eq!(req, req2);
+		// This is sent out of band of Spaceblock
+		let data = b"Spacedrive".to_vec();
+		let req = SpaceblockRequests {
+			id: Uuid::new_v4(),
+			block_size: BlockSize::from_size(data.len() as u64),
+			requests: vec![SpaceblockRequest {
+				name: "Demo".to_string(),
+				size: data.len() as u64,
+				range: Range::Full,
+			}],
+		};
 
-// 		let req = SpaceblockRequest {
-// 			name: "Demo".to_string(),
-// 			size: 42069,
-// 			block_size: BlockSize::from_size(42069),
-// 			range: Range::Partial(0..420),
-// 		};
+		let (tx, rx) = oneshot::channel();
+		tokio::spawn({
+			let req = req.clone();
+			let data = data.clone();
+			async move {
+				let file = BufReader::new(Cursor::new(data));
+				tx.send(()).unwrap();
+				Transfer::new(&req, |_| {}, &Default::default())
+					.send(&mut client, file)
+					.await;
+			}
+		});
 
-// 		let bytes = req.to_bytes();
-// 		let req2 = SpaceblockRequest::from_stream(&mut Cursor::new(bytes))
-// 			.await
-// 			.unwrap();
-// 		assert_eq!(req, req2);
-// 	}
+		rx.await.unwrap();
 
-// 	#[tokio::test]
-// 	async fn test_spaceblock_single_block() {
-// 		let (mut client, mut server) = tokio::io::duplex(64);
+		let mut result = Vec::new();
+		Transfer::new(&req, |_| {}, &Default::default())
+			.receive(&mut server, &mut result)
+			.await;
+		assert_eq!(result, data);
+	}
 
-// 		// This is sent out of band of Spaceblock
-// 		let data = b"Spacedrive".to_vec();
-// 		let req = SpaceblockRequest {
-// 			name: "Demo".to_string(),
-// 			size: data.len() as u64,
-// 			block_size: BlockSize::from_size(data.len() as u64),
-// 			range: Range::Full,
-// 		};
+	// https://github.com/spacedriveapp/spacedrive/pull/942
+	#[tokio::test]
+	async fn test_spaceblock_multiple_blocks() {
+		let (mut client, mut server) = tokio::io::duplex(64);
 
-// 		let (tx, rx) = oneshot::channel();
-// 		tokio::spawn({
-// 			let req = req.clone();
-// 			let data = data.clone();
-// 			async move {
-// 				let file = BufReader::new(Cursor::new(data));
-// 				tx.send(()).unwrap();
-// 				Transfer::new(&req, |_| {}, &Default::default())
-// 					.send(&mut client, file)
-// 					.await;
-// 			}
-// 		});
+		// This is sent out of band of Spaceblock
+		let block_size = 131072u32;
+		let data = vec![0u8; block_size as usize * 4]; // Let's pacman some RAM
+		let block_size = BlockSize::dangerously_new(block_size);
 
-// 		rx.await.unwrap();
+		let req = SpaceblockRequests {
+			id: Uuid::new_v4(),
+			block_size,
+			requests: vec![SpaceblockRequest {
+				name: "Demo".to_string(),
+				size: data.len() as u64,
+				range: Range::Full,
+			}],
+		};
 
-// 		let mut result = Vec::new();
-// 		Transfer::new(&req, |_| {}, &Default::default())
-// 			.receive(&mut server, &mut result)
-// 			.await;
-// 		assert_eq!(result, data);
-// 	}
+		let (tx, rx) = oneshot::channel();
+		tokio::spawn({
+			let req = req.clone();
+			let data = data.clone();
+			async move {
+				let file = BufReader::new(Cursor::new(data));
+				tx.send(()).unwrap();
+				Transfer::new(&req, |_| {}, &Default::default())
+					.send(&mut client, file)
+					.await;
+			}
+		});
 
-// 	// https://github.com/spacedriveapp/spacedrive/pull/942
-// 	#[tokio::test]
-// 	async fn test_spaceblock_multiple_blocks() {
-// 		let (mut client, mut server) = tokio::io::duplex(64);
+		rx.await.unwrap();
 
-// 		// This is sent out of band of Spaceblock
-// 		let block_size = 131072u32;
-// 		let data = vec![0u8; block_size as usize * 4]; // Let's pacman some RAM
-// 		let block_size = BlockSize::dangerously_new(block_size);
+		let mut result = Vec::new();
+		Transfer::new(&req, |_| {}, &Default::default())
+			.receive(&mut server, &mut result)
+			.await;
+		assert_eq!(result, data);
+	}
 
-// 		let req = SpaceblockRequest {
-// 			name: "Demo".to_string(),
-// 			size: data.len() as u64,
-// 			block_size,
-// 			range: Range::Full,
-// 		};
+	#[tokio::test]
+	async fn test_transfer_receiver_cancelled() {
+		let (mut client, mut server) = tokio::io::duplex(64);
 
-// 		let (tx, rx) = oneshot::channel();
-// 		tokio::spawn({
-// 			let req = req.clone();
-// 			let data = data.clone();
-// 			async move {
-// 				let file = BufReader::new(Cursor::new(data));
-// 				tx.send(()).unwrap();
-// 				Transfer::new(&req, |_| {}, &Default::default())
-// 					.send(&mut client, file)
-// 					.await;
-// 			}
-// 		});
+		// This is sent out of band of Spaceblock
+		let block_size = 25u32;
+		let data = vec![0u8; block_size as usize];
+		let block_size = BlockSize::dangerously_new(block_size); // TODO: Determine it using proper algo instead of harcoding it
 
-// 		rx.await.unwrap();
+		let req = SpaceblockRequests {
+			id: Uuid::new_v4(),
+			block_size,
+			requests: vec![SpaceblockRequest {
+				name: "Demo".to_string(),
+				size: data.len() as u64,
+				range: Range::Full,
+			}],
+		};
 
-// 		let mut result = Vec::new();
-// 		Transfer::new(&req, |_| {}, &Default::default())
-// 			.receive(&mut server, &mut result)
-// 			.await;
-// 		assert_eq!(result, data);
-// 	}
+		let (tx, rx) = oneshot::channel();
+		tokio::spawn({
+			let req = req.clone();
+			let data = data.clone();
+			async move {
+				let file = BufReader::new(Cursor::new(data));
+				tx.send(()).unwrap();
 
-// 	// TODO: Unit test the condition when the receiver sets the `cancelled` flag
+				Transfer::new(&req, |_| {}, &Arc::new(AtomicBool::new(true)))
+					.send(&mut client, file)
+					.await;
+			}
+		});
 
-// 	// TODO: Unit test the condition when the sender sets the `cancelled` flag
+		rx.await.unwrap();
 
-// 	#[tokio::test]
-// 	async fn test_msg() {
-// 		let block = Block {
-// 			offset: 0,
-// 			size: 10,
-// 			data: b"Spacedrive".as_ref(),
-// 		};
-// 		let msg = Msg::Block(block);
-// 		let bytes = msg.to_bytes();
-// 		let msg2 = Msg::from_stream(&mut Cursor::new(bytes), &mut [0u8; 64])
-// 			.await
-// 			.unwrap();
-// 		assert_eq!(msg, msg2);
+		let mut result = Vec::new();
+		Transfer::new(&req, |_| {}, &Default::default())
+			.receive(&mut server, &mut result)
+			.await;
+		assert_eq!(result, Vec::<u8>::new()); // Cancelled by sender so no data
+	}
 
-// 		let msg = Msg::Cancelled;
-// 		let bytes = msg.to_bytes();
-// 		let msg2 = Msg::from_stream(&mut Cursor::new(bytes), &mut [0u8; 64])
-// 			.await
-// 			.unwrap();
-// 		assert_eq!(msg, msg2);
-// 	}
-// }
+	#[tokio::test]
+	async fn test_transfer_sender_cancelled() {
+		let (mut client, mut server) = tokio::io::duplex(64);
+
+		// This is sent out of band of Spaceblock
+		let block_size = 25u32;
+		let data = vec![0u8; block_size as usize];
+		let block_size = BlockSize::dangerously_new(block_size); // TODO: Determine it using proper algo instead of harcoding it
+
+		let req = SpaceblockRequests {
+			id: Uuid::new_v4(),
+			block_size,
+			requests: vec![SpaceblockRequest {
+				name: "Demo".to_string(),
+				size: data.len() as u64,
+				range: Range::Full,
+			}],
+		};
+
+		let (tx, rx) = oneshot::channel();
+		tokio::spawn({
+			let req = req.clone();
+			let data = data.clone();
+			async move {
+				let file = BufReader::new(Cursor::new(data));
+				tx.send(()).unwrap();
+
+				Transfer::new(&req, |_| {}, &Default::default())
+					.send(&mut client, file)
+					.await;
+			}
+		});
+
+		rx.await.unwrap();
+
+		let mut result = Vec::new();
+		Transfer::new(&req, |_| {}, &Arc::new(AtomicBool::new(true)))
+			.receive(&mut server, &mut result)
+			.await;
+		assert_eq!(result, Vec::<u8>::new()); // Cancelled by sender so no data
+	}
+
+	#[tokio::test]
+	async fn test_msg() {
+		let block = Block {
+			offset: 0,
+			size: 10,
+			data: b"Spacedrive".as_ref(),
+		};
+		let data_len = block.data.len();
+		let mut msg = Msg::Block(block);
+		let bytes = msg.to_bytes();
+		let mut data2 = vec![0; data_len];
+		let msg2 = Msg::from_stream(&mut Cursor::new(bytes), &mut data2)
+			.await
+			.unwrap();
+		let data = mem::take(match &mut msg {
+			Msg::Block(block) => &mut block.data,
+			_ => unreachable!(),
+		}); // We decode the data into
+		assert_eq!(msg, msg2);
+		assert_eq!(data, data2);
+
+		let msg = Msg::Cancelled;
+		let bytes = msg.to_bytes();
+		let msg2 = Msg::from_stream(&mut Cursor::new(bytes), &mut [0u8; 64])
+			.await
+			.unwrap();
+		assert_eq!(msg, msg2);
+	}
+}


### PR DESCRIPTION
Adding better tests found a bug where two fields where being encoded and decoding in opposing orders. Incredible it was working.

Why unit test?

Debugging the protocol takes soooo much of my time (especially for small things where it works but not quite right) so automating it saves me more time than writing test costs. It also means people on the team other can me can just jump and modify it without risking breaking something.