### PR TITLE
[ENG-1314] Re-enable cache factory on all main commits

### DIFF
--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -23,8 +23,7 @@ runs:
       uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ inputs.save-cache }}
-        prefix-key: 'v0-rust-deps'
-        shared-key: ${{ inputs.target }}
+        shared-key: stable-cache
 
     - name: Cargo config.toml
       shell: bash
@@ -34,7 +33,7 @@ runs:
       id: cache-prisma-restore
       uses: actions/cache/restore@v3
       with:
-        key: prisma-1-${{ runner.os }}-${{ hashFiles('./core/prisma/*', './crates/sync-generator/*', './Cargo.toml') }}
+        key: prisma-1-${{ runner.os }}-${{ hashFiles('./core/prisma/*', './crates/sync-generator/*', './Cargo.*') }}
         path: crates/prisma/src/**/*.rs
 
     - name: Generate Prisma client

--- a/.github/workflows/cache-factory.yaml
+++ b/.github/workflows/cache-factory.yaml
@@ -5,17 +5,10 @@ name: Cache Factory
 
 on:
   push:
-    paths:
-      - 'Cargo.lock'
-      - './scripts/setup.sh'
-      - './scripts/setup.ps1'
-      - '.github/workflows/cache-factory.yaml'
-      - '.github/actions/**/*.yml'
-      - '.github/actions/**/*.yaml'
-      - '**/build.rs'
-      - 'core/prisma/**'
     branches:
       - main
+  schedule:
+    - cron: '0 0 * * *'
 
 # Cancel previous runs of the same workflow on the same branch.
 concurrency:


### PR DESCRIPTION
Runs the cache factory more often so that we have more up-to-date caches. Should improve some CI speed and hopefully improve release workflow speed.