### PR TITLE
Get mobile app to build on Android

### DIFF
--- a/apps/mobile/modules/sd-core/android/build.gradle
+++ b/apps/mobile/modules/sd-core/android/build.gradle
@@ -82,6 +82,11 @@ android {
       withSourcesJar()
     }
   }
+	sourceSets {
+		main {
+			jniLibs.srcDirs = ['../../../../../target/release']
+		}
+	}
 }
 
 repositories {


### PR DESCRIPTION
This PR updates the Android `build.gradle` file for the `sd-core` module to have the final compiled rust library be linked to the application, which allows it to now call the library. 

Closes #1616
