### PR TITLE
Fix casing switch in "Log in" button

### DIFF
--- a/interface/components/LoginButton.tsx
+++ b/interface/components/LoginButton.tsx
@@ -28,7 +28,7 @@ export function LoginButton({
 				}}
 				{...props}
 			>
-				{authState.status !== 'loggingIn' ? children || 'Log in' : 'Logging In...'}
+				{authState.status !== 'loggingIn' ? children || 'Log in' : 'Logging in...'}
 			</Button>
 			{authState.status === 'loggingIn' && (
 				<button


### PR DESCRIPTION
<!-- Put any information about this PR up here -->
The letter 'i' is capitalized for "Logging In", but not capitalized for "Log in". This PR makes both of them lower case.
<!-- Which issue does this PR close? -->

<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->

Closes #1618 
