### PR TITLE
[ENG-955] Hide media view on network, ephemeral, and nodes explorer

### DIFF
--- a/interface/app/$libraryId/Explorer/View/index.tsx
+++ b/interface/app/$libraryId/Explorer/View/index.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react';
 import { createPortal } from 'react-dom';
 import { useKey, useKeys } from 'rooks';
-import { getItemObject, useLibraryContext, type Object } from '@sd/client';
+import { ExplorerLayout, getItemObject, useLibraryContext, type Object } from '@sd/client';
 import { dialogManager, ModifierKeys } from '@sd/ui';
 import { Loader } from '~/components';
 import { useKeyCopyCutPaste, useKeyMatcher, useOperatingSystem } from '~/hooks';
@@ -95,6 +95,15 @@ export default memo(
 			} else setShowLoading(false);
 		}, [explorer.isFetchingNextPage]);
 
+		useEffect(() => {
+			if (explorer.layouts[layoutMode]) return;
+			// If the current layout mode is not available, switch to the first available layout mode
+			const layout = (Object.keys(explorer.layouts) as ExplorerLayout[]).find(
+				(key) => explorer.layouts[key]
+			);
+			explorer.settingsStore.layoutMode = layout ?? 'grid';
+		}, [layoutMode, explorer.layouts, explorer.settingsStore]);
+
 		useKey(['Enter'], (e) => {
 			e.stopPropagation();
 			if (os === 'windows' && !isRenaming) {
@@ -109,6 +118,8 @@ export default memo(
 		});
 
 		useKeyCopyCutPaste();
+
+		if (!explorer.layouts[layoutMode]) return null;
 
 		return (
 			<>
@@ -180,7 +191,7 @@ export const EmptyNotice = (props: {
 	if (props.loading) return null;
 
 	return (
-		<div className="flex flex-col items-center justify-center h-full text-ink-faint">
+		<div className="flex h-full flex-col items-center justify-center text-ink-faint">
 			{props.icon
 				? isValidElement(props.icon)
 					? props.icon

--- a/interface/app/$libraryId/Explorer/useExplorer.ts
+++ b/interface/app/$libraryId/Explorer/useExplorer.ts
@@ -3,6 +3,7 @@ import { proxy, snapshot, subscribe, useSnapshot } from 'valtio';
 import { z } from 'zod';
 import type {
 	ExplorerItem,
+	ExplorerLayout,
 	ExplorerSettings,
 	FilePath,
 	Location,
@@ -49,6 +50,7 @@ export interface UseExplorerProps<TOrder extends Ordering> {
 	 * @defaultValue `true`
 	 */
 	showPathBar?: boolean;
+	layouts?: Partial<Record<ExplorerLayout, boolean>>;
 }
 
 /**
@@ -57,6 +59,7 @@ export interface UseExplorerProps<TOrder extends Ordering> {
  */
 export function useExplorer<TOrder extends Ordering>({
 	settings,
+	layouts,
 	...props
 }: UseExplorerProps<TOrder>) {
 	const scrollRef = useRef<HTMLDivElement>(null);
@@ -68,6 +71,12 @@ export function useExplorer<TOrder extends Ordering>({
 		scrollRef,
 		count: props.items?.length,
 		showPathBar: true,
+		layouts: {
+			grid: true,
+			list: true,
+			media: true,
+			...layouts
+		},
 		...settings,
 		// Provided values
 		...props,

--- a/interface/app/$libraryId/TopBar/TopBarOptions.tsx
+++ b/interface/app/$libraryId/TopBar/TopBarOptions.tsx
@@ -1,10 +1,8 @@
 import clsx from 'clsx';
 import { useLayoutEffect, useState } from 'react';
 import { ModifierKeys, Popover, Tooltip, usePopover } from '@sd/ui';
-import { ExplorerLayout } from '~/../packages/client/src';
-import { useIsDark, useKeybind, useKeyMatcher, useOperatingSystem } from '~/hooks';
+import { useIsDark, useOperatingSystem } from '~/hooks';
 
-import { useExplorerContext } from '../Explorer/Context';
 import TopBarButton from './TopBarButton';
 import TopBarMobile from './TopBarMobile';
 
@@ -29,25 +27,10 @@ export const TOP_BAR_ICON_STYLE = 'm-0.5 w-[18px] h-[18px] text-ink-dull';
 
 export default ({ options }: TopBarChildrenProps) => {
 	const [windowSize, setWindowSize] = useState(0);
-	const explorer = useExplorerContext();
 	const os = useOperatingSystem();
 	const toolsNotSmFlex = options
 		?.flatMap((group) => group)
 		.filter((t) => t.showAtResolution !== 'sm:flex');
-	const metaCtrlKey = useKeyMatcher('Meta').key;
-
-	const layoutKeybinds: Array<{ key: string; mode: ExplorerLayout }> = [
-		{ key: '1', mode: 'grid' },
-		{ key: '2', mode: 'list' },
-		{ key: '3', mode: 'media' }
-	];
-
-	layoutKeybinds.forEach(({ key, mode }) => {
-		useKeybind([metaCtrlKey, key], (e) => {
-			e.stopPropagation();
-			explorer.settingsStore.layoutMode = mode;
-		});
-	});
 
 	useLayoutEffect(() => {
 		const handleResize = () => {
@@ -141,7 +124,7 @@ function ToolGroup({
 							>
 								<Tooltip
 									keybinds={keybinds}
-									tooltipClassName={toolTipClassName}
+									tooltipClassName={clsx('capitalize', toolTipClassName)}
 									label={toolTipLabel}
 								>
 									{icon}
@@ -159,7 +142,7 @@ function ToolGroup({
 					>
 						<Tooltip
 							keybinds={keybinds}
-							tooltipClassName={toolTipClassName}
+							tooltipClassName={clsx('capitalize', toolTipClassName)}
 							label={toolTipLabel}
 						>
 							{icon}

--- a/interface/app/$libraryId/ephemeral.tsx
+++ b/interface/app/$libraryId/ephemeral.tsx
@@ -76,7 +76,8 @@ const EphemeralExplorer = memo((props: { args: PathParams }) => {
 
 	const explorer = useExplorer({
 		items,
-		settings: explorerSettings
+		settings: explorerSettings,
+		layouts: { media: false }
 	});
 
 	return (

--- a/interface/app/$libraryId/network.tsx
+++ b/interface/app/$libraryId/network.tsx
@@ -41,7 +41,8 @@ const Network = memo((props: { args: PathParams }) => {
 				pub_id: []
 			}
 		})),
-		settings: explorerSettings
+		settings: explorerSettings,
+		layouts: { media: false }
 	});
 
 	return (

--- a/interface/app/$libraryId/node/$id.tsx
+++ b/interface/app/$libraryId/node/$id.tsx
@@ -1,6 +1,6 @@
 import { Laptop } from '@sd/assets/icons';
 import { useMemo } from 'react';
-import { ExplorerItem, useBridgeQuery, useLibraryQuery } from '@sd/client';
+import { useBridgeQuery, useLibraryQuery } from '@sd/client';
 import { NodeIdParamsSchema } from '~/app/route-schemas';
 import { useZodRouteParams } from '~/hooks';
 
@@ -38,7 +38,8 @@ export const Component = () => {
 			  }
 			: undefined,
 		settings: explorerSettings,
-		showPathBar: false
+		showPathBar: false,
+		layouts: { media: false }
 	});
 
 	return (


### PR DESCRIPTION
This PR introduces a new `useExplorer` prop called `layouts`, with which we can control, which layouts should be used per explorer.

Hides media view from the network, ephemeral, and nodes explorer.

Closes #1174