### PR TITLE
[ENG-1325]  Vendor openssl in tauri

### DIFF
--- a/.cargo/config.toml.mustache
+++ b/.cargo/config.toml.mustache
@@ -1,10 +1,12 @@
 [env]
 {{#protoc}}
-PROTOC = "{{{protoc}}}"
+PROTOC = { force = true, value = "{{{protoc}}}" }
 {{/protoc}}
 {{^isLinux}}
-FFMPEG_DIR = "{{{nativeDeps}}}"
+FFMPEG_DIR = { force = true, value = "{{{nativeDeps}}}" }
 {{/isLinux}}
+OPENSSL_STATIC = { force = true, value = "1" }
+OPENSSL_NO_VENDOR = { force = true, value = "0" }
 
 {{#isMacOS}}
 [target.x86_64-apple-darwin]

--- a/.cargo/config.toml.mustache
+++ b/.cargo/config.toml.mustache
@@ -7,6 +7,7 @@ FFMPEG_DIR = { force = true, value = "{{{nativeDeps}}}" }
 {{/isLinux}}
 OPENSSL_STATIC = { force = true, value = "1" }
 OPENSSL_NO_VENDOR = { force = true, value = "0" }
+OPENSSL_RUST_USE_NASM = { force = true, value = "1" }
 
 {{#isMacOS}}
 [target.x86_64-apple-darwin]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4884,7 +4884,6 @@ version = "0.9.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
 dependencies = [
- "bindgen",
  "cc",
  "libc",
  "openssl-src",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4884,6 +4884,7 @@ version = "0.9.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
 dependencies = [
+ "bindgen",
  "cc",
  "libc",
  "openssl-src",
@@ -6722,6 +6723,8 @@ dependencies = [
  "normpath",
  "notify",
  "once_cell",
+ "openssl",
+ "openssl-sys",
  "pin-project-lite",
  "plist",
  "prisma-client-rust",
@@ -6942,8 +6945,6 @@ dependencies = [
  "futures-channel",
  "futures-locks",
  "once_cell",
- "openssl",
- "openssl-sys",
  "rspc",
  "sd-core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ tracing-subscriber = { git = "https://github.com/tokio-rs/tracing", rev = "29146
 tracing-appender = { git = "https://github.com/tokio-rs/tracing", rev = "29146260fb4615d271d2e899ad95a753bb42915e" } # Unreleased changes for rolling log deletion
 
 rspc = { version = "0.1.4" }
-specta = { version = "1.0.4" }
+specta = { version = "1.0.5" }
 tauri-specta = { version = "1.0.2" }
 
 swift-rs = { version = "1.0.6" }

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -19,6 +19,7 @@ tauri = { version = "1.5.2", features = [
   "shell-all",
   "updater",
   "window-all",
+	"native-tls-vendored"
 ] }
 
 rspc = { workspace = true, features = ["tauri"] }

--- a/apps/mobile/modules/sd-core/core/Cargo.toml
+++ b/apps/mobile/modules/sd-core/core/Cargo.toml
@@ -14,12 +14,6 @@ sd-core = { path = "../../../../../core", features = [
 rspc = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
-openssl = { version = "0.10.57", features = [
-	"vendored",
-] } # Override features of transitive dependencies
-openssl-sys = { version = "0.9.93", features = [
-	"vendored",
-] } # Override features of transitive dependencies to support IOS Simulator on M1
 futures = "0.3.28"
 tracing = { workspace = true }
 futures-channel = "0.3.28"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -109,7 +109,7 @@ axum = "0.6.20"
 http-body = "0.4.5"
 pin-project-lite = "0.2.13"
 bytes = "1.5.0"
-reqwest = { version = "0.11.20", features = ["json"] }
+reqwest = { version = "0.11.20", features = ["json", "native-tls-vendored"] }
 directories = "5.0.1"
 
 # Override features of transitive dependencies

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,7 +28,11 @@ sd-crypto = { path = "../crates/crypto", features = [
 	"keymanager",
 ] }
 
-sd-images = { path = "../crates/images", features = ["rspc", "serde", "specta"] }
+sd-images = { path = "../crates/images", features = [
+	"rspc",
+	"serde",
+	"specta",
+] }
 sd-file-ext = { path = "../crates/file-ext" }
 sd-sync = { path = "../crates/sync" }
 sd-p2p = { path = "../crates/p2p", features = ["specta", "serde"] }
@@ -107,6 +111,14 @@ pin-project-lite = "0.2.13"
 bytes = "1.5.0"
 reqwest = { version = "0.11.20", features = ["json"] }
 directories = "5.0.1"
+
+# Override features of transitive dependencies
+[dependencies.openssl]
+version = "=0.10.57"
+features = ["vendored", "bindgen"]
+[dependencies.openssl-sys]
+version = "=0.9.93"
+features = ["vendored", "bindgen"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
 plist = "1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -115,10 +115,10 @@ directories = "5.0.1"
 # Override features of transitive dependencies
 [dependencies.openssl]
 version = "=0.10.57"
-features = ["vendored", "bindgen"]
+features = ["vendored"]
 [dependencies.openssl-sys]
 version = "=0.9.93"
-features = ["vendored", "bindgen"]
+features = ["vendored"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
 plist = "1"


### PR DESCRIPTION
Instruct openssl crates to always use [openssl-src-rs](https://github.com/alexcrichton/openssl-src-rs) to vendor the libssl.3 and statically link against it. This avoids the libssl.1.1 vs libssl.3.0 linking problems in the deb release.


Partial fix for #1512