### PR TITLE
[ENG-1332] Fix regression causing P2P to be disabled by default

### DIFF
--- a/crates/p2p/src/manager.rs
+++ b/crates/p2p/src/manager.rs
@@ -203,15 +203,10 @@ pub enum ManagerError {
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 pub struct ManagerConfig {
 	// Enable or disable the P2P layer
-	#[serde(default, skip_serializing_if = "is_true")]
 	pub enabled: bool,
 	// `None` will chose a random free port on startup
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub port: Option<u16>,
-}
-
-fn is_true(b: &bool) -> bool {
-	*b
 }
 
 impl Default for ManagerConfig {


### PR DESCRIPTION
The `#[serde(default)]` on `is_enabled` will be `false` cause it's `bool::default` not `Self::default`  🤦