### PR TITLE
Set shortDescription to Spacedrive

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -27,7 +27,7 @@
 			"resources": [],
 			"externalBin": [],
 			"copyright": "Spacedrive Technology Inc.",
-			"shortDescription": "The universal file manager.",
+			"shortDescription": "Spacedrive",
 			"longDescription": "A cross-platform universal file explorer, powered by an open-source virtual distributed filesystem.",
 			"deb": {
 				"depends": [


### PR DESCRIPTION
Makes Task Manager report the name as Spacedrive rather than 'The universal file manager'