### PR TITLE
Fix account card shrink + overview scrollbar

### DIFF
--- a/interface/app/$libraryId/PageLayout/index.tsx
+++ b/interface/app/$libraryId/PageLayout/index.tsx
@@ -20,7 +20,7 @@ export const Component = () => {
 			style={{ paddingTop: TOP_BAR_HEIGHT }}
 		>
 			<PageLayoutContext.Provider value={{ ref }}>
-				<div className="flex h-screen w-full flex-col">
+				<div className="flex w-full flex-1 flex-col">
 					<Outlet />
 				</div>
 			</PageLayoutContext.Provider>

--- a/interface/app/$libraryId/settings/client/SpacedriveAccount.tsx
+++ b/interface/app/$libraryId/settings/client/SpacedriveAccount.tsx
@@ -4,7 +4,7 @@ import { AuthRequiredOverlay } from '~/components/AuthRequiredOverlay';
 
 export function SpacedriveAccount() {
 	return (
-		<Card className="relative overflow-hidden !p-5">
+		<Card>
 			<AuthRequiredOverlay />
 			<Account />
 		</Card>

--- a/interface/app/$libraryId/settings/client/SpacedriveAccount.tsx
+++ b/interface/app/$libraryId/settings/client/SpacedriveAccount.tsx
@@ -4,7 +4,7 @@ import { AuthRequiredOverlay } from '~/components/AuthRequiredOverlay';
 
 export function SpacedriveAccount() {
 	return (
-		<Card>
+		<Card className="relative">
 			<AuthRequiredOverlay />
 			<Account />
 		</Card>


### PR DESCRIPTION
Stops the account card from shrinking + removes `h-screen` from `PageLayout` since 1) that's just a bad idea and 2) scrollbar hides when there's nothing to scroll