### PR TITLE
Job text tabular-nums to reduce jumpiness

### DIFF
--- a/core/src/location/indexer/indexer_job.rs
+++ b/core/src/location/indexer/indexer_job.rs
@@ -539,7 +539,7 @@ fn update_notifier_fn(ctx: &WorkerContext) -> impl FnMut(&Path, usize) + '_ {
 		IndexerJobData::on_scan_progress(
 			ctx,
 			vec![ScanProgress::Message(format!(
-				"Scanning: {:?}; Found: {total_entries} entries",
+				"Found: {total_entries} entries; Scanning: {:?}",
 				path.file_name().unwrap_or(path.as_os_str())
 			))],
 		);

--- a/interface/app/$libraryId/Layout/Sidebar/JobManager/JobContainer.tsx
+++ b/interface/app/$libraryId/Layout/Sidebar/JobManager/JobContainer.tsx
@@ -60,7 +60,11 @@ const JobContainer = forwardRef<HTMLLIElement, JobContainerProps>((props, ref) =
 					const popoverText = filteredItems.map((i) => i?.text).join(' • ');
 
 					return (
-						<Tooltip label={popoverText} key={index} tooltipClassName="max-w-[400px]">
+						<Tooltip
+							label={popoverText}
+							key={index}
+							tooltipClassName="max-w-[400px] tabular-nums"
+						>
 							<TextLine>
 								{filteredItems.map((textItem, index) => {
 									const Icon = textItem?.icon;
@@ -70,6 +74,7 @@ const JobContainer = forwardRef<HTMLLIElement, JobContainerProps>((props, ref) =
 												onClick={textItem?.onClick}
 												className={clsx(
 													// index > 0 && 'px-1.5 py-0.5 italic',
+													'tabular-nums',
 													textItem?.onClick &&
 														'-ml-1.5 rounded-md hover:bg-app-button/50'
 												)}


### PR DESCRIPTION
— use tabular-nums on job text its tooltips to reduce jumpiness
- also swap Scanning: and Found: text 

https://github.com/spacedriveapp/spacedrive/assets/65303441/9c6223a6-c8c3-413b-99b9-8e568bfb210c

Closes #1646 
