### PR TITLE
major fix: hide frame and border if macos is fullscreen

### DIFF
--- a/interface/app/$libraryId/Layout/index.tsx
+++ b/interface/app/$libraryId/Layout/index.tsx
@@ -76,6 +76,8 @@ const Layout = () => {
 		else return <Navigate to="/" replace />;
 	}
 
+	const macOSFullscreen = os === 'macOS' && windowState.isFullScreen;
+
 	return (
 		<LayoutContext.Provider value={ctxValue}>
 			<div
@@ -84,8 +86,11 @@ const Layout = () => {
 					// App level styles
 					'flex h-screen cursor-default select-none overflow-hidden text-ink',
 					os === 'macOS' && 'has-blur-effects',
-					os === 'macOS' && !windowState.isFullScreen && 'rounded-[10px]',
-					os !== 'browser' && os !== 'windows' && 'frame border border-transparent'
+					!macOSFullscreen && 'rounded-[10px]',
+					os !== 'browser' &&
+						os !== 'windows' &&
+						!macOSFullscreen &&
+						'frame border border-transparent'
 				)}
 				onContextMenu={(e) => {
 					// TODO: allow this on some UI text at least / disable default browser context menu


### PR DESCRIPTION
When going fullscreen on MacOS on an external monitor, the app just goes blank. It only happens when the explorer is visible, not during onboarding or settings. Also doesn't happen if you go fullscreen on the native macbook display and move it over to the external display - it only happens when you fullscreen on an external display with the explorer visible.

I noticed the colour grey shown was not the same as the MacOS bar that displays, and inspect element was not being covered so that ruled out any native Swift/MacOS trickery. When looking at the grey, I noticed it was the same grey used for the corners/border of the app, as that was a bug I had to fix while fixing the fullscreen issue. Conditionally disabling the `frame` class and borders entirely fixes this very odd bug.