### PR TITLE
Improve error message with rustup not found

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -52,7 +52,7 @@ if [ "${CI:-}" != "true" ]; then
       'https://pnpm.io/installation'
   fi
 
-  if ! has rustup rustc cargo; then
+  if ! has rustc cargo; then
     err 'Rust was not found.' \
       "Ensure the 'rustc' and 'cargo' binaries are in your \$PATH." \
       'https://rustup.rs'
@@ -72,6 +72,12 @@ if [ "${1:-}" = "mobile" ]; then
     err 'python3 was not found.' \
       'This is required for Android mobile development.' \
       "Ensure 'python3' is available in your \$PATH and try again."
+  fi
+
+  if ! has rustup; then
+    err 'Rust was not found.' \
+      "Ensure the 'rustup' binary is in your \$PATH." \
+      'https://rustup.rs'
   fi
 
   # Android targets

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -75,7 +75,7 @@ if [ "${1:-}" = "mobile" ]; then
   fi
 
   if ! has rustup; then
-    err 'Rust was not found.' \
+    err 'Rustup was not found. It is required for cross-compiling rust to mobile targets.' \
       "Ensure the 'rustup' binary is in your \$PATH." \
       'https://rustup.rs'
   fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -8,7 +8,7 @@ fi
 
 err() {
   for _line in "$@"; do
-    echo "$@" >&2
+    echo "$_line" >&2
   done
   exit 1
 }


### PR DESCRIPTION
While I've configured `spacedrive` from sources on Arch Linux, I got message like bellow, even I had both `rustc` and `cargo`:
```
$ ./scripts/setup.sh 
Spacedrive Development Environment Setup
To set up your machine for Spacedrive development, this script will install some required dependencies with your system package manager

Press Enter to continue

Rust was not found. Ensure the 'rustc' and 'cargo' binaries are in your $PATH. https://rustup.rs
Rust was not found. Ensure the 'rustc' and 'cargo' binaries are in your $PATH. https://rustup.rs
Rust was not found. Ensure the 'rustc' and 'cargo' binaries are in your $PATH. https://rustup.rs
```
But when I checked in the code, command checks additionally `rustup` package:
```
  if ! has rustup rustc cargo; then
```
So, because on Arch Linux [rustup](https://archlinux.org/packages/extra/x86_64/rustup/) is a different package it would simplify for other users to add also information that `rustup` is needed in the path.

