### PR TITLE
fix: traffic light placement when non-fullscreen

### DIFF
--- a/apps/desktop/crates/macos/src-swift/window.swift
+++ b/apps/desktop/crates/macos/src-swift/window.swift
@@ -46,13 +46,13 @@ public func blurWindowBackground(window: NSWindow) {
 
 @_cdecl("set_titlebar_style")
 public func setTitlebarStyle(window: NSWindow, fullScreen: Bool) {
-  // this results in far less visual artifacts if we just manage it ourselves (tha native taskbar re-appears when fullscreening/un-fullscreening)
+  // this results in far less visual artifacts if we just manage it ourselves (the native taskbar re-appears when fullscreening/un-fullscreening)
   window.titlebarAppearsTransparent = true
   if fullScreen { // fullscreen, give control back to the native OS
     window.toolbar = nil
   } else { // non-fullscreen
     // here we create a uniquely identifiable invisible toolbar in order to correctly pad out the traffic lights
-    // this MUST be hidden while fullscreen as macos has a unique dropdown bar for that, and it's far easier to just let that do its thing
+    // this MUST be hidden while fullscreen as macos has a unique dropdown bar for that, and it's far easier to just let it do its thing
     let toolbar = NSToolbar(identifier: "window_invisible_toolbar")
     toolbar.showsBaselineSeparator = false
     window.toolbar = toolbar

--- a/apps/desktop/crates/macos/src-swift/window.swift
+++ b/apps/desktop/crates/macos/src-swift/window.swift
@@ -45,7 +45,17 @@ public func blurWindowBackground(window: NSWindow) {
 }
 
 @_cdecl("set_titlebar_style")
-public func setTitlebarStyle(window: NSWindow, transparent: Bool) {
-  window.titleVisibility = transparent ? .hidden : .visible
-  window.titlebarAppearsTransparent = transparent
+public func setTitlebarStyle(window: NSWindow, fullScreen: Bool) {
+  // this results in far less visual artifacts if we just manage it ourselves (tha native taskbar re-appears when fullscreening/un-fullscreening)
+  window.titlebarAppearsTransparent = true
+  if fullScreen { // fullscreen, give control back to the native OS
+    window.toolbar = nil
+  } else { // non-fullscreen
+    // here we create a uniquely identifiable invisible toolbar in order to correctly pad out the traffic lights
+    // this MUST be hidden while fullscreen as macos has a unique dropdown bar for that, and it's far easier to just let that do its thing
+    let toolbar = NSToolbar(identifier: "window_invisible_toolbar")
+    toolbar.showsBaselineSeparator = false
+    window.toolbar = toolbar
+  }
+  window.titleVisibility = fullScreen ? .visible : .hidden
 }

--- a/apps/desktop/crates/macos/src/lib.rs
+++ b/apps/desktop/crates/macos/src/lib.rs
@@ -12,7 +12,7 @@ pub enum AppThemeType {
 
 swift!(pub fn lock_app_theme(theme_type: Int));
 swift!(pub fn blur_window_background(window: &NSObject));
-swift!(pub fn set_titlebar_style(window: &NSObject, transparent: Bool));
+swift!(pub fn set_titlebar_style(window: &NSObject, is_fullscreen: Bool));
 // swift!(pub fn setup_disk_watcher(window: &NSObject, transparent: Bool, large: Bool));
 // swift!(pub fn disk_event_callback(mounted: Bool, path: &SRString));
 swift!(pub fn reload_webview(webview: &NSObject));

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -270,20 +270,26 @@ async fn main() -> tauri::Result<()> {
 		.on_menu_event(menu::handle_menu_event)
 		.on_window_event(|event| {
 			if let WindowEvent::Resized(_) = event.event() {
-				let command = if event
+				let (state, command) = if event
 					.window()
 					.is_fullscreen()
 					.expect("Can't get fullscreen state")
 				{
-					"window_fullscreened"
+					(true, "window_fullscreened")
 				} else {
-					"window_not_fullscreened"
+					(false, "window_not_fullscreened")
 				};
 
 				event
 					.window()
 					.emit("keybind", command)
 					.expect("Unable to emit window event");
+
+				#[cfg(target_os = "macos")]
+				{
+					let nswindow = event.window().ns_window().unwrap();
+					unsafe { sd_desktop_macos::set_titlebar_style(&nswindow, state) };
+				}
 			}
 		})
 		.menu(menu::get_menu())

--- a/interface/app/$libraryId/Layout/Sidebar/index.tsx
+++ b/interface/app/$libraryId/Layout/Sidebar/index.tsx
@@ -30,8 +30,8 @@ export default () => {
 			className={clsx(
 				'relative flex min-h-full w-44 shrink-0 grow-0 flex-col gap-2.5 border-r border-sidebar-divider bg-sidebar px-2.5 pb-2 transition-[padding-top] ease-linear motion-reduce:transition-none',
 				os === 'macOS' && windowState.isFullScreen
-					? '-mt-2 pt-[8.75px] duration-300'
-					: 'pt-2 duration-300',
+					? '-mt-2 pt-[8.75px] duration-100'
+					: 'pt-1 duration-75',
 
 				os === 'macOS' || showControls.transparentBg
 					? 'bg-opacity-[0.65]'
@@ -45,7 +45,7 @@ export default () => {
 					data-tauri-drag-region
 					className={clsx(
 						'w-full transition-[height] ease-linear motion-reduce:transition-none',
-						windowState.isFullScreen ? 'h-0 duration-300' : 'h-5 duration-300'
+						windowState.isFullScreen ? 'h-0 duration-100' : 'h-5 duration-75'
 					)}
 				/>
 			)}


### PR DESCRIPTION
This fixes the padding, animation duration and traffic light positioning in regards to the window being fullscreen/non-fullscreen. It turns out our positioning "method" was also the cause of our original issue - we render an invisible menu bar to pad the traffic lights, but the issue is that this menu bar remained in place even after the app was made fullscreen (via the green traffic light). More info can be found in #1582.

The traffic light placement was something I entirely overlooked as I was too busy focused on fixing the bar, borders and then padding to notice they had inadvertently been misaligned - the cause of the issue was also the reason for their alignment, but luckily the challenges that arose from that PR alone caused this one to be quite a simple fix.

There _is_ some minor visual artifacting and shifting when moving between fullscreen/not fullscreen, I played around with the timings in order to minimize the impact but there's only so much a sliding animation can really do to alleviate the (pretty noticeable) shift.

There was also the issue of the `tauri-drag-region` being locked to a 300ms duration, essentially inhibiting and limiting the other durations defined (this was also fixed).