### PR TITLE
Fix adding locations to mobile application

### DIFF
--- a/apps/mobile/src/components/modal/ImportModal.tsx
+++ b/apps/mobile/src/components/modal/ImportModal.tsx
@@ -1,13 +1,12 @@
 import { forwardRef, useCallback } from 'react';
-import { Alert, Text, View } from 'react-native';
+import { Alert, Text, View, Platform } from 'react-native';
 import DocumentPicker from 'react-native-document-picker';
 import { useLibraryMutation } from '@sd/client';
 import { Modal, ModalRef } from '~/components/layout/Modal';
 import { Button } from '~/components/primitive/Button';
 import useForwardedRef from '~/hooks/useForwardedRef';
 import { tw } from '~/lib/tailwind';
-
-// import RFS from 'react-native-fs';
+import RNFS from 'react-native-fs';
 // import * as ML from 'expo-media-library';
 
 // WIP component
@@ -44,11 +43,36 @@ const ImportModal = forwardRef<ModalRef, unknown>((_, ref) => {
 
 			if (!response) return;
 
-			createLocation.mutate({
-				path: decodeURIComponent(response.uri.replace('file://', '')),
-				dry_run: false,
-				indexer_rules_ids: []
-			});
+			const uri = response.uri;
+
+			if (Platform.OS === 'android') {
+				// The following code turns this: content://com.android.externalstorage.documents/tree/[filePath] into this: /storage/emulated/0/[directoryName]
+				// Example: content://com.android.externalstorage.documents/tree/primary%3ADownload%2Ftest into /storage/emulated/0/Download/test
+				const dirName = decodeURIComponent(uri).split('/');
+				// Remove all elements before 'tree'
+				dirName.splice(0, dirName.indexOf('tree') + 1);
+				const parsedDirName = dirName.join('/').split(':')[1]
+				const dirPath = RNFS.ExternalStorageDirectoryPath + '/' + parsedDirName;
+				//Verify that the directory exists
+				const dirExists = await RNFS.exists(dirPath);
+				if (!dirExists) {
+					console.error('Directory does not exist'); //TODO: Make this a UI error
+					return;
+				}
+
+				createLocation.mutate({
+					path: dirPath,
+					dry_run: false,
+					indexer_rules_ids: []
+				});
+			} else {
+				createLocation.mutate({
+					path: decodeURIComponent(uri.replace('file://', '')),
+					dry_run: false,
+					indexer_rules_ids: []
+				});
+			}
+
 		} catch (err) {
 			console.error(err);
 		}


### PR DESCRIPTION
Adds a fix to get locations working on the mobile application as right now, the application just dies when trying to add one.

However, it only works on Android right now. Depends on PR #1670 in order to see if locations break on iOS, to then fix the errors.

Closes #1671
