### PR TITLE
[ENG-1362] Logging in loading state improvement

### DIFF
--- a/interface/components/AuthRequiredOverlay.tsx
+++ b/interface/components/AuthRequiredOverlay.tsx
@@ -8,7 +8,11 @@ export function AuthRequiredOverlay() {
 	if (authState.status !== 'loggedIn')
 		return (
 			<div className="absolute inset-0 z-50 flex items-center justify-center bg-app/75 backdrop-blur-sm">
-				{authState.status === 'loading' ? <Loader /> : <LoginButton />}
+				{authState.status === 'loading' || authState.status === 'loggingIn' ? (
+					<Loader />
+				) : (
+					<LoginButton />
+				)}
 			</div>
 		);
 


### PR DESCRIPTION
When logging in the first time, sometimes loading can take longer than anticipated. A loading spinner should show, so I added the check for that.

- A simple check for 'loggingIn' improves the user experience and makes it more satisfying.
- Logging out is instant, so no need to include the check for that.