### PR TITLE
Add installation of libvips for arch systems to setup script

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -159,6 +159,9 @@ case "$(uname)" in
 
       # Bindgen dependencies - it's used by a dependency of Spacedrive
       set -- "$@" clang
+      
+      # React dependencies
+      set -- "$@" libvips
 
       sudo pacman -Sy --needed "$@"
     elif has dnf; then


### PR DESCRIPTION
<!-- Put any information about this PR up here -->
The libvips package is a system dependency that is not installed by default on Arch-based systems like EndeavourOS. This PR adds the package installation to the setup script for pacman.
<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->

Closes #1687 
