### PR TITLE
Remove unused dependencies from server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7006,14 +7006,12 @@ name = "sd-server"
 version = "0.1.0"
 dependencies = [
  "axum",
- "ctrlc",
  "http",
  "include_dir",
  "mime_guess",
  "rspc",
  "sd-core",
  "tokio",
- "tower-http",
  "tracing 0.2.0",
 ]
 

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -18,8 +18,6 @@ rspc = { workspace = true, features = ["axum"] }
 axum = "0.6.20"
 tokio = { workspace = true, features = ["sync", "rt-multi-thread", "signal"] }
 tracing = { workspace = true }
-ctrlc = "3.4.1"
 http = "0.2.9"
-tower-http = { version = "0.4.4", features = ["fs"] }
 include_dir = "0.7.3"
 mime_guess = "2.0.4"


### PR DESCRIPTION
<!-- Put any information about this PR up here -->
This removes the unnecessary `ctrlc` and `tower-http` dependencies from sd-server, which speeds up build times. 

<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->

Closes #1693 
