### PR TITLE
[ENG-1367] TypeError: null is not an object

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,16 +1383,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctrlc"
-version = "3.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e95fbd621905b854affdc67943b043a0fbb6ed7385fd5a25650d19a8a6cfdf"
-dependencies = [
- "nix 0.27.1",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "cty"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2892,12 +2882,6 @@ name = "http-range"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
-
-[[package]]
-name = "http-range-header"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "httparse"
@@ -4541,17 +4525,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if",
- "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags 2.4.0",
  "cfg-if",
  "libc",
 ]
@@ -8474,31 +8447,6 @@ dependencies = [
  "pin-project",
  "pin-project-lite",
  "tokio",
- "tower-layer",
- "tower-service",
- "tracing 0.1.37",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
-dependencies = [
- "bitflags 2.4.0",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-range-header",
- "httpdate",
- "mime",
- "mime_guess",
- "percent-encoding",
- "pin-project-lite",
- "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing 0.1.37",

--- a/core/src/job/report.rs
+++ b/core/src/job/report.rs
@@ -4,7 +4,10 @@ use crate::{
 	util::db::{maybe_missing, MissingFieldError},
 };
 
-use std::fmt::{Display, Formatter};
+use std::{
+	collections::HashMap,
+	fmt::{Display, Formatter},
+};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -44,6 +47,9 @@ pub struct JobReport {
 	pub name: String,
 	pub action: Option<String>,
 	pub data: Option<Vec<u8>>,
+	// In Typescript `any | null` is just `any` so we don't get prompted for null checks
+	// TODO(@Oscar): This will be fixed
+	#[specta(type = Option<HashMap<String, serde_json::Value>>)]
 	pub metadata: Option<serde_json::Value>,
 	pub is_background: bool,
 	pub errors_text: Vec<String>,

--- a/interface/hooks/useIsLocationIndexing.ts
+++ b/interface/hooks/useIsLocationIndexing.ts
@@ -14,7 +14,11 @@ export const useIsLocationIndexing = (locationId: number): boolean => {
 	const isLocationIndexing =
 		jobGroups?.some((group) =>
 			group.jobs.some((job) => {
-				if (job.name === 'indexer' && job.metadata.location.id === locationId && (job.status === 'Running' || job.status === 'Queued')) {
+				if (
+					job.name === 'indexer' &&
+					job.metadata?.location.id === locationId &&
+					(job.status === 'Running' || job.status === 'Queued')
+				) {
 					return job.completed_task_count === 0;
 				}
 			})

--- a/interface/hooks/useRedirectToNewLocation.ts
+++ b/interface/hooks/useRedirectToNewLocation.ts
@@ -25,7 +25,7 @@ export const useRedirectToNewLocation = () => {
 		.some(
 			(j) =>
 				j.name === 'indexer' &&
-				j.metadata.location.id === newLocation &&
+				j.metadata?.location.id === newLocation &&
 				(j.completed_task_count > 0 || j.completed_at != null)
 		);
 

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -243,7 +243,7 @@ export type JobGroup = { id: string; action: string | null; status: JobStatus; c
 
 export type JobProgressEvent = { id: string; library_id: string; task_count: number; completed_task_count: number; phase: string; message: string; estimated_completion: string }
 
-export type JobReport = { id: string; name: string; action: string | null; data: number[] | null; metadata: any | null; is_background: boolean; errors_text: string[]; created_at: string | null; started_at: string | null; completed_at: string | null; parent_id: string | null; status: JobStatus; task_count: number; completed_task_count: number; phase: string; message: string; estimated_completion: string }
+export type JobReport = { id: string; name: string; action: string | null; data: number[] | null; metadata: { [key: string]: any } | null; is_background: boolean; errors_text: string[]; created_at: string | null; started_at: string | null; completed_at: string | null; parent_id: string | null; status: JobStatus; task_count: number; completed_task_count: number; phase: string; message: string; estimated_completion: string }
 
 export type JobStatus = "Queued" | "Running" | "Completed" | "Canceled" | "Failed" | "Paused" | "CompletedWithErrors"
 


### PR DESCRIPTION
Typescript resolves `any | null` to `any` which means we aren't prompted for null checks leading to bugs.

In a future update, Specta will be modified to fix this but for now, this will work and prevent bugs!