### PR TITLE
[ENG-1341] Landing download links shouldn't open new page

### DIFF
--- a/apps/landing/src/app/Downloads.tsx
+++ b/apps/landing/src/app/Downloads.tsx
@@ -111,7 +111,7 @@ export function Downloads({ latestVersion }: Props) {
 							key={name}
 							size="md"
 							text={name}
-							target="_blank"
+							rel="noopener"
 							href={`${BASE_DL_LINK}/${selectedPlatform.os}/${arch}`}
 							onClick={() => {
 								plausible('download', {
@@ -198,7 +198,7 @@ function Platform({ platform, ...props }: ComponentProps<'a'> & PlatformProps) {
 			? (props: any) => (
 					<a
 						aria-label={platform.name}
-						target="_blank"
+						rel="noopener"
 						href={`${BASE_DL_LINK}/${platform.os}/${links[0].arch}`}
 						{...props}
 					/>

--- a/apps/landing/src/app/HomeCTA.tsx
+++ b/apps/landing/src/app/HomeCTA.tsx
@@ -19,7 +19,6 @@ export function HomeCTA({ className, text, icon, ...props }: Props) {
 				'home-button-border-gradient relative z-30 flex cursor-pointer items-center gap-2 !rounded-[7px] border-0 !bg-[#2F3152]/30 py-2 text-sm text-white !backdrop-blur-lg hover:brightness-110 md:text-[16px]',
 				className
 			)}
-			target="_blank"
 			{...props}
 		>
 			<>


### PR DESCRIPTION
This is specific to the download links.

https://github.com/spacedriveapp/spacedrive/assets/21004798/70dff798-ceeb-4826-8386-296b6add524a

