### PR TITLE
[ENG-1366] Improve ErrorBoundary so user can't get stuck on it

### DIFF
--- a/interface/index.tsx
+++ b/interface/index.tsx
@@ -8,7 +8,6 @@ import dayjs from 'dayjs';
 import advancedFormat from 'dayjs/plugin/advancedFormat';
 import duration from 'dayjs/plugin/duration';
 import relativeTime from 'dayjs/plugin/relativeTime';
-import { ErrorBoundary } from 'react-error-boundary';
 import { RouterProvider, RouterProviderProps } from 'react-router-dom';
 import {
 	NotificationContextProvider,
@@ -20,7 +19,7 @@ import { TooltipProvider } from '@sd/ui';
 
 import { P2P } from './app/p2p';
 import { WithPrismTheme } from './components/TextViewer/prism';
-import ErrorFallback from './ErrorFallback';
+import ErrorFallback, { BetterErrorBoundary } from './ErrorFallback';
 
 export { ErrorPage } from './ErrorFallback';
 export * from './app';
@@ -59,7 +58,7 @@ export const SpacedriveInterface = (props: { router: RouterProviderProps['router
 	useLoadBackendFeatureFlags();
 
 	return (
-		<ErrorBoundary FallbackComponent={ErrorFallback}>
+		<BetterErrorBoundary FallbackComponent={ErrorFallback}>
 			<TooltipProvider>
 				<P2PContextProvider>
 					<NotificationContextProvider>
@@ -70,6 +69,6 @@ export const SpacedriveInterface = (props: { router: RouterProviderProps['router
 					</NotificationContextProvider>
 				</P2PContextProvider>
 			</TooltipProvider>
-		</ErrorBoundary>
+		</BetterErrorBoundary>
 	);
 };


### PR DESCRIPTION
A rendering error would potentially allow the user to get stuck on the error boundary as the "Reload" button would render the same page, hit the same error and rerender the same error boundary. Now we detect if the error boundary is hit after the reload and if that's the case we redirect to "/" to break the cycle.

Before:

https://github.com/spacedriveapp/spacedrive/assets/21004798/2f5115b7-9262-4f3e-bcbb-32ef11133838


After:

https://github.com/spacedriveapp/spacedrive/assets/21004798/71818303-7e6c-41d9-918b-8e34a66ec0a8

