### PR TITLE
Clarify error that occurs when getting the hash of an on-demand file

### DIFF
--- a/core/src/object/file_identifier/mod.rs
+++ b/core/src/object/file_identifier/mod.rs
@@ -124,7 +124,17 @@ async fn identifier_job_step(
 							(metadata, file_path),
 						)
 					})
-					.map_err(|e| error!("Failed to extract file metadata: {e:#?}"))
+					.map_err(|e| {
+						if e.source
+							.raw_os_error()
+							.map(|code| code == 362)
+							.unwrap_or(false)
+						{
+							error!("Attempted to extract metadata from on-demand file: {e:#?}");
+						} else {
+							error!("Failed to extract file metadata: {e:#?}")
+						}
+					})
 					.ok()
 			}),
 	)

--- a/core/src/object/file_identifier/mod.rs
+++ b/core/src/object/file_identifier/mod.rs
@@ -130,7 +130,7 @@ async fn identifier_job_step(
 							.map(|code| code == 362)
 							.unwrap_or(false)
 						{
-							error!("Attempted to extract metadata from on-demand file: {e:#?}");
+							error!("Failed to extract metadata from on-demand file: {e:#?}");
 						} else {
 							error!("Failed to extract file metadata: {e:#?}")
 						}


### PR DESCRIPTION
- Clarifies error that occurs when attempting to read the metadata from an on-demand file
  - Involves issue #1721 but does not solve it

Current Error:
```
2023-11-01T19:29:02.533749Z ERROR sd_core::object::file_identifier: Failed to extract file metadata: FileIOError {
    path: "C:\\Users\\xxxxx\\OneDrive\\Document.docx",
    source: Os {
        code: 362,
        kind: Uncategorized,
        message: "The cloud file provider is not running.",
    },
    maybe_context: None,
}
```
New Error:
```
2023-11-01T15:58:27.994181Z ERROR sd_core::object::file_identifier: Failed to extract metadata from on-demand file: FileIOError {
    path: "C:\\Users\\xxxxx\\OneDrive\\Document.docx",
    source: Os {
        code: 362,
        kind: Uncategorized,
        message: "The cloud file provider is not running.",
    },
    maybe_context: None,
}
```
