### PR TITLE
Remove unused dependencies in src-tauri and p2p

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,12 +194,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
-
-[[package]]
 name = "argon2"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6823,7 +6817,6 @@ dependencies = [
  "uuid",
  "webkit2gtk",
  "webview2-com",
- "window-shadows",
 ]
 
 [[package]]
@@ -6945,7 +6938,6 @@ dependencies = [
 name = "sd-p2p"
 version = "0.1.0"
 dependencies = [
- "arc-swap",
  "base64 0.21.5",
  "ed25519-dalek",
  "flume",
@@ -6956,7 +6948,6 @@ dependencies = [
  "mdns-sd",
  "pin-project-lite",
  "rand_core 0.6.4",
- "rmp-serde",
  "serde",
  "specta",
  "streamunordered",
@@ -9392,18 +9383,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "window-shadows"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d30320647cfc3dc45554c8ad825b84831def81f967a2f7589931328ff9b16d"
-dependencies = [
- "cocoa",
- "objc",
- "raw-window-handle",
- "windows-sys 0.42.0",
-]
 
 [[package]]
 name = "windows"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1489,7 +1489,6 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core 0.9.8",
- "serde",
 ]
 
 [[package]]
@@ -3098,7 +3097,6 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18762faeff7122e89e0857b02f7ce6fcc0d101d5e9ad2ad7846cc01d61b7f19e"
 dependencies = [
- "glob",
  "include_dir_macros",
 ]
 
@@ -6674,24 +6672,19 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.21.5",
  "blake3",
  "bytes",
  "chrono",
  "ctor 0.2.4",
- "dashmap",
  "directories 5.0.1",
- "enumflags2 0.7.7",
  "flate2",
  "futures",
  "futures-concurrency",
  "globset",
- "hex",
  "hostname",
  "http-body",
  "http-range",
  "image",
- "include_dir",
  "int-enum",
  "itertools 0.11.0",
  "mini-moka",
@@ -6705,7 +6698,6 @@ dependencies = [
  "prisma-client-rust",
  "regex",
  "reqwest",
- "rmp",
  "rmp-serde",
  "rmpv",
  "rspc",
@@ -6726,7 +6718,6 @@ dependencies = [
  "slotmap",
  "specta",
  "static_assertions",
- "streamunordered",
  "strum",
  "strum_macros",
  "sysinfo",
@@ -6755,7 +6746,6 @@ dependencies = [
  "sd-utils",
  "serde",
  "serde_json",
- "slotmap",
  "tokio",
  "tracing 0.2.0",
  "uhlc",
@@ -6797,7 +6787,6 @@ dependencies = [
  "futures",
  "http",
  "opener",
- "percent-encoding",
  "prisma-client-rust",
  "rand 0.8.5",
  "rspc",
@@ -6832,7 +6821,6 @@ dependencies = [
 name = "sd-desktop-macos"
 version = "0.1.0"
 dependencies = [
- "serde",
  "swift-rs",
 ]
 
@@ -6866,7 +6854,6 @@ dependencies = [
  "serde_json",
  "specta",
  "strum",
- "strum_macros",
  "tokio",
 ]
 
@@ -6989,9 +6976,7 @@ name = "sd-sync"
 version = "0.1.0"
 dependencies = [
  "prisma-client-rust",
- "rand 0.8.5",
  "serde",
- "serde-value",
  "serde_json",
  "specta",
  "uhlc",
@@ -7003,10 +6988,7 @@ name = "sd-sync-generator"
 version = "0.1.0"
 dependencies = [
  "nom",
- "once_cell",
  "prisma-client-rust-sdk",
- "proc-macro2",
- "quote",
  "serde",
  "thiserror",
 ]

--- a/apps/desktop/crates/macos/Cargo.toml
+++ b/apps/desktop/crates/macos/Cargo.toml
@@ -6,7 +6,6 @@ repository = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-serde = { version = "1.0" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 swift-rs = { workspace = true, features = ["serde"] }

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -29,7 +29,6 @@ sd-core = { path = "../../../core", features = [
 	"heif",
 ] }
 tokio = { workspace = true, features = ["sync"] }
-window-shadows = "0.2.1"
 tracing = { workspace = true }
 serde = "1.0.188"
 percent-encoding = "2.3.0"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -31,7 +31,6 @@ sd-core = { path = "../../../core", features = [
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 serde = "1.0.188"
-percent-encoding = "2.3.0"
 http = "0.2.9"
 opener = { version = "0.6.1", features = ["reveal"] }
 specta = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -56,12 +56,10 @@ tokio = { workspace = true, features = [
 	"time",
 	"process",
 ] }
-base64 = "0.21.4"
 serde = { version = "1.0", features = ["derive"] }
 chrono = { version = "0.4.30", features = ["serde"] }
 serde_json = { workspace = true }
 futures = "0.3"
-rmp = "^0.8.12"
 rmp-serde = "^1.1.2"
 rmpv = "^1.0.1"
 blake3 = "1.4.1"
@@ -69,7 +67,6 @@ hostname = "0.3.1"
 uuid = { workspace = true }
 sysinfo = "0.29.10"
 thiserror = "1.0.48"
-include_dir = { version = "0.7.3", features = ["glob"] }
 async-trait = "^0.1.73"
 image = "0.24.7"
 webp = "0.2.6"
@@ -80,11 +77,9 @@ once_cell = "1.18.0"
 ctor = "0.2.4"
 globset = { version = "^0.4.13", features = ["serde1"] }
 itertools = "^0.11.0"
-enumflags2 = "0.7.7"
 http-range = "0.1.5"
 mini-moka = "0.10.2"
 serde_with = "3.3.0"
-dashmap = { version = "5.5.3", features = ["serde"] }
 notify = { version = "=5.2.0", default-features = false, features = [
 	"macos_fsevent",
 ], optional = true }
@@ -95,7 +90,6 @@ tracing-appender = { workspace = true }
 strum = { version = "0.25", features = ["derive"] }
 strum_macros = "0.25"
 regex = "1.9.5"
-hex = "0.4.3"
 int-enum = "0.5.0"
 tokio-stream = "0.1.14"
 futures-concurrency = "7.4.3"
@@ -111,7 +105,6 @@ pin-project-lite = "0.2.13"
 bytes = "1.5.0"
 reqwest = { version = "0.11.20", features = ["json", "native-tls-vendored"] }
 directories = "5.0.1"
-streamunordered = "0.5.3"
 
 # Override features of transitive dependencies
 [dependencies.openssl]

--- a/core/crates/sync/Cargo.toml
+++ b/core/crates/sync/Cargo.toml
@@ -18,4 +18,3 @@ tokio = { workspace = true }
 uuid = { workspace = true }
 tracing = { workspace = true }
 uhlc = "=0.5.2"
-slotmap = "1.0.6"

--- a/crates/file-ext/Cargo.toml
+++ b/crates/file-ext/Cargo.toml
@@ -13,7 +13,6 @@ edition = { workspace = true }
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = { workspace = true }
 strum = { version = "0.25", features = ["derive"] }
-strum_macros = "0.25"
 tokio = { workspace = true, features = ["fs", "rt", "io-util"] }
 specta = { workspace = true }
 

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -30,11 +30,9 @@ mdns-sd = "0.7.4"
 thiserror = "1.0.48"
 tracing = { workspace = true }
 serde = { version = "1.0.188", features = ["derive"] } # TODO: Optional or remove feature
-rmp-serde = "1.1.2"
 specta = { workspace = true }
 flume = "0.10.0" # Must match version used by `mdns-sd`
 tokio-util = { version = "0.7.8", features = ["compat"] }
-arc-swap = "1.6.0"
 ed25519-dalek = { version = "2.0.0", features = [] }
 rand_core = { version = "0.6.4" }
 uuid = "1.4.1"

--- a/crates/sync-generator/Cargo.toml
+++ b/crates/sync-generator/Cargo.toml
@@ -7,9 +7,6 @@ edition = { workspace = true }
 
 [dependencies]
 nom = "7.1.3"
-once_cell = "1.18.0"
 prisma-client-rust-sdk = { workspace = true }
-proc-macro2 = "1.0.66"
-quote = "1.0.33"
 serde = { version = "1.0.188", features = ["derive"] }
 thiserror = "1.0.48"

--- a/crates/sync/Cargo.toml
+++ b/crates/sync/Cargo.toml
@@ -6,11 +6,9 @@ repository = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-rand = "0.8.5"
 specta = { workspace = true, features = ["uuid", "uhlc"] }
 serde = "1.0.188"
 serde_json = { workspace = true }
 uhlc = "=0.5.2"
 uuid = { version = "1.4.1", features = ["serde", "v4"] }
 prisma-client-rust = { workspace = true }
-serde-value = "0.7.0"


### PR DESCRIPTION
<!-- Put any information about this PR up here -->
This removes the unnecessary `rmp-serde` and `arc-swap` dependencies from `p2p`, as well as the `window-shadows` dependency from `src-tauri` which speeds up build times.
<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->

Closes #1725 
