### PR TITLE
[ENG-1360] Not always unlink objects from file_paths on update

### DIFF
--- a/apps/desktop/src-tauri/src/tauri_plugins.rs
+++ b/apps/desktop/src-tauri/src/tauri_plugins.rs
@@ -15,9 +15,9 @@ use axum::{
 use rand::{distributions::Alphanumeric, Rng};
 use sd_core::{custom_uri, Node, NodeError};
 use serde::Deserialize;
-use tauri::{async_runtime::block_on, plugin::TauriPlugin, Manager, RunEvent, Runtime};
+use tauri::{async_runtime::block_on, plugin::TauriPlugin, RunEvent, Runtime};
 use tokio::task::block_in_place;
-use tracing::{debug, error, info};
+use tracing::info;
 
 /// Inject `window.__SD_ERROR__` so the frontend can render core startup errors.
 /// It's assumed the error happened prior or during settings up the core and rspc.
@@ -75,7 +75,7 @@ pub fn sd_server_plugin<R: Runtime>(node: Arc<Node>) -> io::Result<TauriPlugin<R
 		.js_init_script(format!(
 		        r#"window.__SD_CUSTOM_SERVER_AUTH_TOKEN__ = "{auth_token}"; window.__SD_CUSTOM_URI_SERVER__ = "http://{listen_addr}";"#
 		))
-		.on_event(move |app, e| {
+		.on_event(move |_app, e| {
 			if let RunEvent::Exit { .. } = e {
 				block_in_place(|| {
 					block_on(node.shutdown());

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -169,6 +169,8 @@ impl Node {
 		let collector = tracing_subscriber::registry()
 			.with(
 				tracing_fmt::Subscriber::new()
+					.with_file(true)
+					.with_line_number(true)
 					.with_ansi(false)
 					.with_writer(logfile)
 					.with_filter(
@@ -179,6 +181,8 @@ impl Node {
 			)
 			.with(
 				tracing_fmt::Subscriber::new()
+					.with_file(true)
+					.with_line_number(true)
 					.with_writer(std::io::stdout)
 					.with_filter(
 						EnvFilter::builder()

--- a/core/src/location/file_path_helper/mod.rs
+++ b/core/src/location/file_path_helper/mod.rs
@@ -36,6 +36,7 @@ file_path::select!(file_path_for_file_identifier {
 	is_dir
 	name
 	extension
+	object_id
 });
 file_path::select!(file_path_for_object_validator {
 	pub_id
@@ -72,6 +73,7 @@ file_path::select!(file_path_to_isolate_with_id {
 file_path::select!(file_path_walker {
 	pub_id
 	location_id
+	object_id
 	materialized_path
 	is_dir
 	name

--- a/core/src/object/file_identifier/file_identifier_job.rs
+++ b/core/src/object/file_identifier/file_identifier_job.rs
@@ -17,6 +17,7 @@ use std::{
 	path::{Path, PathBuf},
 };
 
+use prisma_client_rust::or;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tracing::{debug, info, trace};
@@ -253,9 +254,13 @@ fn orphan_path_filters(
 ) -> Vec<file_path::WhereParam> {
 	sd_utils::chain_optional_iter(
 		[
-			file_path::object_id::equals(None),
+			or!(
+				file_path::object_id::equals(None),
+				file_path::cas_id::equals(None)
+			),
 			file_path::is_dir::equals(Some(false)),
 			file_path::location_id::equals(Some(location_id)),
+			file_path::size_in_bytes_bytes::not(Some(0u64.to_be_bytes().to_vec())),
 		],
 		[
 			// this is a workaround for the cursor not working properly

--- a/core/src/object/file_identifier/shallow.rs
+++ b/core/src/object/file_identifier/shallow.rs
@@ -12,6 +12,7 @@ use crate::{
 
 use std::path::{Path, PathBuf};
 
+use prisma_client_rust::or;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, trace, warn};
 
@@ -126,7 +127,10 @@ fn orphan_path_filters(
 ) -> Vec<file_path::WhereParam> {
 	sd_utils::chain_optional_iter(
 		[
-			file_path::object_id::equals(None),
+			or!(
+				file_path::object_id::equals(None),
+				file_path::cas_id::equals(None)
+			),
 			file_path::is_dir::equals(Some(false)),
 			file_path::location_id::equals(Some(location_id)),
 			file_path::materialized_path::equals(Some(
@@ -134,6 +138,7 @@ fn orphan_path_filters(
 					.materialized_path_for_children()
 					.expect("sub path for shallow identifier must be a directory"),
 			)),
+			file_path::size_in_bytes_bytes::not(Some(0u64.to_be_bytes().to_vec())),
 		],
 		[file_path_id.map(file_path::id::gte)],
 	)

--- a/core/src/object/media/media_processor/shallow.rs
+++ b/core/src/object/media/media_processor/shallow.rs
@@ -196,7 +196,7 @@ async fn dispatch_thumbnails_for_processing(
 	if !current_batch.is_empty() {
 		node.thumbnailer
 			.new_indexed_thumbnails_batch(
-				BatchToProcess::new(current_batch, should_regenerate, true),
+				BatchToProcess::new(current_batch, should_regenerate, false),
 				library.id,
 			)
 			.await;

--- a/core/src/object/media/mod.rs
+++ b/core/src/object/media/mod.rs
@@ -28,6 +28,22 @@ pub fn media_data_image_to_query(
 	})
 }
 
+pub fn media_data_image_to_query_params(
+	mdi: ImageMetadata,
+) -> Result<Vec<SetParam>, MediaDataError> {
+	Ok(vec![
+		camera_data::set(serde_json::to_vec(&mdi.camera_data).ok()),
+		media_date::set(serde_json::to_vec(&mdi.date_taken).ok()),
+		resolution::set(serde_json::to_vec(&mdi.resolution).ok()),
+		media_location::set(serde_json::to_vec(&mdi.location).ok()),
+		artist::set(mdi.artist),
+		description::set(mdi.description),
+		copyright::set(mdi.copyright),
+		exif_version::set(mdi.exif_version),
+		epoch_time::set(mdi.date_taken.map(|x| x.unix_timestamp())),
+	])
+}
+
 pub fn media_data_image_from_prisma_data(
 	data: sd_prisma::prisma::media_data::Data,
 ) -> Result<ImageMetadata, MediaDataError> {


### PR DESCRIPTION
This PR introduces some changes trying to preserve an object from being unlinked on file_path updates. Also some watcher fixes and improvements.