### PR TITLE
Update tokio's version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8504,9 +8504,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.33.0"
+version = "1.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
+checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
 dependencies = [
  "backtrace",
  "bytes",
@@ -8523,9 +8523,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ tauri-specta = { version = "1.0.2" }
 
 swift-rs = { version = "1.0.6" }
 
-tokio = { version = "1.33.0" }
+tokio = { version = "1.34.0" }
 uuid = { version = "1.5.0", features = ["v4", "serde"] }
 serde = { version = "1.0" }
 serde_json = { version = "1.0" }


### PR DESCRIPTION
Today's Tokio release include this fix (https://github.com/tokio-rs/tokio/issues/6133), which can potentially explain some mysterious jobs hanging that some users reported to us at the first alpha launch.