### PR TITLE
[ENG-1359] Revert "Fix pdf thumb crashing app (#1460)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5221,9 +5221,9 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pdfium-render"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee60ec2224be18817718989458bf2e7d036829640654a867a8a46ac40f29132d"
+checksum = "9b09ef9c34c66ce232d7af3562dcffe8801b2d0665d2c2770d06cdc46e0d2aff"
 dependencies = [
  "bindgen 0.69.1",
  "bitflags 2.4.1",

--- a/crates/images/Cargo.toml
+++ b/crates/images/Cargo.toml
@@ -30,4 +30,8 @@ tracing = { workspace = true }
 # this broke builds as we build our own liibheif, so i disabled their default features
 libheif-rs = { version = "0.22.0", default-features = false, optional = true }
 libheif-sys = { version = "2.0.0", default-features = false, optional = true }
-pdfium-render = { version = "0.8.14", features = ["image"] }
+pdfium-render = { version = "0.8.15", features = [
+	"sync",
+	"image",
+	"thread_safe",
+] }

--- a/crates/images/src/pdf.rs
+++ b/crates/images/src/pdf.rs
@@ -6,6 +6,7 @@ use std::{
 
 use crate::{consts::PDF_RENDER_WIDTH, Error::PdfiumBinding, ImageHandler, Result};
 use image::DynamicImage;
+use once_cell::sync::Lazy;
 use pdfium_render::prelude::{PdfPageRenderRotation, PdfRenderConfig, Pdfium};
 use tracing::error;
 
@@ -19,64 +20,59 @@ const BINDING_LOCATION: &str = if cfg!(target_os = "macos") {
 	"../lib/spacedrive"
 };
 
-// FIX-ME: This is slow, but using Lazy with thread_safe was causing concurrency bugs that crashed the app
-thread_local! {
-	static PDFIUM: Option<Pdfium> = {
-		let lib_name = Pdfium::pdfium_platform_library_name();
-		let lib_path = current_exe()
-			.ok()
-			.and_then(|exe_path| {
-				exe_path.parent().and_then(|parent_path| {
-					match parent_path
-						.join(BINDING_LOCATION)
-						.join(&lib_name)
-						.canonicalize()
-					{
-						Ok(lib_path) => lib_path.to_str().map(ToOwned::to_owned),
-						Err(err) => {
-							error!("{err:#?}");
-							None
-						}
-					}
-				})
-			})
-			.unwrap_or_else(|| {
-				#[allow(clippy::expect_used)]
-				PathBuf::from(BINDING_LOCATION)
+static PDFIUM: Lazy<Option<Pdfium>> = Lazy::new(|| {
+	let lib_name = Pdfium::pdfium_platform_library_name();
+	let lib_path = current_exe()
+		.ok()
+		.and_then(|exe_path| {
+			exe_path.parent().and_then(|parent_path| {
+				match parent_path
+					.join(BINDING_LOCATION)
 					.join(&lib_name)
-					.to_str()
-					.expect("We are converting valid strs to PathBuf then back, it should not fail")
-					.to_owned()
-			});
-
-		Pdfium::bind_to_library(lib_path)
-			.or_else(|err| {
-				error!("{err:#?}");
-				Pdfium::bind_to_system_library()
+					.canonicalize()
+				{
+					Ok(lib_path) => lib_path.to_str().map(ToOwned::to_owned),
+					Err(err) => {
+						error!("{err:#?}");
+						None
+					}
+				}
 			})
-			.map(Pdfium::new)
-			.map_err(|err| error!("{err:#?}"))
-			.ok()
-	};
-}
+		})
+		.unwrap_or_else(|| {
+			#[allow(clippy::expect_used)]
+			PathBuf::from(BINDING_LOCATION)
+				.join(&lib_name)
+				.to_str()
+				.expect("We are converting valid strs to PathBuf then back, it should not fail")
+				.to_owned()
+		});
+
+	Pdfium::bind_to_library(lib_path)
+		.or_else(|err| {
+			error!("{err:#?}");
+			Pdfium::bind_to_system_library()
+		})
+		.map(Pdfium::new)
+		.map_err(|err| error!("{err:#?}"))
+		.ok()
+});
 
 pub struct PdfHandler {}
 
 impl ImageHandler for PdfHandler {
 	fn handle_image(&self, path: &Path) -> Result<DynamicImage> {
-		PDFIUM.with(|maybe_pdfium| {
-			let pdfium = maybe_pdfium.as_ref().ok_or(PdfiumBinding)?;
+		let pdfium = PDFIUM.as_ref().ok_or(PdfiumBinding)?;
 
-			let render_config = PdfRenderConfig::new()
-				.set_target_width(PDF_RENDER_WIDTH)
-				.rotate_if_landscape(PdfPageRenderRotation::Degrees90, true);
+		let render_config = PdfRenderConfig::new()
+			.set_target_width(PDF_RENDER_WIDTH)
+			.rotate_if_landscape(PdfPageRenderRotation::Degrees90, true);
 
-			Ok(pdfium
-				.load_pdf_from_file(path, None)?
-				.pages()
-				.first()?
-				.render_with_config(&render_config)?
-				.as_image())
-		})
+		Ok(pdfium
+			.load_pdf_from_file(path, None)?
+			.pages()
+			.first()?
+			.render_with_config(&render_config)?
+			.as_image())
 	}
 }


### PR DESCRIPTION
This reverts the changes made in PR #1460. It ended up being an unnecessary set of changes that did not fix the underlying issue and made PDF thumbnail performance way worse. The correct fix for the mentioned issue was implemented in https://github.com/bblanchon/pdfium-binaries/pull/138. Also updated `pdfium-render`.
