### PR TITLE
Fix Clippy Warnings

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -73,7 +73,8 @@ fn reload_webview_inner(webview: PlatformWebview) {
 			.controller()
 			.CoreWebView2()
 			.expect("Unable to get handle on inner webview")
-			.Reload();
+			.Reload()
+			.expect("Unable to reload webview");
 	}
 }
 
@@ -270,7 +271,7 @@ async fn main() -> tauri::Result<()> {
 		.on_menu_event(menu::handle_menu_event)
 		.on_window_event(|event| {
 			if let WindowEvent::Resized(_) = event.event() {
-				let (state, command) = if event
+				let (_state, command) = if event
 					.window()
 					.is_fullscreen()
 					.expect("Can't get fullscreen state")
@@ -288,7 +289,7 @@ async fn main() -> tauri::Result<()> {
 				#[cfg(target_os = "macos")]
 				{
 					let nswindow = event.window().ns_window().unwrap();
-					unsafe { sd_desktop_macos::set_titlebar_style(&nswindow, state) };
+					unsafe { sd_desktop_macos::set_titlebar_style(&nswindow, _state) };
 				}
 			}
 		})

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -8,6 +8,7 @@
 #![warn(clippy::suspicious)]
 #![warn(clippy::nursery)]
 #![warn(clippy::complexity)]
+#![allow(clippy::missing_const_for_fn)]
 #![allow(clippy::missing_panics_doc)]
 #![allow(clippy::missing_errors_doc)]
 #![allow(clippy::module_name_repetitions)]


### PR DESCRIPTION
Fixes Clippy Warnings:
>warning: this could be a `const fn`
- Fixed by adding `#![allow(clippy::missing_const_for_fn)]` to `crates/crypto/src/lib.rs`
>warning: unused variable: `state`
- Fixed by adding an underscore before `state` in `apps\desktop\src-tauri\src\main.rs`
>warning: unused `std::result::Result` that must be used
- Fixed by handling the result using `.expect("Unable to reload webview");`

<!-- Which issue does this PR close? -->
Closes #1775 
