### PR TITLE
Pin rust to 1.73 (Workaround Internal Compiler Error)

### DIFF
--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -16,7 +16,7 @@ runs:
       uses: dtolnay/rust-toolchain@stable
       with:
         target: ${{ inputs.target }}
-        toolchain: stable
+        toolchain: '1.73'
         components: clippy, rustfmt
 
     - name: Cache Rust Dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ To run the landing page:
 
 If you encounter any issues, ensure that you are using the following versions of Rust, Node and Pnpm:
 
-- Rust version: **1.70.0**
+- Rust version: **1.73.0**
 - Node version: **18.17**
 - Pnpm version: **8.0.0**
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -3,7 +3,7 @@ name = "sd-core"
 version = "0.1.2"
 description = "Virtual distributed filesystem engine that powers Spacedrive."
 authors = ["Spacedrive Technology Inc."]
-rust-version = "1.70.0"
+rust-version = "1.73.0"
 license = { workspace = true }
 repository = { workspace = true }
 edition = { workspace = true }

--- a/core/src/api/search/object.rs
+++ b/core/src/api/search/object.rs
@@ -136,8 +136,8 @@ impl ObjectFilterArgs {
 				vec![
 					not![date_accessed::equals(None)],
 					match v {
-						Range::From(v) => date_accessed::gte(v.into()),
-						Range::To(v) => date_accessed::lte(v.into()),
+						Range::From(v) => date_accessed::gte(v),
+						Range::To(v) => date_accessed::lte(v),
 					},
 				]
 			}

--- a/core/src/api/search/saved.rs
+++ b/core/src/api/search/saved.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use specta::Type;
 use uuid::Uuid;
 
-use crate::{api::utils::library, invalidate_query, library::Library, prisma::saved_search};
+use crate::{api::utils::library, library::Library, prisma::saved_search};
 
 use super::{Ctx, R};
 
@@ -111,7 +111,7 @@ pub(crate) fn mount() -> AlphaRouter<Ctx> {
 				let result: Result<Vec<SavedSearchResponse>, _> = searches
 					.into_iter()
 					.map(|search| {
-						let filters_bytes = search.filters.unwrap_or_else(Vec::new);
+						let filters_bytes = search.filters.unwrap_or_default();
 
 						let filters_string = String::from_utf8(filters_bytes).unwrap();
 						let filters: Vec<Filter> = serde_json::from_str(&filters_string).unwrap();

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.73"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -234,7 +234,9 @@ case "$(uname)" in
     ;;
 esac
 
-echo "Installing Rust tools..."
-cargo install cargo-watch
+if [ "${CI:-}" != "true" ]; then
+  echo "Installing Rust tools..."
+  cargo install cargo-watch
+fi
 
 echo 'Your machine has been setup for Spacedrive development!'


### PR DESCRIPTION
This PR pins rust to 1.73 to avoid an internal compiler error present in version 1.74 due to https://github.com/rust-lang/rust/issues/117976