### PR TITLE
fix: app going blank when the last library is deleted

### DIFF
--- a/interface/app/$libraryId/settings/node/libraries/DeleteDialog.tsx
+++ b/interface/app/$libraryId/settings/node/libraries/DeleteDialog.tsx
@@ -1,4 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router';
 import { useBridgeMutation, usePlausibleEvent, useZodForm } from '@sd/client';
 import { Dialog, useDialog, UseDialogProps } from '@sd/ui';
 import { usePlatform } from '~/util/Platform';
@@ -11,6 +12,7 @@ export default function DeleteLibraryDialog(props: Props) {
 	const submitPlausibleEvent = usePlausibleEvent();
 	const queryClient = useQueryClient();
 	const platform = usePlatform();
+	const navigate = useNavigate();
 
 	const deleteLib = useBridgeMutation('library.delete');
 
@@ -29,6 +31,8 @@ export default function DeleteLibraryDialog(props: Props) {
 					type: 'libraryDelete'
 				}
 			});
+
+			navigate('/');
 		} catch (e) {
 			alert(`Failed to delete library: ${e}`);
 		}

--- a/interface/app/onboarding/new-library.tsx
+++ b/interface/app/onboarding/new-library.tsx
@@ -34,7 +34,7 @@ export default function OnboardingNewLibrary() {
 				</OnboardingDescription>
 
 				{importMode ? (
-					<div className="space-x-2 mt-7">
+					<div className="mt-7 space-x-2">
 						<Button onClick={handleImport} variant="accent" size="sm">
 							Import
 						</Button>
@@ -53,7 +53,7 @@ export default function OnboardingNewLibrary() {
 							placeholder={'e.g. "James\' Library"'}
 						/>
 						<div className="flex grow" />
-						<div className="space-x-2 mt-7">
+						<div className="mt-7 space-x-2">
 							<Button
 								type="submit"
 								variant="accent"


### PR DESCRIPTION
This just navigates the user to `/` once a library has been deleted - this will either display onboarding if there are no other libraries available, or display an alternate library. Currently the app goes blank until the webview has been reloaded.