### PR TITLE
Small improvements to sd-server

### DIFF
--- a/apps/server/docker/Dockerfile
+++ b/apps/server/docker/Dockerfile
@@ -74,7 +74,7 @@ RUN cargo build --features assets --release -p sd-server
 
 #--
 
-FROM base
+FROM gcr.io/distroless/static-debian12:debug
 
 ENV TZ=UTC \
 	PUID=1000 \
@@ -85,14 +85,8 @@ ENV TZ=UTC \
 	LANGUAGE=en \
 	DATA_DIR=/data
 
-# Note: This needs to happen before the apt call to avoid locking issues with the previous step
 COPY --from=server /srv/spacedrive/target/release/sd-server /usr/bin/
 COPY --from=server /srv/spacedrive/apps/.deps/lib /usr/lib/spacedrive
-
-RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
-	apt-get install \
-		libavdevice59 libpostproc56 libswscale6 libswresample4 libavformat59 libavutil57 libavfilter8 \
-		libavcodec59
 
 COPY --chmod=755 entrypoint.sh /usr/bin/
 

--- a/apps/server/docker/Dockerfile
+++ b/apps/server/docker/Dockerfile
@@ -74,6 +74,7 @@ RUN cargo build --features assets --release -p sd-server
 
 #--
 
+# Debug just means it includes busybox, and we need its tools both for the entrypoint.sh script and during runtime
 FROM gcr.io/distroless/base-debian12:debug
 
 ENV TZ=UTC \

--- a/apps/server/docker/Dockerfile
+++ b/apps/server/docker/Dockerfile
@@ -74,7 +74,7 @@ RUN cargo build --features assets --release -p sd-server
 
 #--
 
-FROM gcr.io/distroless/static-debian12:debug
+FROM gcr.io/distroless/base-debian12:debug
 
 ENV TZ=UTC \
 	PUID=1000 \

--- a/apps/server/docker/Dockerfile
+++ b/apps/server/docker/Dockerfile
@@ -86,6 +86,7 @@ ENV TZ=UTC \
 	DATA_DIR=/data
 
 COPY --from=server /srv/spacedrive/target/release/sd-server /usr/bin/
+COPY --from=server /lib/x86_64-linux-gnu/libgcc_s.so.1 /usr/lib/
 COPY --from=server /srv/spacedrive/apps/.deps/lib /usr/lib/spacedrive
 
 COPY --chmod=755 entrypoint.sh /usr/bin/

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,7 +2,13 @@ import { hydrate, QueryClient, QueryClientProvider } from '@tanstack/react-query
 import { useEffect, useRef, useState } from 'react';
 import { createBrowserRouter } from 'react-router-dom';
 import { RspcProvider } from '@sd/client';
-import { createRoutes, Platform, PlatformProvider, SpacedriveRouterProvider } from '@sd/interface';
+import {
+	createRoutes,
+	Platform,
+	PlatformProvider,
+	SpacedriveInterfaceRoot,
+	SpacedriveRouterProvider
+} from '@sd/interface';
 import { useShowControls } from '@sd/interface/hooks';
 
 import demoData from './demoData.json';
@@ -99,13 +105,15 @@ function App() {
 				<RspcProvider queryClient={queryClient}>
 					<PlatformProvider platform={platform}>
 						<QueryClientProvider client={queryClient}>
-							<SpacedriveRouterProvider
-								routing={{
-									...router,
-									routes,
-									visible: true
-								}}
-							/>
+							<SpacedriveInterfaceRoot>
+								<SpacedriveRouterProvider
+									routing={{
+										...router,
+										routes,
+										visible: true
+									}}
+								/>
+							</SpacedriveInterfaceRoot>
 						</QueryClientProvider>
 					</PlatformProvider>
 				</RspcProvider>


### PR DESCRIPTION
 - ~Replace `useOperatingSystem` from `App.tsx` to directly using the 'browser' value, as we can't access `usePlatform` yet and the frontend crashes due to it.~ (Already fixed on main)
 - Remove `libav*` deps from server docker, they are not needed anymore
 - Replace debian with distroless for the runtime base image in server docker
 - Add missing `SpacedriveInterfaceRoot` in `web/App.tsx`
