### PR TITLE
Send release message in channel

### DIFF
--- a/apps/landing/src/app/api/slack/webhook/createRelease.ts
+++ b/apps/landing/src/app/api/slack/webhook/createRelease.ts
@@ -228,6 +228,7 @@ export async function handleSubmission(
 		method: 'POST',
 		body: JSON.stringify({
 			replace_original: 'true',
+			response_type: 'in_channel',
 			blocks: [
 				{
 					type: 'section',


### PR DESCRIPTION
Sends the release created message in the channel that `/release` was invoked from, rather than as an ephemeral reply.
<img width="432" alt="image" src="https://github.com/spacedriveapp/spacedrive/assets/14191578/70967a40-2494-46d3-8939-a2a9eeae07ac">
