### PR TITLE
[ENG-1466] dont open quick preview while renaming

### DIFF
--- a/interface/app/$libraryId/Explorer/QuickPreview/index.tsx
+++ b/interface/app/$libraryId/Explorer/QuickPreview/index.tsx
@@ -145,15 +145,6 @@ export const QuickPreview = () => {
 		setShowMetadata(false);
 	}, [item, open]);
 
-	// Toggle quick preview
-	useShortcut('toggleQuickPreview', (e) => {
-		if (isRenaming) return;
-
-		e.preventDefault();
-
-		getQuickPreviewStore().open = !open;
-	});
-
 	const handleMoveBetweenItems = (step: number) => {
 		const nextPreviewItem = items[itemIndex + step];
 		if (nextPreviewItem) {

--- a/interface/app/$libraryId/Explorer/View/index.tsx
+++ b/interface/app/$libraryId/Explorer/View/index.tsx
@@ -26,7 +26,7 @@ import CreateDialog from '../../settings/library/tags/CreateDialog';
 import { useExplorerContext } from '../Context';
 import { QuickPreview } from '../QuickPreview';
 import { useQuickPreviewContext } from '../QuickPreview/Context';
-import { useQuickPreviewStore } from '../QuickPreview/store';
+import { getQuickPreviewStore, useQuickPreviewStore } from '../QuickPreview/store';
 import { ViewContext, type ExplorerViewContext } from '../ViewContext';
 import GridView from './GridView';
 import ListView from './ListView';
@@ -115,6 +115,12 @@ export default memo(
 		useShortcut('showImageSlider', (e) => {
 			e.stopPropagation();
 			getExplorerLayoutStore().showImageSlider = !layoutStore.showImageSlider;
+		});
+
+		useShortcut('toggleQuickPreview', (e) => {
+			if (isRenaming) return;
+			e.preventDefault();
+			getQuickPreviewStore().open = !quickPreviewStore.open;
 		});
 
 		useKeyCopyCutPaste();


### PR DESCRIPTION
Shortcut was defined in the wrong place, we don't want to open quick preview if the user is renaming an object.