### PR TITLE
Replace tauri with new link

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This project is using what I'm calling the **"PRRTT"** stack (Prisma, Rust, Reac
 
 ### Apps:
 
-- `desktop`: A [Tauri](https://tauri.studio) app.
+- `desktop`: A [Tauri](https://tauri.app) app.
 - `mobile`: A [React Native](https://reactnative.dev/) app.
 - `web`: A [React](https://reactjs.org) webapp.
 - `landing`: A [React](https://reactjs.org) app using Vite SSR & Vite pages.


### PR DESCRIPTION
Tauri apps have new URL, that is Tauri.app instead of tauri.studio!

So, it should be updated here in the README

Thank You