### PR TITLE
Fix landing icon sizes

### DIFF
--- a/apps/landing/src/app/Downloads/Platform.tsx
+++ b/apps/landing/src/app/Downloads/Platform.tsx
@@ -96,8 +96,7 @@ export function Platform({ platform, ...props }: ComponentProps<'a'> & PlatformP
 		<Tooltip label={platform.name}>
 			<Outer {...props}>
 				<Icon
-					size={25}
-					className={`h-[25px] text-white ${
+					className={`h-[24px] w-[24px] text-white ${
 						platform.disabled ? 'opacity-20' : 'opacity-90'
 					}`}
 					weight="fill"


### PR DESCRIPTION
<img width="569" alt="image" src="https://github.com/spacedriveapp/spacedrive/assets/74243531/b2c3b193-a572-431d-9468-139956bf7426">