### PR TITLE
fix(landing):Fixed the style of the mobile navigation bar menu bar

### DIFF
--- a/apps/landing/src/app/NavBar/MobileDropdown.tsx
+++ b/apps/landing/src/app/NavBar/MobileDropdown.tsx
@@ -21,13 +21,13 @@ export function MobileDropdown() {
 			button={
 				<Button
 					aria-label="mobile-menu"
-					className="ml-[140px] hover:!bg-transparent"
+					className="hover:!bg-transparent"
 					size="icon"
 				>
 					<DotsThreeVertical weight="bold" className="h-6 w-6 " />
 				</Button>
 			}
-			className="right-4 top-2 block h-6 w-44 text-white lg:hidden"
+			className="right-4 top-2 block text-white lg:hidden"
 			itemsClassName="!rounded-2xl shadow-2xl shadow-black p-2 !bg-gray-850 mt-2 !border-gray-500 text-[15px]"
 		>
 			<Dropdown.Section>

--- a/packages/ui/src/Dropdown.tsx
+++ b/packages/ui/src/Dropdown.tsx
@@ -95,8 +95,8 @@ export interface DropdownRootProps {
 export const Root = (props: PropsWithChildren<DropdownRootProps>) => {
 	return (
 		<div className={props.className}>
-			<Menu as="div" className={clsx('relative flex w-full text-left')}>
-				<Menu.Button role="button" as="div" className="flex-1 outline-none">
+			<Menu as="div" className={clsx('relative flex w-full justify-end text-left')}>
+				<Menu.Button role="button" as="div" className="outline-none">
 					{props.button}
 				</Menu.Button>
 				<Transition


### PR DESCRIPTION
I fixed this click range as well as the centered style
<img width="345" alt="image" src="https://github.com/spacedriveapp/spacedrive/assets/74487590/2441e712-17c7-4713-8bc3-251e1f8779ec">
<img width="356" alt="image" src="https://github.com/spacedriveapp/spacedrive/assets/74487590/904090a0-5e62-4069-abe4-bddf642a7b24">
<img width="178" alt="image" src="https://github.com/spacedriveapp/spacedrive/assets/74487590/aeadb38c-2ea4-4564-883f-21db4f797332">

Closes #1868 
