### PR TITLE
Only handle idle history events

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -95,6 +95,9 @@ function AppInner() {
 		const router = createMemoryRouterWithHistory({ routes, history });
 
 		const dispose = router.subscribe((event) => {
+			// we don't care about non-idle events as those are artifacts of form mutations + suspense
+			if (event.navigation.state !== 'idle') return;
+
 			setTabs((routers) => {
 				const index = routers.findIndex((r) => r.router === router);
 				if (index === -1) return routers;


### PR DESCRIPTION
Forgot to include this change which ignores history events produced by suspense and form events