### PR TITLE
Unpin rustc from version 1.73.0

### DIFF
--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -16,7 +16,7 @@ runs:
       uses: dtolnay/rust-toolchain@stable
       with:
         target: ${{ inputs.target }}
-        toolchain: '1.73'
+        toolchain: stable
         components: clippy, rustfmt
 
     - name: Cache Rust Dependencies

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "1.73"


### PR DESCRIPTION
<!-- Put any information about this PR up here -->
Unpin the version of `rustc` from 1.73.0 now that 1.74.1 has been released. 
Partially reverts #1796 

<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->

Closes #1878
