### PR TITLE
[ENG-1503] Close search bar when navigating into folder

### DIFF
--- a/interface/app/$libraryId/Explorer/View/ViewItem.tsx
+++ b/interface/app/$libraryId/Explorer/View/ViewItem.tsx
@@ -1,5 +1,9 @@
 import { useCallback, type HTMLAttributes, type PropsWithChildren } from 'react';
-import { createSearchParams, useNavigate } from 'react-router-dom';
+import {
+	createSearchParams,
+	useNavigate,
+	useSearchParams as useRawSearchParams
+} from 'react-router-dom';
 import {
 	isPath,
 	useLibraryContext,
@@ -24,6 +28,7 @@ export const useViewItemDoubleClick = () => {
 	const explorer = useExplorerContext();
 	const { library } = useLibraryContext();
 	const { openFilePaths, openEphemeralFiles } = usePlatform();
+	const [_, setSearchParams] = useRawSearchParams();
 
 	const updateAccessTime = useLibraryMutation('files.updateAccessTime');
 
@@ -110,11 +115,16 @@ export const useViewItemDoubleClick = () => {
 			if (items.dirs.length > 0) {
 				const [item] = items.dirs;
 				if (item) {
-					navigate({
-						pathname: `../location/${item.location_id}`,
-						search: createSearchParams({
-							path: `${item.materialized_path}${item.name}/`
-						}).toString()
+					setSearchParams((p) => {
+						const newParams = new URLSearchParams();
+
+						newParams.set('path', `${item.materialized_path}${item.name}/`);
+						const take = p.get('take');
+						if (take !== null) newParams.set('take', take);
+
+						console.log([...newParams]);
+
+						return newParams;
 					});
 					return;
 				}

--- a/interface/app/$libraryId/Explorer/View/ViewItem.tsx
+++ b/interface/app/$libraryId/Explorer/View/ViewItem.tsx
@@ -122,8 +122,6 @@ export const useViewItemDoubleClick = () => {
 						const take = p.get('take');
 						if (take !== null) newParams.set('take', take);
 
-						console.log([...newParams]);
-
 						return newParams;
 					});
 					return;

--- a/interface/app/$libraryId/Search/AppliedFilters.tsx
+++ b/interface/app/$libraryId/Search/AppliedFilters.tsx
@@ -62,7 +62,7 @@ export const AppliedFilters = ({ allowRemove = true }: { allowRemove?: boolean }
 						<RenderIcon className="h-4 w-4" icon={MagnifyingGlass} />
 						<FilterText>{search.search}</FilterText>
 					</StaticSection>
-					{allowRemove && <CloseTab onClick={() => search.setRawSearch('')} />}
+					{allowRemove && <CloseTab onClick={() => search.setSearch('')} />}
 				</FilterContainer>
 			)}
 			<div

--- a/interface/app/$libraryId/Search/SearchBar.tsx
+++ b/interface/app/$libraryId/Search/SearchBar.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useDebouncedCallback } from 'use-debounce';
 import { Input, ModifierKeys, Shortcut } from '@sd/ui';
 import { useOperatingSystem } from '~/hooks';
 import { keybindForOs } from '~/util/keybinds';
@@ -46,15 +47,22 @@ export default () => {
 		};
 	}, [blurHandler, focusHandler]);
 
-	const [value, setValue] = useState(search.search);
+	const [value, setValue] = useState('');
+
+	useEffect(() => {
+		setValue(search.rawSearch);
+	}, [search.rawSearch]);
+
+	const updateDebounce = useDebouncedCallback((value: string) => {
+		search.setSearch(value);
+	}, 300);
 
 	function updateValue(value: string) {
 		setValue(value);
-		search.setSearch(value);
+		updateDebounce(value);
 	}
 
 	function clearValue() {
-		setValue('');
 		search.setSearch('');
 	}
 
@@ -69,10 +77,10 @@ export default () => {
 			onBlur={() => {
 				if (search.rawSearch === '' && !searchStore.interactingWithSearchOptions) {
 					clearValue();
-					search.setOpen(false);
+					search.setSearchBarFocused(false);
 				}
 			}}
-			onFocus={() => search.setOpen(true)}
+			onFocus={() => search.setSearchBarFocused(true)}
 			right={
 				<div className="pointer-events-none flex h-7 items-center space-x-1 opacity-70 group-focus-within:hidden">
 					{

--- a/interface/app/$libraryId/Search/index.tsx
+++ b/interface/app/$libraryId/Search/index.tsx
@@ -292,14 +292,14 @@ function EscapeButton() {
 
 	useKeybind(['Escape'], () => {
 		search.setSearch('');
-		search.setOpen(false);
+		search.setSearchBarFocused(false);
 	});
 
 	return (
 		<kbd
 			onClick={() => {
 				search.setSearch('');
-				search.setOpen(false);
+				search.setSearchBarFocused(false);
 			}}
 			className="ml-2 rounded-lg border border-app-line bg-app-box px-2 py-1 text-[10.5px] tracking-widest shadow"
 		>

--- a/interface/app/$libraryId/Search/useSearch.ts
+++ b/interface/app/$libraryId/Search/useSearch.ts
@@ -1,7 +1,6 @@
 import { produce } from 'immer';
 import { useCallback, useMemo, useState } from 'react';
 import { useDebouncedValue } from 'rooks';
-import { useDebouncedCallback } from 'use-debounce';
 import { SearchFilterArgs } from '@sd/client';
 
 import { filterRegistry } from './Filters';
@@ -22,8 +21,7 @@ export interface UseSearchProps {
 }
 
 export function useSearch(props?: UseSearchProps) {
-	const [open, setOpen] = useState(false);
-	if (props?.open !== undefined && open !== props.open) setOpen(props.open);
+	const [searchBarFocused, setSearchBarFocused] = useState(false);
 
 	const searchState = useSearchStore();
 
@@ -123,13 +121,15 @@ export function useSearch(props?: UseSearchProps) {
 	// Filters generated from the search query
 
 	// rawSearch should only ever be read by the search input
-	const [search, setSearch] = useState(props?.search ?? '');
+	const [rawSearch, setRawSearch] = useState(props?.search ?? '');
 	const [searchFromProps, setSearchFromProps] = useState(props?.search);
 
 	if (searchFromProps !== props?.search) {
 		setSearchFromProps(props?.search);
-		setSearch(props?.search ?? '');
+		setRawSearch(props?.search ?? '');
 	}
+
+	const [search] = useDebouncedValue(rawSearch, 300);
 
 	const searchFilters = useMemo(() => {
 		const [name, ext] = search.split('.') ?? [];
@@ -166,14 +166,14 @@ export function useSearch(props?: UseSearchProps) {
 	}, [allFiltersAsOptions]);
 
 	return {
-		open,
-		setOpen,
+		open: props?.open || searchBarFocused,
 		fixedFilters,
 		fixedFiltersKeys,
 		search,
-		rawSearch: search,
-		setRawSearch: setSearch,
-		setSearch: useDebouncedCallback(setSearch, 300),
+		rawSearch,
+		setSearch: setRawSearch,
+		searchBarFocused,
+		setSearchBarFocused,
 		dynamicFilters,
 		setDynamicFilters,
 		updateDynamicFilters,

--- a/interface/app/$libraryId/location/$id.tsx
+++ b/interface/app/$libraryId/location/$id.tsx
@@ -174,7 +174,14 @@ const LocationExplorer = ({ location }: { location: Location; path?: string }) =
 					<Loader />
 				</div>
 			) : !preferences.isLoading ? (
-				<MemoisedExplorer />
+				<Explorer
+					emptyNotice={
+						<EmptyNotice
+							icon={<Icon name="FolderNoSpace" size={128} />}
+							message="No files found here"
+						/>
+					}
+				/>
 			) : null}
 		</ExplorerContextProvider>
 	);
@@ -188,17 +195,6 @@ function getLastSectionOfPath(path: string): string | undefined {
 	const lastSection = sections[sections.length - 1];
 	return lastSection;
 }
-
-const MemoisedExplorer = memo(() => (
-	<Explorer
-		emptyNotice={
-			<EmptyNotice
-				icon={<Icon name="FolderNoSpace" size={128} />}
-				message="No files found here"
-			/>
-		}
-	/>
-));
 
 function useLocationExplorerSettings(location: Location) {
 	const rspc = useRspcLibraryContext();

--- a/interface/app/$libraryId/tag/$id.tsx
+++ b/interface/app/$libraryId/tag/$id.tsx
@@ -82,18 +82,15 @@ export function Component() {
 					)}
 				</TopBarPortal>
 			</SearchContextProvider>
-			<MemoisedExplorer />
+
+			<Explorer
+				emptyNotice={
+					<EmptyNotice
+						icon={<Icon name="Tags" size={128} />}
+						message="No items assigned to this tag."
+					/>
+				}
+			/>
 		</ExplorerContextProvider>
 	);
 }
-
-const MemoisedExplorer = memo(() => (
-	<Explorer
-		emptyNotice={
-			<EmptyNotice
-				icon={<Icon name="Tags" size={128} />}
-				message="No items assigned to this tag."
-			/>
-		}
-	/>
-));

--- a/interface/app/$libraryId/tag/$id.tsx
+++ b/interface/app/$libraryId/tag/$id.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { memo, useMemo } from 'react';
 import { ObjectKindEnum, ObjectOrder, useCache, useLibraryQuery, useNodes } from '@sd/client';
 import { LocationIdParamsSchema } from '~/app/route-schemas';
 import { Icon } from '~/components';
@@ -82,14 +82,18 @@ export function Component() {
 					)}
 				</TopBarPortal>
 			</SearchContextProvider>
-			<Explorer
-				emptyNotice={
-					<EmptyNotice
-						icon={<Icon name="Tags" size={128} />}
-						message="No items assigned to this tag."
-					/>
-				}
-			/>
+			<MemoisedExplorer />
 		</ExplorerContextProvider>
 	);
 }
+
+const MemoisedExplorer = memo(() => (
+	<Explorer
+		emptyNotice={
+			<EmptyNotice
+				icon={<Icon name="Tags" size={128} />}
+				message="No items assigned to this tag."
+			/>
+		}
+	/>
+));


### PR DESCRIPTION
A couple of things are happening here: Search and filters are being stored in search params so they save across navigations, and the entire state of the location explorer is being reset when navigating to a different folder by keying it on `path`.