### PR TITLE
Multiple HTTP servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3002,9 +3002,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.27"
+version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3017,7 +3017,7 @@ dependencies = [
  "httpdate",
  "itoa 1.0.9",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -7085,6 +7085,7 @@ dependencies = [
  "axum",
  "futures",
  "http",
+ "hyper",
  "opener",
  "prisma-client-rust",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7102,6 +7102,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-window-state",
  "tauri-specta",
+ "thiserror",
  "tokio",
  "tracing",
  "uuid",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -30,6 +30,7 @@ tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 tauri-specta = { workspace = true, features = ["typescript"] }
 uuid = { workspace = true, features = ["serde"] }
+thiserror.workspace = true
 
 opener = { version = "0.6.1", features = ["reveal"] }
 tauri = { version = "1.5.3", features = [

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ sd-fda = { path = "../../../crates/fda" }
 sd-prisma = { path = "../../../crates/prisma" }
 
 axum = { workspace = true, features = ["headers", "query"] }
+hyper = "0.14.28"
 futures = { workspace = true }
 http = { workspace = true }
 prisma-client-rust = { workspace = true }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -195,7 +195,7 @@ async fn main() -> tauri::Result<()> {
 			let node = node.clone();
 			move || node.clone()
 		}))
-		.plugin(sd_server_plugin(node.clone()).unwrap()) // TODO: Handle `unwrap`
+		.plugin(sd_server_plugin(node.clone()).await.unwrap()) // TODO: Handle `unwrap`
 		.manage(node.clone());
 
 	// macOS expected behavior is for the app to not exit when the main window is closed.

--- a/apps/desktop/src/platform.ts
+++ b/apps/desktop/src/platform.ts
@@ -10,6 +10,7 @@ import { createUpdater } from './updater';
 
 const customUriAuthToken = (window as any).__SD_CUSTOM_SERVER_AUTH_TOKEN__ as string | undefined;
 let customUriServerUrl = (window as any).__SD_CUSTOM_URI_SERVER__ as string | undefined;
+const startPort = (window as any).__SD_START_PORT__ as number | undefined;
 
 if (customUriServerUrl === undefined || customUriServerUrl === '')
 	console.warn("'window.__SD_CUSTOM_URI_SERVER__' may have not been injected correctly!");
@@ -32,16 +33,35 @@ async function getOs(): Promise<OperatingSystem> {
 	}
 }
 
+function randomIntFromInterval(min: number, max: number) {
+	// min and max included
+	return Math.floor(Math.random() * (max - min + 1) + min);
+}
+
+function randomPort() {
+	if (!startPort) throw new Error(`'startPort' not defined`);
+	return randomIntFromInterval(startPort, startPort + 3); // Randomly switch between 4 servers
+}
+
 export const platform = {
 	platform: 'tauri',
-	getThumbnailUrlByThumbKey: (keyParts) =>
-		`${customUriServerUrl}thumbnail/${keyParts
+	getThumbnailUrlByThumbKey: (keyParts) => {
+		const url = `http://localhost:${randomPort()}/`;
+		// console.log('A', customUriServerUrl, url);
+		return `${url}thumbnail/${keyParts
 			.map((i) => encodeURIComponent(i))
-			.join('/')}.webp${queryParams}`,
-	getFileUrl: (libraryId, locationLocalId, filePathId) =>
-		`${customUriServerUrl}file/${libraryId}/${locationLocalId}/${filePathId}${queryParams}`,
-	getFileUrlByPath: (path) =>
-		`${customUriServerUrl}local-file-by-path/${encodeURIComponent(path)}${queryParams}`,
+			.join('/')}.webp${queryParams}`;
+	},
+	getFileUrl: (libraryId, locationLocalId, filePathId) => {
+		const url = `http://localhost:${randomPort()}/`;
+		// console.log('B', customUriServerUrl, url);
+		return `${url}file/${libraryId}/${locationLocalId}/${filePathId}${queryParams}`;
+	},
+	getFileUrlByPath: (path) => {
+		const url = `http://localhost:${randomPort()}/`;
+		// console.log('C', customUriServerUrl, url);
+		return `${url}local-file-by-path/${encodeURIComponent(path)}${queryParams}`;
+	},
 	openLink: shell.open,
 	getOs,
 	openDirectoryPickerDialog: (opts) => {

--- a/apps/desktop/src/platform.ts
+++ b/apps/desktop/src/platform.ts
@@ -9,14 +9,7 @@ import { env } from './env';
 import { createUpdater } from './updater';
 
 const customUriAuthToken = (window as any).__SD_CUSTOM_SERVER_AUTH_TOKEN__ as string | undefined;
-let customUriServerUrl = (window as any).__SD_CUSTOM_URI_SERVER__ as string | undefined;
-const startPort = (window as any).__SD_START_PORT__ as number | undefined;
-
-if (customUriServerUrl === undefined || customUriServerUrl === '')
-	console.warn("'window.__SD_CUSTOM_URI_SERVER__' may have not been injected correctly!");
-if (customUriServerUrl && !customUriServerUrl?.endsWith('/')) {
-	customUriServerUrl += '/';
-}
+const customUriServerUrl = (window as any).__SD_CUSTOM_URI_SERVER__ as string[] | undefined;
 
 const queryParams = customUriAuthToken ? `?token=${encodeURIComponent(customUriAuthToken)}` : '';
 
@@ -38,29 +31,25 @@ function randomIntFromInterval(min: number, max: number) {
 	return Math.floor(Math.random() * (max - min + 1) + min);
 }
 
-function randomPort() {
-	if (!startPort) throw new Error(`'startPort' not defined`);
-	return randomIntFromInterval(startPort, startPort + 3); // Randomly switch between 4 servers
+function randomServer() {
+	if (!customUriServerUrl)
+		throw new Error("'window.__SD_CUSTOM_URI_SERVER__' was not injected correctly!");
+	const index = randomIntFromInterval(0, customUriServerUrl.length - 1); // Randomly switch between servers
+	return customUriServerUrl[index] + '/';
 }
 
 export const platform = {
 	platform: 'tauri',
 	getThumbnailUrlByThumbKey: (keyParts) => {
-		const url = `http://localhost:${randomPort()}/`;
-		// console.log('A', customUriServerUrl, url);
-		return `${url}thumbnail/${keyParts
+		return `${randomServer()}thumbnail/${keyParts
 			.map((i) => encodeURIComponent(i))
 			.join('/')}.webp${queryParams}`;
 	},
 	getFileUrl: (libraryId, locationLocalId, filePathId) => {
-		const url = `http://localhost:${randomPort()}/`;
-		// console.log('B', customUriServerUrl, url);
-		return `${url}file/${libraryId}/${locationLocalId}/${filePathId}${queryParams}`;
+		return `${randomServer()}file/${libraryId}/${locationLocalId}/${filePathId}${queryParams}`;
 	},
 	getFileUrlByPath: (path) => {
-		const url = `http://localhost:${randomPort()}/`;
-		// console.log('C', customUriServerUrl, url);
-		return `${url}local-file-by-path/${encodeURIComponent(path)}${queryParams}`;
+		return `${randomServer()}local-file-by-path/${encodeURIComponent(path)}${queryParams}`;
 	},
 	openLink: shell.open,
 	getOs,


### PR DESCRIPTION
Given the explorer only slows down on media-heavy locations, and the MOV tags always render my theory is that we are hitting the HTTP connection limit for the image files. This PRworkarounds that by setting up many servers and randomly load balancing between them.

I don't know how much of a difference this will make but given it's so little code it's probs worth just shipping.

~~The code will need a bit of work before I would be comfortable merging it but this should be good for testing if this actually makes a difference.~~