### PR TITLE
[ENG-1532] Hide window title on macos

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -85,6 +85,7 @@
 		"windows": [
 			{
 				"title": "Spacedrive",
+				"hiddenTitle": true,
 				"width": 1400,
 				"height": 725,
 				"minWidth": 768,


### PR DESCRIPTION
**This change should hide title here**:

This config value only applies to MacOS. Issue can be seen in the image below.

![image](https://github.com/spacedriveapp/spacedrive/assets/33054370/60f4a45b-8703-4a2b-b772-c4400e289376)
