### PR TITLE
[MOB-50] Locations screen

### DIFF
--- a/apps/mobile/src/components/browse/BrowseLocations.tsx
+++ b/apps/mobile/src/components/browse/BrowseLocations.tsx
@@ -41,7 +41,7 @@ const BrowseLocationItem: React.FC<BrowseLocationItemProps> = ({
 			<View
 				style={tw`h-fit w-[100px] flex-col justify-center gap-3 rounded-md border border-sidebar-line/50 bg-sidebar-box p-2`}
 			>
-				<View style={tw`w-full flex-col justify-between gap-1`}>
+				<View style={tw`flex-col justify-between w-full gap-1`}>
 					<View style={tw`flex-row items-center justify-between`}>
 						<View style={tw`relative`}>
 							<FolderIcon size={42} />
@@ -97,17 +97,21 @@ const BrowseLocations = () => {
 
 	return (
 		<View style={tw`gap-5`}>
-			<View style={tw`w-full flex-row items-center justify-between px-7`}>
+			<View style={tw`flex-row items-center justify-between w-full px-7`}>
 				<Text style={tw`text-xl font-bold text-white`}>Locations</Text>
 				<View style={tw`flex-row gap-3`}>
-					<Pressable>
-						<View style={tw`h-8 w-8 items-center justify-center rounded-md bg-accent`}>
+					<Pressable
+						onPress={() => {
+							navigation.navigate('Locations');
+						}}
+					>
+						<View style={tw`items-center justify-center w-8 h-8 rounded-md bg-accent`}>
 							<Eye weight="bold" size={18} style={tw`text-white`} />
 						</View>
 					</Pressable>
 					<Pressable onPress={() => modalRef.current?.present()}>
 						<View
-							style={tw`h-8 w-8 items-center justify-center rounded-md border border-dashed border-ink-faint bg-transparent`}
+							style={tw`items-center justify-center w-8 h-8 bg-transparent border border-dashed rounded-md border-ink-faint`}
 						>
 							<Plus weight="bold" size={18} style={tw`text-ink-faint`} />
 						</View>

--- a/apps/mobile/src/components/header/Header.tsx
+++ b/apps/mobile/src/components/header/Header.tsx
@@ -1,25 +1,51 @@
 import { useNavigation } from '@react-navigation/native';
-import { MagnifyingGlass } from 'phosphor-react-native';
+import { ArrowLeft, MagnifyingGlass } from 'phosphor-react-native';
 import { lazy } from 'react';
 import { Pressable, Text, View } from 'react-native';
 import { tw } from '~/lib/tailwind';
 
-//Not all pages have a library manager - so lazy load it for performance
+//Not all pages use these components - so we lazy load for performance
 const BrowseLibraryManager = lazy(() => import('../browse/DrawerLibraryManager'));
+const Search = lazy(() => import('../inputs/Search'));
 
 interface Props {
-	title?: string;
-	showLibrary?: boolean;
+	title?: string; //title of the page
+	showLibrary?: boolean; //show the library manager
+	searchType?: 'explorer' | 'location'; //Temporary
+	navBack?: boolean; //navigate back to the previous screen
 }
 
 // Default header with search bar and button to open drawer
-export default function Header({ title, showLibrary }: Props) {
+export default function Header({ title, showLibrary, searchType, navBack }: Props) {
 	const navigation = useNavigation();
+
+	const SearchType = () => {
+		switch (searchType) {
+			case 'explorer':
+				return 'Explorer'; //TODO
+			case 'location':
+				return <Search placeholder="Location name..." />;
+			default:
+				return null;
+		}
+	};
+
 	return (
-		<View style={tw`relative h-fit w-full border-b border-app-line/50 bg-mobile-header pt-10`}>
-			<View style={tw`mx-auto mt-5 h-fit w-full justify-center px-7 pb-5`}>
-				<View style={tw`w-full flex-row items-center justify-between`}>
-					<Text style={tw`text-[24px] font-bold text-white`}>{title}</Text>
+		<View style={tw`relative w-full pt-10 border-b h-fit border-app-line/50 bg-mobile-header`}>
+			<View style={tw`justify-center w-full pb-5 mx-auto mt-5 h-fit px-7`}>
+				<View style={tw`flex-row items-center justify-between w-full`}>
+					<View style={tw`flex-row items-center gap-5`}>
+						{navBack && (
+							<Pressable
+								onPress={() => {
+									navigation.goBack();
+								}}
+							>
+								<ArrowLeft size={23} color={tw.color('ink')} />
+							</Pressable>
+						)}
+						<Text style={tw`text-[24px] font-bold text-white`}>{title}</Text>
+					</View>
 					<Pressable onPress={() => navigation.navigate('Search')}>
 						<MagnifyingGlass
 							size={20}
@@ -29,6 +55,7 @@ export default function Header({ title, showLibrary }: Props) {
 					</Pressable>
 				</View>
 				{showLibrary && <BrowseLibraryManager style="mt-4" />}
+				{searchType && <SearchType />}
 			</View>
 		</View>
 	);

--- a/apps/mobile/src/components/inputs/Search.tsx
+++ b/apps/mobile/src/components/inputs/Search.tsx
@@ -1,0 +1,25 @@
+import { MagnifyingGlass } from 'phosphor-react-native';
+import { TextInput, View } from 'react-native';
+import { tw } from '~/lib/tailwind';
+import { getSearchStore } from '~/stores/searchStore';
+
+interface Props {
+	placeholder: string;
+}
+
+export default function Search({ placeholder }: Props) {
+	const searchStore = getSearchStore();
+	return (
+		<View
+			style={tw`flex flex-row items-center justify-between w-full px-3 mt-4 border rounded-md shadow-sm h-11 border-sidebar-line bg-sidebar-button`}
+		>
+			<TextInput
+				onChangeText={(text) => searchStore.setSearch(text)}
+				placeholderTextColor={tw.color('text-ink-dull')}
+				style={tw`w-[90%] text-white`}
+				placeholder={placeholder}
+			/>
+			<MagnifyingGlass size={20} weight="bold" color={tw.color('text-ink-dull')} />
+		</View>
+	);
+}

--- a/apps/mobile/src/components/layout/Fade.tsx
+++ b/apps/mobile/src/components/layout/Fade.tsx
@@ -9,9 +9,22 @@ interface Props {
 	height: DimensionValue; // height of fade
 	style?: string; // tailwind style
 	orientation?: 'horizontal' | 'vertical'; // orientation of fade
+	fadeSides?: 'left-right' | 'top-bottom'; // which sides to fade
 }
 
-const Fade = ({ children, style, color, width, height, orientation = 'horizontal' }: Props) => {
+const Fade = ({
+	children,
+	style,
+	color,
+	width,
+	height,
+	fadeSides = 'left-right',
+	orientation = 'horizontal'
+}: Props) => {
+	const gradientStartEndMap = {
+		'left-right': { start: { x: 0, y: 0 }, end: { x: 1, y: 0 } },
+		'top-bottom': { start: { x: 0, y: 1 }, end: { x: 0, y: 0 } }
+	};
 	return (
 		<>
 			<LinearGradient
@@ -20,12 +33,14 @@ const Fade = ({ children, style, color, width, height, orientation = 'horizontal
 					height: orientation === 'vertical' ? width : height,
 					position: 'absolute',
 					top: 0,
-					left: 0,
+					alignSelf: 'center',
+					left: fadeSides === 'left-right' ? 0 : undefined,
+					transform: fadeSides === 'left-right' ? undefined : [{ rotate: '180deg' }],
 					zIndex: 10,
 					...twStyle(style)
 				}}
-				start={{ x: 0, y: 0 }}
-				end={{ x: 1, y: 0 }}
+				start={gradientStartEndMap[fadeSides].start}
+				end={gradientStartEndMap[fadeSides].end}
 				colors={[tw.color(color) as string, tw.color(color + '/0') as string]}
 			/>
 			{children}
@@ -34,13 +49,16 @@ const Fade = ({ children, style, color, width, height, orientation = 'horizontal
 					width: orientation === 'vertical' ? height : width,
 					height: orientation === 'vertical' ? width : height,
 					position: 'absolute',
-					top: 0,
-					right: 0,
+					alignSelf: 'center',
+					top: fadeSides === 'left-right' ? 0 : undefined,
+					bottom: fadeSides === 'top-bottom' ? 0 : undefined,
+					right: fadeSides === 'left-right' ? 0 : undefined,
+					transform: fadeSides === 'top-bottom' ? undefined : [{ rotate: '180deg' }],
 					zIndex: 10,
 					...twStyle(style)
 				}}
-				start={{ x: 1, y: 0 }}
-				end={{ x: 0, y: 0 }}
+				start={gradientStartEndMap[fadeSides].start}
+				end={gradientStartEndMap[fadeSides].end}
 				colors={[tw.color(color) as string, tw.color(color + '/0') as string]}
 			/>
 		</>

--- a/apps/mobile/src/navigation/tabs/BrowseStack.tsx
+++ b/apps/mobile/src/navigation/tabs/BrowseStack.tsx
@@ -5,6 +5,7 @@ import Header from '~/components/header/Header';
 import { tw } from '~/lib/tailwind';
 import BrowseScreen from '~/screens/browse';
 import LocationScreen from '~/screens/Location';
+import { Locations } from '~/screens/Locations';
 import TagScreen from '~/screens/Tag';
 
 import { TabScreenProps } from '../TabNavigator';
@@ -37,6 +38,13 @@ export default function BrowseStack() {
 				}}
 			/>
 			<Stack.Screen
+				name="Locations"
+				component={Locations}
+				options={{
+					header: () => <Header navBack searchType="location" title="Locations" />
+				}}
+			/>
+			<Stack.Screen
 				name="Tag"
 				component={TagScreen}
 				options={{
@@ -52,6 +60,7 @@ export default function BrowseStack() {
 export type BrowseStackParamList = {
 	Browse: undefined;
 	Location: { id: number; path?: string };
+	Locations: undefined;
 	Tag: { id: number };
 };
 

--- a/apps/mobile/src/screens/Locations.tsx
+++ b/apps/mobile/src/screens/Locations.tsx
@@ -1,0 +1,142 @@
+import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
+import { useNavigation } from '@react-navigation/native';
+import { DotsThreeOutlineVertical } from 'phosphor-react-native';
+import { useMemo, useRef } from 'react';
+import { FlatList, Pressable, Text, View } from 'react-native';
+import { useDebounce } from 'use-debounce';
+import {
+	arraysEqual,
+	byteSize,
+	Location,
+	useCache,
+	useLibraryQuery,
+	useNodes,
+	useOnlineLocations
+} from '@sd/client';
+import FolderIcon from '~/components/icons/FolderIcon';
+import Fade from '~/components/layout/Fade';
+import { ModalRef } from '~/components/layout/Modal';
+import { LocationModal } from '~/components/modal/location/LocationModal';
+import { tw, twStyle } from '~/lib/tailwind';
+import { BrowseStackScreenProps } from '~/navigation/tabs/BrowseStack';
+import { SettingsStackScreenProps } from '~/navigation/tabs/SettingsStack';
+import { useSearchStore } from '~/stores/searchStore';
+
+export const Locations = () => {
+	const locationsQuery = useLibraryQuery(['locations.list']);
+	useNodes(locationsQuery.data?.nodes);
+	const locations = useCache(locationsQuery.data?.items);
+	const { search } = useSearchStore();
+	const [debouncedSearch] = useDebounce(search, 200);
+	const filteredLocations = useMemo(
+		() =>
+			locations?.filter(
+				(location) => location.name?.toLowerCase().includes(debouncedSearch.toLowerCase())
+			) ?? [],
+		[debouncedSearch, locations]
+	);
+
+	const height = useBottomTabBarHeight();
+
+	const navigation = useNavigation<
+		BrowseStackScreenProps<'Browse'>['navigation'] &
+			SettingsStackScreenProps<'Settings'>['navigation']
+	>();
+	return (
+		<View style={twStyle('relative flex-1 bg-mobile-screen px-7', { marginBottom: height })}>
+			<Fade
+				fadeSides="top-bottom"
+				orientation="vertical"
+				color="mobile-screen"
+				width={50}
+				height="100%"
+			>
+				<FlatList
+					data={filteredLocations}
+					contentContainerStyle={tw`py-5`}
+					keyExtractor={(location) => location.id.toString()}
+					ItemSeparatorComponent={() => <View style={tw`h-2`} />}
+					showsVerticalScrollIndicator={false}
+					renderItem={({ item }) => (
+						<LocationItem
+							editLocation={() =>
+								navigation.navigate('SettingsStack', {
+									screen: 'EditLocationSettings',
+									params: { id: item.id }
+								})
+							}
+							onPress={() => navigation.navigate('Location', { id: item.id })}
+							location={item}
+						/>
+					)}
+				/>
+			</Fade>
+		</View>
+	);
+};
+
+interface LocationItemProps {
+	location: Location;
+	onPress: () => void;
+	editLocation: () => void;
+}
+
+const LocationItem: React.FC<LocationItemProps> = ({
+	location,
+	editLocation,
+	onPress
+}: LocationItemProps) => {
+	const onlineLocations = useOnlineLocations();
+	const online = onlineLocations.some((l) => arraysEqual(location.pub_id, l));
+	const modalRef = useRef<ModalRef>(null);
+	return (
+		<Pressable onPress={onPress}>
+			<View
+				style={tw`flex-row justify-between w-full gap-3 p-2 border rounded-md h-fit border-sidebar-line/50 bg-sidebar-box`}
+			>
+				<View style={tw`flex-row items-center gap-2`}>
+					<View style={tw`relative`}>
+						<FolderIcon size={42} />
+						<View
+							style={twStyle(
+								'z-5 absolute bottom-[6px] right-[2px] h-2 w-2 rounded-full',
+								online ? 'bg-green-500' : 'bg-red-500'
+							)}
+						/>
+					</View>
+					<Text
+						style={tw`w-fit max-w-[160px] truncate text-sm font-bold text-white`}
+						numberOfLines={1}
+					>
+						{location.name}
+					</Text>
+				</View>
+				<View style={tw`flex-row items-center gap-3`}>
+					<View style={tw`rounded-md bg-app-input p-1.5`}>
+						<Text
+							style={tw`text-xs font-bold text-left truncate text-ink-dull`}
+							numberOfLines={1}
+						>
+							{`${byteSize(location.size_in_bytes)}`}
+						</Text>
+					</View>
+					<Pressable onPress={() => modalRef.current?.present()}>
+						<DotsThreeOutlineVertical
+							weight="fill"
+							size={20}
+							color={tw.color('ink-faint')}
+						/>
+					</Pressable>
+				</View>
+			</View>
+			<LocationModal
+				editLocation={() => {
+					editLocation();
+					modalRef.current?.close();
+				}}
+				locationId={location.id}
+				ref={modalRef}
+			/>
+		</Pressable>
+	);
+};

--- a/apps/mobile/src/stores/searchStore.ts
+++ b/apps/mobile/src/stores/searchStore.ts
@@ -1,0 +1,24 @@
+import { proxy, useSnapshot } from "valtio";
+
+
+/**
+ This is subject to change, but the idea is to have a global store for search
+ that can be used by any component.
+
+ once the new mobile design is implemented this is likely to change
+ */
+
+const searchStore = proxy({
+	search: '',
+	setSearch: (search: string) => {
+		searchStore.search = search;
+	}
+})
+
+export function useSearchStore() {
+	return useSnapshot(searchStore);
+}
+
+export function getSearchStore() {
+	return searchStore;
+}


### PR DESCRIPTION
**This PR does the following**:

- Locations screen added.
- Fade component improved and adjusted to accomodate more options and needs.
- A temporary search system that uses it's own store just to make the design work, i'll architect something in the future when all screens are done. **This is to share state between the search component and all screens.**
- Header component now has a navBack prop to navigate back to the previous page. **I can extract this value as an arguement from the `header: () =>` but there is no need to do that.**
- A inputs directory with a Search component.

**Future improvements**:

- Organize screen directories with their child screens, e.g. Browse -> Locations screen, and also Browse -> Location.
- A proper search system when designs are implemented.
- Code cleanup in various places that I noticed.

And some more things.

![Screenshot 2024-01-11 at 12 00 40 AM](https://github.com/spacedriveapp/spacedrive/assets/33054370/6ec7341d-8c7a-434a-9480-0b2c21ecc707)
