### PR TITLE
Fix QuickPreview video playback

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,15 +12,16 @@
 		"lint": "eslint src --cache"
 	},
 	"dependencies": {
-		"@remix-run/router": "^1.13.1",
 		"@oscartbeaumont-sd/rspc-client": "=0.0.0-main-dc31e5b2",
 		"@oscartbeaumont-sd/rspc-tauri": "=0.0.0-main-dc31e5b2",
+		"@remix-run/router": "^1.13.1",
 		"@sd/client": "workspace:*",
 		"@sd/interface": "workspace:*",
 		"@sd/ui": "workspace:*",
 		"@t3-oss/env-core": "^0.7.1",
 		"@tanstack/react-query": "^4.36.1",
 		"@tauri-apps/api": "1.5.1",
+		"consistent-hash": "^1.2.2",
 		"immer": "^10.0.3",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",

--- a/apps/desktop/src/platform.ts
+++ b/apps/desktop/src/platform.ts
@@ -41,19 +41,19 @@ function constructServerUrl(urlSuffix: string) {
 	}
 
 	// Randomly switch between servers to avoid HTTP connection limits
-	return hr.get(urlSuffix) + urlSuffix;
+	return hr.get(urlSuffix) + urlSuffix + queryParams;
 }
 
 export const platform = {
 	platform: 'tauri',
 	getThumbnailUrlByThumbKey: (keyParts) =>
 		constructServerUrl(
-			`/thumbnail/${keyParts.map((i) => encodeURIComponent(i)).join('/')}.webp${queryParams}`
+			`/thumbnail/${keyParts.map((i) => encodeURIComponent(i)).join('/')}.webp`
 		),
 	getFileUrl: (libraryId, locationLocalId, filePathId) =>
-		constructServerUrl(`/file/${libraryId}/${locationLocalId}/${filePathId}${queryParams}`),
+		constructServerUrl(`/file/${libraryId}/${locationLocalId}/${filePathId}`),
 	getFileUrlByPath: (path) =>
-		constructServerUrl(`/local-file-by-path/${encodeURIComponent(path)}${queryParams}`),
+		constructServerUrl(`/local-file-by-path/${encodeURIComponent(path)}`),
 	openLink: shell.open,
 	getOs,
 	openDirectoryPickerDialog: (opts) => {

--- a/apps/desktop/src/platform.ts
+++ b/apps/desktop/src/platform.ts
@@ -2,6 +2,8 @@ import { dialog, invoke, os, shell } from '@tauri-apps/api';
 import { confirm } from '@tauri-apps/api/dialog';
 import { homeDir } from '@tauri-apps/api/path';
 import { open } from '@tauri-apps/api/shell';
+// @ts-expect-error: Doesn't have a types package.
+import ConsistentHash from 'consistent-hash';
 import { OperatingSystem, Platform } from '@sd/interface';
 
 import { commands, events } from './commands';
@@ -26,31 +28,32 @@ async function getOs(): Promise<OperatingSystem> {
 	}
 }
 
-function randomIntFromInterval(min: number, max: number) {
-	// min and max included
-	return Math.floor(Math.random() * (max - min + 1) + min);
-}
+let hr: typeof ConsistentHash | undefined;
 
-function randomServer() {
-	if (!customUriServerUrl)
-		throw new Error("'window.__SD_CUSTOM_URI_SERVER__' was not injected correctly!");
-	const index = randomIntFromInterval(0, customUriServerUrl.length - 1); // Randomly switch between servers
-	return customUriServerUrl[index] + '/';
+function constructServerUrl(urlSuffix: string) {
+	if (!hr) {
+		if (!customUriServerUrl)
+			throw new Error("'window.__SD_CUSTOM_URI_SERVER__' was not injected correctly!");
+
+		console.log(ConsistentHash);
+		hr = new ConsistentHash();
+		customUriServerUrl.forEach((url) => hr.add(url));
+	}
+
+	// Randomly switch between servers to avoid HTTP connection limits
+	return hr.get(urlSuffix) + urlSuffix;
 }
 
 export const platform = {
 	platform: 'tauri',
-	getThumbnailUrlByThumbKey: (keyParts) => {
-		return `${randomServer()}thumbnail/${keyParts
-			.map((i) => encodeURIComponent(i))
-			.join('/')}.webp${queryParams}`;
-	},
-	getFileUrl: (libraryId, locationLocalId, filePathId) => {
-		return `${randomServer()}file/${libraryId}/${locationLocalId}/${filePathId}${queryParams}`;
-	},
-	getFileUrlByPath: (path) => {
-		return `${randomServer()}local-file-by-path/${encodeURIComponent(path)}${queryParams}`;
-	},
+	getThumbnailUrlByThumbKey: (keyParts) =>
+		constructServerUrl(
+			`/thumbnail/${keyParts.map((i) => encodeURIComponent(i)).join('/')}.webp${queryParams}`
+		),
+	getFileUrl: (libraryId, locationLocalId, filePathId) =>
+		constructServerUrl(`/file/${libraryId}/${locationLocalId}/${filePathId}${queryParams}`),
+	getFileUrlByPath: (path) =>
+		constructServerUrl(`/local-file-by-path/${encodeURIComponent(path)}${queryParams}`),
 	openLink: shell.open,
 	getOs,
 	openDirectoryPickerDialog: (opts) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       '@tauri-apps/api':
         specifier: 1.5.1
         version: 1.5.1
+      consistent-hash:
+        specifier: ^1.2.2
+        version: 1.2.2
       immer:
         specifier: ^10.0.3
         version: 10.0.3
@@ -6673,7 +6676,7 @@ packages:
       magic-string: 0.27.0
       react-docgen-typescript: 2.2.2(typescript@5.3.3)
       typescript: 5.3.3
-      vite: 5.0.10(less@4.2.0)
+      vite: 5.0.10(@types/node@18.17.19)
 
   /@jridgewell/gen-mapping@0.3.3:
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
@@ -9954,7 +9957,7 @@ packages:
       magic-string: 0.30.5
       rollup: 3.29.4
       typescript: 5.3.3
-      vite: 5.0.10(less@4.2.0)
+      vite: 5.0.10(@types/node@18.17.19)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -10307,7 +10310,7 @@ packages:
       react: 18.2.0
       react-docgen: 6.0.4
       react-dom: 18.2.0(react@18.2.0)
-      vite: 5.0.10(less@4.2.0)
+      vite: 5.0.10(@types/node@18.17.19)
     transitivePeerDependencies:
       - '@preact/preset-vite'
       - encoding
@@ -11709,7 +11712,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.22.5(@babel/core@7.23.2)
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 5.0.10(less@4.2.0)
+      vite: 5.0.10(@types/node@18.17.19)
     transitivePeerDependencies:
       - supports-color
 
@@ -13351,6 +13354,10 @@ packages:
       utils-merge: 1.0.1
     transitivePeerDependencies:
       - supports-color
+
+  /consistent-hash@1.2.2:
+    resolution: {integrity: sha512-xKAVji9aC80uN/h5u4XXwJ8otOh/D/cm8aryKa7+I0qwoBwxYOYkTiyvgwjUBRn+7CRVEvn/DvJtX1YsEugr0w==}
+    dev: false
 
   /consola@2.15.3:
     resolution: {integrity: sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==}
@@ -24823,7 +24830,6 @@ packages:
       rollup: 4.9.2
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
 
   /vite@5.0.10(less@4.2.0):
     resolution: {integrity: sha512-2P8J7WWgmc355HUMlFrwofacvr98DAjoE52BfdbwQtyLH06XKwaL/FMnmKM2crF0iX4MpmMKoDlNCB1ok7zHCw==}
@@ -24859,6 +24865,7 @@ packages:
       rollup: 4.9.2
     optionalDependencies:
       fsevents: 2.3.3
+    dev: true
 
   /vite@5.0.10(sass@1.69.5):
     resolution: {integrity: sha512-2P8J7WWgmc355HUMlFrwofacvr98DAjoE52BfdbwQtyLH06XKwaL/FMnmKM2crF0iX4MpmMKoDlNCB1ok7zHCw==}


### PR DESCRIPTION
Change the URL getter to use consistent hashing.

This means the request for a resource will always be routed to the same backend webserver.

We use multiple webserves to ensure we aren't hitting HTTP connection limits when loading all the images in the explorer.