### PR TITLE
[ENG-1535] - Remove title

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -84,7 +84,7 @@
 		},
 		"windows": [
 			{
-				"title": "Spacedrive",
+				"title": "",
 				"hiddenTitle": true,
 				"width": 1400,
 				"height": 725,

--- a/apps/desktop/src/platform.ts
+++ b/apps/desktop/src/platform.ts
@@ -35,7 +35,6 @@ function constructServerUrl(urlSuffix: string) {
 		if (!customUriServerUrl)
 			throw new Error("'window.__SD_CUSTOM_URI_SERVER__' was not injected correctly!");
 
-		console.log(ConsistentHash);
 		hr = new ConsistentHash();
 		customUriServerUrl.forEach((url) => hr.add(url));
 	}


### PR DESCRIPTION
This resolves the title issue, confirmed and tested on a locally built version of SD.

The Tauri API clearly specifies that hiddenTitle would hide the title on MacOS, but this isn't working. Setting the title to an empty string does it.