### PR TITLE
[ENG-1536] Quick preview fixes: Tooltip, video switching, and media controls flash

### DIFF
--- a/interface/app/$libraryId/Explorer/FilePath/Original.tsx
+++ b/interface/app/$libraryId/Explorer/FilePath/Original.tsx
@@ -1,7 +1,6 @@
 import { getIcon, iconNames } from '@sd/assets/util';
 import clsx from 'clsx';
 import {
-	memo,
 	SyntheticEvent,
 	useEffect,
 	useMemo,
@@ -186,10 +185,8 @@ interface VideoProps extends VideoHTMLAttributes<HTMLVideoElement> {
 
 const Video = ({ paused, blackBars, blackBarsSize, className, ...props }: VideoProps) => {
 	const ref = useRef<HTMLVideoElement>(null);
-
 	const size = useSize(ref);
 	const { style: blackBarsStyle } = useBlackBars(size, blackBarsSize);
-
 	const { t } = useLocale();
 
 	useEffect(() => {
@@ -220,6 +217,14 @@ const Video = ({ paused, blackBars, blackBarsSize, className, ...props }: VideoP
 			style={{ ...(blackBars ? blackBarsStyle : {}) }}
 			className={clsx(blackBars && size.width === 0 && 'invisible', className)}
 			{...props}
+			key={props.src}
+			controls={false}
+			onTimeUpdate={(e) => {
+				const video = e.target as HTMLVideoElement;
+				if (video.currentTime > 0) {
+					video.controls = true;
+				}
+			}}
 		>
 			<p>{t('video_preview_not_supported')}</p>
 		</video>

--- a/interface/app/$libraryId/Explorer/FilePath/Original.tsx
+++ b/interface/app/$libraryId/Explorer/FilePath/Original.tsx
@@ -222,7 +222,7 @@ const Video = ({ paused, blackBars, blackBarsSize, className, ...props }: VideoP
 			onTimeUpdate={(e) => {
 				const video = e.target as HTMLVideoElement;
 				if (video.currentTime > 0) {
-					video.controls = true;
+					video.controls = props.controls ?? true;
 				}
 			}}
 		>

--- a/interface/app/$libraryId/Explorer/FilePath/Thumb.tsx
+++ b/interface/app/$libraryId/Explorer/FilePath/Thumb.tsx
@@ -56,7 +56,6 @@ export const FileThumb = forwardRef<HTMLImageElement, ThumbProps>((props, ref) =
 	const [loadState, setLoadState] = useState<{
 		[K in 'original' | 'thumbnail' | 'icon']: 'notLoaded' | 'loaded' | 'error';
 	}>({ original: 'notLoaded', thumbnail: 'notLoaded', icon: 'notLoaded' });
-	const [videoLoaded, setVideoLoaded] = useState(false);
 
 	const childClassName = 'max-h-full max-w-full object-contain';
 	const frameClassName = clsx(

--- a/interface/app/$libraryId/Explorer/FilePath/Thumb.tsx
+++ b/interface/app/$libraryId/Explorer/FilePath/Thumb.tsx
@@ -56,6 +56,7 @@ export const FileThumb = forwardRef<HTMLImageElement, ThumbProps>((props, ref) =
 	const [loadState, setLoadState] = useState<{
 		[K in 'original' | 'thumbnail' | 'icon']: 'notLoaded' | 'loaded' | 'error';
 	}>({ original: 'notLoaded', thumbnail: 'notLoaded', icon: 'notLoaded' });
+	const [videoLoaded, setVideoLoaded] = useState(false);
 
 	const childClassName = 'max-h-full max-w-full object-contain';
 	const frameClassName = clsx(
@@ -194,6 +195,7 @@ export const FileThumb = forwardRef<HTMLImageElement, ThumbProps>((props, ref) =
 
 	return (
 		<div
+			key={thumbType.variant}
 			style={{
 				...(props.size
 					? { maxWidth: props.size, width: props.size, height: props.size }

--- a/interface/app/$libraryId/Explorer/QuickPreview/ImageSlider.tsx
+++ b/interface/app/$libraryId/Explorer/QuickPreview/ImageSlider.tsx
@@ -91,7 +91,7 @@ const Image = memo(({ item, active }: { item: ExplorerItem; active: boolean }) =
 	);
 
 	return (
-		<Tooltip label={fullName} position="top">
+		<Tooltip tooltipClassName="!break-all" label={fullName} position="top">
 			<div
 				onClick={() => explorer.resetSelectedItems([item])}
 				className={clsx(


### PR DESCRIPTION
**Quick preview fixes:  here are the following issues that have been addressed**:

- When you switched videos using the slider, videos wouldnt't play. So, a key value has been set to make sure React recognizes that a component update has happened therefore a re-render needs to happen so the newly selected video plays.
- Video controls only show when videos current time is > 0 - when you switched between videos the video controls would span the entire width of quick preview before the video even loaded, making the UI look strange.
- Tooltip fixed, if a name is a singe word that is long, it would overflow.