### PR TITLE
[ENG-1535] Fix MacOS window title showing

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -286,7 +286,7 @@ async fn main() -> tauri::Result<()> {
 
 					let nswindow = window.ns_window().unwrap();
 
-					unsafe { set_titlebar_style(&nswindow, true) };
+					unsafe { set_titlebar_style(&nswindow, false) };
 					unsafe { blur_window_background(&nswindow) };
 
 					tokio::spawn({


### PR DESCRIPTION
<img width="1512" alt="Screenshot 2024-01-12 at 23 29 18" src="https://github.com/spacedriveapp/spacedrive/assets/77554505/799fd69f-b8cf-4d86-8878-0d34941b6082">
