### PR TITLE
Remove deprecated is_background from JobReport

### DIFF
--- a/core/src/job/report.rs
+++ b/core/src/job/report.rs
@@ -50,7 +50,6 @@ pub struct JobReport {
 	// TODO(@Oscar): This will be fixed
 	#[specta(type = Option<HashMap<String, serde_json::Value>>)]
 	pub metadata: Option<serde_json::Value>,
-	pub is_background: bool,
 	pub errors_text: Vec<String>,
 
 	pub created_at: Option<DateTime<Utc>>,
@@ -85,7 +84,6 @@ impl TryFrom<job::Data> for JobReport {
 	fn try_from(data: job::Data) -> Result<Self, Self::Error> {
 		Ok(Self {
 			id: Uuid::from_slice(&data.id).expect("corrupted database"),
-			is_background: false, // deprecated
 			name: maybe_missing(data.name, "job.name")?,
 			action: data.action,
 			data: data.data,
@@ -127,7 +125,6 @@ impl TryFrom<job_without_data::Data> for JobReport {
 	fn try_from(data: job_without_data::Data) -> Result<Self, Self::Error> {
 		Ok(Self {
 			id: Uuid::from_slice(&data.id).expect("corrupted database"),
-			is_background: false, // deprecated
 			name: maybe_missing(data.name, "job.name")?,
 			action: data.action,
 			data: None,
@@ -165,7 +162,6 @@ impl JobReport {
 	pub fn new(uuid: Uuid, name: String) -> Self {
 		Self {
 			id: uuid,
-			is_background: false, // deprecated
 			name,
 			action: None,
 			created_at: None,
@@ -316,7 +312,6 @@ impl JobReportBuilder {
 	pub fn build(self) -> JobReport {
 		JobReport {
 			id: self.id,
-			is_background: false, // deprecated
 			name: self.name,
 			action: self.action,
 			created_at: None,


### PR DESCRIPTION
<!-- Put any information about this PR up here -->
This field `is_background` is unused and deprecated. Removing it would simplify `JobReport` (an already large struct) and improve readability.

<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->

Closes #1937 
