### PR TITLE
[ENG-1540] Remove `localStorage` if no libraries are created

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -182,7 +182,7 @@ async fn main() -> tauri::Result<()> {
 	let (_guard, result) = match Node::init_logger(&data_dir) {
 		Ok(guard) => (
 			Some(guard),
-			Node::new(data_dir, sd_core::Env::new(CLIENT_ID)).await,
+			Node::new(data_dir, sd_core::Env::new(CLIENT_ID), true).await,
 		),
 		Err(err) => (None, Err(NodeError::Logger(err))),
 	};

--- a/apps/mobile/modules/sd-core/core/src/lib.rs
+++ b/apps/mobile/modules/sd-core/core/src/lib.rs
@@ -75,7 +75,7 @@ pub fn handle_core_msg(
 					let _guard = Node::init_logger(&data_dir);
 
 					// TODO: probably don't unwrap
-					let new_node = Node::new(data_dir, sd_core::Env::new(CLIENT_ID))
+					let new_node = Node::new(data_dir, sd_core::Env::new(CLIENT_ID), false)
 						.await
 						.unwrap();
 					node.replace(new_node.clone());

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -47,6 +47,7 @@ async fn main() {
 			client_id: std::env::var("SD_CLIENT_ID")
 				.unwrap_or_else(|_| "04701823-a498-406e-aef9-22081c1dae34".to_string()),
 		},
+		false,
 	)
 	.await
 	{

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -4,6 +4,7 @@ use crate::{
 	api::{CoreEvent, Router},
 	location::LocationManagerError,
 	object::media::thumbnail::actor::Thumbnailer,
+	util::clear_localstorage::clear_localstorage,
 };
 
 #[cfg(feature = "ai")]
@@ -108,6 +109,11 @@ impl Node {
 		let (locations, locations_actor) = location::Locations::new();
 		let (jobs, jobs_actor) = job::Jobs::new();
 		let libraries = library::Libraries::new(data_dir.join("libraries")).await?;
+
+		if libraries.get_all().await.is_empty() {
+			clear_localstorage().await;
+		}
+
 		let (p2p, p2p_actor) = p2p::P2PManager::new(config.clone(), libraries.clone()).await?;
 		let node = Arc::new(Node {
 			data_dir: data_dir.to_path_buf(),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -83,6 +83,7 @@ impl Node {
 	pub async fn new(
 		data_dir: impl AsRef<Path>,
 		env: env::Env,
+		desktop: bool,
 	) -> Result<(Arc<Node>, Arc<Router>), NodeError> {
 		let data_dir = data_dir.as_ref();
 
@@ -110,7 +111,7 @@ impl Node {
 		let (jobs, jobs_actor) = job::Jobs::new();
 		let libraries = library::Libraries::new(data_dir.join("libraries")).await?;
 
-		if libraries.get_all().await.is_empty() {
+		if desktop && libraries.get_all().await.is_empty() {
 			clear_localstorage().await;
 		}
 

--- a/core/src/util/clear_localstorage.rs
+++ b/core/src/util/clear_localstorage.rs
@@ -20,7 +20,7 @@ pub async fn clear_localstorage() {
 		#[cfg(target_os = "windows")]
 		fs::remove_dir_all(&base_dir.data_local_dir().join("com.spacedrive.desktop"))
 			.await
-			.map_err(|_| warn!("Unable to delete the `localStorage` primary directory."))
+			.map_err(|_| warn!("Unable to delete the `localStorage` directory in Local AppData."))
 			.ok();
 
 		info!("Deleted {}", data_dir.display());

--- a/core/src/util/clear_localstorage.rs
+++ b/core/src/util/clear_localstorage.rs
@@ -9,12 +9,16 @@ const EXTRA_DIRS: [&str; 2] = ["Library/WebKit/Spacedrive", "Library/Caches/Spac
 
 pub async fn clear_localstorage() {
 	if let Some(base_dir) = BaseDirs::new() {
-		// this equates to `~/.local/share` on Linux, ~/Library/Application Support` on MacOS
-		// and `~/AppData/Local` on Windows. you can find `localStorage` and other cached files here, as
-		// well as in a few other dedicated paths on Linux and MacOS (which are cleared below)
-		let data_dir = base_dir.data_local_dir().join("com.spacedrive.desktop"); // maybe tie this into something static?
+		let data_dir = base_dir.data_dir().join("com.spacedrive.desktop"); // maybe tie this into something static?
 
 		fs::remove_dir_all(&data_dir)
+			.await
+			.map_err(|_| warn!("Unable to delete the `localStorage` primary directory."))
+			.ok();
+
+		// Windows needs both AppData/Local and AppData/Roaming clearing as it stores data in both
+		#[cfg(target_os = "windows")]
+		fs::remove_dir_all(&base_dir.data_local_dir().join("com.spacedrive.desktop"))
 			.await
 			.map_err(|_| warn!("Unable to delete the `localStorage` primary directory."))
 			.ok();

--- a/core/src/util/clear_localstorage.rs
+++ b/core/src/util/clear_localstorage.rs
@@ -4,11 +4,20 @@ use tracing::{info, warn};
 
 pub async fn clear_localstorage() {
 	if let Some(base_dirs) = BaseDirs::new() {
-		let data_dir = BaseDirs::data_dir(&base_dirs);
+		let data_dir = BaseDirs::data_dir(&base_dirs).join("com.spacedrive.desktop"); // app identifier, maybe tie this into something?
 
-		fs::remove_dir_all(data_dir.join("com.spacedrive.desktop")) // app identifier, maybe tie this into something?
+		fs::remove_dir_all(data_dir)
 			.await
 			.map_err(|_| warn!("Unable to delete the localstorage directory"))
+			.ok();
+
+		#[cfg(target_os = "macos")]
+		let webkit_dir = BaseDirs::home_dir(&base_dirs).join("Library/WebKit/Spacedrive"); // macos stores some localstorage stuff here
+
+		#[cfg(target_os = "macos")]
+		fs::remove_dir_all(webkit_dir)
+			.await
+			.map_err(|_| warn!("Unable to delete the WebKit localstorage directory"))
 			.ok();
 
 		info!("Cleared localstorage successfully")

--- a/core/src/util/clear_localstorage.rs
+++ b/core/src/util/clear_localstorage.rs
@@ -2,6 +2,11 @@ use directories::BaseDirs;
 use tokio::fs;
 use tracing::{info, warn};
 
+#[cfg(target_os = "macos")]
+const EXTRA_DIRS: [&str; 2] = ["Library/WebKit/Spacedrive", "Library/Caches/Spacedrive"];
+#[cfg(target_os = "linux")]
+const EXTRA_DIRS: [&str; 1] = [".cache/spacedrive"];
+
 pub async fn clear_localstorage() {
 	if let Some(base_dirs) = BaseDirs::new() {
 		let data_dir = BaseDirs::data_dir(&base_dirs).join("com.spacedrive.desktop"); // app identifier, maybe tie this into something?
@@ -11,25 +16,17 @@ pub async fn clear_localstorage() {
 			.map_err(|_| warn!("Unable to delete the localstorage directory"))
 			.ok();
 
-		#[cfg(target_os = "macos")]
-		fs::remove_dir_all(BaseDirs::home_dir(&base_dirs).join("Library/WebKit/Spacedrive"))
-			.await
-			.map_err(|_| warn!("Unable to delete the WebKit localstorage directory"))
-			.ok();
+		#[cfg(any(target_os = "macos", target_os = "linux"))]
+		for path in EXTRA_DIRS {
+			fs::remove_dir_all(BaseDirs::home_dir(&base_dirs).join(path))
+				.await
+				.map_err(|_| warn!("Unable to delete {path}"))
+				.ok();
 
-		#[cfg(target_os = "macos")]
-		fs::remove_dir_all(BaseDirs::home_dir(&base_dirs).join("Library/Caches/Spacedrive"))
-			.await
-			.map_err(|_| warn!("Unable to delete the Spacedrive cache directory"))
-			.ok();
+			info!("Deleted {path}");
+		}
 
-		#[cfg(target_os = "linux")]
-		fs::remove_dir_all(BaseDirs::home_dir(&base_dirs).join(".cache/spacedrive"))
-			.await
-			.map_err(|_| warn!("Unable to delete the Spacedrive cache directory"))
-			.ok();
-
-		info!("Cleared localstorage successfully")
+		info!("Cleared localstorage fully")
 	} else {
 		warn!("Unable to source the base directories in order to clear localstorage")
 	}

--- a/core/src/util/clear_localstorage.rs
+++ b/core/src/util/clear_localstorage.rs
@@ -12,12 +12,21 @@ pub async fn clear_localstorage() {
 			.ok();
 
 		#[cfg(target_os = "macos")]
-		let webkit_dir = BaseDirs::home_dir(&base_dirs).join("Library/WebKit/Spacedrive"); // macos stores some localstorage stuff here
-
-		#[cfg(target_os = "macos")]
-		fs::remove_dir_all(webkit_dir)
+		fs::remove_dir_all(BaseDirs::home_dir(&base_dirs).join("Library/WebKit/Spacedrive"))
 			.await
 			.map_err(|_| warn!("Unable to delete the WebKit localstorage directory"))
+			.ok();
+
+		#[cfg(target_os = "macos")]
+		fs::remove_dir_all(BaseDirs::home_dir(&base_dirs).join("Library/Caches/Spacedrive"))
+			.await
+			.map_err(|_| warn!("Unable to delete the Spacedrive cache directory"))
+			.ok();
+
+		#[cfg(target_os = "linux")]
+		fs::remove_dir_all(BaseDirs::home_dir(&base_dirs).join(".cache/spacedrive"))
+			.await
+			.map_err(|_| warn!("Unable to delete the Spacedrive cache directory"))
 			.ok();
 
 		info!("Cleared localstorage successfully")

--- a/core/src/util/clear_localstorage.rs
+++ b/core/src/util/clear_localstorage.rs
@@ -1,0 +1,18 @@
+use directories::BaseDirs;
+use tokio::fs;
+use tracing::{info, warn};
+
+pub async fn clear_localstorage() {
+	if let Some(base_dirs) = BaseDirs::new() {
+		let data_dir = BaseDirs::data_dir(&base_dirs);
+
+		fs::remove_dir_all(data_dir.join("com.spacedrive.desktop")) // app identifier, maybe tie this into something?
+			.await
+			.map_err(|_| warn!("Unable to delete the localstorage directory"))
+			.ok();
+
+		info!("Cleared localstorage successfully")
+	} else {
+		warn!("Unable to source the base directories in order to clear localstorage")
+	}
+}

--- a/core/src/util/clear_localstorage.rs
+++ b/core/src/util/clear_localstorage.rs
@@ -2,39 +2,39 @@ use directories::BaseDirs;
 use tokio::fs;
 use tracing::{info, warn};
 
-#[cfg(target_os = "macos")]
-const EXTRA_DIRS: [&str; 2] = ["Library/WebKit/Spacedrive", "Library/Caches/Spacedrive"];
 #[cfg(target_os = "linux")]
 const EXTRA_DIRS: [&str; 1] = [".cache/spacedrive"];
+#[cfg(target_os = "macos")]
+const EXTRA_DIRS: [&str; 2] = ["Library/WebKit/Spacedrive", "Library/Caches/Spacedrive"];
 
 pub async fn clear_localstorage() {
 	if let Some(base_dir) = BaseDirs::new() {
-		// `data_local_dir` gives Local AppData on Windows, while still using `~/.local/share` and
-		// `~/Library/Application Support` on Linux and MacOS respectively.
-		// `com.spacedrive.desktop` is in the Local AppData directory on Windows, not the Roaming AppData
+		// this equates to `~/.local/share` on Linux, ~/Library/Application Support` on MacOS
+		// and `~/AppData/Local` on Windows. you can find `localStorage` and other cached files here, as
+		// well as in a few other dedicated paths on Linux and MacOS (which are cleared below)
 		let data_dir = base_dir.data_local_dir().join("com.spacedrive.desktop"); // maybe tie this into something static?
 
 		fs::remove_dir_all(&data_dir)
 			.await
-			.map_err(|_| warn!("Unable to delete the localstorage directory"))
+			.map_err(|_| warn!("Unable to delete the `localStorage` primary directory."))
 			.ok();
 
 		info!("Deleted {}", data_dir.display());
 
 		let home_dir = base_dir.home_dir();
 
-		#[cfg(any(target_os = "macos", target_os = "linux"))]
+		#[cfg(any(target_os = "linux", target_os = "macos"))]
 		for path in EXTRA_DIRS {
 			fs::remove_dir_all(home_dir.join(path))
 				.await
-				.map_err(|_| warn!("Unable to delete {path}"))
+				.map_err(|_| warn!("Unable to delete a `localStorage` cache: {path}"))
 				.ok();
 
 			info!("Deleted {path}");
 		}
 
-		info!("Cleared localstorage fully")
+		info!("Successfully wiped `localStorage` and related caches.")
 	} else {
-		warn!("Unable to source the base directories in order to clear localstorage")
+		warn!("Unable to source `BaseDirs` in order to clear `localStorage`.")
 	}
 }

--- a/core/src/util/mod.rs
+++ b/core/src/util/mod.rs
@@ -1,5 +1,6 @@
 mod abort_on_drop;
 mod batched_stream;
+pub mod clear_localstorage;
 #[cfg(debug_assertions)]
 pub mod debug_initializer;
 mod infallible_request;


### PR DESCRIPTION
This will 1) reset the onboarding progress on each app load, so that prior information isn't retained and 2) reduce the amount of app crashes/blank pages that happen due to invalid `localStorage` configurations.

For web, I think this will have to be handled in the TS side of things, but for desktop we can do this. I'm not sure if the TS approach will be suitable for desktop also, we can probably do some testing in due course (this works great though).

I've tested this on Linux so far and it works, and I don't see why the other platforms wouldn't work either, but I will be testing shortly just to validate.