### PR TITLE
Update prisma-client-rust to fix compiling from source on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6136,7 +6136,7 @@ dependencies = [
 [[package]]
 name = "prisma-client-rust"
 version = "0.6.8"
-source = "git+https://github.com/spacedriveapp/prisma-client-rust?rev=9f8ac122e8f2b2e4957b71f48a37e06565adba40#9f8ac122e8f2b2e4957b71f48a37e06565adba40"
+source = "git+https://github.com/spacedriveapp/prisma-client-rust?rev=f99d6f5566570f3ab1edecb7a172ad25b03d95af#f99d6f5566570f3ab1edecb7a172ad25b03d95af"
 dependencies = [
  "base64 0.13.1",
  "bigdecimal 0.3.1",
@@ -6169,7 +6169,7 @@ dependencies = [
 [[package]]
 name = "prisma-client-rust-cli"
 version = "0.6.8"
-source = "git+https://github.com/spacedriveapp/prisma-client-rust?rev=9f8ac122e8f2b2e4957b71f48a37e06565adba40#9f8ac122e8f2b2e4957b71f48a37e06565adba40"
+source = "git+https://github.com/spacedriveapp/prisma-client-rust?rev=f99d6f5566570f3ab1edecb7a172ad25b03d95af#f99d6f5566570f3ab1edecb7a172ad25b03d95af"
 dependencies = [
  "directories 4.0.1",
  "flate2",
@@ -6189,7 +6189,7 @@ dependencies = [
 [[package]]
 name = "prisma-client-rust-generator"
 version = "0.6.8"
-source = "git+https://github.com/spacedriveapp/prisma-client-rust?rev=9f8ac122e8f2b2e4957b71f48a37e06565adba40#9f8ac122e8f2b2e4957b71f48a37e06565adba40"
+source = "git+https://github.com/spacedriveapp/prisma-client-rust?rev=f99d6f5566570f3ab1edecb7a172ad25b03d95af#f99d6f5566570f3ab1edecb7a172ad25b03d95af"
 dependencies = [
  "directories 4.0.1",
  "flate2",
@@ -6209,7 +6209,7 @@ dependencies = [
 [[package]]
 name = "prisma-client-rust-macros"
 version = "0.6.8"
-source = "git+https://github.com/spacedriveapp/prisma-client-rust?rev=9f8ac122e8f2b2e4957b71f48a37e06565adba40#9f8ac122e8f2b2e4957b71f48a37e06565adba40"
+source = "git+https://github.com/spacedriveapp/prisma-client-rust?rev=f99d6f5566570f3ab1edecb7a172ad25b03d95af#f99d6f5566570f3ab1edecb7a172ad25b03d95af"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -6221,7 +6221,7 @@ dependencies = [
 [[package]]
 name = "prisma-client-rust-sdk"
 version = "0.6.8"
-source = "git+https://github.com/spacedriveapp/prisma-client-rust?rev=9f8ac122e8f2b2e4957b71f48a37e06565adba40#9f8ac122e8f2b2e4957b71f48a37e06565adba40"
+source = "git+https://github.com/spacedriveapp/prisma-client-rust?rev=f99d6f5566570f3ab1edecb7a172ad25b03d95af#f99d6f5566570f3ab1edecb7a172ad25b03d95af"
 dependencies = [
  "convert_case 0.5.0",
  "dmmf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,19 +22,19 @@ repository = "https://github.com/spacedriveapp/spacedrive"
 
 [workspace.dependencies]
 # First party dependencies
-prisma-client-rust = { git = "https://github.com/spacedriveapp/prisma-client-rust", rev = "9f8ac122e8f2b2e4957b71f48a37e06565adba40", features = [
+prisma-client-rust = { git = "https://github.com/spacedriveapp/prisma-client-rust", rev = "f99d6f5566570f3ab1edecb7a172ad25b03d95af", features = [
 	"rspc",
 	"sqlite-create-many",
 	"migrations",
 	"sqlite",
 ], default-features = false }
-prisma-client-rust-cli = { git = "https://github.com/spacedriveapp/prisma-client-rust", rev = "9f8ac122e8f2b2e4957b71f48a37e06565adba40", features = [
+prisma-client-rust-cli = { git = "https://github.com/spacedriveapp/prisma-client-rust", rev = "f99d6f5566570f3ab1edecb7a172ad25b03d95af", features = [
 	"rspc",
 	"sqlite-create-many",
 	"migrations",
 	"sqlite",
 ], default-features = false }
-prisma-client-rust-sdk = { git = "https://github.com/spacedriveapp/prisma-client-rust", rev = "9f8ac122e8f2b2e4957b71f48a37e06565adba40", features = [
+prisma-client-rust-sdk = { git = "https://github.com/spacedriveapp/prisma-client-rust", rev = "f99d6f5566570f3ab1edecb7a172ad25b03d95af", features = [
 	"sqlite",
 ], default-features = false }
 


### PR DESCRIPTION
- Fix rolling release distros that are already using OpenSSL > 3.0