### PR TITLE
Use PathBuf instead of String for paths

### DIFF
--- a/core/src/api/backups.rs
+++ b/core/src/api/backups.rs
@@ -121,29 +121,25 @@ pub(crate) fn mount() -> AlphaRouter<Ctx> {
 				)
 		})
 		.procedure("restore", {
-			R
-				// TODO: Paths as strings is bad but here we want the flexibility of the frontend allowing any path
-				.mutation(|node, path: String| async move {
-					start_restore(node, path.into()).await;
-					Ok(())
-				})
+			R.mutation(|node, path: PathBuf| async move {
+				start_restore(node, path.into()).await;
+				Ok(())
+			})
 		})
 		.procedure("delete", {
-			R
-				// TODO: Paths as strings is bad but here we want the flexibility of the frontend allowing any path
-				.mutation(|node, path: String| async move {
-					fs::remove_file(path)
-						.await
-						.map(|_| {
-							invalidate_query!(node; node, "backups.getAll");
-						})
-						.map_err(|_| {
-							rspc::Error::new(
-								ErrorCode::InternalServerError,
-								"Error deleting backup!".to_string(),
-							)
-						})
-				})
+			R.mutation(|node, path: PathBuf| async move {
+				fs::remove_file(path)
+					.await
+					.map(|_| {
+						invalidate_query!(node; node, "backups.getAll");
+					})
+					.map_err(|_| {
+						rspc::Error::new(
+							ErrorCode::InternalServerError,
+							"Error deleting backup!".to_string(),
+						)
+					})
+			})
 		})
 }
 

--- a/core/src/api/backups.rs
+++ b/core/src/api/backups.rs
@@ -122,7 +122,7 @@ pub(crate) fn mount() -> AlphaRouter<Ctx> {
 		})
 		.procedure("restore", {
 			R.mutation(|node, path: PathBuf| async move {
-				start_restore(node, path.into()).await;
+				start_restore(node, path).await;
 				Ok(())
 			})
 		})


### PR DESCRIPTION
<!-- Put any information about this PR up here -->
There are two instances in `core/src/api/backups.rs` where `String` is used as a path type, when `PathBuf` could be used instead. This PR makes the replacement.

<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->

Closes #1959
