### PR TITLE
Add missing zeroize to Identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7781,6 +7781,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]
@@ -10919,6 +10920,20 @@ name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.42",
+]
 
 [[package]]
 name = "zip"

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -44,7 +44,7 @@ libp2p-quic = { version = "0.9.3", features = ["tokio"] }
 mdns-sd = "0.9.3"
 rand_core = { version = "0.6.4" }
 streamunordered = "0.5.3"
-
+zeroize = { version = "1.7.0", features = ["derive"]}
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/crates/p2p/src/spacetunnel/identity.rs
+++ b/crates/p2p/src/spacetunnel/identity.rs
@@ -9,6 +9,7 @@ use rand_core::OsRng;
 use serde::{Deserialize, Serialize};
 use specta::Type;
 use thiserror::Error;
+use zeroize::ZeroizeOnDrop;
 
 pub const REMOTE_IDENTITY_LEN: usize = 32;
 
@@ -22,8 +23,8 @@ pub enum IdentityErr {
 }
 
 /// TODO
-#[derive(Debug, Clone)]
-pub struct Identity(ed25519_dalek::SigningKey); // TODO: Zeroize on this type
+#[derive(Debug, Clone, ZeroizeOnDrop)]
+pub struct Identity(ed25519_dalek::SigningKey);
 
 impl PartialEq for Identity {
 	fn eq(&self, other: &Self) -> bool {


### PR DESCRIPTION
<!-- Put any information about this PR up here -->
`Identity` should be zeroized when no longer in use. This PR adds a `derive(ZeroizeOnDrop)` to `Identity`.

<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->

Closes #1961
