### PR TITLE
Windows: Remove os check for mouse nav

### DIFF
--- a/interface/app/$libraryId/TopBar/NavigationButtons.tsx
+++ b/interface/app/$libraryId/TopBar/NavigationButtons.tsx
@@ -42,8 +42,6 @@ export const NavigationButtons = () => {
 	});
 
 	useEffect(() => {
-		if (os === 'windows') return; //windows already navigates back and forth with mouse buttons
-
 		const onMouseDown = (e: MouseEvent) => {
 			e.stopPropagation();
 			if (e.buttons === 8) {


### PR DESCRIPTION
Due to recent changes - this is no longer needed.