### PR TITLE
[ENG-1529] Round thumbnails for labels

### DIFF
--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -6,6 +6,7 @@ repository = { workspace = true }
 edition = { workspace = true }
 
 [features]
+default = ["ai-models"]
 assets = []
 ai-models = ["sd-core/ai"]
 

--- a/interface/app/$libraryId/Explorer/View/GridView/Item/index.tsx
+++ b/interface/app/$libraryId/Explorer/View/GridView/Item/index.tsx
@@ -85,6 +85,7 @@ const ItemFileThumb = () => {
 			extension
 			className={clsx('px-2 py-1', item.cut && 'opacity-60')}
 			ref={setDraggableRef}
+			frameClassName={clsx(item.data.type === "Label" && "!rounded-2xl")}
 			childProps={{
 				style,
 				...attributes,

--- a/interface/app/$libraryId/Explorer/View/ListView/useTable.tsx
+++ b/interface/app/$libraryId/Explorer/View/ListView/useTable.tsx
@@ -38,7 +38,7 @@ const NameCell = memo(({ item, selected }: { item: ExplorerItem; selected: boole
 			<FileThumb
 				data={item}
 				frame
-				frameClassName="!border"
+				frameClassName={clsx("!border", item.type === "Label" && "!rounded-lg")}
 				blackBars
 				size={35}
 				className={clsx('mr-2.5', cut && 'opacity-60')}


### PR DESCRIPTION
not implemented nicely but it'll do

<img width="190" alt="image" src="https://github.com/spacedriveapp/spacedrive/assets/14191578/2880b427-ad57-4025-bbe6-1ba95322a485">
<img width="207" alt="image" src="https://github.com/spacedriveapp/spacedrive/assets/14191578/2e1f1534-ea3c-439d-a05a-1f32b0374e19">
