### PR TITLE
[ENG-1564] Delete dialog keypress 

### DIFF
--- a/interface/app/$libraryId/Explorer/FilePath/RenameTextBox.tsx
+++ b/interface/app/$libraryId/Explorer/FilePath/RenameTextBox.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react';
 import TruncateMarkup from 'react-truncate-markup';
 import { useSelector } from '@sd/client';
-import { Tooltip } from '@sd/ui';
+import { dialogManager, Tooltip } from '@sd/ui';
 import { useOperatingSystem, useShortcut } from '~/hooks';
 
 import { explorerStore } from '../store';
@@ -111,6 +111,7 @@ export const RenameTextBox = forwardRef<HTMLDivElement, RenameTextBoxProps>(
 		};
 
 		useShortcut('renameObject', (e) => {
+			if (dialogManager.isAnyDialogOpen()) return;
 			e.preventDefault();
 			if (allowRename) blur();
 			else if (!disabled) setAllowRename(true);

--- a/interface/app/$libraryId/Explorer/View/Grid/index.tsx
+++ b/interface/app/$libraryId/Explorer/View/Grid/index.tsx
@@ -2,6 +2,7 @@ import { Grid, useGrid } from '@virtual-grid/react';
 import { memo, ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import Selecto from 'react-selecto';
 import { type ExplorerItem } from '@sd/client';
+import { dialogManager } from '@sd/ui';
 import { useOperatingSystem, useShortcut } from '~/hooks';
 
 import { useExplorerContext } from '../../Context';
@@ -287,7 +288,7 @@ const Component = memo(({ children }: { children: RenderItem }) => {
 	};
 
 	useShortcut('explorerDown', (e) => {
-		if (!explorerView.selectable) return;
+		if (!explorerView.selectable || dialogManager.isAnyDialogOpen()) return;
 
 		if (explorer.selectedItems.size === 0) {
 			const item = grid.getItem(0);
@@ -308,21 +309,21 @@ const Component = memo(({ children }: { children: RenderItem }) => {
 	});
 
 	useShortcut('explorerUp', (e) => {
-		if (!explorerView.selectable) return;
+		if (!explorerView.selectable || dialogManager.isAnyDialogOpen()) return;
 		const newIndex = getGridItemHandler('ArrowUp');
 		if (newIndex === undefined) return;
 		keyboardHandler(e, newIndex);
 	});
 
 	useShortcut('explorerLeft', (e) => {
-		if (!explorerView.selectable) return;
+		if (!explorerView.selectable || dialogManager.isAnyDialogOpen()) return;
 		const newIndex = getGridItemHandler('ArrowLeft');
 		if (newIndex === undefined) return;
 		keyboardHandler(e, newIndex);
 	});
 
 	useShortcut('explorerRight', (e) => {
-		if (!explorerView.selectable) return;
+		if (!explorerView.selectable || dialogManager.isAnyDialogOpen()) return;
 		const newIndex = getGridItemHandler('ArrowRight');
 		if (newIndex === undefined) return;
 		keyboardHandler(e, newIndex);

--- a/interface/app/$libraryId/Explorer/View/index.tsx
+++ b/interface/app/$libraryId/Explorer/View/index.tsx
@@ -171,7 +171,7 @@ const useShortcuts = () => {
 	useKeyCopyCutPaste();
 
 	useShortcut('toggleQuickPreview', (e) => {
-		if (isRenaming) return;
+		if (isRenaming || dialogManager.isAnyDialogOpen()) return;
 		e.preventDefault();
 		getQuickPreviewStore().open = !quickPreviewStore.open;
 	});

--- a/packages/ui/src/Dialog.tsx
+++ b/packages/ui/src/Dialog.tsx
@@ -53,6 +53,10 @@ class DialogManager {
 		return this.state[id];
 	}
 
+	isAnyDialogOpen() {
+		return Object.values(this.state).some((s) => s.open);
+	}
+
 	remove(id: number) {
 		const state = this.getState(id);
 
@@ -142,7 +146,6 @@ export function Dialog<S extends FieldValues>({
 	...props
 }: DialogProps<S>) {
 	const stateSnap = useSnapshot(dialog.state);
-
 	const transitions = useTransition(stateSnap.open, {
 		from: {
 			opacity: 0,


### PR DESCRIPTION
This PR prevents explorer interaction when a dialog is open, this addresses the issue of not being able to press 'Enter' on your keyboard when focus is active on a button.