### PR TITLE
Remove `enableElevatedUpdateTask` from Wix installer config

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -44,7 +44,6 @@
 				"digestAlgorithm": "sha256",
 				"timestampUrl": "",
 				"wix": {
-					"enableElevatedUpdateTask": true,
 					"dialogImagePath": "icons/WindowsDialogImage.bmp",
 					"bannerPath": "icons/WindowsBanner.bmp"
 				}


### PR DESCRIPTION
This config option seems to be crashing the installer for a lot of Windows users, and I am not 100% why I enabled anyway, so revert it.

__Rationale__:
According to this log, from an affected user:
https://github.com/spacedriveapp/spacedrive/issues/1994#issuecomment-1909596918
The problem steams from the `CreateUpdateTask` action present in tauri's Wix template:
https://github.com/tauri-apps/tauri/blob/tauri-v1.5.3/tooling/bundler/src/bundle/windows/templates/main.wxs#L282-L307
Which tries to execute this Powershell script:
https://github.com/tauri-apps/tauri/blob/tauri-v1.5.3/tooling/bundler/src/bundle/windows/templates/install-task.ps1
That fails for a lot of our users for some reason.
However, this is a non-default behavior that I enabled in the AI PR for some reason (maybe by mistake):
https://github.com/spacedriveapp/spacedrive/pull/1845/files#diff-25f93a9e45647c833a5769e5c21fb1735e0ffd08f536dad2337de462ed7d14ddR47
https://tauri.app/v1/api/config#wixconfig.enableelevatedupdatetask

The best solution is to revert this for now

Close #1994 