### PR TITLE
Fix Location Settings (due to Normalised Cache bugs)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7453,7 +7453,7 @@ dependencies = [
 
 [[package]]
 name = "sd-core"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "aovec",
  "async-channel",
@@ -7590,7 +7590,7 @@ dependencies = [
 
 [[package]]
 name = "sd-desktop"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "axum",
  "futures",

--- a/interface/app/$libraryId/settings/library/locations/$id.tsx
+++ b/interface/app/$libraryId/settings/library/locations/$id.tsx
@@ -31,7 +31,7 @@ const FlexCol = tw.label`flex flex-col flex-1`;
 const ToggleSection = tw.label`flex flex-row w-full`;
 
 const schema = z.object({
-	name: z.string().nullable(),
+	name: z.string().min(1).nullable(),
 	path: z.string().min(1).nullable(),
 	hidden: z.boolean().nullable(),
 	indexerRulesIds: z.array(z.number()),


### PR DESCRIPTION
Changes:
 - [x] Introduce `specialMerge` function so we can merge `CacheNode`'s if the property is `null` but we have the data from another `CacheNode` of the same type and ID. The `null` is probs from PCR's `Option<Relation>` in the data struct.
 - [x] Properly restore nested relations