### PR TITLE
[ENG-1548] use in-memory instances when sending messages to cloud

### DIFF
--- a/core/src/cloud/sync/mod.rs
+++ b/core/src/cloud/sync/mod.rs
@@ -24,14 +24,7 @@ pub async fn declare_actors(library: &Arc<Library>, node: &Arc<Node>) {
 				let library = library.clone();
 				let node = node.clone();
 
-				move || {
-					send::run_actor(
-						library.db.clone(),
-						library.id,
-						library.sync.clone(),
-						node.clone(),
-					)
-				}
+				move || send::run_actor(library.id, library.sync.clone(), node.clone())
 			},
 			autorun,
 		)

--- a/core/src/cloud/sync/send.rs
+++ b/core/src/cloud/sync/send.rs
@@ -26,6 +26,7 @@ pub async fn run_actor(
 				.cloned()
 				.collect::<Vec<_>>();
 
+			// obtains a lock on the timestamp collections for the instances we have
 			let req_adds = err_break!(
 				sd_cloud_api::library::message_collections::request_add(
 					cloud_api_config_provider.get_request_config().await,
@@ -39,6 +40,7 @@ pub async fn run_actor(
 
 			use sd_cloud_api::library::message_collections::do_add;
 
+			// gets new operations for each instance to send to cloud
 			for req_add in req_adds {
 				let ops = err_break!(
 					sync.get_ops(GetOpsArgs {
@@ -78,6 +80,7 @@ pub async fn run_actor(
 				break;
 			}
 
+			// uses lock we acquired earlier to send the operations to the cloud
 			err_break!(
 				do_add(
 					cloud_api_config_provider.get_request_config().await,

--- a/core/src/cloud/sync/send.rs
+++ b/core/src/cloud/sync/send.rs
@@ -2,8 +2,6 @@ use super::CompressedCRDTOperations;
 
 use sd_cloud_api::RequestConfigProvider;
 use sd_core_sync::{GetOpsArgs, SyncMessage, NTP64};
-use sd_prisma::prisma::{instance, PrismaClient};
-use sd_utils::from_bytes_to_uuid;
 use uuid::Uuid;
 
 use std::{sync::Arc, time::Duration};
@@ -13,23 +11,20 @@ use tokio::time::sleep;
 use super::err_break;
 
 pub async fn run_actor(
-	db: Arc<PrismaClient>,
 	library_id: Uuid,
 	sync: Arc<sd_core_sync::Manager>,
 	cloud_api_config_provider: Arc<impl RequestConfigProvider>,
 ) {
 	loop {
 		loop {
-			let instances = err_break!(
-				db.instance()
-					.find_many(vec![])
-					.select(instance::select!({ pub_id }))
-					.exec()
-					.await
-			)
-			.into_iter()
-			.map(|i| from_bytes_to_uuid(&i.pub_id))
-			.collect::<Vec<_>>();
+			// all available instances will have a default timestamp from create_instance
+			let instances = sync
+				.timestamps
+				.read()
+				.await
+				.keys()
+				.cloned()
+				.collect::<Vec<_>>();
 
 			let req_adds = err_break!(
 				sd_cloud_api::library::message_collections::request_add(


### PR DESCRIPTION
Reading from memory is much faster than scanning through db rows (which is done on app startup), we just need to ensure that the db and in-memory values are being updated together.