### PR TITLE
Improve error handling by using decode::Error instead of io::Result

### DIFF
--- a/core/src/p2p/sync/proto.rs
+++ b/core/src/p2p/sync/proto.rs
@@ -1,3 +1,4 @@
+use sd_p2p::proto::decode;
 use tokio::io::{AsyncRead, AsyncReadExt};
 
 // will probs have more variants in future
@@ -8,14 +9,13 @@ pub enum SyncMessage {
 
 impl SyncMessage {
 	// TODO: Per field errors for better error handling
-	// TODO: Using `decode::Error` instead of `io::Result`
-	pub async fn from_stream(stream: &mut (impl AsyncRead + Unpin)) -> std::io::Result<Self> {
+	pub async fn from_stream(stream: &mut (impl AsyncRead + Unpin)) -> Result<Self, decode::Error> {
 		match stream.read_u8().await? {
 			b'N' => Ok(Self::NewOperations),
-			header => Err(std::io::Error::new(
+			header => Err(decode::Error::IoError(std::io::Error::new(
 				std::io::ErrorKind::InvalidData,
 				format!("Invalid sync message header: {}", (header as char)),
-			)),
+			))),
 		}
 	}
 


### PR DESCRIPTION
<!-- Put any information about this PR up here -->

This resolves a TODO comment in `core/src/p2p/sync/proto.rs`:
```
// TODO: Using `decode::Error` instead of `io::Result`
```

<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->

Closes #2077 
