### PR TITLE
New Android Build Script

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,8 @@
 # built product/cache
 target/
 dist/
+apps/mobile/android/app/build
+apps/mobile/modules/sd-core/android/build
 
 # macOS/iOS product/cache
 .build/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,8 @@ Make sure to read the [guidelines](https://spacedrive.com/docs/developers/prereq
 
 To run the mobile app:
 
+- Install Java JDK <= 17 for Android
+  - Java 21 is not compatible: https://github.com/react-native-async-storage/async-storage/issues/1057#issuecomment-1925963956
 - Install [Android Studio](https://developer.android.com/studio) for Android and [Xcode](https://apps.apple.com/au/app/xcode/id497799835) for iOS development.
 - Run `./scripts/setup.sh mobile`
   - This will set up most of the dependencies required to build the mobile app.

--- a/apps/mobile/modules/sd-core/android/build.gradle
+++ b/apps/mobile/modules/sd-core/android/build.gradle
@@ -82,11 +82,6 @@ android {
       withSourcesJar()
     }
   }
-	sourceSets {
-		main {
-			jniLibs.srcDirs = ['../../../../../target/release']
-		}
-	}
 }
 
 repositories {
@@ -98,41 +93,11 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
 }
 
-apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
-
-def cargoTargets = ["x86_64"]
-
-if (System.getenv('SPACEDRIVE_CI') != "1") {
-    cargoTargets = ["arm", "arm64", "x86"]
+// Run the ./build.sh script to build the Rust code
+task buildRustCode(type: Exec) {
+  commandLine "./build.sh"
 }
 
-cargo {
-	  final String osName = System.getProperty("os.name").toLowerCase();
-
-    module  = "./crate"
-    libname = "sd_mobile_android"
-    pythonCommand = 'python3'
-    profile = 'release' // 'debug'
-    targets = cargoTargets
-    targetDirectory = "../../../../../target" // Monorepo moment
-		exec { spec, toolchain ->
-
-			def dir = "${android.ndkDirectory}/toolchains/llvm/prebuilt/${osName.contains("mac") ? "darwin" : osName}-x86_64/bin/llvm-ranlib"
-
-			spec.environment("RANLIB_armv7-linux-androideabi", "${dir}")
-			spec.environment("RANLIB_aarch64-linux-android", "${dir}")
-			spec.environment("RANLIB_i686-linux-android", "${dir}")
-			spec.environment("RANLIB_x86_64-linux-android", "${dir}")
-		}
-}
-
-tasks.whenTaskAdded { task ->
-	// Require cargo to be run before copying native libraries.
-	if ((task.name == 'mergeDebugJniLibFolders' || task.name == 'mergeReleaseJniLibFolders')) {
-			task.dependsOn 'cargoBuild'
-	}
-	// Require "clean builds" to avoid issues with build caches.
-	if (task.name == 'assembleDebug' || task.name == 'assembleRelease')  {
-			task.dependsOn 'clean'
-	}
+tasks.named('preBuild').configure {
+	dependsOn buildRustCode
 }

--- a/apps/mobile/modules/sd-core/android/build.sh
+++ b/apps/mobile/modules/sd-core/android/build.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env sh
+
+set -eu
+
+if [ "${CI:-}" = "true" ]; then
+  set -x
+fi
+
+if [ -z "${HOME:-}" ]; then
+  HOME="$(CDPATH='' cd -- "$(osascript -e 'set output to (POSIX path of (path to home folder))')" && pwd -P)"
+  export HOME
+fi
+
+echo "Building 'sd-mobile-android' library..."
+
+__dirname="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)"
+
+# Ensure target dir exists
+TARGET_DIRECTORY="${__dirname}/../../../../../target/android"
+OUTPUT_DIRECTORY="${__dirname}/../../../../../apps/mobile/android/app/src/main/jniLibs"
+mkdir -p "$TARGET_DIRECTORY"
+TARGET_DIRECTORY="$(CDPATH='' cd -- "$TARGET_DIRECTORY" && pwd -P)"
+
+# if [ "${CONFIGURATION:-}" != "Debug" ]; then
+#   CARGO_FLAGS=--debug
+#   export CARGO_FLAGS
+# fi
+
+# Clean OUTPUT_DIRECTORY before building
+echo "Cleaning $OUTPUT_DIRECTORY"
+rm -rf $OUTPUT_DIRECTORY/*
+mkdir -p $OUTPUT_DIRECTORY
+
+# Required for CI and for everyone I guess?
+export PATH="${CARGO_HOME:-"${HOME}/.cargo"}/bin:$PATH"
+
+ANDROID_BUILD_TARGET_LIST="arm64-v8a armeabi-v7a x86 x86_64"
+
+# Loop through the list of targets and build them concurrently
+cd crate/
+
+echo "Building targets: $ANDROID_BUILD_TARGET_LIST"
+
+# Build for each target
+for target in $ANDROID_BUILD_TARGET_LIST; do
+  echo "Building for target: $target"
+  cargo ndk --platform 34 -t $target -o $TARGET_DIRECTORY build --release
+done
+
+# Clean up apps/mobile/android/app/src/main/jniLibs directory before moving new files
+# rm -rf ${__dirname}/apps/mobile/android/app/src/main/jniLibs/*
+
+# Move contents of target directory to apps/mobile/android/app/src/main/jniLibs
+echo "Moving files to $OUTPUT_DIRECTORY"
+for target in $ANDROID_BUILD_TARGET_LIST; do
+  mv $TARGET_DIRECTORY/$target $OUTPUT_DIRECTORY
+done

--- a/apps/mobile/modules/sd-core/android/build.sh
+++ b/apps/mobile/modules/sd-core/android/build.sh
@@ -6,8 +6,28 @@ if [ "${CI:-}" = "true" ]; then
   set -x
 fi
 
+err() {
+  for _line in "$@"; do
+    echo "$_line" >&2
+  done
+  exit 1
+}
+
 if [ -z "${HOME:-}" ]; then
-  HOME="$(CDPATH='' cd -- "$(osascript -e 'set output to (POSIX path of (path to home folder))')" && pwd -P)"
+  case "$(uname)" in
+    "Darwin")
+      HOME="$(CDPATH='' cd -- "$(osascript -e 'set output to (POSIX path of (path to home folder))')" && pwd -P)"
+      ;;
+    "Linux")
+      HOME="$(CDPATH='' cd -- "$(getent passwd "$(id -un)" | cut -d: -f6)" && pwd -P)"
+      ;;
+    *)
+      err "Your OS ($(uname)) is not supported by this script." \
+        'We would welcome a PR or some help adding your OS to this script.' \
+        'https://github.com/spacedriveapp/spacedrive/issues'
+      ;;
+  esac
+
   export HOME
 fi
 
@@ -15,20 +35,9 @@ echo "Building 'sd-mobile-android' library..."
 
 __dirname="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)"
 
-# Ensure target dir exists
-TARGET_DIRECTORY="${__dirname}/../../../../../target/android"
+# Ensure output dir exists
 OUTPUT_DIRECTORY="${__dirname}/../../../../../apps/mobile/android/app/src/main/jniLibs"
-mkdir -p "$TARGET_DIRECTORY"
-TARGET_DIRECTORY="$(CDPATH='' cd -- "$TARGET_DIRECTORY" && pwd -P)"
-
-# If CI, then we can skip the clean: we know we're starting from a clean state
-if [ "${CI:-}" = "true" ]; then
-  echo "CI environment detected, skipping clean"
-else
-  # Clean the target directory
-  echo "Cleaning $TARGET_DIRECTORY"
-  rm -rf $TARGET_DIRECTORY/*
-fi
+mkdir -p "$OUTPUT_DIRECTORY"
 
 # Required for CI and for everyone I guess?
 export PATH="${CARGO_HOME:-"${HOME}/.cargo"}/bin:$PATH"
@@ -36,24 +45,18 @@ export PATH="${CARGO_HOME:-"${HOME}/.cargo"}/bin:$PATH"
 # Set the targets to build
 # If CI, then we build x86_64 else we build all targets
 if [ "${CI:-}" = "true" ]; then
+  # TODO: This need to be adjusted for future mobile release CI
   ANDROID_BUILD_TARGET_LIST="x86_64"
 else
-  ANDROID_BUILD_TARGET_LIST="arm64-v8a armeabi-v7a x86"
+  ANDROID_BUILD_TARGET_LIST="arm64-v8a armeabi-v7a x86_64"
 fi
 
-# Loop through the list of targets and build them concurrently
-cd crate/
-
+# Configure build targets CLI arg for `cargo ndk`
 echo "Building targets: $ANDROID_BUILD_TARGET_LIST"
-
-# Build for each target
-for target in $ANDROID_BUILD_TARGET_LIST; do
-  echo "Building for target: $target"
-  cargo ndk --platform 34 -t $target -o $TARGET_DIRECTORY build --release
+set --
+for _target in $ANDROID_BUILD_TARGET_LIST; do
+  set -- "$@" -t "$_target"
 done
 
-# Move contents of target directory to apps/mobile/android/app/src/main/jniLibs
-echo "Moving files to $OUTPUT_DIRECTORY"
-for target in $ANDROID_BUILD_TARGET_LIST; do
-  mv $TARGET_DIRECTORY/$target $OUTPUT_DIRECTORY
-done
+cd "${__dirname}/crate"
+cargo ndk --platform 34 "$@" -o "$OUTPUT_DIRECTORY" build --release

--- a/apps/mobile/modules/sd-core/android/build.sh
+++ b/apps/mobile/modules/sd-core/android/build.sh
@@ -46,7 +46,17 @@ export PATH="${CARGO_HOME:-"${HOME}/.cargo"}/bin:$PATH"
 # If CI, then we build x86_64 else we build all targets
 if [ "${CI:-}" = "true" ]; then
   # TODO: This need to be adjusted for future mobile release CI
-  ANDROID_BUILD_TARGET_LIST="x86_64"
+  case "$(uname -m)" in
+    "arm64" | "aarch64")
+      ANDROID_BUILD_TARGET_LIST="arm64-v8a"
+      ;;
+    "x86_64")
+      ANDROID_BUILD_TARGET_LIST="x86_64"
+      ;;
+    *)
+      err 'Unsupported architecture for CI build.'
+      ;;
+  esac
 else
   ANDROID_BUILD_TARGET_LIST="arm64-v8a armeabi-v7a x86_64"
 fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -41,9 +41,9 @@ script_failure() {
 trap 'script_failure ${LINENO:-}' ERR
 
 case "${OSTYPE:-}" in
-'msys' | 'mingw' | 'cygwin')
-  err 'Bash for windows is not supported, please interact with this repo from Powershell or CMD'
-  ;;
+  'msys' | 'mingw' | 'cygwin')
+    err 'Bash for windows is not supported, please interact with this repo from Powershell or CMD'
+    ;;
 esac
 
 if [ "${CI:-}" != "true" ]; then
@@ -88,15 +88,15 @@ if [ "${1:-}" = "mobile" ]; then
   # Android targets
   echo "Installing Android targets for Rust..."
 
-  rustup target add armv7-linux-androideabi  # for arm
-  rustup target add aarch64-linux-android    # for arm64
-  rustup target add i686-linux-android       # for x86
-  rustup target add x86_64-linux-android     # for x86_64
-  rustup target add x86_64-unknown-linux-gnu # for linux-x86-64
-  rustup target add aarch64-apple-darwin     # for darwin arm64 (if you have an M1 Mac)
-  rustup target add x86_64-apple-darwin      # for darwin x86_64 (if you have an Intel Mac)
-  rustup target add x86_64-pc-windows-gnu    # for win32-x86-64-gnu
-  rustup target add x86_64-pc-windows-msvc   # for win32-x86-64-msvc
+  if [ "${CI:-}" = "true" ]; then
+    # TODO: This need to be adjusted for future mobile release CI
+    rustup target add x86_64-linux-android
+  else
+    rustup target add \
+      aarch64-linux-android \
+      armv7-linux-androideabi \
+      x86_64-linux-android
+  fi
 
   echo
 else
@@ -105,141 +105,149 @@ fi
 
 # Install system deps
 case "$(uname)" in
-"Darwin")
-  if [ "$(uname -m)" = 'x86_64' ]; then (
-    if [ "${CI:-}" = "true" ]; then
-      export NONINTERACTIVE=1
-    fi
-    brew install nasm
-  ); fi
-
-  # Install rust deps for iOS
-  if [ $MOBILE -eq 1 ]; then
-    echo "Checking for Xcode..."
-    if ! /usr/bin/xcodebuild -version >/dev/null; then
-      err "Xcode was not detected." \
-        "Please ensure Xcode is installed and try again."
+  "Darwin")
+    if [ "$(uname -m)" = 'x86_64' ] && ! [ "${CI:-}" = "true" ]; then
+      brew install nasm
     fi
 
-    echo "Installing iOS targets for Rust..."
+    # Install rust deps for iOS
+    if [ $MOBILE -eq 1 ]; then
+      echo "Checking for Xcode..."
+      if ! /usr/bin/xcodebuild -version >/dev/null; then
+        err "Xcode was not detected." \
+          "Please ensure Xcode is installed and try again."
+      fi
 
-    rustup target add aarch64-apple-ios
-    rustup target add aarch64-apple-ios-sim
-    rustup target add x86_64-apple-ios # for CI
+      echo "Installing iOS targets for Rust..."
 
-    echo
-  fi
-  ;;
-"Linux") # https://github.com/tauri-apps/tauri-docs/blob/dev/docs/guides/getting-started/prerequisites.md#setting-up-linux
-  if has apt-get; then
-    echo "Detected apt!"
-    echo "Installing dependencies with apt..."
+      case "$(uname -m)" in
+        "arm64" | "aarch64") # M series
+          rustup target add aarch64-apple-ios aarch64-apple-ios-sim
+          ;;
+        "x86_64") # Intel
+          rustup target add x86_64-apple-ios aarch64-apple-ios
+          ;;
+        *)
+          err 'Unsupported architecture for CI build.'
+          ;;
+      esac
 
-    # Tauri dependencies
-    set -- build-essential curl wget file openssl libssl-dev libgtk-3-dev librsvg2-dev \
-      libwebkit2gtk-4.0-dev libayatana-appindicator3-dev
+      echo
+    fi
+    ;;
+  "Linux") # https://github.com/tauri-apps/tauri-docs/blob/dev/docs/guides/getting-started/prerequisites.md#setting-up-linux
+    if has apt-get; then
+      echo "Detected apt!"
+      echo "Installing dependencies with apt..."
 
-    # Webkit2gtk requires gstreamer plugins for video playback to work
-    set -- "$@" gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
+      # Tauri dependencies
+      set -- build-essential curl wget file openssl libssl-dev libgtk-3-dev librsvg2-dev \
+        libwebkit2gtk-4.0-dev libayatana-appindicator3-dev
 
-    # C/C++ build dependencies, required to build some *-sys crates
-    set -- "$@" llvm-dev libclang-dev clang nasm perl
+      # Webkit2gtk requires gstreamer plugins for video playback to work
+      set -- "$@" gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
 
-    # React dependencies
-    set -- "$@" libvips42
+      # C/C++ build dependencies, required to build some *-sys crates
+      set -- "$@" llvm-dev libclang-dev clang nasm perl
 
-    sudo apt-get -y update
-    sudo apt-get -y install "$@"
-  elif has pacman; then
-    echo "Detected pacman!"
-    echo "Installing dependencies with pacman..."
+      # React dependencies
+      set -- "$@" libvips42
 
-    # Tauri dependencies
-    set -- base-devel curl wget file openssl gtk3 librsvg webkit2gtk libayatana-appindicator
+      sudo apt-get -y update
+      sudo apt-get -y install "$@"
+    elif has pacman; then
+      echo "Detected pacman!"
+      echo "Installing dependencies with pacman..."
 
-    # Webkit2gtk requires gstreamer plugins for video playback to work
-    set -- "$@" gst-plugins-base gst-plugins-good gst-plugins-ugly
+      # Tauri dependencies
+      set -- base-devel curl wget file openssl gtk3 librsvg webkit2gtk libayatana-appindicator
 
-    # C/C++ build dependencies, required to build some *-sys crates
-    set -- "$@" clang nasm perl
+      # Webkit2gtk requires gstreamer plugins for video playback to work
+      set -- "$@" gst-plugins-base gst-plugins-good gst-plugins-ugly
 
-    # React dependencies
-    set -- "$@" libvips
+      # C/C++ build dependencies, required to build some *-sys crates
+      set -- "$@" clang nasm perl
 
-    sudo pacman -Sy --needed "$@"
-  elif has dnf; then
-    echo "Detected dnf!"
-    echo "Installing dependencies with dnf..."
+      # React dependencies
+      set -- "$@" libvips
 
-    # For Enterprise Linux, you also need "Development Tools" instead of "C Development Tools and Libraries"
-    if ! { sudo dnf group install "C Development Tools and Libraries" || sudo dnf group install "Development Tools"; }; then
-      err 'We were unable to install the "C Development Tools and Libraries"/"Development Tools" package.' \
-        'Please open an issue if you feel that this is incorrect.' \
+      sudo pacman -Sy --needed "$@"
+    elif has dnf; then
+      echo "Detected dnf!"
+      echo "Installing dependencies with dnf..."
+
+      # For Enterprise Linux, you also need "Development Tools" instead of "C Development Tools and Libraries"
+      if ! { sudo dnf group install "C Development Tools and Libraries" || sudo dnf group install "Development Tools"; }; then
+        err 'We were unable to install the "C Development Tools and Libraries"/"Development Tools" package.' \
+          'Please open an issue if you feel that this is incorrect.' \
+          'https://github.com/spacedriveapp/spacedrive/issues'
+      fi
+
+      # For Fedora 36 and below, and all Enterprise Linux Distributions, you need to install webkit2gtk3-devel instead of webkit2gtk4.0-devel
+      if ! { sudo dnf install webkit2gtk4.0-devel || sudo dnf install webkit2gtk3-devel; }; then
+        err 'We were unable to install the webkit2gtk4.0-devel/webkit2gtk3-devel package.' \
+          'Please open an issue if you feel that this is incorrect.' \
+          'https://github.com/spacedriveapp/spacedrive/issues'
+      fi
+
+      # Tauri dependencies
+      set -- openssl openssl-dev curl wget file libappindicator-gtk3-devel librsvg2-devel
+
+      # Webkit2gtk requires gstreamer plugins for video playback to work
+      set -- "$@" gstreamer1-devel gstreamer1-plugins-base-devel gstreamer1-plugins-good \
+        gstreamer1-plugins-good-extras gstreamer1-plugins-ugly-free
+
+      # C/C++ build dependencies, required to build some *-sys crates
+      set -- "$@" clang clang-devel nasm perl-core
+
+      # React dependencies
+      set -- "$@" vips
+
+      sudo dnf install "$@"
+    elif has apk; then
+      echo "Detected apk!"
+      echo "Installing dependencies with apk..."
+      echo "Alpine suport is experimental" >&2
+
+      # Tauri dependencies
+      set -- build-base curl wget file openssl-dev gtk+3.0-dev librsvg-dev \
+        webkit2gtk-dev libayatana-indicator-dev
+
+      # Webkit2gtk requires gstreamer plugins for video playback to work
+      set -- "$@" gst-plugins-base-dev gst-plugins-good gst-plugins-ugly
+
+      # C/C++ build dependencies, required to build some *-sys crates
+      set -- "$@" llvm16-dev clang16 nasm perl
+
+      # React dependencies
+      set -- "$@" vips
+
+      sudo apk add "$@"
+    else
+      if has lsb_release; then
+        _distro="'$(lsb_release -s -d)' "
+      fi
+      err "Your Linux distro ${_distro:-}is not supported by this script." \
+        'We would welcome a PR or some help adding your OS to this script:' \
         'https://github.com/spacedriveapp/spacedrive/issues'
     fi
-
-    # For Fedora 36 and below, and all Enterprise Linux Distributions, you need to install webkit2gtk3-devel instead of webkit2gtk4.0-devel
-    if ! { sudo dnf install webkit2gtk4.0-devel || sudo dnf install webkit2gtk3-devel; }; then
-      err 'We were unable to install the webkit2gtk4.0-devel/webkit2gtk3-devel package.' \
-        'Please open an issue if you feel that this is incorrect.' \
-        'https://github.com/spacedriveapp/spacedrive/issues'
-    fi
-
-    # Tauri dependencies
-    set -- openssl openssl-dev curl wget file libappindicator-gtk3-devel librsvg2-devel
-
-    # Webkit2gtk requires gstreamer plugins for video playback to work
-    set -- "$@" gstreamer1-devel gstreamer1-plugins-base-devel gstreamer1-plugins-good \
-      gstreamer1-plugins-good-extras gstreamer1-plugins-ugly-free
-
-    # C/C++ build dependencies, required to build some *-sys crates
-    set -- "$@" clang clang-devel nasm perl-core
-
-    # React dependencies
-    set -- "$@" vips
-
-    sudo dnf install "$@"
-  elif has apk; then
-    echo "Detected apk!"
-    echo "Installing dependencies with apk..."
-    echo "Alpine suport is experimental" >&2
-
-    # Tauri dependencies
-    set -- build-base curl wget file openssl-dev gtk+3.0-dev librsvg-dev \
-      webkit2gtk-dev libayatana-indicator-dev
-
-    # Webkit2gtk requires gstreamer plugins for video playback to work
-    set -- "$@" gst-plugins-base-dev gst-plugins-good gst-plugins-ugly
-
-    # C/C++ build dependencies, required to build some *-sys crates
-    set -- "$@" llvm16-dev clang16 nasm perl
-
-    # React dependencies
-    set -- "$@" vips
-
-    sudo apk add "$@"
-  else
-    if has lsb_release; then
-      _distro="'$(lsb_release -s -d)' "
-    fi
-    err "Your Linux distro ${_distro:-}is not supported by this script." \
-      'We would welcome a PR or some help adding your OS to this script:' \
+    ;;
+  *)
+    err "Your OS ($(uname)) is not supported by this script." \
+      'We would welcome a PR or some help adding your OS to this script.' \
       'https://github.com/spacedriveapp/spacedrive/issues'
-  fi
-  ;;
-*)
-  err "Your OS ($(uname)) is not supported by this script." \
-    'We would welcome a PR or some help adding your OS to this script.' \
-    'https://github.com/spacedriveapp/spacedrive/issues'
-  ;;
+    ;;
 esac
 
 if [ "${CI:-}" != "true" ]; then
   echo "Installing Rust tools..."
-  cargo install cargo-watch
+
+  _tools="cargo-watch"
   if [ $MOBILE -eq 1 ]; then
-    cargo install cargo-ndk # For building Android
+    _tools="$_tools cargo-ndk" # For building Android
   fi
+
+  echo "$_tools" | xargs cargo install
 fi
 
 echo 'Your machine has been setup for Spacedrive development!'

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -41,9 +41,9 @@ script_failure() {
 trap 'script_failure ${LINENO:-}' ERR
 
 case "${OSTYPE:-}" in
-  'msys' | 'mingw' | 'cygwin')
-    err 'Bash for windows is not supported, please interact with this repo from Powershell or CMD'
-    ;;
+'msys' | 'mingw' | 'cygwin')
+  err 'Bash for windows is not supported, please interact with this repo from Powershell or CMD'
+  ;;
 esac
 
 if [ "${CI:-}" != "true" ]; then
@@ -105,138 +105,141 @@ fi
 
 # Install system deps
 case "$(uname)" in
-  "Darwin")
-    if [ "$(uname -m)" = 'x86_64' ]; then (
-      if [ "${CI:-}" = "true" ]; then
-        export NONINTERACTIVE=1
-      fi
-      brew install nasm
-    ); fi
-
-    # Install rust deps for iOS
-    if [ $MOBILE -eq 1 ]; then
-      echo "Checking for Xcode..."
-      if ! /usr/bin/xcodebuild -version >/dev/null; then
-        err "Xcode was not detected." \
-          "Please ensure Xcode is installed and try again."
-      fi
-
-      echo "Installing iOS targets for Rust..."
-
-      rustup target add aarch64-apple-ios
-      rustup target add aarch64-apple-ios-sim
-      rustup target add x86_64-apple-ios # for CI
-
-      echo
+"Darwin")
+  if [ "$(uname -m)" = 'x86_64' ]; then (
+    if [ "${CI:-}" = "true" ]; then
+      export NONINTERACTIVE=1
     fi
-    ;;
-  "Linux") # https://github.com/tauri-apps/tauri-docs/blob/dev/docs/guides/getting-started/prerequisites.md#setting-up-linux
-    if has apt-get; then
-      echo "Detected apt!"
-      echo "Installing dependencies with apt..."
+    brew install nasm
+  ); fi
 
-      # Tauri dependencies
-      set -- build-essential curl wget file openssl libssl-dev libgtk-3-dev librsvg2-dev \
-        libwebkit2gtk-4.0-dev libayatana-appindicator3-dev
+  # Install rust deps for iOS
+  if [ $MOBILE -eq 1 ]; then
+    echo "Checking for Xcode..."
+    if ! /usr/bin/xcodebuild -version >/dev/null; then
+      err "Xcode was not detected." \
+        "Please ensure Xcode is installed and try again."
+    fi
 
-      # Webkit2gtk requires gstreamer plugins for video playback to work
-      set -- "$@" gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
+    echo "Installing iOS targets for Rust..."
 
-      # C/C++ build dependencies, required to build some *-sys crates
-      set -- "$@" llvm-dev libclang-dev clang nasm perl
+    rustup target add aarch64-apple-ios
+    rustup target add aarch64-apple-ios-sim
+    rustup target add x86_64-apple-ios # for CI
 
-      # React dependencies
-      set -- "$@" libvips42
+    echo
+  fi
+  ;;
+"Linux") # https://github.com/tauri-apps/tauri-docs/blob/dev/docs/guides/getting-started/prerequisites.md#setting-up-linux
+  if has apt-get; then
+    echo "Detected apt!"
+    echo "Installing dependencies with apt..."
 
-      sudo apt-get -y update
-      sudo apt-get -y install "$@"
-    elif has pacman; then
-      echo "Detected pacman!"
-      echo "Installing dependencies with pacman..."
+    # Tauri dependencies
+    set -- build-essential curl wget file openssl libssl-dev libgtk-3-dev librsvg2-dev \
+      libwebkit2gtk-4.0-dev libayatana-appindicator3-dev
 
-      # Tauri dependencies
-      set -- base-devel curl wget file openssl gtk3 librsvg webkit2gtk libayatana-appindicator
+    # Webkit2gtk requires gstreamer plugins for video playback to work
+    set -- "$@" gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
 
-      # Webkit2gtk requires gstreamer plugins for video playback to work
-      set -- "$@" gst-plugins-base gst-plugins-good gst-plugins-ugly
+    # C/C++ build dependencies, required to build some *-sys crates
+    set -- "$@" llvm-dev libclang-dev clang nasm perl
 
-      # C/C++ build dependencies, required to build some *-sys crates
-      set -- "$@" clang nasm perl
+    # React dependencies
+    set -- "$@" libvips42
 
-      # React dependencies
-      set -- "$@" libvips
+    sudo apt-get -y update
+    sudo apt-get -y install "$@"
+  elif has pacman; then
+    echo "Detected pacman!"
+    echo "Installing dependencies with pacman..."
 
-      sudo pacman -Sy --needed "$@"
-    elif has dnf; then
-      echo "Detected dnf!"
-      echo "Installing dependencies with dnf..."
+    # Tauri dependencies
+    set -- base-devel curl wget file openssl gtk3 librsvg webkit2gtk libayatana-appindicator
 
-      # For Enterprise Linux, you also need "Development Tools" instead of "C Development Tools and Libraries"
-      if ! { sudo dnf group install "C Development Tools and Libraries" || sudo dnf group install "Development Tools"; }; then
-        err 'We were unable to install the "C Development Tools and Libraries"/"Development Tools" package.' \
-          'Please open an issue if you feel that this is incorrect.' \
-          'https://github.com/spacedriveapp/spacedrive/issues'
-      fi
+    # Webkit2gtk requires gstreamer plugins for video playback to work
+    set -- "$@" gst-plugins-base gst-plugins-good gst-plugins-ugly
 
-      # For Fedora 36 and below, and all Enterprise Linux Distributions, you need to install webkit2gtk3-devel instead of webkit2gtk4.0-devel
-      if ! { sudo dnf install webkit2gtk4.0-devel || sudo dnf install webkit2gtk3-devel; }; then
-        err 'We were unable to install the webkit2gtk4.0-devel/webkit2gtk3-devel package.' \
-          'Please open an issue if you feel that this is incorrect.' \
-          'https://github.com/spacedriveapp/spacedrive/issues'
-      fi
+    # C/C++ build dependencies, required to build some *-sys crates
+    set -- "$@" clang nasm perl
 
-      # Tauri dependencies
-      set -- openssl openssl-dev curl wget file libappindicator-gtk3-devel librsvg2-devel
+    # React dependencies
+    set -- "$@" libvips
 
-      # Webkit2gtk requires gstreamer plugins for video playback to work
-      set -- "$@" gstreamer1-devel gstreamer1-plugins-base-devel gstreamer1-plugins-good \
-        gstreamer1-plugins-good-extras gstreamer1-plugins-ugly-free
+    sudo pacman -Sy --needed "$@"
+  elif has dnf; then
+    echo "Detected dnf!"
+    echo "Installing dependencies with dnf..."
 
-      # C/C++ build dependencies, required to build some *-sys crates
-      set -- "$@" clang clang-devel nasm perl-core
-
-      # React dependencies
-      set -- "$@" vips
-
-      sudo dnf install "$@"
-    elif has apk; then
-      echo "Detected apk!"
-      echo "Installing dependencies with apk..."
-      echo "Alpine suport is experimental" >&2
-
-      # Tauri dependencies
-      set -- build-base curl wget file openssl-dev gtk+3.0-dev librsvg-dev \
-        webkit2gtk-dev libayatana-indicator-dev
-
-      # Webkit2gtk requires gstreamer plugins for video playback to work
-      set -- "$@" gst-plugins-base-dev gst-plugins-good gst-plugins-ugly
-
-      # C/C++ build dependencies, required to build some *-sys crates
-      set -- "$@" llvm16-dev clang16 nasm perl
-
-      # React dependencies
-      set -- "$@" vips
-
-      sudo apk add "$@"
-    else
-      if has lsb_release; then
-        _distro="'$(lsb_release -s -d)' "
-      fi
-      err "Your Linux distro ${_distro:-}is not supported by this script." \
-        'We would welcome a PR or some help adding your OS to this script:' \
+    # For Enterprise Linux, you also need "Development Tools" instead of "C Development Tools and Libraries"
+    if ! { sudo dnf group install "C Development Tools and Libraries" || sudo dnf group install "Development Tools"; }; then
+      err 'We were unable to install the "C Development Tools and Libraries"/"Development Tools" package.' \
+        'Please open an issue if you feel that this is incorrect.' \
         'https://github.com/spacedriveapp/spacedrive/issues'
     fi
-    ;;
-  *)
-    err "Your OS ($(uname)) is not supported by this script." \
-      'We would welcome a PR or some help adding your OS to this script.' \
+
+    # For Fedora 36 and below, and all Enterprise Linux Distributions, you need to install webkit2gtk3-devel instead of webkit2gtk4.0-devel
+    if ! { sudo dnf install webkit2gtk4.0-devel || sudo dnf install webkit2gtk3-devel; }; then
+      err 'We were unable to install the webkit2gtk4.0-devel/webkit2gtk3-devel package.' \
+        'Please open an issue if you feel that this is incorrect.' \
+        'https://github.com/spacedriveapp/spacedrive/issues'
+    fi
+
+    # Tauri dependencies
+    set -- openssl openssl-dev curl wget file libappindicator-gtk3-devel librsvg2-devel
+
+    # Webkit2gtk requires gstreamer plugins for video playback to work
+    set -- "$@" gstreamer1-devel gstreamer1-plugins-base-devel gstreamer1-plugins-good \
+      gstreamer1-plugins-good-extras gstreamer1-plugins-ugly-free
+
+    # C/C++ build dependencies, required to build some *-sys crates
+    set -- "$@" clang clang-devel nasm perl-core
+
+    # React dependencies
+    set -- "$@" vips
+
+    sudo dnf install "$@"
+  elif has apk; then
+    echo "Detected apk!"
+    echo "Installing dependencies with apk..."
+    echo "Alpine suport is experimental" >&2
+
+    # Tauri dependencies
+    set -- build-base curl wget file openssl-dev gtk+3.0-dev librsvg-dev \
+      webkit2gtk-dev libayatana-indicator-dev
+
+    # Webkit2gtk requires gstreamer plugins for video playback to work
+    set -- "$@" gst-plugins-base-dev gst-plugins-good gst-plugins-ugly
+
+    # C/C++ build dependencies, required to build some *-sys crates
+    set -- "$@" llvm16-dev clang16 nasm perl
+
+    # React dependencies
+    set -- "$@" vips
+
+    sudo apk add "$@"
+  else
+    if has lsb_release; then
+      _distro="'$(lsb_release -s -d)' "
+    fi
+    err "Your Linux distro ${_distro:-}is not supported by this script." \
+      'We would welcome a PR or some help adding your OS to this script:' \
       'https://github.com/spacedriveapp/spacedrive/issues'
-    ;;
+  fi
+  ;;
+*)
+  err "Your OS ($(uname)) is not supported by this script." \
+    'We would welcome a PR or some help adding your OS to this script.' \
+    'https://github.com/spacedriveapp/spacedrive/issues'
+  ;;
 esac
 
 if [ "${CI:-}" != "true" ]; then
   echo "Installing Rust tools..."
   cargo install cargo-watch
+  if [ $MOBILE -eq 1 ]; then
+    cargo install cargo-ndk # For building Android
+  fi
 fi
 
 echo 'Your machine has been setup for Spacedrive development!'


### PR DESCRIPTION
When building for Android, many errors pop up when using Rust's cargo build with Gradle Daemons. Errors ranging from building but not uploading the latest `.so` file to JNI Merging issues. Therefore, I moved the build script away from `org.mozilla.rust-android-gradle:plugin:0.9.3` into a custom `.sh` build script like the iOS `build_rust.sh` script. 

The following changes are happening to `setup.sh` due to the introduction of `cargo ndk` into the build so that we can build for the android build targets. 

I've tested it on my android location-watcher testing branch, so please let me know if any issues occur on your own machine. However, from my testing, I have found this new script to be more consistent due to it working directly from the File System instead of through Gradle.