### PR TITLE
Update github actions due to nodejs 16 deprecation

### DIFF
--- a/.cargo/config.toml.mustache
+++ b/.cargo/config.toml.mustache
@@ -1,3 +1,4 @@
+{{#nativeDeps}}
 [env]
 PROTOC = { force = true, value = "{{{protoc}}}" }
 FFMPEG_DIR = { force = true, value = "{{{nativeDeps}}}" }
@@ -7,17 +8,28 @@ ORT_LIB_LOCATION = { force = true, value = "{{{nativeDeps}}}/lib" }
 OPENSSL_STATIC = { force = true, value = "1" }
 OPENSSL_NO_VENDOR = { force = true, value = "0" }
 OPENSSL_RUST_USE_NASM = { force = true, value = "1" }
+{{/nativeDeps}}
 
 {{#isMacOS}}
 [target.x86_64-apple-darwin]
-rustflags = ["-L", "{{{nativeDeps}}}/lib"]
+rustflags = [
+	"-L", "{{{nativeDeps}}}/lib", "-Csplit-debuginfo=unpacked",
+	{{#hasZLD}}
+	"-C", "link-arg=-fuse-ld=/usr/local/bin/zld",
+	{{/hasZLD}}
+]
 
 [target.x86_64-apple-darwin.heif]
 rustc-link-search = ["{{{nativeDeps}}}/lib"]
 rustc-link-lib = ["heif"]
 
 [target.aarch64-apple-darwin]
-rustflags = ["-L", "{{{nativeDeps}}}/lib"]
+rustflags = [
+	"-L", "{{{nativeDeps}}}/lib", "-Csplit-debuginfo=unpacked",
+	{{#hasZLD}}
+	"-C", "link-arg=-fuse-ld=/usr/local/bin/zld",
+	{{/hasZLD}}
+]
 
 [target.aarch64-apple-darwin.heif]
 rustc-link-search = ["{{{nativeDeps}}}/lib"]
@@ -26,6 +38,9 @@ rustc-link-lib = ["heif"]
 
 {{#isWin}}
 [target.x86_64-pc-windows-msvc]
+{{#hasLLD}}
+linker = "lld-link.exe"
+{{/hasLLD}}
 rustflags = ["-L", "{{{nativeDeps}}}\\lib"]
 
 [target.x86_64-pc-windows-msvc.heif]
@@ -35,14 +50,30 @@ rustc-link-lib = ["heif"]
 
 {{#isLinux}}
 [target.x86_64-unknown-linux-gnu]
-rustflags = ["-L", "{{{nativeDeps}}}/lib", "-C", "link-arg=-Wl,-rpath=${ORIGIN}/../lib/spacedrive"]
+{{#hasLLD}}
+linker = "clang"
+{{/hasLLD}}
+rustflags = [
+	"-L", "{{{nativeDeps}}}/lib", "-C", "link-arg=-Wl,-rpath=${ORIGIN}/../lib/spacedrive",
+	{{#hasLLD}}
+	"-C", "link-arg=-fuse-ld={{{linker}}}",
+	{{/hasLLD}}
+]
 
 [target.x86_64-unknown-linux-gnu.heif]
 rustc-link-search = ["{{{nativeDeps}}}/lib"]
 rustc-link-lib = ["heif"]
 
 [target.aarch64-unknown-linux-gnu]
-rustflags = ["-L", "{{{nativeDeps}}}/lib", "-C", "link-arg=-Wl,-rpath=${ORIGIN}/../lib/spacedrive"]
+{{#hasLLD}}
+linker = "clang"
+{{/hasLLD}}
+rustflags = [
+	"-L", "{{{nativeDeps}}}/lib", "-C", "link-arg=-Wl,-rpath=${ORIGIN}/../lib/spacedrive",
+	{{#hasLLD}}
+	"-C", "link-arg=-fuse-ld={{{linker}}}",
+	{{/hasLLD}}
+]
 
 [target.aarch64-unknown-linux-gnu.heif]
 rustc-link-search = ["{{{nativeDeps}}}/lib"]

--- a/.cargo/config.toml.mustache
+++ b/.cargo/config.toml.mustache
@@ -12,24 +12,14 @@ OPENSSL_RUST_USE_NASM = { force = true, value = "1" }
 
 {{#isMacOS}}
 [target.x86_64-apple-darwin]
-rustflags = [
-	"-L", "{{{nativeDeps}}}/lib", "-Csplit-debuginfo=unpacked",
-	{{#hasZLD}}
-	"-C", "link-arg=-fuse-ld=/usr/local/bin/zld",
-	{{/hasZLD}}
-]
+rustflags = ["-L", "{{{nativeDeps}}}/lib", "-Csplit-debuginfo=unpacked"]
 
 [target.x86_64-apple-darwin.heif]
 rustc-link-search = ["{{{nativeDeps}}}/lib"]
 rustc-link-lib = ["heif"]
 
 [target.aarch64-apple-darwin]
-rustflags = [
-	"-L", "{{{nativeDeps}}}/lib", "-Csplit-debuginfo=unpacked",
-	{{#hasZLD}}
-	"-C", "link-arg=-fuse-ld=/usr/local/bin/zld",
-	{{/hasZLD}}
-]
+rustflags = ["-L", "{{{nativeDeps}}}/lib", "-Csplit-debuginfo=unpacked"]
 
 [target.aarch64-apple-darwin.heif]
 rustc-link-search = ["{{{nativeDeps}}}/lib"]

--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -9,12 +9,12 @@ runs:
   using: 'composite'
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@v2
+      uses: pnpm/action-setup@v3
       with:
         version: 8.x.x
 
     - name: Install Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         token: ${{ inputs.token }}
         check-latest: true

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -31,6 +31,7 @@ runs:
       run: echo '{}' | npx -y mustache - .cargo/config.toml.mustache .cargo/config.toml
 
     - name: Turn Off Debuginfo and bump opt-level
+      shell: bash
       if: ${{ runner.os != 'Windows' }}
       run: |
         sed '/\[profile.dev]/a\

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -30,6 +30,26 @@ runs:
       shell: bash
       run: echo '{}' | npx -y mustache - .cargo/config.toml.mustache .cargo/config.toml
 
+    - name: Turn Off Debuginfo and bump opt-level
+      if: ${{ runner.os != 'Windows' }}
+      run: |
+        sed '/\[profile.dev]/a\
+        debug = 0
+        ' Cargo.toml > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+
+        sed '/\[profile.dev]/a\
+        opt-level=1
+        ' Cargo.toml > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+
+    - name: Turn Off Debuginfo and bump opt-level
+      if: ${{ runner.os == 'Windows' }}
+      shell: powershell
+      run: |
+        (Get-Content Cargo.toml) -replace '\[profile.dev\]', '[profile.dev]
+        debug = 0' | Set-Content Cargo.toml
+        (Get-Content Cargo.toml) -replace '\[profile.dev\]', '[profile.dev]
+        opt-level=1' | Set-Content Cargo.toml
+
     - name: Restore cached Prisma codegen
       id: cache-prisma-restore
       uses: actions/cache/restore@v4

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -22,6 +22,7 @@ runs:
     - name: Cache Rust Dependencies
       uses: Swatinem/rust-cache@v2
       with:
+        key: ${{ inputs.target }}
         save-if: ${{ inputs.save-cache }}
         shared-key: stable-cache
 

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -8,6 +8,10 @@ inputs:
     description: Whether to save the Rust cache
     required: false
     default: 'false'
+  restore-cache:
+    description: Whether to restore the Rust cache
+    required: false
+    default: 'true'
 runs:
   using: 'composite'
   steps:
@@ -20,6 +24,7 @@ runs:
         components: clippy, rustfmt
 
     - name: Cache Rust Dependencies
+      if: ${{ inputs.restore-cache == 'true' }}
       uses: Swatinem/rust-cache@v2
       with:
         key: ${{ inputs.target }}
@@ -66,7 +71,7 @@ runs:
 
     - name: Save Prisma codegen
       id: cache-prisma-save
-      if: ${{ inputs.save-cache == 'true' }}
+      if: ${{ steps.cache-prisma-restore.outputs.cache-hit != 'true' }}
       uses: actions/cache/save@v4
       with:
         key: ${{ steps.cache-prisma-restore.outputs.cache-primary-key }}

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -31,7 +31,7 @@ runs:
 
     - name: Restore cached Prisma codegen
       id: cache-prisma-restore
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         key: prisma-1-${{ runner.os }}-${{ hashFiles('./core/prisma/*', './crates/sync-generator/*', './Cargo.*') }}
         path: crates/prisma/src/**/*.rs
@@ -45,7 +45,7 @@ runs:
     - name: Save Prisma codegen
       id: cache-prisma-save
       if: ${{ inputs.save-cache == 'true' }}
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       with:
         key: ${{ steps.cache-prisma-restore.outputs.cache-primary-key }}
         path: crates/prisma/src/**/*.rs

--- a/.github/actions/setup-system/action.yml
+++ b/.github/actions/setup-system/action.yml
@@ -53,14 +53,6 @@ runs:
         curl -L# 'https://github.com/rui314/mold/releases/download/v2.4.0/mold-2.4.0-x86_64-linux.tar.gz' \
         | sudo tar -xzf- -C /usr/local
 
-    - name: Install ZLD
-      shell: bash
-      if: ${{ runner.os == 'macOS' }}
-      run: |
-        curl -L# 'https://github.com/michaeleisel/zld/releases/download/1.3.9.1/zld.zip' \
-        | bsdtar -xf- -C /usr/local/bin
-        chmod +x /usr/local/bin/zld
-
     - name: Setup Rust and Dependencies
       uses: ./.github/actions/setup-rust
       with:

--- a/.github/actions/setup-system/action.yml
+++ b/.github/actions/setup-system/action.yml
@@ -51,7 +51,7 @@ runs:
       if: ${{ runner.os == 'Linux' }}
       run: |
         curl -L# 'https://github.com/rui314/mold/releases/download/v2.4.0/mold-2.4.0-x86_64-linux.tar.gz' \
-        | tar -xzf- -C /usr/local
+        | sudo tar -xzf- -C /usr/local
 
     - name: Install ZLD
       shell: bash

--- a/.github/actions/setup-system/action.yml
+++ b/.github/actions/setup-system/action.yml
@@ -22,7 +22,7 @@ runs:
     - name: Restore cached LLVM and Clang
       if: ${{ runner.os == 'Windows' }}
       id: cache-llvm-restore
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         key: llvm-15
         path: C:/Program Files/LLVM
@@ -37,7 +37,7 @@ runs:
     - name: Save LLVM and Clang
       if: ${{ runner.os == 'Windows' && inputs.save-cache == 'true' }}
       id: cache-llvm-save
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       with:
         key: ${{ steps.cache-llvm-restore.outputs.cache-primary-key }}
         path: C:/Program Files/LLVM

--- a/.github/actions/setup-system/action.yml
+++ b/.github/actions/setup-system/action.yml
@@ -51,7 +51,7 @@ runs:
       if: ${{ runner.os == 'Linux' }}
       run: |
         curl -L# 'https://github.com/rui314/mold/releases/download/v2.4.0/mold-2.4.0-x86_64-linux.tar.gz' \
-        | bsdtar -xf- -C /usr/local
+        | tar -xzf- -C /usr/local
 
     - name: Install ZLD
       shell: bash

--- a/.github/actions/setup-system/action.yml
+++ b/.github/actions/setup-system/action.yml
@@ -48,14 +48,14 @@ runs:
 
     - name: Install Mold
       shell: bash
-      if: ${{ runner.os = 'Linux' }}
+      if: ${{ runner.os == 'Linux' }}
       run: |
         curl -L# 'https://github.com/rui314/mold/releases/download/v2.4.0/mold-2.4.0-x86_64-linux.tar.gz' \
         | bsdtar -xf- -C /usr/local
 
     - name: Install ZLD
       shell: bash
-      if: ${{ runner.os = 'macOS' }}
+      if: ${{ runner.os == 'macOS' }}
       run: |
         curl -L# 'https://github.com/michaeleisel/zld/releases/download/1.3.9.1/zld.zip' \
         | bsdtar -xf- -C /usr/local/bin

--- a/.github/actions/setup-system/action.yml
+++ b/.github/actions/setup-system/action.yml
@@ -47,12 +47,14 @@ runs:
       uses: ilammy/setup-nasm@v1
 
     - name: Install Mold
+      shell: bash
       if: ${{ runner.os = 'Linux' }}
       run: |
         curl -L# 'https://github.com/rui314/mold/releases/download/v2.4.0/mold-2.4.0-x86_64-linux.tar.gz' \
         | bsdtar -xf- -C /usr/local
 
     - name: Install ZLD
+      shell: bash
       if: ${{ runner.os = 'macOS' }}
       run: |
         curl -L# 'https://github.com/michaeleisel/zld/releases/download/1.3.9.1/zld.zip' \

--- a/.github/actions/setup-system/action.yml
+++ b/.github/actions/setup-system/action.yml
@@ -46,6 +46,19 @@ runs:
       if: ${{ runner.os != 'Linux' }}
       uses: ilammy/setup-nasm@v1
 
+    - name: Install Mold
+      if: ${{ runner.os = 'Linux' }}
+      run: |
+        curl -L# 'https://github.com/rui314/mold/releases/download/v2.4.0/mold-2.4.0-x86_64-linux.tar.gz' \
+        | bsdtar -xf- -C /usr/local
+
+    - name: Install ZLD
+      if: ${{ runner.os = 'macOS' }}
+      run: |
+        curl -L# 'https://github.com/michaeleisel/zld/releases/download/1.3.9.1/zld.zip' \
+        | bsdtar -xf- -C /usr/local/bin
+        chmod +x /usr/local/bin/zld
+
     - name: Setup Rust and Dependencies
       uses: ./.github/actions/setup-rust
       with:

--- a/.github/workflows/cache-factory.yaml
+++ b/.github/workflows/cache-factory.yaml
@@ -81,26 +81,6 @@ jobs:
           target: ${{ matrix.settings.target }}
           save-cache: 'true'
 
-      - name: Turn Off Debuginfo and bump opt-level
-        if: ${{ runner.os != 'Windows' }}
-        run: |
-          sed '/\[profile.dev]/a\
-          debug = 0
-          ' Cargo.toml > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-
-          sed '/\[profile.dev]/a\
-          opt-level=1
-          ' Cargo.toml > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-
-      - name: Turn Off Debuginfo and bump opt-level
-        if: ${{ runner.os == 'Windows' }}
-        shell: powershell
-        run: |
-          (Get-Content Cargo.toml) -replace '\[profile.dev\]', '[profile.dev]
-          debug = 0' | Set-Content Cargo.toml
-          (Get-Content Cargo.toml) -replace '\[profile.dev\]', '[profile.dev]
-          opt-level=1' | Set-Content Cargo.toml
-
       - name: Compile tests (debug)
         run: cargo test --workspace --all-features --no-run --locked --target ${{ matrix.settings.target }}
 

--- a/.github/workflows/cache-factory.yaml
+++ b/.github/workflows/cache-factory.yaml
@@ -84,8 +84,13 @@ jobs:
 
       - name: Turn Off Debuginfo and bump opt-level
         run: |
-          sed -i '/\[profile.dev]/a debug = 0' Cargo.toml
-          sed -i '/\[profile.dev]/a opt-level=1' Cargo.toml
+          sed '/\[profile.dev]/a\
+          debug = 0
+          ' Cargo.toml > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+
+          sed '/\[profile.dev]/a\
+          opt-level=1
+          ' Cargo.toml > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
 
       - name: Compile tests (debug)
         run: cargo test --workspace --all-features --no-run --locked --target ${{ matrix.settings.target }}

--- a/.github/workflows/cache-factory.yaml
+++ b/.github/workflows/cache-factory.yaml
@@ -64,6 +64,13 @@ jobs:
           remove-haskell: 'true'
           remove-docker-images: 'true'
 
+      - name: Symlink target to C:\
+        if: ${{ runner.os == 'Windows' }}
+        shell: powershell
+        run: |
+          New-Item -ItemType Directory -Force -Path C:\spacedrive_target
+          New-Item -Path target -ItemType Junction -Value C:\spacedrive_target
+
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/cache-factory.yaml
+++ b/.github/workflows/cache-factory.yaml
@@ -24,7 +24,6 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   RUST_BACKTRACE: short
-  RUSTFLAGS: "-D warnings"
   RUSTUP_MAX_RETRIES: 10
 
 jobs:

--- a/.github/workflows/cache-factory.yaml
+++ b/.github/workflows/cache-factory.yaml
@@ -54,7 +54,7 @@ jobs:
           remove-docker-images: 'true'
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Symlink target to C:\
         if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/cache-factory.yaml
+++ b/.github/workflows/cache-factory.yaml
@@ -9,6 +9,9 @@ on:
       - main
   schedule:
     - cron: '0 0 * * *'
+  pull_request:
+    paths:
+      - '.github/workflows/cache-factory.yaml'
   workflow_dispatch:
 
 # Cancel previous runs of the same workflow on the same branch.

--- a/.github/workflows/cache-factory.yaml
+++ b/.github/workflows/cache-factory.yaml
@@ -9,11 +9,20 @@ on:
       - main
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 
 # Cancel previous runs of the same workflow on the same branch.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+# From: https://github.com/rust-lang/rust-analyzer/blob/master/.github/workflows/ci.yaml
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUST_BACKTRACE: short
+  RUSTFLAGS: "-D warnings"
+  RUSTUP_MAX_RETRIES: 10
 
 jobs:
   make_cache:
@@ -70,11 +79,23 @@ jobs:
           target: ${{ matrix.settings.target }}
           save-cache: 'true'
 
-      - name: Clippy
-        run: cargo clippy --workspace --all-features --target ${{ matrix.settings.target }}
+      - name: Turn Off Debuginfo and bump opt-level
+        run: |
+          sed -i '/\[profile.dev]/a debug = 0' Cargo.toml
+          sed -i '/\[profile.dev]/a opt-level=1' Cargo.toml
 
+      - name: Compile tests (debug)
+        run: cargo test --workspace --all-features --no-run --locked --target ${{ matrix.settings.target }}
+
+      - name: Compile tests (release)
+        run: cargo test --workspace --all-features --no-run --locked --release --target ${{ matrix.settings.target }}
+
+      # It's faster to `test` before `build` ¯\_(ツ)_/¯
       - name: Compile (debug)
-        run: cargo test --workspace --all-features --no-run --target ${{ matrix.settings.target }}
+        run: cargo build --quiet --workspace --all-features --target ${{ matrix.settings.target }}
 
       - name: Compile (release)
-        run: cargo test --workspace --all-features --no-run --release --target ${{ matrix.settings.target }}
+        run: cargo build --quiet --workspace --all-features --release --target ${{ matrix.settings.target }}
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-features --target ${{ matrix.settings.target }}

--- a/.github/workflows/cache-factory.yaml
+++ b/.github/workflows/cache-factory.yaml
@@ -82,6 +82,7 @@ jobs:
           save-cache: 'true'
 
       - name: Turn Off Debuginfo and bump opt-level
+        if: ${{ runner.os != 'Windows' }}
         run: |
           sed '/\[profile.dev]/a\
           debug = 0
@@ -90,6 +91,13 @@ jobs:
           sed '/\[profile.dev]/a\
           opt-level=1
           ' Cargo.toml > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+
+      - name: Turn Off Debuginfo and bump opt-level
+        if: ${{ runner.os == 'Windows' }}
+        shell: powershell
+        run: |
+          (Get-Content Cargo.toml) -replace '\[profile.dev\]', '[profile.dev]`n  debug = 0' | Set-Content Cargo.toml
+          (Get-Content Cargo.toml) -replace '\[profile.dev\]', '[profile.dev]`n  opt-level=1' | Set-Content Cargo.toml
 
       - name: Compile tests (debug)
         run: cargo test --workspace --all-features --no-run --locked --target ${{ matrix.settings.target }}

--- a/.github/workflows/cache-factory.yaml
+++ b/.github/workflows/cache-factory.yaml
@@ -96,8 +96,10 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         shell: powershell
         run: |
-          (Get-Content Cargo.toml) -replace '\[profile.dev\]', '[profile.dev]`n  debug = 0' | Set-Content Cargo.toml
-          (Get-Content Cargo.toml) -replace '\[profile.dev\]', '[profile.dev]`n  opt-level=1' | Set-Content Cargo.toml
+          (Get-Content Cargo.toml) -replace '\[profile.dev\]', '[profile.dev]
+          debug = 0' | Set-Content Cargo.toml
+          (Get-Content Cargo.toml) -replace '\[profile.dev\]', '[profile.dev]
+          opt-level=1' | Set-Content Cargo.toml
 
       - name: Compile tests (debug)
         run: cargo test --workspace --all-features --no-run --locked --target ${{ matrix.settings.target }}

--- a/.github/workflows/cache-factory.yaml
+++ b/.github/workflows/cache-factory.yaml
@@ -67,13 +67,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Symlink target to C:\
-        if: ${{ runner.os == 'Windows' }}
-        shell: powershell
-        run: |
-          New-Item -ItemType Directory -Force -Path C:\spacedrive_target
-          New-Item -Path target -ItemType Junction -Value C:\spacedrive_target
-
       - name: Setup System and Rust
         uses: ./.github/actions/setup-system
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,13 @@ jobs:
           remove-haskell: 'true'
           remove-docker-images: 'true'
 
+      - name: Symlink target to C:\
+        if: ${{ runner.os == 'Windows' }}
+        shell: powershell
+        run: |
+          New-Item -ItemType Directory -Force -Path C:\spacedrive_target
+          New-Item -Path target -ItemType Junction -Value C:\spacedrive_target
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -104,6 +111,13 @@ jobs:
           remove-codeql: 'true'
           remove-haskell: 'true'
           remove-docker-images: 'true'
+
+      - name: Symlink target to C:\
+        if: ${{ runner.os == 'Windows' }}
+        shell: powershell
+        run: |
+          New-Item -ItemType Directory -Force -Path C:\spacedrive_target
+          New-Item -Path target -ItemType Junction -Value C:\spacedrive_target
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   merge_group:
 
 env:
+  RUSTFLAGS: -D warnings
   SPACEDRIVE_CUSTOM_APT_FLAGS: --no-install-recommends
 
 # Cancel previous runs of the same workflow on the same branch.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
   merge_group:
 
 env:
-  RUSTFLAGS: -D warnings
   SPACEDRIVE_CUSTOM_APT_FLAGS: --no-install-recommends
 
 # Cancel previous runs of the same workflow on the same branch.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js, pnpm and dependencies
         uses: ./.github/actions/setup-pnpm
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js, pnpm and dependencies
         uses: ./.github/actions/setup-pnpm
@@ -59,7 +59,7 @@ jobs:
           remove-docker-images: 'true'
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Symlink target to C:\
         if: ${{ runner.os == 'Windows' }}
@@ -68,7 +68,7 @@ jobs:
           New-Item -ItemType Directory -Force -Path C:\spacedrive_target
           New-Item -Path target -ItemType Junction -Value C:\spacedrive_target
 
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
@@ -111,7 +111,7 @@ jobs:
           remove-docker-images: 'true'
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Symlink target to C:\
         if: ${{ runner.os == 'Windows' }}
@@ -120,7 +120,7 @@ jobs:
           New-Item -ItemType Directory -Force -Path C:\spacedrive_target
           New-Item -Path target -ItemType Junction -Value C:\spacedrive_target
 
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
@@ -146,10 +146,9 @@ jobs:
 
       - name: Run Clippy
         if: steps.filter.outputs.changes == 'true'
-        uses: actions-rs/clippy-check@v1
+        uses: actions-rs-plus/clippy-check@v2
         with:
           args: --workspace --all-features
-          token: ${{ secrets.GITHUB_TOKEN }}
 
   # test:
   #   name: Test (${{ matrix.platform }})
@@ -159,7 +158,7 @@ jobs:
   #       platform: [ubuntu-20.04, macos-latest, windows-latest]
   #   steps:
   #     - name: Checkout repository
-  #       uses: actions/checkout@v3
+  #       uses: actions/checkout@v4
   #
   #     - name: Setup
   #       uses: ./.github/actions/setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,13 +61,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Symlink target to C:\
-        if: ${{ runner.os == 'Windows' }}
-        shell: powershell
-        run: |
-          New-Item -ItemType Directory -Force -Path C:\spacedrive_target
-          New-Item -Path target -ItemType Junction -Value C:\spacedrive_target
-
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -86,7 +79,9 @@ jobs:
 
       - name: Setup Rust and Prisma
         if: steps.filter.outputs.changes == 'true'
-        uses: ./.github/actions/setup-rust
+        uses: ./.github/actions/setup-
+        with:
+          restore-cache: 'false'
 
       - name: Run rustfmt
         if: steps.filter.outputs.changes == 'true'
@@ -112,13 +107,6 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Symlink target to C:\
-        if: ${{ runner.os == 'Windows' }}
-        shell: powershell
-        run: |
-          New-Item -ItemType Directory -Force -Path C:\spacedrive_target
-          New-Item -Path target -ItemType Junction -Value C:\spacedrive_target
 
       - uses: dorny/paths-filter@v3
         id: filter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Setup Rust and Prisma
         if: steps.filter.outputs.changes == 'true'
-        uses: ./.github/actions/setup-
+        uses: ./.github/actions/setup-rust
         with:
           restore-cache: 'false'
 

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -139,7 +139,7 @@ jobs:
 
   ios:
     name: iOS
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -18,6 +18,7 @@ on:
 env:
   SPACEDRIVE_CUSTOM_APT_FLAGS: --no-install-recommends
   SPACEDRIVE_CI: '1'
+  RUSTFLAGS: -D warnings
 
 # Cancel previous runs of the same workflow on the same branch.
 concurrency:

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -187,7 +187,7 @@ jobs:
 
       - name: Build iOS
         working-directory: ./apps/mobile/ios
-        run: xcodebuild -workspace ./Spacedrive.xcworkspace -scheme Spacedrive -configuration Release -sdk iphonesimulator -derivedDataPath build -arch x86_64
+        run: xcodebuild -workspace ./Spacedrive.xcworkspace -scheme Spacedrive -configuration Release -sdk iphonesimulator -derivedDataPath build -arch "$(uname -m)"
 
       - name: Install Maestro
         run: |

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -172,7 +172,7 @@ jobs:
           version: latest
 
       # - name: Cache Pods
-      #   uses: actions/cache@v3
+      #   uses: actions/cache@v4
       #   with:
       #     path: |
       #       ./apps/mobile/ios/Pods

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -18,7 +18,6 @@ on:
 env:
   SPACEDRIVE_CUSTOM_APT_FLAGS: --no-install-recommends
   SPACEDRIVE_CI: '1'
-  RUSTFLAGS: -D warnings
 
 # Cancel previous runs of the same workflow on the same branch.
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,13 +55,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Symlink target to C:\
-        if: ${{ runner.os == 'Windows' }}
-        shell: powershell
-        run: |
-          New-Item -ItemType Directory -Force -Path C:\spacedrive_target
-          New-Item -Path target -ItemType Junction -Value C:\spacedrive_target
-
       - name: Remove 32-bit libs
         if: ${{ runner.os == 'Linux' }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           remove-docker-images: 'true'
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Symlink target to C:\
         if: ${{ runner.os == 'Windows' }}
@@ -140,10 +140,11 @@ jobs:
       contents: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        # TODO: Change to stable version when available
+        uses: softprops/action-gh-release@4634c16
         with:
           draft: true
           files: '*/**'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,13 @@ jobs:
           remove-haskell: 'true'
           remove-docker-images: 'true'
 
+      - name: Symlink target to C:\
+        if: ${{ runner.os == 'Windows' }}
+        shell: powershell
+        run: |
+          New-Item -ItemType Directory -Force -Path C:\spacedrive_target
+          New-Item -Path target -ItemType Junction -Value C:\spacedrive_target
+
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -25,7 +25,7 @@ jobs:
           remove-docker-images: 'true'
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Update buildah
         shell: bash
@@ -54,7 +54,8 @@ jobs:
 
       - name: Build image
         id: build-image
-        uses: redhat-actions/buildah-build@v2
+        # TODO: Change to stable version when available
+        uses: redhat-actions/buildah-build@c79846f
         with:
           tags: ${{ steps.image_info.outputs.tag }} ${{ github.event_name == 'release' && 'latest' || 'staging' }}
           archs: amd64
@@ -68,7 +69,9 @@ jobs:
             ./apps/server/docker/Dockerfile
 
       - name: Push image to ghcr.io
-        uses: redhat-actions/push-to-registry@v2
+        # TODO: Restore redhat-actions/push-to-registry after PR is merged:
+        # https://github.com/redhat-actions/push-to-registry/pull/93
+        uses: Eusebiotrigo/push-to-registry@5acfa47
         with:
           tags: ${{ steps.build-image.outputs.tags }}
           image: ${{ steps.build-image.outputs.image }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,9 @@
 # built product/cache
 target/
 dist/
+
+# Mobile build artifacts
+apps/mobile/.expo
 apps/mobile/android/app/build
 apps/mobile/modules/sd-core/android/build
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,8 @@ libp2p-core = { git = "https://github.com/spacedriveapp/rust-libp2p.git", rev = 
 libp2p-swarm = { git = "https://github.com/spacedriveapp/rust-libp2p.git", rev = "a005656df7e82059a0eb2e333ebada4731d23f8c" }
 libp2p-stream = { git = "https://github.com/spacedriveapp/rust-libp2p.git", rev = "a005656df7e82059a0eb2e333ebada4731d23f8c" }
 
+[profile.dev]
+
 # Set the settings for build scripts and proc-macros.
 [profile.dev.build-override]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,8 @@ libp2p-swarm = { git = "https://github.com/spacedriveapp/rust-libp2p.git", rev =
 libp2p-stream = { git = "https://github.com/spacedriveapp/rust-libp2p.git", rev = "a005656df7e82059a0eb2e333ebada4731d23f8c" }
 
 [profile.dev]
+# Make compilation faster on macOS
+split-debuginfo = "unpacked"
 
 # Set the settings for build scripts and proc-macros.
 [profile.dev.build-override]

--- a/apps/mobile/modules/sd-core/ios/build-rust.sh
+++ b/apps/mobile/modules/sd-core/ios/build-rust.sh
@@ -6,6 +6,13 @@ if [ "${CI:-}" = "true" ]; then
   set -x
 fi
 
+err() {
+  for _line in "$@"; do
+    echo "$_line" >&2
+  done
+  exit 1
+}
+
 if [ -z "${HOME:-}" ]; then
   HOME="$(CDPATH='' cd -- "$(osascript -e 'set output to (POSIX path of (path to home folder))')" && pwd -P)"
   export HOME
@@ -28,23 +35,21 @@ fi
 # Required for CI and for everyone I guess?
 export PATH="${CARGO_HOME:-"${HOME}/.cargo"}/bin:$PATH"
 
-# TODO: Also do this for non-Apple Silicon Macs
-if [ "${SPACEDRIVE_CI:-}" = "1" ]; then
-
-  cargo build -p sd-mobile-ios --target x86_64-apple-ios
-
-  if [ "${PLATFORM_NAME:-}" = "iphonesimulator" ]; then
-    lipo -create -output "$TARGET_DIRECTORY"/libsd_mobile_iossim.a "$TARGET_DIRECTORY"/x86_64-apple-ios/debug/libsd_mobile_ios.a
-  else
-    lipo -create -output "$TARGET_DIRECTORY"/libsd_mobile_ios.a "$TARGET_DIRECTORY"/x86_64-apple-ios/debug/libsd_mobile_ios.a
-  fi
-  exit 0
-fi
-
 if [ "${PLATFORM_NAME:-}" = "iphonesimulator" ]; then
-  cargo build -p sd-mobile-ios --target aarch64-apple-ios-sim
-  lipo -create -output "$TARGET_DIRECTORY"/libsd_mobile_iossim.a "$TARGET_DIRECTORY"/aarch64-apple-ios-sim/debug/libsd_mobile_ios.a
+  case "$(uname -m)" in
+    "arm64" | "aarch64") # M series
+      cargo build -p sd-mobile-ios --target aarch64-apple-ios-sim
+      lipo -create -output "$TARGET_DIRECTORY"/libsd_mobile_iossim.a "$TARGET_DIRECTORY"/aarch64-apple-ios-sim/debug/libsd_mobile_ios.a
+      ;;
+    "x86_64") # Intel
+      cargo build -p sd-mobile-ios --target x86_64-apple-ios
+      lipo -create -output "$TARGET_DIRECTORY"/libsd_mobile_iossim.a "$TARGET_DIRECTORY"/x86_64-apple-ios/debug/libsd_mobile_ios.a
+      ;;
+    *)
+      err 'Unsupported architecture.'
+      ;;
+  esac
 else
-  cargo build -p sd-mobile-ios --target aarch64-apple-ios
-  lipo -create -output "$TARGET_DIRECTORY"/libsd_mobile_ios.a "$TARGET_DIRECTORY"/aarch64-apple-ios/debug/libsd_mobile_ios.a
+  cargo build -p sd-mobile-ios --target aarch64-apple-ios --release
+  lipo -create -output "$TARGET_DIRECTORY"/libsd_mobile_ios.a "$TARGET_DIRECTORY"/aarch64-apple-ios/release/libsd_mobile_ios.a
 fi

--- a/scripts/preprep.mjs
+++ b/scripts/preprep.mjs
@@ -1,11 +1,9 @@
 #!/usr/bin/env node
 
-import { exec as execCb } from 'node:child_process'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import { env, exit, umask } from 'node:process'
 import { fileURLToPath } from 'node:url'
-import { promisify } from 'node:util'
 
 import { extractTo } from 'archive-wasm/src/fs.mjs'
 import * as _mustache from 'mustache'
@@ -106,7 +104,6 @@ try {
 	let isWin = false
 	let isMacOS = false
 	let isLinux = false
-	let hasZLD = false
 	/** @type {boolean | { linker: string }} */
 	let hasLLD = false
 	switch (machineId[0]) {
@@ -120,15 +117,9 @@ try {
 				}
 			}
 			break
-		case 'Darwin': {
+		case 'Darwin':
 			isMacOS = true
-			const exec = promisify(execCb)
-			hasZLD = await exec('zld -v').then(
-				ret => ret.stderr.startsWith('@(#)PROGRAM:zld  PROJECT:zld-'),
-				() => false
-			)
 			break
-		}
 		case 'Windows_NT':
 			isWin = true
 			hasLLD = await which('lld-link')
@@ -155,7 +146,6 @@ try {
 						)
 						.replaceAll('\\', '\\\\'),
 					nativeDeps: nativeDeps.replaceAll('\\', '\\\\'),
-					hasZLD,
 					hasLLD,
 				}
 			)


### PR DESCRIPTION
 - Replace archived actions-rs/clippy-check with maintained fork actions-rs-plus/clippy-check
 - Replace redhat-actions/push-to-registry with updated fork Eusebiotrigo/push-to-registry
 - Point redhat-actions/buildah-build and softprops/action-gh-release to current master to fix Node.js deprecation
 - Made some change to the iOS build_rust script and Mobile CI to build the app and lib for the same arch as the host machine when using iphone_simulator
 - Made some changes to make cache-factory faster and avoid failing so much
 - Add trigger to run cache-factory on pull requests when there are changes to itself

