### PR TITLE
[ENG-1598] Don't show update toast if no previous version

### DIFF
--- a/apps/desktop/src/updater.tsx
+++ b/apps/desktop/src/updater.tsx
@@ -96,6 +96,7 @@ export function createUpdater(t: ReturnType<typeof useLocale>['t']) {
 	async function runJustUpdatedCheck(onViewChangelog: () => void) {
 		const version = window.__SD_DESKTOP_VERSION__;
 		const lastVersion = localStorage.getItem(SD_VERSION_LOCALSTORAGE);
+		if (!lastVersion) return;
 
 		if (lastVersion !== version) {
 			localStorage.setItem(SD_VERSION_LOCALSTORAGE, version);


### PR DESCRIPTION
Not sure if this will fix the updater toast showing on first launch but it's certainly better logic than before