### PR TITLE
[ENG-1613] Enable sync operation generation with backfill

### DIFF
--- a/core/crates/sync/src/backfill.rs
+++ b/core/crates/sync/src/backfill.rs
@@ -12,295 +12,298 @@ use serde_json::json;
 use crate::crdt_op_unchecked_db;
 
 pub async fn backfill_operations(db: &PrismaClient, sync: &crate::Manager, instance_id: i32) {
-	println!("backfill started");
-	db.crdt_operation()
-		.delete_many(vec![])
-		.exec()
-		.await
-		.unwrap();
-	let locations = db.location().find_many(vec![]).exec().await.unwrap();
-	db.crdt_operation()
-		.create_many(
-			locations
-				.into_iter()
-				.flat_map(|l| {
-					use location::*;
+	db._transaction()
+		.run(|db| async move {
+			println!("backfill started");
+			db.crdt_operation().delete_many(vec![]).exec().await?;
+			let locations = db.location().find_many(vec![]).exec().await?;
+			db.crdt_operation()
+				.create_many(
+					locations
+						.into_iter()
+						.flat_map(|l| {
+							use location::*;
 
-					sync.shared_create(
-						prisma_sync::location::SyncId { pub_id: l.pub_id },
-						chain_optional_iter(
-							[],
-							[
-								option_sync_entry!(l.name, name),
-								option_sync_entry!(l.path, path),
-								option_sync_entry!(l.total_capacity, total_capacity),
-								option_sync_entry!(l.available_capacity, available_capacity),
-								option_sync_entry!(l.size_in_bytes, size_in_bytes),
-								option_sync_entry!(l.is_archived, is_archived),
-								option_sync_entry!(
-									l.generate_preview_media,
-									generate_preview_media
+							sync.shared_create(
+								prisma_sync::location::SyncId { pub_id: l.pub_id },
+								chain_optional_iter(
+									[],
+									[
+										option_sync_entry!(l.name, name),
+										option_sync_entry!(l.path, path),
+										option_sync_entry!(l.total_capacity, total_capacity),
+										option_sync_entry!(
+											l.available_capacity,
+											available_capacity
+										),
+										option_sync_entry!(l.size_in_bytes, size_in_bytes),
+										option_sync_entry!(l.is_archived, is_archived),
+										option_sync_entry!(
+											l.generate_preview_media,
+											generate_preview_media
+										),
+										option_sync_entry!(
+											l.sync_preview_media,
+											sync_preview_media
+										),
+										option_sync_entry!(l.hidden, hidden),
+										option_sync_entry!(l.date_created, date_created),
+									],
 								),
-								option_sync_entry!(l.sync_preview_media, sync_preview_media),
-								option_sync_entry!(l.hidden, hidden),
-								option_sync_entry!(l.date_created, date_created),
-							],
-						),
-					)
-				})
-				.map(|o| crdt_op_unchecked_db(&o, instance_id))
-				.collect(),
-		)
-		.exec()
-		.await
-		.unwrap();
+							)
+						})
+						.map(|o| crdt_op_unchecked_db(&o, instance_id))
+						.collect(),
+				)
+				.exec()
+				.await?;
 
-	let objects = db.object().find_many(vec![]).exec().await.unwrap();
-	db.crdt_operation()
-		.create_many(
-			objects
-				.into_iter()
-				.flat_map(|o| {
-					use object::*;
+			let objects = db.object().find_many(vec![]).exec().await?;
+			db.crdt_operation()
+				.create_many(
+					objects
+						.into_iter()
+						.flat_map(|o| {
+							use object::*;
 
-					sync.shared_create(
-						prisma_sync::object::SyncId { pub_id: o.pub_id },
-						chain_optional_iter(
-							[],
-							[
-								option_sync_entry!(o.kind, kind),
-								option_sync_entry!(o.hidden, hidden),
-								option_sync_entry!(o.favorite, favorite),
-								option_sync_entry!(o.important, important),
-								option_sync_entry!(o.note, note),
-								option_sync_entry!(o.date_created, date_created),
-								option_sync_entry!(o.date_accessed, date_accessed),
-							],
-						),
-					)
-				})
-				.map(|o| crdt_op_unchecked_db(&o, instance_id))
-				.collect(),
-		)
-		.exec()
-		.await
-		.unwrap();
-
-	let media_datas = db
-		.media_data()
-		.find_many(vec![])
-		.include(media_data::include!({
-			object: select { pub_id }
-		}))
-		.exec()
-		.await
-		.unwrap();
-	db.crdt_operation()
-		.create_many(
-			media_datas
-				.into_iter()
-				.flat_map(|md| {
-					use media_data::*;
-
-					sync.shared_create(
-						prisma_sync::media_data::SyncId {
-							object: prisma_sync::object::SyncId {
-								pub_id: md.object.pub_id,
-							},
-						},
-						chain_optional_iter(
-							[],
-							[
-								option_sync_entry!(md.resolution, resolution),
-								option_sync_entry!(md.media_date, media_date),
-								option_sync_entry!(md.media_location, media_location),
-								option_sync_entry!(md.camera_data, camera_data),
-								option_sync_entry!(md.artist, artist),
-								option_sync_entry!(md.description, description),
-								option_sync_entry!(md.copyright, copyright),
-								option_sync_entry!(md.exif_version, exif_version),
-								option_sync_entry!(md.epoch_time, epoch_time),
-							],
-						),
-					)
-				})
-				.map(|o| crdt_op_unchecked_db(&o, instance_id))
-				.collect(),
-		)
-		.exec()
-		.await
-		.unwrap();
-
-	let file_paths = db
-		.file_path()
-		.find_many(vec![])
-		.include(file_path::include!({
-			location: select { pub_id }
-			object: select { pub_id }
-		}))
-		.exec()
-		.await
-		.unwrap();
-
-	db.crdt_operation()
-		.create_many(
-			file_paths
-				.into_iter()
-				.flat_map(|fp| {
-					use file_path::*;
-
-					sync.shared_create(
-						prisma_sync::file_path::SyncId { pub_id: fp.pub_id },
-						chain_optional_iter(
-							[],
-							[
-								option_sync_entry!(fp.is_dir, is_dir),
-								option_sync_entry!(fp.cas_id, cas_id),
-								option_sync_entry!(fp.integrity_checksum, integrity_checksum),
-								option_sync_entry!(
-									fp.location.map(|l| prisma_sync::location::SyncId {
-										pub_id: l.pub_id
-									}),
-									location
+							sync.shared_create(
+								prisma_sync::object::SyncId { pub_id: o.pub_id },
+								chain_optional_iter(
+									[],
+									[
+										option_sync_entry!(o.kind, kind),
+										option_sync_entry!(o.hidden, hidden),
+										option_sync_entry!(o.favorite, favorite),
+										option_sync_entry!(o.important, important),
+										option_sync_entry!(o.note, note),
+										option_sync_entry!(o.date_created, date_created),
+										option_sync_entry!(o.date_accessed, date_accessed),
+									],
 								),
-								option_sync_entry!(fp.materialized_path, materialized_path),
-								option_sync_entry!(fp.name, name),
-								option_sync_entry!(fp.extension, extension),
-								option_sync_entry!(fp.hidden, hidden),
-								option_sync_entry!(fp.size_in_bytes_bytes, size_in_bytes_bytes),
-								option_sync_entry!(fp.inode, inode),
-								option_sync_entry!(fp.date_created, date_created),
-								option_sync_entry!(fp.date_modified, date_modified),
-								option_sync_entry!(fp.date_indexed, date_indexed),
-							],
-						),
-					)
-				})
-				.map(|o| crdt_op_unchecked_db(&o, instance_id))
-				.collect(),
-		)
-		.exec()
-		.await
-		.unwrap();
-	let tags = db.tag().find_many(vec![]).exec().await.unwrap();
-	db.crdt_operation()
-		.create_many(
-			tags.into_iter()
-				.flat_map(|t| {
-					sync.shared_create(
-						prisma_sync::tag::SyncId { pub_id: t.pub_id },
-						chain_optional_iter(
-							[],
-							[
-								t.name.map(|v| (tag::name::NAME, json!(v))),
-								t.color.map(|v| (tag::color::NAME, json!(v))),
-								t.date_created.map(|v| (tag::date_created::NAME, json!(v))),
-								t.date_modified
-									.map(|v| (tag::date_modified::NAME, json!(v))),
-							],
-						),
-					)
-				})
-				.map(|o| crdt_op_unchecked_db(&o, instance_id))
-				.collect(),
-		)
-		.exec()
-		.await
-		.unwrap();
+							)
+						})
+						.map(|o| crdt_op_unchecked_db(&o, instance_id))
+						.collect(),
+				)
+				.exec()
+				.await?;
 
-	let tag_on_objects = db
-		.tag_on_object()
-		.find_many(vec![])
-		.include(tag_on_object::include!({
-			tag: select { pub_id }
-			object: select { pub_id }
-		}))
-		.exec()
-		.await
-		.unwrap();
-	db.crdt_operation()
-		.create_many(
-			tag_on_objects
-				.into_iter()
-				.flat_map(|t_o| {
-					sync.relation_create(
-						prisma_sync::tag_on_object::SyncId {
-							tag: prisma_sync::tag::SyncId {
-								pub_id: t_o.tag.pub_id,
-							},
-							object: prisma_sync::object::SyncId {
-								pub_id: t_o.object.pub_id,
-							},
-						},
-						chain_optional_iter(
-							[],
-							[option_sync_entry!(
-								t_o.date_created,
-								tag_on_object::date_created
-							)],
-						),
-					)
-				})
-				.map(|o| crdt_op_unchecked_db(&o, instance_id))
-				.collect(),
-		)
-		.exec()
-		.await
-		.unwrap();
+			let media_datas = db
+				.media_data()
+				.find_many(vec![])
+				.include(media_data::include!({
+					object: select { pub_id }
+				}))
+				.exec()
+				.await?;
+			db.crdt_operation()
+				.create_many(
+					media_datas
+						.into_iter()
+						.flat_map(|md| {
+							use media_data::*;
 
-	let labels = db.label().find_many(vec![]).exec().await.unwrap();
-	db.crdt_operation()
-		.create_many(
-			labels
-				.into_iter()
-				.flat_map(|l| {
-					sync.shared_create(
-						prisma_sync::label::SyncId { name: l.name },
-						[
-							(label::date_created::NAME, json!(l.date_created)),
-							(label::date_modified::NAME, json!(l.date_modified)),
-						],
-					)
-				})
-				.map(|o| crdt_op_unchecked_db(&o, instance_id))
-				.collect(),
-		)
-		.exec()
-		.await
-		.unwrap();
+							sync.shared_create(
+								prisma_sync::media_data::SyncId {
+									object: prisma_sync::object::SyncId {
+										pub_id: md.object.pub_id,
+									},
+								},
+								chain_optional_iter(
+									[],
+									[
+										option_sync_entry!(md.resolution, resolution),
+										option_sync_entry!(md.media_date, media_date),
+										option_sync_entry!(md.media_location, media_location),
+										option_sync_entry!(md.camera_data, camera_data),
+										option_sync_entry!(md.artist, artist),
+										option_sync_entry!(md.description, description),
+										option_sync_entry!(md.copyright, copyright),
+										option_sync_entry!(md.exif_version, exif_version),
+										option_sync_entry!(md.epoch_time, epoch_time),
+									],
+								),
+							)
+						})
+						.map(|o| crdt_op_unchecked_db(&o, instance_id))
+						.collect(),
+				)
+				.exec()
+				.await?;
 
-	let label_on_objects = db
-		.label_on_object()
-		.find_many(vec![])
-		.select(label_on_object::select!({
-			object: select { pub_id }
-			label: select { name }
-		}))
-		.exec()
+			let file_paths = db
+				.file_path()
+				.find_many(vec![])
+				.include(file_path::include!({
+					location: select { pub_id }
+					object: select { pub_id }
+				}))
+				.exec()
+				.await?;
+
+			db.crdt_operation()
+				.create_many(
+					file_paths
+						.into_iter()
+						.flat_map(|fp| {
+							use file_path::*;
+
+							sync.shared_create(
+								prisma_sync::file_path::SyncId { pub_id: fp.pub_id },
+								chain_optional_iter(
+									[],
+									[
+										option_sync_entry!(fp.is_dir, is_dir),
+										option_sync_entry!(fp.cas_id, cas_id),
+										option_sync_entry!(
+											fp.integrity_checksum,
+											integrity_checksum
+										),
+										option_sync_entry!(
+											fp.location.map(|l| prisma_sync::location::SyncId {
+												pub_id: l.pub_id
+											}),
+											location
+										),
+										option_sync_entry!(fp.materialized_path, materialized_path),
+										option_sync_entry!(fp.name, name),
+										option_sync_entry!(fp.extension, extension),
+										option_sync_entry!(fp.hidden, hidden),
+										option_sync_entry!(
+											fp.size_in_bytes_bytes,
+											size_in_bytes_bytes
+										),
+										option_sync_entry!(fp.inode, inode),
+										option_sync_entry!(fp.date_created, date_created),
+										option_sync_entry!(fp.date_modified, date_modified),
+										option_sync_entry!(fp.date_indexed, date_indexed),
+									],
+								),
+							)
+						})
+						.map(|o| crdt_op_unchecked_db(&o, instance_id))
+						.collect(),
+				)
+				.exec()
+				.await?;
+			let tags = db.tag().find_many(vec![]).exec().await?;
+			db.crdt_operation()
+				.create_many(
+					tags.into_iter()
+						.flat_map(|t| {
+							sync.shared_create(
+								prisma_sync::tag::SyncId { pub_id: t.pub_id },
+								chain_optional_iter(
+									[],
+									[
+										t.name.map(|v| (tag::name::NAME, json!(v))),
+										t.color.map(|v| (tag::color::NAME, json!(v))),
+										t.date_created.map(|v| (tag::date_created::NAME, json!(v))),
+										t.date_modified
+											.map(|v| (tag::date_modified::NAME, json!(v))),
+									],
+								),
+							)
+						})
+						.map(|o| crdt_op_unchecked_db(&o, instance_id))
+						.collect(),
+				)
+				.exec()
+				.await?;
+
+			let tag_on_objects = db
+				.tag_on_object()
+				.find_many(vec![])
+				.include(tag_on_object::include!({
+					tag: select { pub_id }
+					object: select { pub_id }
+				}))
+				.exec()
+				.await?;
+			db.crdt_operation()
+				.create_many(
+					tag_on_objects
+						.into_iter()
+						.flat_map(|t_o| {
+							sync.relation_create(
+								prisma_sync::tag_on_object::SyncId {
+									tag: prisma_sync::tag::SyncId {
+										pub_id: t_o.tag.pub_id,
+									},
+									object: prisma_sync::object::SyncId {
+										pub_id: t_o.object.pub_id,
+									},
+								},
+								chain_optional_iter(
+									[],
+									[option_sync_entry!(
+										t_o.date_created,
+										tag_on_object::date_created
+									)],
+								),
+							)
+						})
+						.map(|o| crdt_op_unchecked_db(&o, instance_id))
+						.collect(),
+				)
+				.exec()
+				.await?;
+
+			let labels = db.label().find_many(vec![]).exec().await?;
+			db.crdt_operation()
+				.create_many(
+					labels
+						.into_iter()
+						.flat_map(|l| {
+							sync.shared_create(
+								prisma_sync::label::SyncId { name: l.name },
+								[
+									(label::date_created::NAME, json!(l.date_created)),
+									(label::date_modified::NAME, json!(l.date_modified)),
+								],
+							)
+						})
+						.map(|o| crdt_op_unchecked_db(&o, instance_id))
+						.collect(),
+				)
+				.exec()
+				.await?;
+
+			let label_on_objects = db
+				.label_on_object()
+				.find_many(vec![])
+				.select(label_on_object::select!({
+					object: select { pub_id }
+					label: select { name }
+				}))
+				.exec()
+				.await?;
+			let res = db
+				.crdt_operation()
+				.create_many(
+					label_on_objects
+						.into_iter()
+						.flat_map(|l_o| {
+							sync.relation_create(
+								prisma_sync::label_on_object::SyncId {
+									label: prisma_sync::label::SyncId {
+										name: l_o.label.name,
+									},
+									object: prisma_sync::object::SyncId {
+										pub_id: l_o.object.pub_id,
+									},
+								},
+								[],
+							)
+						})
+						.map(|o| crdt_op_unchecked_db(&o, instance_id))
+						.collect(),
+				)
+				.exec()
+				.await;
+			println!("backfill ended");
+			res
+		})
 		.await
 		.unwrap();
-	db.crdt_operation()
-		.create_many(
-			label_on_objects
-				.into_iter()
-				.flat_map(|l_o| {
-					sync.relation_create(
-						prisma_sync::label_on_object::SyncId {
-							label: prisma_sync::label::SyncId {
-								name: l_o.label.name,
-							},
-							object: prisma_sync::object::SyncId {
-								pub_id: l_o.object.pub_id,
-							},
-						},
-						[],
-					)
-				})
-				.map(|o| crdt_op_unchecked_db(&o, instance_id))
-				.collect(),
-		)
-		.exec()
-		.await
-		.unwrap();
-	println!("backfill ended")
 }

--- a/core/src/api/cloud.rs
+++ b/core/src/api/cloud.rs
@@ -85,6 +85,7 @@ mod library {
 								None,
 								MaybeUndefined::Undefined,
 								MaybeUndefined::Value(cloud_library.id),
+								None,
 							)
 							.await?;
 
@@ -127,6 +128,7 @@ mod library {
 							None,
 							MaybeUndefined::Undefined,
 							MaybeUndefined::Value(cloud_library.id),
+							None,
 						)
 						.await?;
 

--- a/core/src/api/libraries.rs
+++ b/core/src/api/libraries.rs
@@ -338,7 +338,7 @@ pub(crate) fn mount() -> AlphaRouter<Ctx> {
 				 }: EditLibraryArgs| async move {
 					Ok(node
 						.libraries
-						.edit(id, name, description, MaybeUndefined::Undefined)
+						.edit(id, name, description, MaybeUndefined::Undefined, None)
 						.await?)
 				},
 			)

--- a/core/src/api/sync.rs
+++ b/core/src/api/sync.rs
@@ -1,6 +1,10 @@
+use std::sync::atomic::Ordering;
+
 use sd_core_sync::GetOpsArgs;
 
 use rspc::alpha::AlphaRouter;
+
+use crate::util::MaybeUndefined;
 
 use super::{utils::library, Ctx, R};
 
@@ -32,9 +36,18 @@ pub(crate) fn mount() -> AlphaRouter<Ctx> {
 					.await?)
 			})
 		})
-		.procedure("backfill", {
+		.procedure("enable", {
 			R.with2(library())
-				.mutation(|(_, library), _: ()| async move {
+				.mutation(|(node, library), _: ()| async move {
+					if library
+						.config()
+						.await
+						.generate_sync_operations
+						.load(Ordering::Relaxed)
+					{
+						return Ok(());
+					}
+
 					sd_core_sync::backfill::backfill_operations(
 						&library.db,
 						&library.sync,
@@ -42,7 +55,27 @@ pub(crate) fn mount() -> AlphaRouter<Ctx> {
 					)
 					.await;
 
+					node.libraries
+						.edit(
+							library.id,
+							None,
+							MaybeUndefined::Undefined,
+							MaybeUndefined::Undefined,
+							Some(true),
+						)
+						.await
+						.unwrap();
+
 					Ok(())
 				})
+		})
+		.procedure("enabled", {
+			R.with2(library()).query(|(_, library), _: ()| async move {
+				Ok(library
+					.config()
+					.await
+					.generate_sync_operations
+					.load(Ordering::Relaxed))
+			})
 		})
 }

--- a/core/src/library/manager/mod.rs
+++ b/core/src/library/manager/mod.rs
@@ -25,7 +25,10 @@ use std::{
 	collections::HashMap,
 	path::{Path, PathBuf},
 	str::FromStr,
-	sync::{atomic::AtomicBool, Arc},
+	sync::{
+		atomic::{AtomicBool, Ordering},
+		Arc,
+	},
 	time::Duration,
 };
 
@@ -246,6 +249,7 @@ impl Libraries {
 		name: Option<LibraryName>,
 		description: MaybeUndefined<String>,
 		cloud_id: MaybeUndefined<String>,
+		enable_sync: Option<bool>,
 	) -> Result<(), LibraryManagerError> {
 		// check library is valid
 		let libraries = self.libraries.read().await;
@@ -273,6 +277,12 @@ impl Libraries {
 						MaybeUndefined::Undefined => {}
 						MaybeUndefined::Null => config.cloud_id = None,
 						MaybeUndefined::Value(cloud_id) => config.cloud_id = Some(cloud_id),
+					}
+					match enable_sync {
+						None => {}
+						Some(value) => config
+							.generate_sync_operations
+							.store(value, Ordering::SeqCst),
 					}
 				},
 				self.libraries_dir.join(format!("{id}.sdlibrary")),
@@ -449,7 +459,7 @@ impl Libraries {
 		// let key_manager = Arc::new(KeyManager::new(vec![]).await?);
 		// seed_keymanager(&db, &key_manager).await?;
 
-		let sync = sync::Manager::new(&db, instance_id, &self.emit_messages_flag, {
+		let sync = sync::Manager::new(&db, instance_id, &config.generate_sync_operations, {
 			db._batch(
 				instances
 					.iter()
@@ -621,6 +631,7 @@ impl Libraries {
 											None,
 											MaybeUndefined::Undefined,
 											MaybeUndefined::Null,
+											None,
 										)
 										.await;
 								}

--- a/interface/app/$libraryId/debug/sync.tsx
+++ b/interface/app/$libraryId/debug/sync.tsx
@@ -19,9 +19,14 @@ type MessageGroup = {
 export const Component = () => {
 	useRouteTitle('Sync');
 
+	const syncEnabled = useLibraryQuery(['sync.enabled']);
+
 	const messages = useLibraryQuery(['sync.messages']);
-	const backfillSyncMessages = useLibraryMutation(['sync.backfill'], {
-		onSuccess: () => messages.refetch()
+	const enableSync = useLibraryMutation(['sync.enable'], {
+		onSuccess: async () => {
+			await syncEnabled.refetch();
+			await messages.refetch();
+		}
 	});
 
 	useLibrarySubscription(['sync.newMessage'], {
@@ -35,13 +40,15 @@ export const Component = () => {
 
 	return (
 		<ul className="space-y-4 p-4">
-			<Button
-				variant="accent"
-				onClick={() => backfillSyncMessages.mutate(null)}
-				disabled={backfillSyncMessages.isLoading}
-			>
-				Backfill Sync Messages
-			</Button>
+			{!syncEnabled.data && (
+				<Button
+					variant="accent"
+					onClick={() => enableSync.mutate(null)}
+					disabled={enableSync.isLoading}
+				>
+					Enable sync messages
+				</Button>
+			)}
 			{groups?.map((group, index) => <OperationGroup key={index} group={group} />)}
 		</ul>
 	);

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -48,6 +48,7 @@ export type Procedures = {
         { key: "search.pathsCount", input: LibraryArgs<{ filters?: SearchFilterArgs[] }>, result: number } | 
         { key: "search.saved.get", input: LibraryArgs<number>, result: { id: number; pub_id: number[]; search: string | null; filters: string | null; name: string | null; icon: string | null; description: string | null; date_created: string | null; date_modified: string | null } | null } | 
         { key: "search.saved.list", input: LibraryArgs<null>, result: SavedSearch[] } | 
+        { key: "sync.enabled", input: LibraryArgs<null>, result: boolean } | 
         { key: "sync.messages", input: LibraryArgs<null>, result: CRDTOperation[] } | 
         { key: "tags.get", input: LibraryArgs<number>, result: { item: Reference<Tag>; nodes: CacheNode[] } | null } | 
         { key: "tags.getForObject", input: LibraryArgs<number>, result: NormalisedResults<Tag> } | 
@@ -118,7 +119,7 @@ export type Procedures = {
         { key: "search.saved.create", input: LibraryArgs<{ name: string; search?: string | null; filters?: string | null; description?: string | null; icon?: string | null }>, result: null } | 
         { key: "search.saved.delete", input: LibraryArgs<number>, result: null } | 
         { key: "search.saved.update", input: LibraryArgs<[number, Args]>, result: null } | 
-        { key: "sync.backfill", input: LibraryArgs<null>, result: null } | 
+        { key: "sync.enable", input: LibraryArgs<null>, result: null } | 
         { key: "tags.assign", input: LibraryArgs<{ targets: Target[]; tag_id: number; unassign: boolean }>, result: null } | 
         { key: "tags.create", input: LibraryArgs<TagCreateArgs>, result: Tag } | 
         { key: "tags.delete", input: LibraryArgs<number>, result: null } | 
@@ -386,7 +387,7 @@ instance_id: number;
  * cloud_id is the ID of the cloud library this library is linked to.
  * If this is set we can assume the library is synced with the Cloud.
  */
-cloud_id?: string | null; version: LibraryConfigVersion }
+cloud_id?: string | null; generate_sync_operations?: boolean; version: LibraryConfigVersion }
 
 export type LibraryConfigVersion = "V0" | "V1" | "V2" | "V3" | "V4" | "V5" | "V6" | "V7" | "V8" | "V9"
 


### PR DESCRIPTION
Integrates the backfill system with the sync operation emitting toggle, so that existing libraries can go from no sync -> backfill + generation enabled with 1 button.