### PR TITLE
Revert x86_64-apple-darwin CI runners to macos-13

### DIFF
--- a/.github/workflows/cache-factory.yaml
+++ b/.github/workflows/cache-factory.yaml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: true
       matrix:
         settings:
-          - host: macos-14
+          - host: macos-13
             target: x86_64-apple-darwin
           - host: macos-14
             target: aarch64-apple-darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         settings:
-          - host: macos-14
+          - host: macos-13
             target: x86_64-apple-darwin
             bundles: app,dmg
             os: darwin


### PR DESCRIPTION
Attempt to workaround weird bug where rust thinks x86_64-apple-darwin std is not installed for some reason

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the macOS version used in GitHub workflow configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->