### PR TITLE
[ENG-1614] Remove @default from synced models

### DIFF
--- a/core/prisma/schema.prisma
+++ b/core/prisma/schema.prisma
@@ -348,8 +348,8 @@ model TagOnObject {
 model Label {
   id            Int      @id @default(autoincrement())
   name          String   @unique
-  date_created  DateTime @default(now())
-  date_modified DateTime @default(now())
+  date_created  DateTime?
+  date_modified DateTime?
 
   label_objects LabelOnObject[]
 

--- a/core/src/api/mod.rs
+++ b/core/src/api/mod.rs
@@ -64,7 +64,6 @@ pub enum CoreEvent {
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Type)]
 #[serde(rename_all = "camelCase")]
 pub enum BackendFeature {
-	SyncEmitMessages,
 	FilesOverP2P,
 	CloudSync,
 }
@@ -72,11 +71,6 @@ pub enum BackendFeature {
 impl BackendFeature {
 	pub fn restore(&self, node: &Node) {
 		match self {
-			BackendFeature::SyncEmitMessages => {
-				node.libraries
-					.emit_messages_flag
-					.store(true, Ordering::Relaxed);
-			}
 			BackendFeature::FilesOverP2P => {
 				node.files_over_p2p_flag.store(true, Ordering::Relaxed);
 			}
@@ -187,11 +181,6 @@ pub(crate) fn mount() -> Arc<Router> {
 				.map_err(|err| rspc::Error::new(ErrorCode::InternalServerError, err.to_string()))?;
 
 				match feature {
-					BackendFeature::SyncEmitMessages => {
-						node.libraries
-							.emit_messages_flag
-							.store(enabled, Ordering::Relaxed);
-					}
 					BackendFeature::FilesOverP2P => {
 						node.files_over_p2p_flag.store(enabled, Ordering::Relaxed);
 					}

--- a/crates/ai/src/image_labeler/process.rs
+++ b/crates/ai/src/image_labeler/process.rs
@@ -434,7 +434,7 @@ pub async fn assign_labels(
 				));
 
 				db.label()
-					.create(name, vec![label::date_created::set(date_created)])
+					.create(name, vec![label::date_created::set(Some(date_created))])
 					.select(label::select!({ id name }))
 			})
 			.collect::<Vec<_>>();

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -19,7 +19,7 @@ export type Procedures = {
         { key: "jobs.isActive", input: LibraryArgs<null>, result: boolean } | 
         { key: "jobs.reports", input: LibraryArgs<null>, result: JobGroup[] } | 
         { key: "labels.count", input: LibraryArgs<null>, result: number } | 
-        { key: "labels.get", input: LibraryArgs<number>, result: { id: number; name: string; date_created: string; date_modified: string } | null } | 
+        { key: "labels.get", input: LibraryArgs<number>, result: { id: number; name: string; date_created: string | null; date_modified: string | null } | null } | 
         { key: "labels.getForObject", input: LibraryArgs<number>, result: Label[] } | 
         { key: "labels.getWithObjects", input: LibraryArgs<number[]>, result: { [key in number]: { date_created: string; object: { id: number } }[] } } | 
         { key: "labels.list", input: LibraryArgs<null>, result: Label[] } | 
@@ -148,7 +148,7 @@ export type AudioMetadata = { duration: number | null; audio_codec: string | nul
  * 
  * If you want a variant of this to show up on the frontend it must be added to `backendFeatures` in `useFeatureFlag.tsx`
  */
-export type BackendFeature = "syncEmitMessages" | "filesOverP2P" | "cloudSync"
+export type BackendFeature = "filesOverP2P" | "cloudSync"
 
 export type Backup = ({ id: string; timestamp: string; library_id: string; library_name: string }) & { path: string }
 
@@ -358,9 +358,9 @@ export type KindStatistic = { kind: number; name: string; count: number; total_b
 
 export type KindStatistics = { statistics: KindStatistic[] }
 
-export type Label = { id: number; name: string; date_created: string; date_modified: string }
+export type Label = { id: number; name: string; date_created: string | null; date_modified: string | null }
 
-export type LabelWithObjects = { id: number; name: string; date_created: string; date_modified: string; label_objects: { object: { id: number; file_paths: FilePath[] } }[] }
+export type LabelWithObjects = { id: number; name: string; date_created: string | null; date_modified: string | null; label_objects: { object: { id: number; file_paths: FilePath[] } }[] }
 
 /**
  * Can wrap a query argument to require it to contain a `library_id` and provide helpers for working with libraries.

--- a/packages/client/src/stores/featureFlags.tsx
+++ b/packages/client/src/stores/featureFlags.tsx
@@ -15,7 +15,7 @@ export const features = [
 
 // This defines which backend feature flags show up in the UI.
 // This is kinda a hack to not having the runtime array of possible features as Specta only exports the types.
-export const backendFeatures: BackendFeature[] = ['syncEmitMessages', 'filesOverP2P', 'cloudSync'];
+export const backendFeatures: BackendFeature[] = ['filesOverP2P', 'cloudSync'];
 
 export type FeatureFlag = (typeof features)[number] | BackendFeature;
 


### PR DESCRIPTION
Default values for fields that are intended to be synced are not allowed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Removed the `syncEmitMessages` feature to streamline backend operations.
- **Refactor**
	- Updated label creation and handling processes to allow optional `date_created` and `date_modified` fields.
- **Chores**
	- Simplified feature flags by removing `syncEmitMessages`, focusing on `'filesOverP2P'` and `'cloudSync'`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->