### PR TITLE
[ENG-1102] Remove non-sync compatible raw query from watcher

### DIFF
--- a/core/src/location/manager/watcher/utils.rs
+++ b/core/src/location/manager/watcher/utils.rs
@@ -839,7 +839,7 @@ pub(super) async fn rename(
 				})
 				.unzip();
 
-			sync.write_ops(&db, (sync_params, db_params)).await?;
+			sync.write_ops(db, (sync_params, db_params)).await?;
 
 			trace!("Updated {len} file_paths");
 		}

--- a/core/src/location/manager/watcher/utils.rs
+++ b/core/src/location/manager/watcher/utils.rs
@@ -53,7 +53,6 @@ use std::{
 
 use chrono::{DateTime, FixedOffset, Local, Utc};
 use notify::Event;
-use prisma_client_rust::{raw, PrismaValue};
 use serde_json::json;
 use tokio::{
 	fs,


### PR DESCRIPTION
Removes the last `execute_raw` and replaces it with a slower but sync-compatible set of queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced file renaming process for efficiency and maintainability by implementing batch processing and synchronization of changes.
	- Replaced raw SQL update operation with ORM queries for better abstraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->