### PR TITLE
Remove err_return macro

### DIFF
--- a/core/src/cloud/sync/ingest.rs
+++ b/core/src/cloud/sync/ingest.rs
@@ -1,9 +1,8 @@
-use super::err_return;
-
 use std::sync::Arc;
-
 use tokio::sync::Notify;
 use tracing::info;
+
+use crate::cloud::sync::err_break;
 
 pub async fn run_actor(sync: Arc<sd_core_sync::Manager>, notify: Arc<Notify>) {
 	loop {
@@ -28,7 +27,7 @@ pub async fn run_actor(sync: Arc<sd_core_sync::Manager>, notify: Arc<Notify>) {
 						_ => continue,
 					};
 
-					let ops = err_return!(
+					let ops = err_break!(
 						sync.get_cloud_ops(GetOpsArgs {
 							clocks: timestamps,
 							count: OPS_PER_REQUEST,
@@ -38,7 +37,7 @@ pub async fn run_actor(sync: Arc<sd_core_sync::Manager>, notify: Arc<Notify>) {
 
 					info!("Got {} cloud ops to ingest", ops.len());
 
-					err_return!(
+					err_break!(
 						sync.ingest
 							.event_tx
 							.send(sd_core_sync::Event::Messages(MessagesEvent {

--- a/core/src/cloud/sync/mod.rs
+++ b/core/src/cloud/sync/mod.rs
@@ -80,19 +80,6 @@ macro_rules! err_break {
 }
 pub(crate) use err_break;
 
-macro_rules! err_return {
-	($e:expr) => {
-		match $e {
-			Ok(d) => d,
-			Err(e) => {
-				tracing::error!("{e}");
-				return;
-			}
-		}
-	};
-}
-pub(crate) use err_return;
-
 pub type CompressedCRDTOperationsForModel = Vec<(Value, Vec<CompressedCRDTOperation>)>;
 
 #[derive(Serialize, Deserialize)]

--- a/core/src/cloud/sync/receive.rs
+++ b/core/src/cloud/sync/receive.rs
@@ -1,6 +1,6 @@
 use crate::library::{Libraries, Library};
 
-use super::{err_break, err_return, CompressedCRDTOperations};
+use super::{err_break, CompressedCRDTOperations};
 use sd_cloud_api::RequestConfigProvider;
 use sd_core_sync::NTP64;
 use sd_p2p2::{IdentityOrRemoteIdentity, RemoteIdentity};
@@ -36,7 +36,7 @@ pub async fn run_actor(
 			let mut cloud_timestamps = {
 				let timestamps = sync.timestamps.read().await;
 
-				err_return!(
+				err_break!(
 					db._batch(
 						timestamps
 							.keys()


### PR DESCRIPTION
Cloud sync processes shouldn't just die if an error occurs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

"""
- **Refactor**
	- Improved error handling and control flow in cloud synchronization processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->