### PR TITLE
fix doAdd cloud api and provide operations count

### DIFF
--- a/core/src/cloud/sync/send.rs
+++ b/core/src/cloud/sync/send.rs
@@ -66,6 +66,8 @@ pub async fn run_actor(
 				let start_time = ops[0].timestamp.0.to_string();
 				let end_time = ops[ops.len() - 1].timestamp.0.to_string();
 
+				let ops_len = ops.len();
+
 				instances.push(do_add::Input {
 					uuid: req_add.instance_uuid,
 					key: req_add.key,
@@ -73,6 +75,7 @@ pub async fn run_actor(
 					end_time,
 					contents: serde_json::to_value(CompressedCRDTOperations::new(ops))
 						.expect("CompressedCRDTOperation should serialize!"),
+					ops_count: ops_len,
 				})
 			}
 

--- a/crates/cloud-api/src/lib.rs
+++ b/crates/cloud-api/src/lib.rs
@@ -451,6 +451,7 @@ pub mod library {
 				pub start_time: String,
 				pub end_time: String,
 				pub contents: serde_json::Value,
+				pub ops_count: usize,
 			}
 
 			pub async fn exec(
@@ -465,7 +466,7 @@ pub mod library {
 				config
 					.client
 					.post(&format!(
-						"{}/api/v1/libraries/{}/messageCollections/requestAdd",
+						"{}/api/v1/libraries/{}/messageCollections/doAdd",
 						config.api_url, library_id
 					))
 					.json(&json!({ "instances": instances }))


### PR DESCRIPTION
dunno how doAdd was broken but it's fixed now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced cloud synchronization capabilities by including an operation count in data transmissions, improving visibility into data flow.
- **Refactor**
	- Updated API endpoint for adding instances to a library for increased efficiency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->