### PR TITLE
Fix Release and Server actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
 
       - name: Create Release
         # TODO: Change to stable version when available
-        uses: softprops/action-gh-release@4634c16
+        uses: softprops/action-gh-release@4634c16e79c963813287e889244c50009e7f0981
         with:
           draft: true
           files: '*/**'

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Build image
         id: build-image
         # TODO: Change to stable version when available
-        uses: redhat-actions/buildah-build@c79846f
+        uses: redhat-actions/buildah-build@c79846fb306beeba490e89fb75d2d1af95831e79
         with:
           tags: ${{ steps.image_info.outputs.tag }} ${{ github.event_name == 'release' && 'latest' || 'staging' }}
           archs: amd64
@@ -71,7 +71,7 @@ jobs:
       - name: Push image to ghcr.io
         # TODO: Restore redhat-actions/push-to-registry after PR is merged:
         # https://github.com/redhat-actions/push-to-registry/pull/93
-        uses: Eusebiotrigo/push-to-registry@5acfa47
+        uses: Eusebiotrigo/push-to-registry@5acfa470857b62a053884f7214581d55ffeb54ac
         with:
           tags: ${{ steps.build-image.outputs.tags }}
           image: ${{ steps.build-image.outputs.image }}


### PR DESCRIPTION
 - GitHub CI don't support shortened commit SHA