### PR TITLE
[ENG-1662] Fix thumb black bars

### DIFF
--- a/interface/app/$libraryId/Explorer/FilePath/utils.ts
+++ b/interface/app/$libraryId/Explorer/FilePath/utils.ts
@@ -1,10 +1,28 @@
-import { useMemo, useState, type CSSProperties, type RefObject } from 'react';
+import { useEffect, useMemo, useRef, useState, type CSSProperties, type RefObject } from 'react';
 import { useCallbackToWatchResize } from '~/hooks';
 
+import { useExplorerContext } from '../Context';
+
 export function useSize(ref: RefObject<Element>) {
+	const explorerSettings = useExplorerContext().useSettingsSnapshot();
+
+	const initialized = useRef(false);
+
 	const [size, setSize] = useState({ width: 0, height: 0 });
 
-	useCallbackToWatchResize(({ width, height }) => setSize({ width, height }), [], ref);
+	useEffect(() => {
+		initialized.current = false;
+	}, [explorerSettings.gridItemSize]);
+
+	useCallbackToWatchResize(
+		({ width, height }) => {
+			if (initialized.current) return;
+			setSize({ width, height });
+			initialized.current = true;
+		},
+		[],
+		ref
+	);
 
 	return size;
 }


### PR DESCRIPTION
Black bars cause the image to resize, which triggers the resize watcher and causes a loop of constant resizing. The solution isn't the best but does the job.

Closes #2150