### PR TITLE
Make `fullRescan` button work on mobile

### DIFF
--- a/apps/mobile/src/screens/settings/library/EditLocationSettings.tsx
+++ b/apps/mobile/src/screens/settings/library/EditLocationSettings.tsx
@@ -164,7 +164,7 @@ const EditLocationSettingsScreen = ({
 					title="Reindex"
 					description="Perform a full rescan of this location"
 					buttonPress={() =>
-						fullRescan.mutate({ location_id: id, reidentify_objects: true })
+						fullRescan.mutate({ location_id: id, reidentify_objects: false }) //FIXME: The famous serializing error for fullRescan. Keep this false until it's fixed.
 					}
 					buttonText="Full Reindex"
 					buttonIcon={<ArrowsClockwise color="white" size={20} />}


### PR DESCRIPTION
Currently, `reidentify_objects` does not work on iOS or Android for fullRescan. So, this just keeps it false with a `FIXME` message until it's patched and fixed. 

Otherwise, it'll make it so users can't `fullRescan` locations on the mobile applications, and production doesn't show any errors when it fails.
