### PR TITLE
p2p-block: check for out-of-bounds indexing

### DIFF
--- a/crates/p2p-block/src/lib.rs
+++ b/crates/p2p-block/src/lib.rs
@@ -204,9 +204,12 @@ where
 
 					file.write_all(&data_buf[..block.size as usize]).await?;
 
+					let req = self.reqs.requests.get(self.i).ok_or_else(|| {
+						debug!("Vector read out of bounds!");
+						io::ErrorKind::Other
+					})?;
 					// TODO: Should this be `read == 0`
-					// TODO: Out of range protection on indexed access
-					if offset == self.reqs.requests[self.i].size {
+					if offset == req.size {
 						break;
 					}
 


### PR DESCRIPTION
<!-- Put any information about this PR up here -->
Resolves a TODO comment: `// TODO: Out of range protection on indexed access` by using `Vector.get()` and returning an `Error`, instead of directly indexing the vector and panicking.

<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->

Closes #2186 
