### PR TITLE
upsert sync timestamp rather than overwrite

### DIFF
--- a/core/src/api/cloud.rs
+++ b/core/src/api/cloud.rs
@@ -144,7 +144,7 @@ mod library {
 					.await?;
 
 					for instance in instances {
-						crate::cloud::sync::receive::create_instance(
+						crate::cloud::sync::receive::upsert_instance(
 							&library,
 							&node.libraries,
 							instance.uuid,

--- a/core/src/cloud/sync/receive.rs
+++ b/core/src/cloud/sync/receive.rs
@@ -254,7 +254,13 @@ pub async fn create_instance(
 		.exec()
 		.await?;
 
-	library.sync.timestamps.write().await.insert(uuid, NTP64(0));
+	library
+		.sync
+		.timestamps
+		.write()
+		.await
+		.entry(uuid)
+		.or_default();
 
 	// Called again so the new instances are picked up
 	libraries.update_instances(library.clone()).await;

--- a/core/src/cloud/sync/receive.rs
+++ b/core/src/cloud/sync/receive.rs
@@ -156,7 +156,7 @@ pub async fn run_actor(
 					};
 
 					err_break!(
-						create_instance(
+						upsert_instance(
 							&library,
 							&libraries,
 							collection.instance_uuid,
@@ -226,7 +226,7 @@ fn crdt_op_db(op: &CRDTOperation) -> cloud_crdt_operation::Create {
 	}
 }
 
-pub async fn create_instance(
+pub async fn upsert_instance(
 	library: &Arc<Library>,
 	libraries: &Libraries,
 	uuid: Uuid,

--- a/core/src/library/manager/mod.rs
+++ b/core/src/library/manager/mod.rs
@@ -614,7 +614,7 @@ impl Libraries {
 											&library,
 											&node.libraries,
 											instance.uuid,
-											instance.identity,
+											instance.identity,upsert_instnace
 											instance.node_id,
 											instance.metadata,
 										)

--- a/core/src/library/manager/mod.rs
+++ b/core/src/library/manager/mod.rs
@@ -614,7 +614,7 @@ impl Libraries {
 											&library,
 											&node.libraries,
 											instance.uuid,
-											instance.identity,upsert_instnace
+											instance.identity,
 											instance.node_id,
 											instance.metadata,
 										)

--- a/core/src/library/manager/mod.rs
+++ b/core/src/library/manager/mod.rs
@@ -610,7 +610,7 @@ impl Libraries {
 									}
 
 									for instance in lib.instances {
-										if let Err(err) = cloud::sync::receive::create_instance(
+										if let Err(err) = cloud::sync::receive::upsert_instance(
 											&library,
 											&node.libraries,
 											instance.uuid,


### PR DESCRIPTION
in pulling cloud library and instance information, timestamps should be upserted rather than overwritten to 0