### PR TITLE
fix topbar hmr

### DIFF
--- a/interface/app/$libraryId/Explorer/View/DragScrollable.tsx
+++ b/interface/app/$libraryId/Explorer/View/DragScrollable.tsx
@@ -1,7 +1,7 @@
 import { useExplorerLayoutStore } from '@sd/client';
 import { tw } from '@sd/ui';
 
-import { useTopBarContext } from '../../TopBar/Layout';
+import { useTopBarContext } from '../../TopBar/Context';
 import { useExplorerContext } from '../Context';
 import { PATH_BAR_HEIGHT } from '../ExplorerPath';
 import { useDragScrollable } from './useDragScrollable';

--- a/interface/app/$libraryId/Explorer/index.tsx
+++ b/interface/app/$libraryId/Explorer/index.tsx
@@ -8,7 +8,7 @@ import {
 } from '@sd/client';
 import { useShortcut } from '~/hooks';
 
-import { useTopBarContext } from '../TopBar/Layout';
+import { useTopBarContext } from '../TopBar/Context';
 import { useExplorerContext } from './Context';
 import ContextMenu from './ContextMenu';
 import DismissibleNotice from './DismissibleNotice';

--- a/interface/app/$libraryId/PageLayout/index.tsx
+++ b/interface/app/$libraryId/PageLayout/index.tsx
@@ -3,7 +3,7 @@ import { useRef } from 'react';
 import { Outlet } from 'react-router';
 
 import { useShowControls } from '../../../hooks';
-import { useTopBarContext } from '../TopBar/Layout';
+import { useTopBarContext } from '../TopBar/Context';
 import { PageLayoutContext } from './Context';
 
 export const Component = () => {

--- a/interface/app/$libraryId/TopBar/Context.tsx
+++ b/interface/app/$libraryId/TopBar/Context.tsx
@@ -1,0 +1,36 @@
+import { createContext, useContext, useState } from 'react';
+import { SearchFilterArgs } from '@sd/client';
+
+export const TopBarContext = createContext<ReturnType<typeof useContextValue> | null>(null);
+
+export function useContextValue() {
+	const [left, setLeft] = useState<HTMLDivElement | null>(null);
+	const [center, setCenter] = useState<HTMLDivElement | null>(null);
+	const [right, setRight] = useState<HTMLDivElement | null>(null);
+	const [children, setChildren] = useState<HTMLDivElement | null>(null);
+	const [fixedArgs, setFixedArgs] = useState<SearchFilterArgs[] | null>(null);
+	const [topBarHeight, setTopBarHeight] = useState(0);
+
+	return {
+		left,
+		setLeft,
+		center,
+		setCenter,
+		right,
+		setRight,
+		children,
+		setChildren,
+		fixedArgs,
+		setFixedArgs,
+		topBarHeight,
+		setTopBarHeight
+	};
+}
+
+export function useTopBarContext() {
+	const ctx = useContext(TopBarContext);
+
+	if (!ctx) throw new Error('TopBarContext not found!');
+
+	return ctx;
+}

--- a/interface/app/$libraryId/TopBar/Layout.tsx
+++ b/interface/app/$libraryId/TopBar/Layout.tsx
@@ -1,35 +1,9 @@
-import { createContext, useContext, useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { Outlet } from 'react-router';
-import { SearchFilterArgs } from '@sd/client';
 
 import TopBar from '.';
 import { explorerStore } from '../Explorer/store';
-
-const TopBarContext = createContext<ReturnType<typeof useContextValue> | null>(null);
-
-function useContextValue() {
-	const [left, setLeft] = useState<HTMLDivElement | null>(null);
-	const [center, setCenter] = useState<HTMLDivElement | null>(null);
-	const [right, setRight] = useState<HTMLDivElement | null>(null);
-	const [children, setChildren] = useState<HTMLDivElement | null>(null);
-	const [fixedArgs, setFixedArgs] = useState<SearchFilterArgs[] | null>(null);
-	const [topBarHeight, setTopBarHeight] = useState(0);
-
-	return {
-		left,
-		setLeft,
-		center,
-		setCenter,
-		right,
-		setRight,
-		children,
-		setChildren,
-		fixedArgs,
-		setFixedArgs,
-		topBarHeight,
-		setTopBarHeight
-	};
-}
+import { TopBarContext, useContextValue } from './Context';
 
 export const Component = () => {
 	const value = useContextValue();
@@ -48,11 +22,3 @@ export const Component = () => {
 		</TopBarContext.Provider>
 	);
 };
-
-export function useTopBarContext() {
-	const ctx = useContext(TopBarContext);
-
-	if (!ctx) throw new Error('TopBarContext not found!');
-
-	return ctx;
-}

--- a/interface/app/$libraryId/TopBar/Portal.tsx
+++ b/interface/app/$libraryId/TopBar/Portal.tsx
@@ -1,7 +1,7 @@
 import { PropsWithChildren, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 
-import { useTopBarContext } from './Layout';
+import { useTopBarContext } from './Context';
 
 interface Props extends PropsWithChildren {
 	left?: ReactNode;

--- a/interface/app/$libraryId/TopBar/index.tsx
+++ b/interface/app/$libraryId/TopBar/index.tsx
@@ -15,7 +15,7 @@ import { useRoutingContext } from '~/RoutingContext';
 import { useTabsContext } from '~/TabsContext';
 
 import { explorerStore } from '../Explorer/store';
-import { useTopBarContext } from './Layout';
+import { useTopBarContext } from './Context';
 import { NavigationButtons } from './NavigationButtons';
 
 // million-ignore

--- a/interface/app/$libraryId/ephemeral.tsx
+++ b/interface/app/$libraryId/ephemeral.tsx
@@ -37,7 +37,7 @@ import { DefaultTopBarOptions } from './Explorer/TopBarOptions';
 import { useExplorer, useExplorerSettings } from './Explorer/useExplorer';
 import { EmptyNotice } from './Explorer/View/EmptyNotice';
 import { AddLocationButton } from './settings/library/locations/AddLocationButton';
-import { useTopBarContext } from './TopBar/Layout';
+import { useTopBarContext } from './TopBar/Context';
 import { TopBarPortal } from './TopBar/Portal';
 import TopBarButton from './TopBar/TopBarButton';
 


### PR DESCRIPTION
a general rule of react hmr + fast refresh is to not export components in the safe file or you can get errors during hmr like this

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HZ9fSeQ0necPUyMNJtXb/12a47309-cab9-4662-bba0-fc34ebcb1273.png)

source
https://github.com/ArnaudBarre/eslint-plugin-react-refresh