### PR TITLE
Make quic field of P2PManager private

### DIFF
--- a/core/src/p2p/manager.rs
+++ b/core/src/p2p/manager.rs
@@ -40,8 +40,7 @@ use super::{P2PEvents, PeerMetadata};
 pub struct P2PManager {
 	pub(crate) p2p: Arc<P2P>,
 	mdns: Mutex<Option<Mdns>>,
-	// TODO: Make private
-	pub quic: QuicTransport,
+	quic: QuicTransport,
 	// The `libp2p::PeerId`. This is for debugging only, use `RemoteIdentity` instead.
 	lp2p_peer_id: Libp2pPeerId,
 	pub(crate) events: P2PEvents,


### PR DESCRIPTION
<!-- Put any information about this PR up here -->
Resolves a TODO comment in `core/src/p2p/manager.rs`: 
```
// TODO: Make private
pub quic: QuicTransport,
```

<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->

Closes #2233 
