### PR TITLE
Remove the `.unwrap()` from the mobile core

### DIFF
--- a/apps/mobile/modules/sd-core/core/src/lib.rs
+++ b/apps/mobile/modules/sd-core/core/src/lib.rs
@@ -74,10 +74,15 @@ pub fn handle_core_msg(
 				None => {
 					let _guard = Node::init_logger(&data_dir);
 
-					// TODO: probably don't unwrap
-					let new_node = Node::new(data_dir, sd_core::Env::new(CLIENT_ID))
-						.await
-						.unwrap();
+					let new_node = match Node::new(data_dir, sd_core::Env::new(CLIENT_ID)).await {
+						Ok(node) => node,
+						Err(err) => {
+							error!("failed to initialise node: {}", err);
+							callback(Err(query));
+							return;
+						}
+					};
+
 					node.replace(new_node.clone());
 					new_node
 				}


### PR DESCRIPTION
So, `.unwrap()` can cause issues when the core dies by throwing a panic. So, by moving to a `match` instead, we can stop the panic from occurring and get a proper error in the console/logs.
