### PR TITLE
[ENG-1693] Prevent default webview search

### DIFF
--- a/interface/app/$libraryId/TopBar/index.tsx
+++ b/interface/app/$libraryId/TopBar/index.tsx
@@ -1,16 +1,10 @@
 import { Plus, X } from '@phosphor-icons/react';
 import clsx from 'clsx';
-import { useLayoutEffect, useRef } from 'react';
+import { useEffect, useLayoutEffect, useRef } from 'react';
 import useResizeObserver from 'use-resize-observer';
 import { useSelector } from '@sd/client';
 import { Tooltip } from '@sd/ui';
-import {
-	useKeyMatcher,
-	useLocale,
-	useOperatingSystem,
-	useShortcut,
-	useShowControls
-} from '~/hooks';
+import { useKeyMatcher, useLocale, useShortcut, useShowControls } from '~/hooks';
 import { useRoutingContext } from '~/RoutingContext';
 import { useTabsContext } from '~/TabsContext';
 
@@ -35,6 +29,15 @@ const TopBar = () => {
 			ctx.setTopBarHeight(bounds.height);
 		}
 	});
+
+	//prevent default search from opening
+	useEffect(() => {
+		document.body.addEventListener('keydown', (e) => {
+			if (e.key === 'f' && e.ctrlKey) {
+				e.preventDefault();
+			}
+		});
+	}, []);
 
 	// when the component mounts + crucial state changes, we need to update the height _before_ the browser paints
 	// in order to avoid jank. resize observer doesn't fire early enought to account for this.
@@ -154,7 +157,6 @@ function Tabs() {
 
 function useTabKeybinds(props: { addTab(): void; removeTab(index: number): void }) {
 	const ctx = useTabsContext()!;
-	const os = useOperatingSystem();
 	const { visible } = useRoutingContext();
 
 	useShortcut('newTab', (e) => {

--- a/interface/app/$libraryId/TopBar/index.tsx
+++ b/interface/app/$libraryId/TopBar/index.tsx
@@ -30,13 +30,17 @@ const TopBar = () => {
 		}
 	});
 
-	//prevent default search from opening
+	//prevent default search from opening from edge webview
 	useEffect(() => {
-		document.body.addEventListener('keydown', (e) => {
+		const handleKeyDown = (e: KeyboardEvent) => {
 			if (e.key === 'f' && e.ctrlKey) {
 				e.preventDefault();
 			}
-		});
+		};
+		document.body.addEventListener('keydown', handleKeyDown);
+		return () => {
+			document.body.removeEventListener('keydown', handleKeyDown);
+		};
 	}, []);
 
 	// when the component mounts + crucial state changes, we need to update the height _before_ the browser paints

--- a/interface/app/$libraryId/search/SearchBar.tsx
+++ b/interface/app/$libraryId/search/SearchBar.tsx
@@ -28,7 +28,6 @@ export default ({ redirectToSearch }: Props) => {
 				event.key.toUpperCase() === 'F' &&
 				event.getModifierState(os === 'macOS' ? ModifierKeys.Meta : ModifierKeys.Control)
 			) {
-				event.preventDefault();
 				searchRef.current?.focus();
 			}
 		},
@@ -36,10 +35,13 @@ export default ({ redirectToSearch }: Props) => {
 	);
 
 	const blurHandler = useCallback((event: KeyboardEvent) => {
-		if (event.key === 'Escape' && document.activeElement === searchRef.current) {
-			// Check if element is in focus, then remove it
+		//condition prevents default search of webview
+		if (document.activeElement === searchRef.current) {
 			event.preventDefault();
-			searchRef.current?.blur();
+			if (event.key === 'Escape') {
+				// Check if element is in focus, then remove it
+				searchRef.current?.blur();
+			}
 		}
 	}, []);
 


### PR DESCRIPTION
^

Keep in mind the search input is not rendered at all times **(Ephemeral locations)**. Hence the approach.