### PR TITLE
[ENG-1691] Sync status subscription

### DIFF
--- a/core/crates/sync/src/lib.rs
+++ b/core/crates/sync/src/lib.rs
@@ -32,6 +32,8 @@ pub struct SharedState {
 	pub instance: uuid::Uuid,
 	pub timestamps: Timestamps,
 	pub clock: uhlc::HLC,
+	pub active: AtomicBool,
+	pub active_notify: tokio::sync::Notify,
 }
 
 #[must_use]

--- a/core/crates/sync/src/manager.rs
+++ b/core/crates/sync/src/manager.rs
@@ -22,7 +22,7 @@ use uuid::Uuid;
 pub struct Manager {
 	pub tx: broadcast::Sender<SyncMessage>,
 	pub ingest: ingest::Handler,
-	shared: Arc<SharedState>,
+	pub shared: Arc<SharedState>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]
@@ -54,6 +54,8 @@ impl Manager {
 			clock,
 			timestamps: Arc::new(RwLock::new(timestamps)),
 			emit_messages_flag: emit_messages_flag.clone(),
+			active: Default::default(),
+			active_notify: Default::default(),
 		});
 
 		let ingest = ingest::Actor::spawn(shared.clone());

--- a/core/src/api/cloud.rs
+++ b/core/src/api/cloud.rs
@@ -145,7 +145,9 @@ mod library {
 
 					for instance in instances {
 						crate::cloud::sync::receive::upsert_instance(
-							&library,
+							library.id,
+							&library.db,
+							&library.sync,
 							&node.libraries,
 							instance.uuid,
 							instance.identity,

--- a/core/src/api/sync.rs
+++ b/core/src/api/sync.rs
@@ -1,8 +1,6 @@
-use std::sync::atomic::Ordering;
-
-use sd_core_sync::GetOpsArgs;
-
 use rspc::alpha::AlphaRouter;
+use sd_core_sync::GetOpsArgs;
+use std::sync::atomic::Ordering;
 
 use crate::util::MaybeUndefined;
 
@@ -76,5 +74,26 @@ pub(crate) fn mount() -> AlphaRouter<Ctx> {
 					.generate_sync_operations
 					.load(Ordering::Relaxed))
 			})
+		})
+		.procedure("active", {
+			R.with2(library())
+				.subscription(|(_, library), _: ()| async move {
+					async_stream::stream! {
+						let cloud_sync = &library.cloud.sync;
+						let sync = &library.sync.shared;
+
+						loop {
+							yield sync.active.load(Ordering::Relaxed)
+								|| cloud_sync.send_active.load(Ordering::Relaxed)
+								|| cloud_sync.receive_active.load(Ordering::Relaxed)
+								|| cloud_sync.ingest_active.load(Ordering::Relaxed);
+
+							tokio::select! {
+								_ = cloud_sync.notifier.notified() => {},
+								_ = sync.active_notify.notified() => {}
+							}
+						}
+					}
+				})
 		})
 }

--- a/core/src/cloud/mod.rs
+++ b/core/src/cloud/mod.rs
@@ -1,1 +1,33 @@
+use std::sync::Arc;
+
+use uuid::Uuid;
+
+use crate::Node;
+
 pub mod sync;
+
+#[derive(Default)]
+pub struct State {
+	pub sync: sync::State,
+}
+
+pub async fn start(
+	node: &Arc<Node>,
+	actors: &Arc<sd_actors::Actors>,
+	library_id: Uuid,
+	instance_uuid: Uuid,
+	sync: &Arc<sd_core_sync::Manager>,
+	db: &Arc<sd_prisma::prisma::PrismaClient>,
+) -> State {
+	let sync = sync::declare_actors(
+		node,
+		actors,
+		library_id,
+		instance_uuid,
+		sync.clone(),
+		db.clone(),
+	)
+	.await;
+
+	State { sync }
+}

--- a/core/src/library/library.rs
+++ b/core/src/library/library.rs
@@ -1,4 +1,6 @@
-use crate::{api::CoreEvent, object::media::old_thumbnail::get_indexed_thumbnail_path, sync, Node};
+use crate::{
+	api::CoreEvent, cloud, object::media::old_thumbnail::get_indexed_thumbnail_path, sync, Node,
+};
 
 use sd_file_path_helper::{file_path_to_full_path, IsolatedFilePathData};
 use sd_p2p::Identity;
@@ -35,6 +37,7 @@ pub struct Library {
 	/// db holds the database client for the current library.
 	pub db: Arc<PrismaClient>,
 	pub sync: Arc<sync::Manager>,
+	pub cloud: cloud::State,
 	/// key manager that provides encryption keys to functions that require them
 	// pub key_manager: Arc<KeyManager>,
 	/// p2p identity
@@ -76,12 +79,15 @@ impl Library {
 		db: Arc<PrismaClient>,
 		node: &Arc<Node>,
 		sync: Arc<sync::Manager>,
+		cloud: cloud::State,
 		do_cloud_sync: broadcast::Sender<()>,
+		actors: Arc<sd_actors::Actors>,
 	) -> Arc<Self> {
 		Arc::new(Self {
 			id,
 			config: RwLock::new(config),
 			sync,
+			cloud,
 			db: db.clone(),
 			// key_manager,
 			identity,
@@ -90,7 +96,7 @@ impl Library {
 			do_cloud_sync,
 			env: node.env.clone(),
 			event_bus_tx: node.event_bus.0.clone(),
-			actors: Default::default(),
+			actors,
 		})
 	}
 

--- a/core/src/library/manager/mod.rs
+++ b/core/src/library/manager/mod.rs
@@ -489,6 +489,11 @@ impl Libraries {
 			})
 			.collect()
 		});
+		let sync_manager = Arc::new(sync.manager);
+
+		let actors = Default::default();
+
+		let cloud = crate::cloud::start(&node, &actors, id, instance_id, &sync_manager, &db).await;
 
 		let (tx, mut rx) = broadcast::channel(10);
 		let library = Library::new(
@@ -499,15 +504,15 @@ impl Libraries {
 			// key_manager,
 			db,
 			node,
-			Arc::new(sync.manager),
+			sync_manager,
+			cloud,
 			tx,
+			actors,
 		)
 		.await;
 
 		// This is an exception. Generally subscribe to this by `self.tx.subscribe`.
 		tokio::spawn(sync_rx_actor(library.clone(), node.clone(), sync.rx));
-
-		crate::cloud::sync::declare_actors(&library, node).await;
 
 		self.tx
 			.emit(LibraryManagerEvent::Load(library.clone()))
@@ -611,7 +616,9 @@ impl Libraries {
 
 									for instance in lib.instances {
 										if let Err(err) = cloud::sync::receive::upsert_instance(
-											&library,
+											library.id,
+											&library.db,
+											&library.sync,
 											&node.libraries,
 											instance.uuid,
 											instance.identity,
@@ -660,6 +667,17 @@ impl Libraries {
 	}
 
 	pub async fn update_instances(&self, library: Arc<Library>) {
+		self.tx
+			.emit(LibraryManagerEvent::InstancesModified(library))
+			.await;
+	}
+
+	pub async fn update_instances_by_id(&self, library_id: Uuid) {
+		let Some(library) = self.libraries.read().await.get(&library_id).cloned() else {
+			warn!("Failed to find instance to update by id");
+			return;
+		};
+
 		self.tx
 			.emit(LibraryManagerEvent::InstancesModified(library))
 			.await;

--- a/core/src/library/manager/mod.rs
+++ b/core/src/library/manager/mod.rs
@@ -493,7 +493,7 @@ impl Libraries {
 
 		let actors = Default::default();
 
-		let cloud = crate::cloud::start(&node, &actors, id, instance_id, &sync_manager, &db).await;
+		let cloud = crate::cloud::start(node, &actors, id, instance_id, &sync_manager, &db).await;
 
 		let (tx, mut rx) = broadcast::channel(10);
 		let library = Library::new(

--- a/interface/app/$libraryId/Layout/Sidebar/SidebarLayout/Footer.tsx
+++ b/interface/app/$libraryId/Layout/Sidebar/SidebarLayout/Footer.tsx
@@ -1,6 +1,6 @@
 import { Gear } from '@phosphor-icons/react';
 import { useNavigate } from 'react-router';
-import { JobManagerContextProvider, useClientContext, useDebugState } from '@sd/client';
+import { JobManagerContextProvider, LibraryContextProvider, useClientContext, useDebugState, useLibrarySubscription } from '@sd/client';
 import { Button, ButtonLink, Popover, Tooltip, usePopover } from '@sd/ui';
 import { useKeysMatcher, useLocale, useShortcut } from '~/hooks';
 import { usePlatform } from '~/util/Platform';
@@ -8,6 +8,7 @@ import { usePlatform } from '~/util/Platform';
 import DebugPopover from '../DebugPopover';
 import { IsRunningJob, JobManager } from '../JobManager';
 import FeedbackButton from './FeedbackButton';
+import { useState } from 'react';
 
 export default () => {
 	const { library } = useClientContext();
@@ -44,6 +45,7 @@ export default () => {
 					)}
 				</>
 			)}
+			{library && <LibraryContextProvider library={library}><SyncStatusIndicator/></LibraryContextProvider>}
 			<div className="flex w-full items-center justify-between">
 				<div className="flex">
 					<ButtonLink
@@ -95,3 +97,13 @@ export default () => {
 		</div>
 	);
 };
+
+function SyncStatusIndicator() {
+	const [syncing, setSyncing] = useState(false);
+
+	useLibrarySubscription(["sync.active"], {
+		onData: setSyncing
+	})
+
+	return null
+}

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -136,6 +136,7 @@ export type Procedures = {
         { key: "notifications.listen", input: never, result: Notification } | 
         { key: "p2p.events", input: never, result: P2PEvent } | 
         { key: "search.ephemeralPaths", input: LibraryArgs<EphemeralPathSearchArgs>, result: EphemeralPathsResultItem } | 
+        { key: "sync.active", input: LibraryArgs<null>, result: boolean } | 
         { key: "sync.newMessage", input: LibraryArgs<null>, result: null }
 };
 


### PR DESCRIPTION
Adds a `sync.active` subscription that indicates whether sync send, receive, or ingest is currently active.
A sample UI is implemented in the sidebar footer but it we can put it wherever.