### PR TITLE
Add Warning for SD Docker Container

### DIFF
--- a/apps/landing/src/app/roadmap/items.ts
+++ b/apps/landing/src/app/roadmap/items.ts
@@ -171,6 +171,11 @@ export const items = [
 			'Automatically save versions of files when they change, with a timeline view and the ability to restore.'
 	},
 	{
+		title: 'Server Authentication',
+		description:
+			'Protect local instances of Spacedrive\'s server from other clients on your network.'
+	},
+	{
 		when: '0.5 Beta',
 		subtext: 'June 2024',
 		title: 'Encrypted vault(s)',

--- a/apps/landing/src/app/roadmap/items.ts
+++ b/apps/landing/src/app/roadmap/items.ts
@@ -171,7 +171,7 @@ export const items = [
 			'Automatically save versions of files when they change, with a timeline view and the ability to restore.'
 	},
 	{
-		title: 'Server Authentication',
+		title: 'Local Server Protection',
 		description:
 			'Protect local instances of Spacedrive\'s server from other clients on your network.'
 	},

--- a/docs/product/getting-started/setup.mdx
+++ b/docs/product/getting-started/setup.mdx
@@ -34,6 +34,10 @@ You can run Spacedrive in a Docker container using the following command.
 	type="note"
 	text="For the best performance of the docker container, we recommend to run on Linux (linux/amd64). The container is not yet optimized for other platforms."
 />
+<Notice
+	type="warning"
+	text="Currently, Spacedrive's Docker Server does not support authentication methods. Use at your own risk as your data will not be protected from other devices (or users) on your network. The feature is under active development and you can check when it will launch on the [roadmap](/roadmap)."
+/>
 
 ```bash
 docker run -d --name spacedrive -p 8080:8080 -v /var/spacedrive:/var/spacedrive ghcr.io/spacedriveapp/spacedrive/server


### PR DESCRIPTION
Currently, Spacedrive's Docker Server does not support authentication methods. So, adding a warning about it on the setup page.
