### PR TITLE
remove fixed filters

### DIFF
--- a/interface/app/$libraryId/favorites.tsx
+++ b/interface/app/$libraryId/favorites.tsx
@@ -25,19 +25,7 @@ export function Component() {
 
 	const explorerSettingsSnapshot = explorerSettings.useSettingsSnapshot();
 
-	const fixedFilters = useMemo<SearchFilterArgs[]>(
-		() => [
-			// { object: { favorite: true } },
-			...(explorerSettingsSnapshot.layoutMode === 'media'
-				? [{ object: { kind: { in: [ObjectKindEnum.Image, ObjectKindEnum.Video] } } }]
-				: [])
-		],
-		[explorerSettingsSnapshot.layoutMode]
-	);
-
-	const search = useSearch({
-		fixedFilters
-	});
+	const search = useSearch();
 
 	const objects = useObjectsExplorerQuery({
 		arg: {
@@ -45,7 +33,10 @@ export function Component() {
 			filters: [
 				...search.allFilters,
 				// TODO: Add filter to search options
-				{ object: { favorite: true } }
+				{ object: { favorite: true } },
+				...(explorerSettingsSnapshot.layoutMode === 'media'
+					? [{ object: { kind: { in: [ObjectKindEnum.Image, ObjectKindEnum.Video] } } }]
+					: [])
 			]
 		},
 		order: explorerSettings.useSettingsSnapshot().order

--- a/interface/app/$libraryId/labels.tsx
+++ b/interface/app/$libraryId/labels.tsx
@@ -27,7 +27,7 @@ export function Component() {
 
 	// const explorerSettingsSnapshot = explorerSettings.useSettingsSnapshot();
 
-	// const fixedFilters = useMemo<SearchFilterArgs[]>(
+	// const filters = useMemo<SearchFilterArgs[]>(
 	// 	() => [
 	// 		...(explorerSettingsSnapshot.layoutMode === 'media'
 	// 			? [{ object: { kind: { in: [ObjectKindEnum.Image, ObjectKindEnum.Video] } } }]
@@ -36,7 +36,7 @@ export function Component() {
 	// 	[explorerSettingsSnapshot.layoutMode]
 	// );
 
-	const search = useSearch({});
+	const search = useSearch();
 
 	// const objects = useObjectsExplorerQuery({
 	// 	arg: {

--- a/interface/app/$libraryId/recents.tsx
+++ b/interface/app/$libraryId/recents.tsx
@@ -25,19 +25,7 @@ export function Component() {
 
 	const explorerSettingsSnapshot = explorerSettings.useSettingsSnapshot();
 
-	const fixedFilters = useMemo<SearchFilterArgs[]>(
-		() => [
-			// { object: { dateAccessed: { from: new Date(0).toISOString() } } },
-			...(explorerSettingsSnapshot.layoutMode === 'media'
-				? [{ object: { kind: { in: [ObjectKindEnum.Image, ObjectKindEnum.Video] } } }]
-				: [])
-		],
-		[explorerSettingsSnapshot.layoutMode]
-	);
-
-	const search = useSearch({
-		fixedFilters
-	});
+	const search = useSearch();
 
 	const objects = useObjectsExplorerQuery({
 		arg: {
@@ -45,7 +33,10 @@ export function Component() {
 			filters: [
 				...search.allFilters,
 				// TODO: Add fil ter to search options
-				{ object: { dateAccessed: { from: new Date(0).toISOString() } } }
+				{ object: { dateAccessed: { from: new Date(0).toISOString() } } },
+				...(explorerSettingsSnapshot.layoutMode === 'media'
+					? [{ object: { kind: { in: [ObjectKindEnum.Image, ObjectKindEnum.Video] } } }]
+					: [])
 			]
 		},
 		order: explorerSettings.useSettingsSnapshot().order

--- a/interface/app/$libraryId/saved-search/$id.tsx
+++ b/interface/app/$libraryId/saved-search/$id.tsx
@@ -46,14 +46,14 @@ export const Component = () => {
 
 	const rawFilters = savedSearch.data?.filters;
 
-	const dynamicFilters = useMemo(() => {
+	const filters = useMemo(() => {
 		if (rawFilters) return JSON.parse(rawFilters) as SearchFilterArgs[];
 	}, [rawFilters]);
 
 	const search = useSearch({
 		open: true,
 		search: savedSearch.data?.search ?? undefined,
-		dynamicFilters
+		filters: filters
 	});
 
 	const paths = usePathsExplorerQuery({
@@ -85,7 +85,7 @@ export const Component = () => {
 				>
 					<hr className="w-full border-t border-sidebar-divider bg-sidebar-divider" />
 					<SearchOptions>
-						{(search.dynamicFilters !== dynamicFilters ||
+						{(search.filters !== filters ||
 							search.search !== savedSearch.data?.search) && (
 							<SaveButton searchId={id} />
 						)}
@@ -123,7 +123,7 @@ function SaveButton({ searchId }: { searchId: number }) {
 				updateSavedSearch.mutate([
 					searchId,
 					{
-						filters: JSON.stringify(search.dynamicFilters),
+						filters: JSON.stringify(search.filters),
 						search: search.search
 					}
 				]);

--- a/interface/app/$libraryId/search/AppliedFilters.tsx
+++ b/interface/app/$libraryId/search/AppliedFilters.tsx
@@ -55,13 +55,11 @@ export const AppliedFilters = ({ allowRemove = true }: { allowRemove?: boolean }
 									onDelete={
 										removalIndex !== null && allowRemove
 											? () => {
-													search.updateDynamicFilters(
-														(dyanmicFilters) => {
-															dyanmicFilters.splice(removalIndex, 1);
+													search.updateFilters((dyanmicFilters) => {
+														dyanmicFilters.splice(removalIndex, 1);
 
-															return dyanmicFilters;
-														}
-													);
+														return dyanmicFilters;
+													});
 												}
 											: undefined
 									}

--- a/interface/app/$libraryId/search/Filters.tsx
+++ b/interface/app/$libraryId/search/Filters.tsx
@@ -71,28 +71,25 @@ export function useToggleOptionSelected({ search }: { search: UseSearch }) {
 		option: FilterOption;
 		select: boolean;
 	}) => {
-		search.updateDynamicFilters((dynamicFilters) => {
-			const key = getKey({ ...option, type: filter.name });
-			if (search.fixedFiltersKeys?.has(key)) return dynamicFilters;
-
-			const rawArg = dynamicFilters.find((arg) => filter.extract(arg));
+		search.updateFilters((filters) => {
+			const rawArg = filters.find((arg) => filter.extract(arg));
 
 			if (!rawArg) {
 				const arg = filter.create(option.value);
-				dynamicFilters.push(arg);
+				filters.push(arg);
 			} else {
-				const rawArgIndex = dynamicFilters.findIndex((arg) => filter.extract(arg))!;
+				const rawArgIndex = filters.findIndex((arg) => filter.extract(arg))!;
 
 				const arg = filter.extract(rawArg)!;
 
 				if (select) {
 					if (rawArg) filter.applyAdd(arg, option);
 				} else {
-					if (!filter.applyRemove(arg, option)) dynamicFilters.splice(rawArgIndex, 1);
+					if (!filter.applyRemove(arg, option)) filters.splice(rawArgIndex, 1);
 				}
 			}
 
-			return dynamicFilters;
+			return filters;
 		});
 	};
 }
@@ -159,14 +156,14 @@ const FilterOptionText = ({ filter, search }: { filter: SearchFilterCRUD; search
 				className="flex gap-1.5"
 				onSubmit={(e) => {
 					e.preventDefault();
-					search.updateDynamicFilters((dynamicFilters) => {
-						if (allFiltersKeys.has(key)) return dynamicFilters;
+					search.updateFilters((filters) => {
+						if (allFiltersKeys.has(key)) return filters;
 
 						const arg = filter.create(value);
-						dynamicFilters.push(arg);
+						filters.push(arg);
 						setValue('');
 
-						return dynamicFilters;
+						return filters;
 					});
 				}}
 			>
@@ -191,7 +188,7 @@ const FilterOptionBoolean = ({
 	filter: SearchFilterCRUD;
 	search: UseSearch;
 }) => {
-	const { fixedFiltersKeys, allFiltersKeys } = search;
+	const { allFiltersKeys } = search;
 
 	const key = getKey({
 		type: filter.name,
@@ -204,19 +201,17 @@ const FilterOptionBoolean = ({
 			icon={filter.icon}
 			selected={allFiltersKeys?.has(key)}
 			setSelected={() => {
-				search.updateDynamicFilters((dynamicFilters) => {
-					if (fixedFiltersKeys?.has(key)) return dynamicFilters;
-
-					const index = dynamicFilters.findIndex((f) => filter.extract(f) !== undefined);
+				search.updateFilters((filters) => {
+					const index = filters.findIndex((f) => filter.extract(f) !== undefined);
 
 					if (index !== -1) {
-						dynamicFilters.splice(index, 1);
+						filters.splice(index, 1);
 					} else {
 						const arg = filter.create(true);
-						dynamicFilters.push(arg);
+						filters.push(arg);
 					}
 
-					return dynamicFilters;
+					return filters;
 				});
 			}}
 		>

--- a/interface/app/$libraryId/search/SearchBar.tsx
+++ b/interface/app/$libraryId/search/SearchBar.tsx
@@ -95,7 +95,6 @@ export default ({ redirectToSearch }: Props) => {
 				updateValue(e.target.value);
 			}}
 			onBlur={() => {
-				console.log('');
 				if (search.rawSearch === '' && !searchStore.interactingWithSearchOptions) {
 					clearValue();
 					search.setSearchBarFocused(false);

--- a/interface/app/$libraryId/search/SearchBar.tsx
+++ b/interface/app/$libraryId/search/SearchBar.tsx
@@ -81,6 +81,7 @@ export default ({ redirectToSearch }: Props) => {
 
 	function clearValue() {
 		search.setSearch('');
+		search.setFilters([]);
 	}
 
 	return (
@@ -94,12 +95,16 @@ export default ({ redirectToSearch }: Props) => {
 				updateValue(e.target.value);
 			}}
 			onBlur={() => {
+				console.log('');
 				if (search.rawSearch === '' && !searchStore.interactingWithSearchOptions) {
 					clearValue();
 					search.setSearchBarFocused(false);
 				}
 			}}
-			onFocus={() => search.setSearchBarFocused(true)}
+			onFocus={() => {
+				search.setSearchBarFocused(true);
+				if (search.defaultFilters) search.setFilters(search.defaultFilters);
+			}}
 			right={
 				<div className="pointer-events-none flex h-7 items-center space-x-1 opacity-70 group-focus-within:hidden">
 					{

--- a/interface/app/$libraryId/search/SearchOptions.tsx
+++ b/interface/app/$libraryId/search/SearchOptions.tsx
@@ -124,9 +124,7 @@ export const SearchOptions = ({
 
 			{children ?? (
 				<>
-					{(search.dynamicFilters.length > 0 || search.search !== '') && (
-						<SaveSearchButton />
-					)}
+					{(search.filters.length > 0 || search.search !== '') && <SaveSearchButton />}
 
 					<EscapeButton />
 				</>

--- a/interface/app/$libraryId/settings/library/saved-searches/index.tsx
+++ b/interface/app/$libraryId/settings/library/saved-searches/index.tsx
@@ -82,13 +82,13 @@ function EditForm({ savedSearch, onDelete }: { savedSearch: SavedSearch; onDelet
 		updateSavedSearch.mutate([savedSearch.id, { name: data.name ?? '' }]);
 	});
 
-	const fixedFilters = useMemo(() => {
+	const filters = useMemo(() => {
 		if (savedSearch.filters === null) return [];
 
 		return JSON.parse(savedSearch.filters) as SearchFilterArgs[];
 	}, [savedSearch.filters]);
 
-	const search = useSearch({ search: savedSearch.search ?? undefined, fixedFilters });
+	const search = useSearch({ search: savedSearch.search ?? undefined, filters });
 
 	return (
 		<Form form={form}>

--- a/interface/app/$libraryId/tag/$id.tsx
+++ b/interface/app/$libraryId/tag/$id.tsx
@@ -38,22 +38,20 @@ export function Component() {
 
 	const explorerSettingsSnapshot = explorerSettings.useSettingsSnapshot();
 
-	const fixedFilters = useMemo(
-		() => [
-			{ object: { tags: { in: [tag!.id] } } },
-			...(explorerSettingsSnapshot.layoutMode === 'media'
-				? [{ object: { kind: { in: [ObjectKindEnum.Image, ObjectKindEnum.Video] } } }]
-				: [])
-		],
-		[tag, explorerSettingsSnapshot.layoutMode]
-	);
-
 	const search = useSearch({
-		fixedFilters
+		defaultFilters: [{ object: { tags: { in: [tag!.id] } } }]
 	});
 
 	const objects = useObjectsExplorerQuery({
-		arg: { take: 100, filters: search.allFilters },
+		arg: {
+			take: 100,
+			filters: [
+				...search.allFilters,
+				...(explorerSettingsSnapshot.layoutMode === 'media'
+					? [{ object: { kind: { in: [ObjectKindEnum.Image, ObjectKindEnum.Video] } } }]
+					: [])
+			]
+		},
 		order: explorerSettings.useSettingsSnapshot().order
 	});
 


### PR DESCRIPTION
Removes `fixedFilters` in favour of `defaultFilters`, which are only used when search is being focused. Will allow multiple filters of the same type to be added since there's no more merge logic.