### PR TITLE
Don't fail CI job if  `dorny/paths-filter` step fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,7 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v3
+        continue-on-error: true
         id: filter
         with:
           filters: |
@@ -139,13 +140,13 @@ jobs:
               - 'Cargo.lock'
 
       - name: Setup Rust and Prisma
-        if: steps.filter.outputs.changes == 'true'
+        if: steps.filter.outcome != 'success' || steps.filter.outputs.changes == 'true'
         uses: ./.github/actions/setup-rust
         with:
           restore-cache: 'false'
 
       - name: Run rustfmt
-        if: steps.filter.outputs.changes == 'true'
+        if: steps.filter.outcome != 'success' || steps.filter.outputs.changes == 'true'
         run: cargo fmt --all -- --check
 
   clippy:
@@ -177,6 +178,7 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v3
+        continue-on-error: true
         id: filter
         with:
           filters: |
@@ -195,13 +197,13 @@ jobs:
               - 'Cargo.lock'
 
       - name: Setup System and Rust
-        if: steps.filter.outputs.changes == 'true'
+        if: steps.filter.outcome != 'success' || steps.filter.outputs.changes == 'true'
         uses: ./.github/actions/setup-system
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Clippy
-        if: steps.filter.outputs.changes == 'true'
+        if: steps.filter.outcome != 'success' || steps.filter.outputs.changes == 'true'
         uses: actions-rs-plus/clippy-check@v2
         with:
           args: --workspace --all-features


### PR DESCRIPTION
Avoid CI failing in main due to `dorny/paths-filter` step sometimes failing to read the merged PR branch by ignoring it and  running Clippy and Rust format anyways