### PR TITLE
[ENG-1702] Fix space for command palette

### DIFF
--- a/interface/app/$libraryId/Layout/CMDK/index.tsx
+++ b/interface/app/$libraryId/Layout/CMDK/index.tsx
@@ -21,6 +21,7 @@ import Sparkles from '~/components/Sparkles';
 import { useLocale, useShortcut } from '~/hooks';
 import { usePlatform } from '~/util/Platform';
 
+import { useQuickPreviewStore } from '../../Explorer/QuickPreview/store';
 import { explorerStore } from '../../Explorer/store';
 import { AddLocationDialog } from '../../settings/library/locations/AddLocationDialog';
 import { openDirectoryPickerDialog } from '../../settings/library/locations/openDirectoryPickerDialog';
@@ -30,13 +31,14 @@ import CMDKTags from './pages/CMDKTags';
 
 const CMDK = () => {
 	const [isOpen, setIsOpen] = useState<boolean>(false);
-
+	const quickPreviewStore = useQuickPreviewStore();
 	const platform = usePlatform();
 	const libraryId = useLibraryContext().library.uuid;
 
 	useShortcut('toggleCommandPalette', (e) => {
 		e.preventDefault();
 		e.stopPropagation();
+		if (quickPreviewStore.open) return;
 		setIsOpen((v) => !v);
 	});
 

--- a/interface/app/$libraryId/TopBar/index.tsx
+++ b/interface/app/$libraryId/TopBar/index.tsx
@@ -5,7 +5,6 @@ import useResizeObserver from 'use-resize-observer';
 import { useSelector } from '@sd/client';
 import { Tooltip } from '@sd/ui';
 import { useKeyMatcher, useLocale, useShortcut, useShowControls } from '~/hooks';
-import { useRoutingContext } from '~/RoutingContext';
 import { useTabsContext } from '~/TabsContext';
 
 import { explorerStore } from '../Explorer/store';
@@ -161,35 +160,25 @@ function Tabs() {
 
 function useTabKeybinds(props: { addTab(): void; removeTab(index: number): void }) {
 	const ctx = useTabsContext()!;
-	const { visible } = useRoutingContext();
 
 	useShortcut('newTab', (e) => {
-		if (!visible) return;
 		e.stopPropagation();
+		if (e.shiftKey) return; //to prevent colliding with 'navToSettings' shortcut
 		props.addTab();
 	});
 
 	useShortcut('closeTab', (e) => {
-		if (!visible) return;
-
 		e.stopPropagation();
-
 		props.removeTab(ctx.tabIndex);
 	});
 
 	useShortcut('nextTab', (e) => {
-		if (!visible) return;
-
 		e.stopPropagation();
-
 		ctx.setTabIndex(Math.min(ctx.tabIndex + 1, ctx.tabs.length - 1));
 	});
 
 	useShortcut('previousTab', (e) => {
-		if (!visible) return;
-
 		e.stopPropagation();
-
 		ctx.setTabIndex(Math.max(ctx.tabIndex - 1, 0));
 	});
 }

--- a/interface/hooks/useShortcut.ts
+++ b/interface/hooks/useShortcut.ts
@@ -169,8 +169,9 @@ export const useShortcut = (shortcut: Shortcuts, func: (e: KeyboardEvent) => voi
 
 	// useKeys doesn't like readonly
 	useKeys(keys as string[], (e) => {
-		if (!visible) return;
 		if (!import.meta.env.DEV) e.preventDefault();
 		return func(e);
+	}, {
+		when: visible
 	});
 };


### PR DESCRIPTION
**This PR**: 

- Fixes using space in command palette
- Fix navToSettings shortcut/new tab. Both were being triggered due to similar keys.
- Also added a condition so that it does not open when quick preview is open, otherwise you can't close quick preview.