### PR TITLE
Fix pnpm prep fails to download native-deps on some specific network env

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -32,3 +32,6 @@ interface/components/TextViewer/prism-lazy.ts
 
 # Stops from constant package.json changes showing up in commits
 package*.json
+
+# Dont format locales json
+interface/locales

--- a/apps/landing/src/app/page.tsx
+++ b/apps/landing/src/app/page.tsx
@@ -1,3 +1,4 @@
+import { ArrowUp } from '@phosphor-icons/react/dist/ssr';
 import Image from 'next/image';
 import CyclingImage from '~/components/CyclingImage';
 import { toTitleCase } from '~/utils/util';
@@ -6,7 +7,6 @@ import { getLatestRelease, getReleaseFrontmatter, githubFetch } from './api/gith
 import { Background } from './Background';
 import { Downloads } from './Downloads';
 import { NewBanner } from './NewBanner';
-import { ArrowUp } from '@phosphor-icons/react/dist/ssr';
 
 export const metadata = {
 	title: 'Spacedrive — A file manager from the future.',
@@ -78,7 +78,7 @@ export default async function Page() {
 							src="/images/app/gradient.webp"
 						/>
 						<div className="relative m-auto mt-10 flex w-full max-w-7xl overflow-hidden rounded-lg transition-transform duration-700 ease-in-out hover:-translate-y-4 hover:scale-[1.02] md:mt-0">
-							<div className='flex flex-col items-center justify-center'>
+							<div className="flex flex-col items-center justify-center">
 								<div className="z-30 flex w-full rounded-lg border-t border-app-line/50 backdrop-blur">
 									<CyclingImage
 										loading="eager"
@@ -108,8 +108,10 @@ export default async function Page() {
 										src="/images/app/gradient-overlay.png"
 									/>
 								</div>
-								<ArrowUp className='invisible size-7 pt-2 text-white/40 md:visible' />
-								<p className='invisible pt-2 text-xs text-white/40 md:visible'>Hover to see more</p>
+								<ArrowUp className="invisible size-7 pt-2 text-white/40 md:visible" />
+								<p className="invisible pt-2 text-xs text-white/40 md:visible">
+									Hover to see more
+								</p>
 							</div>
 						</div>
 					</div>

--- a/apps/landing/src/app/roadmap/items.ts
+++ b/apps/landing/src/app/roadmap/items.ts
@@ -173,7 +173,7 @@ export const items = [
 	{
 		title: 'Local Server Protection',
 		description:
-			'Protect local instances of Spacedrive\'s server from other clients on your network.'
+			"Protect local instances of Spacedrive's server from other clients on your network."
 	},
 	{
 		when: '0.5 Beta',

--- a/apps/landing/src/components/mdx/Pre.tsx
+++ b/apps/landing/src/components/mdx/Pre.tsx
@@ -1,19 +1,20 @@
-"use client";
+'use client';
+
 import { Check } from '@phosphor-icons/react';
 import { Copy } from '@phosphor-icons/react/dist/ssr';
-import { useState, useRef, FC } from 'react'
+import { FC, useRef, useState } from 'react';
 
 const Pre: FC<{ children: React.ReactNode }> = ({ children }) => {
-	const textInput = useRef<HTMLDivElement | null>(null)
-	const [copied, setCopied] = useState(false)
+	const textInput = useRef<HTMLDivElement | null>(null);
+	const [copied, setCopied] = useState(false);
 
 	const onCopy = () => {
-		setCopied(true)
-		navigator.clipboard.writeText(textInput.current!.textContent ?? '')
+		setCopied(true);
+		navigator.clipboard.writeText(textInput.current!.textContent ?? '');
 		setTimeout(() => {
-			setCopied(false)
-		}, 2000)
-	}
+			setCopied(false);
+		}, 2000);
+	};
 
 	return (
 		<div ref={textInput} className="relative">
@@ -23,15 +24,15 @@ const Pre: FC<{ children: React.ReactNode }> = ({ children }) => {
 				className="absolute right-2 top-2 z-10 rounded-md bg-app-box p-3 text-white/60 transition-colors duration-200 ease-in-out hover:bg-app-darkBox"
 				onClick={onCopy}
 			>
-				{copied ?
+				{copied ? (
 					<Check className="my-0 size-5 text-green-400/60" />
-					:
+				) : (
 					<Copy className="my-0 size-5 text-white" />
-				}
+				)}
 			</button>
-			<pre className='language-container'>{children}</pre>
-		</div >
-	)
-}
+			<pre className="language-container">{children}</pre>
+		</div>
+	);
+};
 
-export default Pre
+export default Pre;

--- a/apps/landing/src/components/mdx/index.tsx
+++ b/apps/landing/src/components/mdx/index.tsx
@@ -3,8 +3,8 @@ import NextImage, { ImageProps } from 'next/image';
 import { env } from '~/env';
 
 import Notice from './Notice';
-import Video from './Video';
 import Pre from './Pre';
+import Video from './Video';
 
 const Image = (props: ImageProps) => (
 	<NextImage

--- a/apps/web/cypress/support/commands.ts
+++ b/apps/web/cypress/support/commands.ts
@@ -3,10 +3,10 @@
 import {
 	libraryRegex,
 	librarySettingsRegex,
+	onboardingCreatingLibraryRegex,
 	onboardingLibraryRegex,
 	onboardingLocationRegex,
 	onboardingPrivacyRegex,
-	onboardingCreatingLibraryRegex,
 	onboardingRegex
 } from '../fixtures/routes';
 

--- a/interface/app/$libraryId/Explorer/View/ListView/index.tsx
+++ b/interface/app/$libraryId/Explorer/View/ListView/index.tsx
@@ -1,6 +1,4 @@
 import { CaretDown, CaretUp } from '@phosphor-icons/react';
-import { createOrdering, getOrderingDirection, orderingKey, type ExplorerItem } from '@sd/client';
-import { ContextMenu } from '@sd/ui';
 import { flexRender, type ColumnSizingState, type Row } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import clsx from 'clsx';
@@ -8,6 +6,8 @@ import React, { memo, useCallback, useEffect, useLayoutEffect, useRef, useState 
 import BasicSticky from 'react-sticky-el';
 import { useWindowEventListener } from 'rooks';
 import useResizeObserver from 'use-resize-observer';
+import { createOrdering, getOrderingDirection, orderingKey, type ExplorerItem } from '@sd/client';
+import { ContextMenu } from '@sd/ui';
 import { TruncatedText } from '~/components';
 import { useShortcut } from '~/hooks';
 import { isNonEmptyObject } from '~/util';

--- a/interface/app/$libraryId/Layout/Sidebar/store.ts
+++ b/interface/app/$libraryId/Layout/Sidebar/store.ts
@@ -1,10 +1,10 @@
-import { proxy, useSnapshot } from "valtio";
+import { proxy, useSnapshot } from 'valtio';
 
 //This store is being used
 //to record the state of the sidebar for specific behaviours i.e pinning
 
 const store = proxy({
-	pinJobManager: false as boolean,
+	pinJobManager: false as boolean
 });
 
 export const useSidebarStore = () => useSnapshot(store);

--- a/interface/components/TextViewer/index.tsx
+++ b/interface/components/TextViewer/index.tsx
@@ -73,7 +73,7 @@ export const TextViewer = memo(
 					className={clsx(
 						'relative w-full whitespace-pre text-sm text-ink',
 						codeExtension &&
-						`language-${languageMapping.get(codeExtension) ?? codeExtension}`
+							`language-${languageMapping.get(codeExtension) ?? codeExtension}`
 					)}
 					style={{
 						height: `${rowVirtualizer.getTotalSize()}px`

--- a/interface/hooks/useShortcut.ts
+++ b/interface/hooks/useShortcut.ts
@@ -168,10 +168,14 @@ export const useShortcut = (shortcut: Shortcuts, func: (e: KeyboardEvent) => voi
 	}, [os, shortcut, shortcuts, visible]);
 
 	// useKeys doesn't like readonly
-	useKeys(keys as string[], (e) => {
-		if (!import.meta.env.DEV) e.preventDefault();
-		return func(e);
-	}, {
-		when: visible
-	});
+	useKeys(
+		keys as string[],
+		(e) => {
+			if (!import.meta.env.DEV) e.preventDefault();
+			return func(e);
+		},
+		{
+			when: visible
+		}
+	);
 };

--- a/scripts/utils/fetch.mjs
+++ b/scripts/utils/fetch.mjs
@@ -3,13 +3,17 @@ import { dirname, join as joinPath } from 'node:path'
 import { env } from 'node:process'
 import { fileURLToPath } from 'node:url'
 
-import { fetch, Headers } from 'undici'
+import { fetch, Headers, Agent } from 'undici'
 
 const __debug = env.NODE_ENV === 'debug'
 const __offline = env.OFFLINE === 'true'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 const cacheDir = joinPath(__dirname, '.tmp')
+const dispatcher = new Agent({
+	allowH2: true,
+	autoSelectFamily: true,
+})
 await fs.mkdir(cacheDir, { recursive: true, mode: 0o751 })
 
 /**
@@ -124,7 +128,7 @@ export async function get(resource, headers, preferCache) {
 
 	if (cache?.header) headers.append(...cache.header)
 
-	const response = await fetch(resource, { headers })
+	const response = await fetch(resource, { dispatcher, headers })
 
 	if (!response.ok) {
 		if (cache?.data) {


### PR DESCRIPTION
 - Adjust fetch call to enable `autoSelectFamily` and `allowH2` so `pnpm prep` can function correctly on some specific network environments (Ex: corporate networks with proxies)
 - ESLint/Prettier auto format