### PR TITLE
CI now checks if a migration is missing

### DIFF
--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -67,7 +67,18 @@ runs:
       working-directory: core
       if: ${{ steps.cache-prisma-restore.outputs.cache-hit != 'true' }}
       shell: bash
-      run: cargo prisma generate
+      run: |
+        cargo prisma generate
+
+        # Check if a new migration should be created due to changes in the schema
+        cargo prisma migrate dev -n test --create-only --skip-generate
+        if git ls-files --others --exclude-standard | grep -q '^core/prisma/migrations/'; then
+          echo "::error file=core/prisma/schema.prisma,title=Missing migration::New migration should be generated due to changes in prisma schema"
+          # Fail action if we are on main or a release tag, to avoid releasing a app with broken db
+          if [ "$GITHUB_REF" == "refs/heads/main" ] || [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            exit 1
+          fi
+        fi
 
     - name: Save Prisma codegen
       id: cache-prisma-save

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -56,16 +56,16 @@ runs:
         (Get-Content Cargo.toml) -replace '\[profile.dev\]', '[profile.dev]
         opt-level=1' | Set-Content Cargo.toml
 
-    # - name: Restore cached Prisma codegen
-    #   id: cache-prisma-restore
-    #   uses: actions/cache/restore@v4
-    #   with:
-    #     key: prisma-1-${{ runner.os }}-${{ hashFiles('./core/prisma/*', './crates/sync-generator/*', './Cargo.*') }}
-    #     path: crates/prisma/src/**/*.rs
+    - name: Restore cached Prisma codegen
+      id: cache-prisma-restore
+      uses: actions/cache/restore@v4
+      with:
+        key: prisma-1-${{ runner.os }}-${{ hashFiles('./core/prisma/*', './crates/sync-generator/*', './Cargo.*') }}
+        path: crates/prisma/src/**/*.rs
 
     - name: Generate Prisma client
       working-directory: core
-      # if: ${{ steps.cache-prisma-restore.outputs.cache-hit != 'true' }}
+      if: ${{ steps.cache-prisma-restore.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
         set -euxo pipefail
@@ -81,10 +81,10 @@ runs:
           fi
         fi
 
-    # - name: Save Prisma codegen
-    #   id: cache-prisma-save
-    #   if: ${{ steps.cache-prisma-restore.outputs.cache-hit != 'true' }}
-    #   uses: actions/cache/save@v4
-    #   with:
-    #     key: ${{ steps.cache-prisma-restore.outputs.cache-primary-key }}
-    #     path: crates/prisma/src/**/*.rs
+    - name: Save Prisma codegen
+      id: cache-prisma-save
+      if: ${{ steps.cache-prisma-restore.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@v4
+      with:
+        key: ${{ steps.cache-prisma-restore.outputs.cache-primary-key }}
+        path: crates/prisma/src/**/*.rs

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -7,20 +7,20 @@ inputs:
   save-cache:
     description: Whether to save the Rust cache
     required: false
-    default: "false"
+    default: 'false'
   restore-cache:
     description: Whether to restore the Rust cache
     required: false
-    default: "true"
+    default: 'true'
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Install Rust
       id: toolchain
       uses: dtolnay/rust-toolchain@stable
       with:
         target: ${{ inputs.target }}
-        toolchain: "1.75"
+        toolchain: '1.75'
         components: clippy, rustfmt
 
     - name: Cache Rust Dependencies
@@ -83,7 +83,7 @@ runs:
 
     - name: Save Prisma codegen
       id: cache-prisma-save
-      if: ${{ steps.cache-prisma-restore.outputs.cache-hit != 'true' }}
+      if: ${{ steps.cache-prisma-restore.outputs.cache-hit != 'true' && (github.ref == 'refs/heads/main' || inputs.save-cache == 'true') }}
       uses: actions/cache/save@v4
       with:
         key: ${{ steps.cache-prisma-restore.outputs.cache-primary-key }}

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -68,6 +68,7 @@ runs:
       if: ${{ steps.cache-prisma-restore.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
+        set -euxo pipefail
         cargo prisma generate
 
         # Check if a new migration should be created due to changes in the schema

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -7,20 +7,20 @@ inputs:
   save-cache:
     description: Whether to save the Rust cache
     required: false
-    default: 'false'
+    default: "false"
   restore-cache:
     description: Whether to restore the Rust cache
     required: false
-    default: 'true'
+    default: "true"
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Install Rust
       id: toolchain
       uses: dtolnay/rust-toolchain@stable
       with:
         target: ${{ inputs.target }}
-        toolchain: '1.75'
+        toolchain: "1.75"
         components: clippy, rustfmt
 
     - name: Cache Rust Dependencies
@@ -73,7 +73,7 @@ runs:
 
         # Check if a new migration should be created due to changes in the schema
         cargo prisma migrate dev -n test --create-only --skip-generate
-        if git ls-files --others --exclude-standard | grep -q '^core/prisma/migrations/'; then
+        if git ls-files --others --exclude-standard | grep -q '^prisma/migrations/'; then
           echo "::error file=core/prisma/schema.prisma,title=Missing migration::New migration should be generated due to changes in prisma schema"
           # Fail action if we are on main or a release tag, to avoid releasing a app with broken db
           if [ "$GITHUB_REF" == "refs/heads/main" ] || [[ "$GITHUB_REF" == refs/tags/* ]]; then

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -56,16 +56,16 @@ runs:
         (Get-Content Cargo.toml) -replace '\[profile.dev\]', '[profile.dev]
         opt-level=1' | Set-Content Cargo.toml
 
-    - name: Restore cached Prisma codegen
-      id: cache-prisma-restore
-      uses: actions/cache/restore@v4
-      with:
-        key: prisma-1-${{ runner.os }}-${{ hashFiles('./core/prisma/*', './crates/sync-generator/*', './Cargo.*') }}
-        path: crates/prisma/src/**/*.rs
+    # - name: Restore cached Prisma codegen
+    #   id: cache-prisma-restore
+    #   uses: actions/cache/restore@v4
+    #   with:
+    #     key: prisma-1-${{ runner.os }}-${{ hashFiles('./core/prisma/*', './crates/sync-generator/*', './Cargo.*') }}
+    #     path: crates/prisma/src/**/*.rs
 
     - name: Generate Prisma client
       working-directory: core
-      if: ${{ steps.cache-prisma-restore.outputs.cache-hit != 'true' }}
+      # if: ${{ steps.cache-prisma-restore.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
         set -euxo pipefail
@@ -81,10 +81,10 @@ runs:
           fi
         fi
 
-    - name: Save Prisma codegen
-      id: cache-prisma-save
-      if: ${{ steps.cache-prisma-restore.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v4
-      with:
-        key: ${{ steps.cache-prisma-restore.outputs.cache-primary-key }}
-        path: crates/prisma/src/**/*.rs
+    # - name: Save Prisma codegen
+    #   id: cache-prisma-save
+    #   if: ${{ steps.cache-prisma-restore.outputs.cache-hit != 'true' }}
+    #   uses: actions/cache/save@v4
+    #   with:
+    #     key: ${{ steps.cache-prisma-restore.outputs.cache-primary-key }}
+    #     path: crates/prisma/src/**/*.rs

--- a/core/prisma/schema.prisma
+++ b/core/prisma/schema.prisma
@@ -39,7 +39,6 @@ model Node {
     pub_id       Bytes    @unique
     name         String
     // Enum: sd_core::node::Platform
-    platform     Int
     date_created DateTime
     identity     Bytes? // TODO: Change to required field in future
 

--- a/core/prisma/schema.prisma
+++ b/core/prisma/schema.prisma
@@ -39,6 +39,7 @@ model Node {
     pub_id       Bytes    @unique
     name         String
     // Enum: sd_core::node::Platform
+    platform     Int
     date_created DateTime
     identity     Bytes? // TODO: Change to required field in future
 


### PR DESCRIPTION
**For main and release tags:** Fail CI if changes to db schema are not reflected in a migration for prod builds
**For PRs:** Add an error msg to `schema.prisma` file if a migration was not created to reflect changes made to it, but do NOT fail CI
 
![image](https://github.com/spacedriveapp/spacedrive/assets/9082460/774f5e67-84fe-467e-b2ce-d835b212cdf6)

