### PR TITLE
Fix CI (due to python 3.12 update) + Fix migration CI check

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -8,6 +8,10 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
     - name: Install pnpm
       uses: pnpm/action-setup@v3
       with:

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -74,10 +74,11 @@ runs:
         # Check if a new migration should be created due to changes in the schema
         cargo prisma migrate dev -n test --create-only --skip-generate
         _new_migrations="$(
-            git ls-files --others --exclude-standard \
-                | { grep '^prisma/migrations/' || true; } \
-                | xargs sh -euxc '[ "$#" -lt 2 ] || grep -L "$@" || true' sh 'This is an empty migration' \
-                | wc -l
+          git ls-files --others --exclude-standard \
+            | { grep '^prisma/migrations/' || true; } \
+            | xargs sh -euxc '[ "$#" -lt 2 ] || grep -L "$@" || true' sh 'This is an empty migration' \
+            | wc -l \
+            | awk '{$1=$1};1'
         )"
         if [ "$_new_migrations" -gt 0 ]; then
             echo "::error file=core/prisma/schema.prisma,title=Missing migration::New migration should be generated due to changes in prisma schema"

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -7,20 +7,20 @@ inputs:
   save-cache:
     description: Whether to save the Rust cache
     required: false
-    default: 'false'
+    default: "false"
   restore-cache:
     description: Whether to restore the Rust cache
     required: false
-    default: 'true'
+    default: "true"
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Install Rust
       id: toolchain
       uses: dtolnay/rust-toolchain@stable
       with:
         target: ${{ inputs.target }}
-        toolchain: '1.75'
+        toolchain: "1.75"
         components: clippy, rustfmt
 
     - name: Cache Rust Dependencies
@@ -76,7 +76,7 @@ runs:
         _new_migrations="$(
             git ls-files --others --exclude-standard \
                 | { grep '^prisma/migrations/' || true; } \
-                | xargs -r grep -L 'This is an empty migration' \
+                | xargs sh -euxc '[ "$#" -lt 2 ] || grep -L "$@" || true' sh 'This is an empty migration' \
                 | wc -l
         )"
         if [ "$_new_migrations" -gt 0 ]; then

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -75,8 +75,8 @@ runs:
         cargo prisma migrate dev -n test --create-only --skip-generate
         _new_migrations="$(
             git ls-files --others --exclude-standard \
-                | grep '^prisma/migrations/' \
-                | xargs grep -L 'This is an empty migration' \
+                | { grep '^prisma/migrations/' || true; } \
+                | xargs -r grep -L 'This is an empty migration' \
                 | wc -l
         )"
         if [ "$_new_migrations" -gt 0 ]; then

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -73,14 +73,20 @@ runs:
 
         # Check if a new migration should be created due to changes in the schema
         cargo prisma migrate dev -n test --create-only --skip-generate
-        if git ls-files --others --exclude-standard | grep -q '^prisma/migrations/'; then
-          echo "::error file=core/prisma/schema.prisma,title=Missing migration::New migration should be generated due to changes in prisma schema"
-          case "$GITHUB_REF" in
-            "refs/heads/main" | "refs/heads/gh-readonly-queue/main/"* | "refs/tags/"*)
-              # Fail action if we are on main or a release tag, to avoid releasing an app with a broken db
-              exit 1
-              ;;
-          esac
+        _new_migrations="$(
+            git ls-files --others --exclude-standard \
+                | grep '^prisma/migrations/' \
+                | xargs grep -L 'This is an empty migration' \
+                | wc -l
+        )"
+        if [ "$_new_migrations" -gt 0 ]; then
+            echo "::error file=core/prisma/schema.prisma,title=Missing migration::New migration should be generated due to changes in prisma schema"
+            case "$GITHUB_REF" in
+                "refs/heads/main" | "refs/heads/gh-readonly-queue/main/"* | "refs/tags/"*)
+                    # Fail action if we are on main or a release tag, to avoid releasing an app with a broken db
+                    exit 1
+                    ;;
+            esac
         fi
 
     - name: Save Prisma codegen

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -75,10 +75,12 @@ runs:
         cargo prisma migrate dev -n test --create-only --skip-generate
         if git ls-files --others --exclude-standard | grep -q '^prisma/migrations/'; then
           echo "::error file=core/prisma/schema.prisma,title=Missing migration::New migration should be generated due to changes in prisma schema"
-          # Fail action if we are on main or a release tag, to avoid releasing a app with broken db
-          if [ "$GITHUB_REF" == "refs/heads/main" ] || [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            exit 1
-          fi
+          case "$GITHUB_REF" in
+            "refs/heads/main" | "refs/heads/gh-readonly-queue/main/"* | "refs/tags/"*)
+              # Fail action if we are on main or a release tag, to avoid releasing an app with a broken db
+              exit 1
+              ;;
+          esac
         fi
 
     - name: Save Prisma codegen

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -7,20 +7,20 @@ inputs:
   save-cache:
     description: Whether to save the Rust cache
     required: false
-    default: "false"
+    default: 'false'
   restore-cache:
     description: Whether to restore the Rust cache
     required: false
-    default: "true"
+    default: 'true'
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Install Rust
       id: toolchain
       uses: dtolnay/rust-toolchain@stable
       with:
         target: ${{ inputs.target }}
-        toolchain: "1.75"
+        toolchain: '1.75'
         components: clippy, rustfmt
 
     - name: Cache Rust Dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,6 +169,27 @@ Once that has completed, run `xcode-select --install` in the terminal to install
 
 Also ensure that Rosetta is installed, as a few of our dependencies require it. You can install Rosetta with `softwareupdate --install-rosetta --agree-to-license`.
 
+#### `ModuleNotFoundError: No module named 'distutils'`
+
+If you run into this issue, or some other error involving `node-gyp`:
+```
+File "pnpm@8.15.6/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py", line 42, in <module>
+  import gyp  # noqa: E402
+  ^^^^^^^^^^
+File "pnpm@8.15.6/node_modules/pnpm/dist/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 9, in <module>
+  import gyp.input
+File "pnpm@8.15.6/node_modules/pnpm/dist/node_modules/node-gyp/gyp/pylib/gyp/input.py", line 19, in <module>
+  from distutils.version import StrictVersion
+```
+
+Some pnpm dependencies require compilation steps that depend on Python to execute.
+However, a recent change in Python version 3.12 broke the utility used to bridge these compilation steps to node/npm/pnpm.
+
+Currently, there is no definitive solution to this issue due to it being fairly new. But there are two workarounds:
+
+1. Downgrade your system Python version to 3.11 or lower.
+2. Update pnpm to version v9.0.0-rc.0 (Release Candidate, not fully stable yet).
+
 ### Credits
 
 This CONTRIBUTING.md file was inspired by the [github/docs CONTRIBUTING.md](https://github.com/github/docs/blob/main/CONTRIBUTING.md) file, and we extend our gratitude to the original author.

--- a/core/prisma/migrations/20240409210455_improve_job_errors/migration.sql
+++ b/core/prisma/migrations/20240409210455_improve_job_errors/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "job" ADD COLUMN "critical_error" TEXT;
+ALTER TABLE "job" ADD COLUMN "non_critical_errors" BLOB;

--- a/core/prisma/migrations/20240409210455_improve_job_errors/migration.sql
+++ b/core/prisma/migrations/20240409210455_improve_job_errors/migration.sql
@@ -1,3 +1,0 @@
--- AlterTable
-ALTER TABLE "job" ADD COLUMN "critical_error" TEXT;
-ALTER TABLE "job" ADD COLUMN "non_critical_errors" BLOB;


### PR DESCRIPTION
 - Fix CI: Downgrade runner python to version 3.11 to fix `node-gyp` breaking due to changes in python 3.12
 - Fix migration check not always failing when it should on main
 - Fix check due to GitHub using `refs/heads/gh-readonly-queue/main/` as ref when merging a PR from merge-queue to main
 - Fix missing migration error message being showed when it shouldn't
 - Filter out empty migrations files when testing if a migration is missing
 - ~Add migration due to changes made in #2161~
