### PR TITLE
Remove soon-to-be deprecated `clippy.toml` in the crypto crate

### DIFF
--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -108,6 +108,9 @@ criterion = "0.5.1"
 paste = "1.0.14"
 tempfile = "3.10.1"
 
+[clippy]
+allow = ["unwrap_in_tests"]
+
 [[bench]]
 path = "benches/crypto/aes-256-gcm-siv.rs"
 name = "aes-256-gcm-siv"

--- a/crates/crypto/clippy.toml
+++ b/crates/crypto/clippy.toml
@@ -1,1 +1,0 @@
-allow-unwrap-in-tests = true


### PR DESCRIPTION
The `clippy.toml` file will be deprecated soon, so I've replaced it with the newer convention (which is a `[clippy]` key in the `Cargo.toml` file).