### PR TITLE
Fix Tauri link

### DIFF
--- a/docs/product/resources/faq.mdx
+++ b/docs/product/resources/faq.mdx
@@ -52,8 +52,8 @@ We will offer a range of optional services related to hosting, sharing and backi
 
 ## What is the stack?
 
-We call it "PRRTT"; [Prisma](https://prisma.io), [Rust](https://rustlang.org), [React](https://reactjs.org), [TypeScript](https://typescriptlang.org) and [Tauri](https://tauri.studio).
+We call it "PRRTT"; [Prisma](https://prisma.io), [Rust](https://rustlang.org), [React](https://reactjs.org), [TypeScript](https://typescriptlang.org) and [Tauri](https://tauri.app).
 
 ## Why Rust?
 
-Rust is a powerful, fast, memory safe, cross-platform, low-level language and thanks to [Tauri](https://tauri.studio)—its the perfect tool to power a desktop application.
+Rust is a powerful, fast, memory safe, cross-platform, low-level language and thanks to [Tauri](https://tauri.app)—its the perfect tool to power a desktop application.


### PR DESCRIPTION
The old domain no longer redirects and is some sort of gross news placeholder site. See also #1852
