### PR TITLE
Update pnpm to version 9

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -8,10 +8,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-
     - name: Install pnpm
       uses: pnpm/action-setup@v3
       with:

--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -15,7 +15,7 @@ runs:
     - name: Install pnpm
       uses: pnpm/action-setup@v3
       with:
-        version: 8.x.x
+        version: 9.x.x
 
     - name: Install Node.js
       uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install Cypress
+        run: pnpm exec cypress install
+
       - name: Setup Cypress
         uses: cypress-io/github-action@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,11 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Cypress
-        run: pnpm exec cypress install
+        run: |
+          set -euxo pipefail
+          pnpm exec cypress install
+          rm -rf /Users/runner/.cache/Cypress
+          ln -sf /Users/runner/Library/Caches/Cypress /Users/runner/.cache/Cypress
 
       - name: Setup Cypress
         uses: cypress-io/github-action@v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ If you encounter any issues, ensure that you are using the following versions of
 
 - Rust version: **1.75**
 - Node version: **18.18**
-- Pnpm version: **8.15**
+- Pnpm version: **9.0.1**
 
 After cleaning out your build artifacts using `pnpm clean`, `git clean`, or `cargo clean`, it is necessary to re-run the `setup-system` script.
 
@@ -168,28 +168,6 @@ Ensure that macOS is fully updated, and that you have Xcode installed (via the a
 Once that has completed, run `xcode-select --install` in the terminal to install the command line tools. If they are already installed, ensure that you update macOS to the latest version available.
 
 Also ensure that Rosetta is installed, as a few of our dependencies require it. You can install Rosetta with `softwareupdate --install-rosetta --agree-to-license`.
-
-#### `ModuleNotFoundError: No module named 'distutils'`
-
-If you run into this issue, or some other error involving `node-gyp`:
-
-```
-File "pnpm@8.15.6/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py", line 42, in <module>
-  import gyp  # noqa: E402
-  ^^^^^^^^^^
-File "pnpm@8.15.6/node_modules/pnpm/dist/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 9, in <module>
-  import gyp.input
-File "pnpm@8.15.6/node_modules/pnpm/dist/node_modules/node-gyp/gyp/pylib/gyp/input.py", line 19, in <module>
-  from distutils.version import StrictVersion
-```
-
-Some pnpm dependencies require compilation steps that depend on Python to execute.
-However, a recent change in Python version 3.12 broke the utility used to bridge these compilation steps to node/npm/pnpm.
-
-Currently, there is no definitive solution to this issue due to it being fairly new. But there are two workarounds:
-
-1. Downgrade your system Python version to 3.11 or lower.
-2. Update pnpm to version v9.0.0-rc.0 (Release Candidate, not fully stable yet).
 
 ### Credits
 

--- a/apps/server/docker/Dockerfile
+++ b/apps/server/docker/Dockerfile
@@ -29,7 +29,7 @@ ENV PNPM_HOME="/usr/share/pnpm" \
 	PATH="/usr/share/pnpm:$PATH"
 
 RUN pnpm env use --global latest
-RUN pnpm add -g pnpm@latest-8
+RUN pnpm add -g pnpm@latest-9
 
 WORKDIR /srv
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"vite": "^5.1.6"
 	},
 	"engines": {
-		"pnpm": ">=8.0.0",
+		"pnpm": ">=9.0.0",
 		"npm": "pnpm",
 		"yarn": "pnpm",
 		"node": ">=18.18 <19 || >=20.1"
@@ -67,5 +67,5 @@
 	"eslintConfig": {
 		"root": true
 	},
-	"packageManager": "pnpm@8.15.6+sha256.01c01eeb990e379b31ef19c03e9d06a14afa5250b82e81303f88721c99ff2e6f"
+	"packageManager": "pnpm@9.0.1"
 }


### PR DESCRIPTION
This fix the incompatibility with Python 3.12, which is getting worse due to distros and macOS (brew) updating it and breaking `pnpm i` with pnpm < 9.