### PR TITLE
Replace Appimage with deb

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Install pnpm
       uses: pnpm/action-setup@v3
       with:
-        version: 9.x.x
+        version: 9.0.2
 
     - name: Install Node.js
       uses: actions/setup-node@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ If you encounter any issues, ensure that you are using the following versions of
 
 - Rust version: **1.75**
 - Node version: **18.18**
-- Pnpm version: **9.0.1**
+- Pnpm version: **9.0.2**
 
 After cleaning out your build artifacts using `pnpm clean`, `git clean`, or `cargo clean`, it is necessary to re-run the `setup-system` script.
 

--- a/apps/landing/src/app/Downloads/Platform.tsx
+++ b/apps/landing/src/app/Downloads/Platform.tsx
@@ -36,7 +36,7 @@ export const platforms = {
 		name: 'Linux',
 		os: 'linux',
 		icon: LinuxLogo,
-		version: 'AppImage',
+		version: 'deb',
 		links: [{ name: 'x86_64', arch: 'x86_64' }]
 	},
 	docker: { name: 'Docker', icon: Docker },

--- a/apps/landing/src/app/api/releases/desktop/[version]/[target]/[arch]/route.ts
+++ b/apps/landing/src/app/api/releases/desktop/[version]/[target]/[arch]/route.ts
@@ -7,7 +7,7 @@ const tauriTarget = z.union([z.literal('linux'), z.literal('windows'), z.literal
 const tauriArch = z.union([z.literal('x86_64'), z.literal('aarch64')]);
 
 const extensions = {
-	linux: 'AppImage',
+	linux: 'deb',
 	windows: 'msi',
 	darwin: 'dmg'
 } as const satisfies Record<z.infer<typeof tauriTarget>, string>;

--- a/package.json
+++ b/package.json
@@ -67,5 +67,5 @@
 	"eslintConfig": {
 		"root": true
 	},
-	"packageManager": "pnpm@9.0.1"
+	"packageManager": "pnpm@9.0.2"
 }


### PR DESCRIPTION
AppImage doesn't work with Ubuntu < 22.04 based distros, Arch Linux etc.

Related: https://github.com/spacedriveapp/spacedrive/issues/2039