### PR TITLE
[ENG-1753] Only open quick preview when items are selected

### DIFF
--- a/interface/app/$libraryId/Explorer/View/index.tsx
+++ b/interface/app/$libraryId/Explorer/View/index.tsx
@@ -204,6 +204,7 @@ const useShortcuts = () => {
 	useShortcut('toggleQuickPreview', (e) => {
 		if (isRenaming || dialogManager.isAnyDialogOpen()) return;
 		if (explorerStore.isCMDPOpen) return;
+		if (explorer.selectedItems.size === 0) return;
 		e.preventDefault();
 		getQuickPreviewStore().open = !quickPreviewStore.open;
 	});


### PR DESCRIPTION
Fixes a bug where if you select items on the grid view and switch to media view, then toggle quick preview and the selected items from the grid view are not available on the media view, quick preview won't open but if you switch back to grid view it will open on its own. This is more of a temporary solution until we make quick preview not rely on currently available items.