### PR TITLE
Batch ingest sync operations

### DIFF
--- a/core/crates/sync/src/ingest.rs
+++ b/core/crates/sync/src/ingest.rs
@@ -1,4 +1,5 @@
 use std::{
+	collections::BTreeMap,
 	ops::Deref,
 	sync::{atomic::Ordering, Arc},
 };
@@ -7,7 +8,10 @@ use sd_prisma::{
 	prisma::{crdt_operation, SortOrder},
 	prisma_sync::ModelSyncData,
 };
-use sd_sync::{CRDTOperation, OperationKind};
+use sd_sync::{
+	CRDTOperation, CRDTOperationData, CompressedCRDTOperation, CompressedCRDTOperations,
+	OperationKind,
+};
 use tokio::sync::{mpsc, oneshot, Mutex};
 use tracing::debug;
 use uhlc::{Timestamp, NTP64};
@@ -106,16 +110,20 @@ impl Actor {
 				}
 			}
 			State::Ingesting(event) => {
-				if !event.messages.is_empty() {
-					debug!(
-						"ingesting {} operations: {} to {}",
-						event.messages.len(),
-						event.messages.first().unwrap().timestamp.as_u64(),
-						event.messages.last().unwrap().timestamp.as_u64(),
-					);
+				debug!(
+					"ingesting {} operations: {} to {}",
+					event.messages.len(),
+					event.messages.first().unwrap().3.timestamp.as_u64(),
+					event.messages.last().unwrap().3.timestamp.as_u64(),
+				);
 
-					for op in event.messages {
-						self.receive_crdt_operation(op).await;
+				for (instance, data) in event.messages.0 {
+					for (model, data) in data {
+						for (record, ops) in data {
+							self.receive_crdt_operations(instance, model, record, ops)
+								.await
+								.expect("sync ingest failed");
+						}
 					}
 				}
 
@@ -161,105 +169,245 @@ impl Actor {
 	}
 
 	// where the magic happens
-	async fn receive_crdt_operation(
+	async fn receive_crdt_operations(
 		&mut self,
-		mut op: CRDTOperation,
+		instance: Uuid,
+		model: u16,
+		record_id: rmpv::Value,
+		mut ops: Vec<CompressedCRDTOperation>,
 	) -> prisma_client_rust::Result<()> {
 		let db = &self.db;
+
+		ops.sort_by_key(|op| op.timestamp);
+
+		let new_timestamp = ops.last().expect("Empty ops array").timestamp;
 
 		// first, we update the HLC's timestamp with the incoming one.
 		// this involves a drift check + sets the last time of the clock
 		self.clock
-			.update_with_timestamp(&Timestamp::new(op.timestamp, op.instance.into()))
+			.update_with_timestamp(&Timestamp::new(new_timestamp, instance.into()))
 			.expect("timestamp has too much drift!");
 
 		// read the timestamp for the operation's instance, or insert one if it doesn't exist
-		let timestamp = self.timestamps.read().await.get(&op.instance).cloned();
+		let timestamp = self.timestamps.read().await.get(&instance).cloned();
 
-		// copy some fields bc rust ownership
-		let op_instance = op.instance;
-		let op_timestamp = op.timestamp;
-
-		// resolve conflicts
-		// this can be outside the transaction as there's only ever one ingester
-		match &mut op.data {
-			// don't apply Create operations if the record has been deleted
-			sd_sync::CRDTOperationData::Create(_) => {
-				let delete = db
-					.crdt_operation()
-					.find_first(vec![
-						crdt_operation::model::equals(op.model as i32),
-						crdt_operation::record_id::equals(
-							rmp_serde::to_vec(&op.record_id).unwrap(),
-						),
-						crdt_operation::kind::equals(OperationKind::Delete.to_string()),
-					])
-					.order_by(crdt_operation::timestamp::order(SortOrder::Desc))
-					.exec()
-					.await?;
-
-				if delete.is_some() {
-					return Ok(());
-				}
-			}
-			// don't apply Update operations if the record hasn't been created, or a newer Update for the same field has been applied
-			sd_sync::CRDTOperationData::Update { field, .. } => {
-				let (create, update) = db
-					._batch((
-						db.crdt_operation()
-							.find_first(vec![
-								crdt_operation::model::equals(op.model as i32),
-								crdt_operation::record_id::equals(
-									rmp_serde::to_vec(&op.record_id).unwrap(),
-								),
-								crdt_operation::kind::equals(OperationKind::Create.to_string()),
-							])
-							.order_by(crdt_operation::timestamp::order(SortOrder::Desc)),
-						db.crdt_operation()
-							.find_first(vec![
-								crdt_operation::timestamp::gt(op.timestamp.as_u64() as i64),
-								crdt_operation::model::equals(op.model as i32),
-								crdt_operation::record_id::equals(
-									rmp_serde::to_vec(&op.record_id).unwrap(),
-								),
-								crdt_operation::kind::equals(
-									OperationKind::Update(field).to_string(),
-								),
-							])
-							.order_by(crdt_operation::timestamp::order(SortOrder::Desc)),
-					))
-					.await?;
-
-				// we don't care about the contents of the create operation, just that it exists
-				// - all update operations come after creates, no check is necessary
-				if create.is_none() || update.is_some() {
-					return Ok(());
-				}
-			}
+		// Delete - ignores all other messages
+		if let Some(delete_op) = ops
+			.iter()
+			.rev()
+			.find(|op| matches!(op.data, sd_sync::CRDTOperationData::Delete))
+		{
 			// deletes are the be all and end all, no need to check anything
-			sd_sync::CRDTOperationData::Delete => {}
-		};
 
-		// we don't want these writes to not apply together!
-		self.db
-			._transaction()
-			.with_timeout(30 * 1000)
-			.run(|db| async move {
-				// apply the operation to the actual record
-				ModelSyncData::from_op(op.clone())
+			let op = CRDTOperation {
+				instance,
+				model,
+				record_id,
+				timestamp: delete_op.timestamp,
+				data: CRDTOperationData::Delete,
+			};
+
+			self.db
+				._transaction()
+				.with_timeout(30 * 1000)
+				.run(|db| async move {
+					ModelSyncData::from_op(op.clone())
+						.unwrap()
+						.exec(&db)
+						.await?;
+					write_crdt_op_to_db(&op, &db).await?;
+
+					Ok(())
+				})
+				.await?;
+		}
+		// Create + > 0 Update - overwrites the create's data with the updates
+		else if let Some(timestamp) = ops.iter().rev().find_map(|op| {
+			if let sd_sync::CRDTOperationData::Create(_) = &op.data {
+				return Some(op.timestamp);
+			}
+
+			None
+		}) {
+			// conflict resolution
+			let delete = db
+				.crdt_operation()
+				.find_first(vec![
+					crdt_operation::model::equals(model as i32),
+					crdt_operation::record_id::equals(rmp_serde::to_vec(&record_id).unwrap()),
+					crdt_operation::kind::equals(OperationKind::Delete.to_string()),
+				])
+				.order_by(crdt_operation::timestamp::order(SortOrder::Desc))
+				.exec()
+				.await?;
+
+			if delete.is_some() {
+				return Ok(());
+			}
+
+			let mut data = BTreeMap::new();
+
+			let mut applied_ops = vec![];
+
+			// search for all Updates until a Create is found
+			for op in ops.iter().rev() {
+				match &op.data {
+					CRDTOperationData::Delete => unreachable!("Delete can't exist here!"),
+					CRDTOperationData::Create(create_data) => {
+						for (k, v) in create_data {
+							data.entry(k).or_insert(v);
+						}
+
+						applied_ops.push(op);
+
+						break;
+					}
+					CRDTOperationData::Update { field, value } => {
+						applied_ops.push(op);
+						data.insert(field, value);
+					}
+				}
+			}
+
+			self.db
+				._transaction()
+				.with_timeout(30 * 1000)
+				.run(|db| async move {
+					// fake a create with a bunch of data rather than individual insert
+					ModelSyncData::from_op(CRDTOperation {
+						instance,
+						model,
+						record_id: record_id.clone(),
+						timestamp,
+						data: CRDTOperationData::Create(
+							data.into_iter()
+								.map(|(k, v)| (k.clone(), v.clone()))
+								.collect(),
+						),
+					})
 					.unwrap()
 					.exec(&db)
-					.await
-					.unwrap();
+					.await?;
 
-				// write the operation to the operations table
-				write_crdt_op_to_db(&op, &db).await
-			})
-			.await?;
+					for op in applied_ops {
+						write_crdt_op_to_db(
+							&CRDTOperation {
+								instance,
+								model,
+								record_id: record_id.clone(),
+								timestamp: op.timestamp,
+								data: op.data.clone(),
+							},
+							&db,
+						)
+						.await?;
+					}
+
+					Ok(())
+				})
+				.await?;
+		}
+		// > 0 Update - batches updates with a fake Create op
+		else {
+			let mut data = BTreeMap::new();
+
+			for op in ops.into_iter().rev() {
+				let CRDTOperationData::Update { field, value } = op.data else {
+					unreachable!("Create + Delete should be filtered out!");
+				};
+
+				data.insert(field, (value, op.timestamp));
+			}
+
+			// conflict resolution
+			let (create, updates) = db
+				._batch((
+					db.crdt_operation()
+						.find_first(vec![
+							crdt_operation::model::equals(model as i32),
+							crdt_operation::record_id::equals(
+								rmp_serde::to_vec(&record_id).unwrap(),
+							),
+							crdt_operation::kind::equals(OperationKind::Create.to_string()),
+						])
+						.order_by(crdt_operation::timestamp::order(SortOrder::Desc)),
+					data.iter()
+						.map(|(k, (_, timestamp))| {
+							db.crdt_operation()
+								.find_first(vec![
+									crdt_operation::timestamp::gt(timestamp.as_u64() as i64),
+									crdt_operation::model::equals(model as i32),
+									crdt_operation::record_id::equals(
+										rmp_serde::to_vec(&record_id).unwrap(),
+									),
+									crdt_operation::kind::equals(
+										OperationKind::Update(k).to_string(),
+									),
+								])
+								.order_by(crdt_operation::timestamp::order(SortOrder::Desc))
+						})
+						.collect::<Vec<_>>(),
+				))
+				.await?;
+
+			if create.is_none() {
+				return Ok(());
+			}
+
+			// does the same thing as processing ops one-by-one and returning early if a newer op was found
+			for (update, key) in updates
+				.into_iter()
+				.zip(data.keys().cloned().collect::<Vec<_>>())
+			{
+				if update.is_some() {
+					data.remove(&key);
+				}
+			}
+
+			self.db
+				._transaction()
+				.with_timeout(30 * 1000)
+				.run(|db| async move {
+					// fake operation to batch them all at once
+					ModelSyncData::from_op(CRDTOperation {
+						instance,
+						model,
+						record_id: record_id.clone(),
+						timestamp: NTP64(0),
+						data: CRDTOperationData::Create(
+							data.iter()
+								.map(|(k, (data, _))| (k.to_string(), data.clone()))
+								.collect(),
+						),
+					})
+					.unwrap()
+					.exec(&db)
+					.await?;
+
+					// need to only apply ops that haven't been filtered out
+					for (field, (value, timestamp)) in data {
+						write_crdt_op_to_db(
+							&CRDTOperation {
+								instance,
+								model,
+								record_id: record_id.clone(),
+								timestamp,
+								data: CRDTOperationData::Update { field, value },
+							},
+							&db,
+						)
+						.await?;
+					}
+
+					Ok(())
+				})
+				.await?;
+		}
 
 		// update the stored timestamp for this instance - will be derived from the crdt operations table on restart
-		let new_ts = NTP64::max(timestamp.unwrap_or_default(), op_timestamp);
-		self.timestamps.write().await.insert(op_instance, new_ts);
+		let new_ts = NTP64::max(timestamp.unwrap_or_default(), new_timestamp);
+
+		self.timestamps.write().await.insert(instance, new_ts);
 
 		self.io.req_tx.send(Request::Ingested).await.ok();
 
@@ -283,7 +431,7 @@ pub struct Handler {
 #[derive(Debug)]
 pub struct MessagesEvent {
 	pub instance_id: Uuid,
-	pub messages: Vec<CRDTOperation>,
+	pub messages: CompressedCRDTOperations,
 	pub has_more: bool,
 }
 

--- a/core/crates/sync/src/manager.rs
+++ b/core/crates/sync/src/manager.rs
@@ -104,11 +104,13 @@ impl Manager {
 				))
 				.await?;
 
-			self.shared
-				.timestamps
-				.write()
-				.await
-				.insert(self.instance, ops.last().unwrap().timestamp);
+			if let Some(last) = ops.last() {
+				self.shared
+					.timestamps
+					.write()
+					.await
+					.insert(self.instance, last.timestamp);
+			}
 
 			self.tx.send(SyncMessage::Created).ok();
 

--- a/core/src/cloud/sync/ingest.rs
+++ b/core/src/cloud/sync/ingest.rs
@@ -1,3 +1,4 @@
+use sd_sync::CompressedCRDTOperations;
 use std::sync::{
 	atomic::{AtomicBool, Ordering},
 	Arc,
@@ -68,7 +69,7 @@ pub async fn run_actor(
 							.send(sd_core_sync::Event::Messages(MessagesEvent {
 								instance_id: sync.instance,
 								has_more: ops.len() == OPS_PER_REQUEST as usize,
-								messages: ops,
+								messages: CompressedCRDTOperations::new(ops),
 							}))
 							.await
 					);

--- a/core/src/p2p/sync/mod.rs
+++ b/core/src/p2p/sync/mod.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 use sd_p2p_proto::{decode, encode};
-use sd_sync::CRDTOperation;
+use sd_sync::CompressedCRDTOperations;
 
 use std::sync::Arc;
 
@@ -28,10 +28,11 @@ mod originator {
 	use sd_p2p_tunnel::Tunnel;
 
 	pub mod tx {
+
 		use super::*;
 
 		#[derive(Debug, PartialEq)]
-		pub struct Operations(pub Vec<CRDTOperation>);
+		pub struct Operations(pub CompressedCRDTOperations);
 
 		impl Operations {
 			// TODO: Per field errors for better error handling
@@ -56,8 +57,10 @@ mod originator {
 		#[cfg(test)]
 		#[tokio::test]
 		async fn test() {
+			use sd_sync::CRDTOperation;
+
 			{
-				let original = Operations(vec![]);
+				let original = Operations(CompressedCRDTOperations::new(vec![]));
 
 				let mut cursor = std::io::Cursor::new(original.to_bytes());
 				let result = Operations::from_stream(&mut cursor).await.unwrap();
@@ -65,13 +68,13 @@ mod originator {
 			}
 
 			{
-				let original = Operations(vec![CRDTOperation {
+				let original = Operations(CompressedCRDTOperations::new(vec![CRDTOperation {
 					instance: Uuid::new_v4(),
 					timestamp: sync::NTP64(0),
 					record_id: rmpv::Value::Nil,
 					model: 0,
 					data: sd_sync::CRDTOperationData::create(),
-				}]);
+				}]));
 
 				let mut cursor = std::io::Cursor::new(original.to_bytes());
 				let result = Operations::from_stream(&mut cursor).await.unwrap();
@@ -115,7 +118,7 @@ mod originator {
 					let ops = sync.get_ops(args).await.unwrap();
 
 					tunnel
-						.write_all(&tx::Operations(ops).to_bytes())
+						.write_all(&tx::Operations(CompressedCRDTOperations::new(ops)).to_bytes())
 						.await
 						.unwrap();
 					tunnel.flush().await.unwrap();


### PR DESCRIPTION
Sync operations belonging to the same record will now be ingested together, according to a few rules based on what is in the batch:
- A delete: All other messages will be ignored
- Create + >0 Update: Overwrites the create's data with the updates
- \>0 Update: Updates are applied at once using a fake Create op

This is helpful since in the case of Deletes it allows less work to be done, and in the case of Updates we can reuse some of the queries used in conflict resolution, reducing the amount of back and forth with the db.