### PR TITLE
Fix `cargo test`  & improve `pnpm prep` native deps download

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -187,7 +187,7 @@ async fn open_trash_in_os_explorer() -> Result<(), ()> {
 			.wait()
 			.map_err(|err| error!("Error opening trash: {err:#?}"))?;
 
-		return Ok(());
+		Ok(())
 	}
 }
 

--- a/core/src/api/files.rs
+++ b/core/src/api/files.rs
@@ -561,7 +561,7 @@ pub(crate) fn mount() -> AlphaRouter<Ctx> {
 							);
 
 							#[cfg(not(any(target_os = "ios", target_os = "android")))]
-							trash::delete(&full_path).unwrap();
+							trash::delete(full_path).unwrap();
 
 							Ok(())
 						}

--- a/core/src/api/p2p.rs
+++ b/core/src/api/p2p.rs
@@ -79,8 +79,7 @@ pub(crate) fn mount() -> AlphaRouter<Ctx> {
 					.p2p
 					.listeners()
 					.iter()
-					.map(|l| l.addrs.clone())
-					.flatten()
+					.flat_map(|l| l.addrs.clone())
 					.collect::<Vec<_>>();
 
 				let errors = node

--- a/crates/crypto/src/keyring/linux/secret_service.rs
+++ b/crates/crypto/src/keyring/linux/secret_service.rs
@@ -33,14 +33,11 @@ impl KeyringInterface for SecretServiceKeyring {
 	}
 
 	fn contains_key(&self, id: &Identifier) -> bool {
-		self.get_collection()
-			.ok()
-			.map(|k| {
-				k.search_items(id.as_sec_ser_identifier())
-					.ok()
-					.map_or(false, |x| !x.is_empty())
-			})
-			.unwrap_or_default()
+		self.get_collection().ok().is_some_and(|k| {
+			k.search_items(id.as_sec_ser_identifier())
+				.ok()
+				.map_or(false, |x| !x.is_empty())
+		})
 	}
 
 	fn get(&self, id: &Identifier) -> Result<Protected<Vec<u8>>> {

--- a/crates/p2p-block/src/block.rs
+++ b/crates/p2p-block/src/block.rs
@@ -58,8 +58,6 @@ impl<'a> Block<'a> {
 mod tests {
 	use std::io::Cursor;
 
-	use crate::BlockSize;
-
 	use super::*;
 
 	#[tokio::test]

--- a/crates/p2p-block/src/sb_request.rs
+++ b/crates/p2p-block/src/sb_request.rs
@@ -198,7 +198,7 @@ mod tests {
 	async fn test_spaceblock_requests_empty() {
 		let req = SpaceblockRequests {
 			id: Uuid::new_v4(),
-			block_size: BlockSize::from_size(42069),
+			block_size: BlockSize::from_file_size(42069),
 			requests: vec![],
 		};
 

--- a/crates/sync/src/compressed.rs
+++ b/crates/sync/src/compressed.rs
@@ -23,7 +23,7 @@ impl CompressedCRDTOperations {
 		let mut instance_id = first.instance;
 		let mut instance = vec![];
 
-		let mut model_str = first.model.clone();
+		let mut model_str = first.model;
 		let mut model = vec![];
 
 		let mut record_id = first.record_id.clone();
@@ -36,7 +36,7 @@ impl CompressedCRDTOperations {
 					std::mem::take(&mut record),
 				));
 				instance.push((
-					std::mem::replace(&mut model_str, op.model.clone()),
+					std::mem::replace(&mut model_str, op.model),
 					std::mem::take(&mut model),
 				));
 				compressed.push((
@@ -49,7 +49,7 @@ impl CompressedCRDTOperations {
 					std::mem::take(&mut record),
 				));
 				instance.push((
-					std::mem::replace(&mut model_str, op.model.clone()),
+					std::mem::replace(&mut model_str, op.model),
 					std::mem::take(&mut model),
 				));
 			} else if record_id != op.record_id {
@@ -72,10 +72,8 @@ impl CompressedCRDTOperations {
 	pub fn first(&self) -> Option<(Uuid, u16, &rmpv::Value, &CompressedCRDTOperation)> {
 		self.0.first().and_then(|(instance, data)| {
 			data.first().and_then(|(model, data)| {
-				data.first().and_then(|(record, ops)| {
-					ops.first()
-						.and_then(|op| Some((*instance, *model, record, op)))
-				})
+				data.first()
+					.and_then(|(record, ops)| ops.first().map(|op| (*instance, *model, record, op)))
 			})
 		})
 	}
@@ -83,10 +81,8 @@ impl CompressedCRDTOperations {
 	pub fn last(&self) -> Option<(Uuid, u16, &rmpv::Value, &CompressedCRDTOperation)> {
 		self.0.last().and_then(|(instance, data)| {
 			data.last().and_then(|(model, data)| {
-				data.last().and_then(|(record, ops)| {
-					ops.last()
-						.and_then(|op| Some((*instance, *model, record, op)))
-				})
+				data.last()
+					.and_then(|(record, ops)| ops.last().map(|op| (*instance, *model, record, op)))
 			})
 		})
 	}
@@ -111,7 +107,7 @@ impl CompressedCRDTOperations {
 					for op in record {
 						ops.push(CRDTOperation {
 							instance: instance_id,
-							model: model_str.clone(),
+							model: model_str,
 							record_id: record_id.clone(),
 							timestamp: op.timestamp,
 							data: op.data,

--- a/scripts/utils/fetch.mjs
+++ b/scripts/utils/fetch.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url'
 import { getSystemProxy } from 'os-proxy-config'
 import { fetch, Headers, Agent, ProxyAgent } from 'undici'
 
+const CONNECT_TIMEOUT = 5 * 60 * 1000
 const __debug = env.NODE_ENV === 'debug'
 const __offline = env.OFFLINE === 'true'
 const __filename = fileURLToPath(import.meta.url)
@@ -15,12 +16,19 @@ const cacheDir = joinPath(__dirname, '.tmp')
 /** @type {Agent.Options} */
 const agentOpts = {
 	allowH2: true,
+	connect: { timeout: CONNECT_TIMEOUT },
+	connectTimeout: CONNECT_TIMEOUT,
 	autoSelectFamily: true,
 }
 
 const { proxyUrl } = (await getSystemProxy()) ?? {}
 const dispatcher = proxyUrl
-	? new ProxyAgent({ ...agentOpts, uri: proxyUrl })
+	? new ProxyAgent({
+			...agentOpts,
+			proxyTls: { timeout: CONNECT_TIMEOUT },
+			requestTls: { timeout: CONNECT_TIMEOUT },
+			uri: proxyUrl,
+		})
 	: new Agent(agentOpts)
 
 await fs.mkdir(cacheDir, { recursive: true, mode: 0o751 })


### PR DESCRIPTION
 - Increase `pnpm prep` connection timeout to 5min, to better handle downloading native deps under flaky network conditions
 - Fix `cargo test` and cache-factory CI
 - Clippy and fmt