### PR TITLE
Fix folder double click

### DIFF
--- a/interface/app/$libraryId/Explorer/View/ViewItem.tsx
+++ b/interface/app/$libraryId/Explorer/View/ViewItem.tsx
@@ -30,7 +30,7 @@ export const useViewItemDoubleClick = () => {
 	const explorer = useExplorerContext();
 	const { library } = useLibraryContext();
 	const { openFilePaths, openEphemeralFiles } = usePlatform();
-	const [_, setSearchParams] = useRawSearchParams();
+	const [searchParams, setSearchParams] = useRawSearchParams();
 
 	const updateAccessTime = useLibraryMutation('files.updateAccessTime');
 
@@ -61,9 +61,7 @@ export const useViewItemDoubleClick = () => {
 							break;
 						default: {
 							const paths =
-								selectedItem.type === 'Path'
-									? [selectedItem.item]
-									: selectedItem.item.file_paths;
+								selectedItem.type === 'Path' ? [selectedItem.item] : selectedItem.item.file_paths;
 
 							for (const filePath of paths) {
 								if (filePath.is_dir) {
@@ -117,15 +115,15 @@ export const useViewItemDoubleClick = () => {
 			if (items.dirs.length > 0) {
 				const [item] = items.dirs;
 				if (item) {
-					setSearchParams((p) => {
-						const newParams = new URLSearchParams();
+					if (item.location_id !== null) {
+						const take = searchParams.get('take');
+						const params = new URLSearchParams({
+							path: `${item.materialized_path}${item.name}/`,
+							...(take !== null && { take })
+						});
 
-						newParams.set('path', `${item.materialized_path}${item.name}/`);
-						const take = p.get('take');
-						if (take !== null) newParams.set('take', take);
-
-						return newParams;
-					});
+						navigate(`/${library.uuid}/location/${item.location_id}?${params}`);
+					}
 					return;
 				}
 			}

--- a/interface/app/$libraryId/Explorer/View/ViewItem.tsx
+++ b/interface/app/$libraryId/Explorer/View/ViewItem.tsx
@@ -5,7 +5,6 @@ import {
 	useSearchParams as useRawSearchParams
 } from 'react-router-dom';
 import {
-	FilePathFilterArgs,
 	isPath,
 	SearchFilterArgs,
 	useLibraryContext,
@@ -30,7 +29,7 @@ export const useViewItemDoubleClick = () => {
 	const explorer = useExplorerContext();
 	const { library } = useLibraryContext();
 	const { openFilePaths, openEphemeralFiles } = usePlatform();
-	const [searchParams, setSearchParams] = useRawSearchParams();
+	const [searchParams] = useRawSearchParams();
 
 	const updateAccessTime = useLibraryMutation('files.updateAccessTime');
 

--- a/interface/app/$libraryId/Explorer/View/ViewItem.tsx
+++ b/interface/app/$libraryId/Explorer/View/ViewItem.tsx
@@ -182,7 +182,7 @@ export const useViewItemDoubleClick = () => {
 			}
 		},
 		[
-			setSearchParams,
+			searchParams,
 			explorer.selectedItems,
 			explorer.settingsStore.openOnDoubleClick,
 			library.uuid,


### PR DESCRIPTION
Specifies a location to navigate to when double clicking an explorer item, rather than just setting search params