### PR TITLE
Fix BLAKE3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common 0.1.6",
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1218,16 +1218,18 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cca6d3674597c30ddf2c587bf8d9d65c9a84d2326d941cc79c9842dfe0ef52"
+version = "1.5.0"
+source = "git+https://github.com/spacedriveapp/blake3.git?rev=d3aab416c12a75c2bfabce33bcd594e428a79069#d3aab416c12a75c2bfabce33bcd594e428a79069"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "digest 0.10.7",
+ "digest 0.11.0-pre.8",
+ "generic-array 1.0.0",
+ "hybrid-array",
+ "typenum",
  "zeroize",
 ]
 
@@ -1243,7 +1245,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1252,7 +1254,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1641,7 +1643,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -2045,7 +2047,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
@@ -2078,7 +2080,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "typenum",
 ]
@@ -2385,7 +2387,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -2590,7 +2592,7 @@ dependencies = [
  "der 0.6.1",
  "digest 0.10.7",
  "ff",
- "generic-array",
+ "generic-array 0.14.7",
  "group",
  "pkcs8 0.9.0",
  "rand_core 0.6.4",
@@ -3280,6 +3282,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "generic-array"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe739944a5406424e080edccb6add95685130b9f160d5407c639c7df0c5836b0"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -4107,7 +4118,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -8740,7 +8751,7 @@ checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
  "base16ct 0.1.1",
  "der 0.6.1",
- "generic-array",
+ "generic-array 0.14.7",
  "pkcs8 0.9.0",
  "subtle",
  "zeroize",
@@ -8755,7 +8766,7 @@ dependencies = [
  "aes 0.7.5",
  "block-modes",
  "futures-util",
- "generic-array",
+ "generic-array 0.14.7",
  "hkdf",
  "num",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common 0.1.6",
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -1218,18 +1218,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.5.0"
-source = "git+https://github.com/brxken128/blake3?rev=d3aab416c12a75c2bfabce33bcd594e428a79069#d3aab416c12a75c2bfabce33bcd594e428a79069"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cca6d3674597c30ddf2c587bf8d9d65c9a84d2326d941cc79c9842dfe0ef52"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "digest 0.11.0-pre.8",
- "generic-array 1.0.0",
- "hybrid-array",
- "typenum",
+ "digest 0.10.7",
  "zeroize",
 ]
 
@@ -1245,7 +1243,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -1254,7 +1252,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -1643,7 +1641,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -2047,7 +2045,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
@@ -2080,7 +2078,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "rand_core 0.6.4",
  "typenum",
 ]
@@ -2387,7 +2385,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -2592,7 +2590,7 @@ dependencies = [
  "der 0.6.1",
  "digest 0.10.7",
  "ff",
- "generic-array 0.14.7",
+ "generic-array",
  "group",
  "pkcs8 0.9.0",
  "rand_core 0.6.4",
@@ -3282,15 +3280,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "generic-array"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe739944a5406424e080edccb6add95685130b9f160d5407c639c7df0c5836b0"
-dependencies = [
- "typenum",
 ]
 
 [[package]]
@@ -4118,7 +4107,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -8751,7 +8740,7 @@ checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
  "base16ct 0.1.1",
  "der 0.6.1",
- "generic-array 0.14.7",
+ "generic-array",
  "pkcs8 0.9.0",
  "subtle",
  "zeroize",
@@ -8766,7 +8755,7 @@ dependencies = [
  "aes 0.7.5",
  "block-modes",
  "futures-util",
- "generic-array 0.14.7",
+ "generic-array",
  "hkdf",
  "num",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ async-channel = "2.0.0"
 async-trait = "0.1.77"
 axum = "=0.6.20"
 base64 = "0.21.5"
-blake3 = "1.5.1"
+blake3 = "1.5.0"
 chrono = "0.4.31"
 clap = "4.4.7"
 futures = "0.3.30"
@@ -107,6 +107,8 @@ libp2p = { git = "https://github.com/spacedriveapp/rust-libp2p.git", rev = "a005
 libp2p-core = { git = "https://github.com/spacedriveapp/rust-libp2p.git", rev = "a005656df7e82059a0eb2e333ebada4731d23f8c" }
 libp2p-swarm = { git = "https://github.com/spacedriveapp/rust-libp2p.git", rev = "a005656df7e82059a0eb2e333ebada4731d23f8c" }
 libp2p-stream = { git = "https://github.com/spacedriveapp/rust-libp2p.git", rev = "a005656df7e82059a0eb2e333ebada4731d23f8c" }
+
+blake3 = { git = "https://github.com/spacedriveapp/blake3.git", rev = "d3aab416c12a75c2bfabce33bcd594e428a79069" }
 
 [profile.dev]
 # Make compilation faster on macOS

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,17 @@
 [workspace]
 resolver = "2"
 members = [
-    "core",
-    "core/crates/*",
-    "crates/*",
-    "apps/cli",
-    "apps/p2p-relay",
-    "apps/desktop/src-tauri",
-    "apps/desktop/crates/*",
-    "apps/mobile/modules/sd-core/core",
-    "apps/mobile/modules/sd-core/android/crate",
-    "apps/mobile/modules/sd-core/ios/crate",
-    "apps/server",
+	"core",
+	"core/crates/*",
+	"crates/*",
+	"apps/cli",
+	"apps/p2p-relay",
+	"apps/desktop/src-tauri",
+	"apps/desktop/crates/*",
+	"apps/mobile/modules/sd-core/core",
+	"apps/mobile/modules/sd-core/android/crate",
+	"apps/mobile/modules/sd-core/ios/crate",
+	"apps/server",
 ]
 
 [workspace.package]
@@ -22,19 +22,19 @@ repository = "https://github.com/spacedriveapp/spacedrive"
 [workspace.dependencies]
 # First party dependencies
 prisma-client-rust = { git = "https://github.com/spacedriveapp/prisma-client-rust", rev = "f99d6f5566570f3ab1edecb7a172ad25b03d95af", features = [
-    "specta",
-    "sqlite-create-many",
-    "migrations",
-    "sqlite",
+	"specta",
+	"sqlite-create-many",
+	"migrations",
+	"sqlite",
 ], default-features = false }
 prisma-client-rust-cli = { git = "https://github.com/spacedriveapp/prisma-client-rust", rev = "f99d6f5566570f3ab1edecb7a172ad25b03d95af", features = [
-    "specta",
-    "sqlite-create-many",
-    "migrations",
-    "sqlite",
+	"specta",
+	"sqlite-create-many",
+	"migrations",
+	"sqlite",
 ], default-features = false }
 prisma-client-rust-sdk = { git = "https://github.com/spacedriveapp/prisma-client-rust", rev = "f99d6f5566570f3ab1edecb7a172ad25b03d95af", features = [
-    "sqlite",
+	"sqlite",
 ], default-features = false }
 
 tracing = "0.1.40"
@@ -54,7 +54,7 @@ async-channel = "2.0.0"
 async-trait = "0.1.77"
 axum = "=0.6.20"
 base64 = "0.21.5"
-blake3 = "1.5.0"
+blake3 = "1.5.1"
 chrono = "0.4.31"
 clap = "4.4.7"
 futures = "0.3.30"
@@ -107,10 +107,6 @@ libp2p = { git = "https://github.com/spacedriveapp/rust-libp2p.git", rev = "a005
 libp2p-core = { git = "https://github.com/spacedriveapp/rust-libp2p.git", rev = "a005656df7e82059a0eb2e333ebada4731d23f8c" }
 libp2p-swarm = { git = "https://github.com/spacedriveapp/rust-libp2p.git", rev = "a005656df7e82059a0eb2e333ebada4731d23f8c" }
 libp2p-stream = { git = "https://github.com/spacedriveapp/rust-libp2p.git", rev = "a005656df7e82059a0eb2e333ebada4731d23f8c" }
-
-# aes = { git = "https://github.com/RustCrypto/block-ciphers", rev = "5837233f86419dbe75b8e3824349e30f6bc40b22" }
-
-blake3 = { git = "https://github.com/brxken128/blake3", rev = "d3aab416c12a75c2bfabce33bcd594e428a79069" }
 
 [profile.dev]
 # Make compilation faster on macOS

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -10,10 +10,7 @@ edition = { workspace = true }
 
 [dependencies]
 # Spacedrive Sub-crates
-sd-core = { path = "../../../core", features = [
-	"ffmpeg",
-	"heif",
-] }
+sd-core = { path = "../../../core", features = ["ffmpeg", "heif"] }
 sd-fda = { path = "../../../crates/fda" }
 sd-prisma = { path = "../../../crates/prisma" }
 
@@ -34,17 +31,17 @@ thiserror.workspace = true
 
 opener = { version = "0.6.1", features = ["reveal"] }
 tauri = { version = "=1.5.3", features = [
-    "macos-private-api",
-    "path-all",
-    "protocol-all",
-    "os-all",
-    "shell-all",
-    "dialog-all",
-    "linux-protocol-headers",
-    "updater",
-    "window-all",
-    "native-tls-vendored",
-    "tracing",
+	"macos-private-api",
+	"path-all",
+	"protocol-all",
+	"os-all",
+	"shell-all",
+	"dialog-all",
+	"linux-protocol-headers",
+	"updater",
+	"window-all",
+	"native-tls-vendored",
+	"tracing",
 ] }
 directories = "5.0.1"
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -31,15 +31,15 @@ sd-actors = { version = "0.1.0", path = "../crates/actors" }
 sd-ai = { path = "../crates/ai", optional = true }
 sd-cloud-api = { version = "0.1.0", path = "../crates/cloud-api" }
 sd-crypto = { path = "../crates/crypto", features = [
-    "sys",
-    "tokio",
+	"sys",
+	"tokio",
 ], optional = true }
 sd-ffmpeg = { path = "../crates/ffmpeg", optional = true }
 sd-file-ext = { path = "../crates/file-ext" }
 sd-images = { path = "../crates/images", features = [
-    "rspc",
-    "serde",
-    "specta",
+	"rspc",
+	"serde",
+	"specta",
 ] }
 sd-media-metadata = { path = "../crates/media-metadata" }
 sd-p2p = { path = "../crates/p2p", features = ["specta"] }
@@ -70,12 +70,12 @@ reqwest = { workspace = true, features = ["json", "native-tls-vendored"] }
 rmp-serde = { workspace = true }
 rmpv = { workspace = true }
 rspc = { workspace = true, features = [
-    "axum",
-    "uuid",
-    "chrono",
-    "tracing",
-    "alpha",
-    "unstable",
+	"axum",
+	"uuid",
+	"chrono",
+	"tracing",
+	"alpha",
+	"unstable",
 ] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -86,12 +86,12 @@ strum_macros = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = [
-    "sync",
-    "rt-multi-thread",
-    "io-util",
-    "macros",
-    "time",
-    "process",
+	"sync",
+	"rt-multi-thread",
+	"io-util",
+	"macros",
+	"time",
+	"process",
 ] }
 tokio-stream = { workspace = true, features = ["fs"] }
 tokio-util = { workspace = true, features = ["io"] }
@@ -121,7 +121,7 @@ int-enum = "0.5.0"
 libc = "0.2.153"
 mini-moka = "0.10.2"
 notify = { git = "https://github.com/notify-rs/notify.git", rev = "c3929ed114fbb0bc7457a9a498260461596b00ca", default-features = false, features = [
-    "macos_fsevent",
+	"macos_fsevent",
 ] }
 rmp = "0.8.12"
 serde-hashkey = "0.4.5"
@@ -153,10 +153,10 @@ trash = "4.1.0"
 
 [target.'cfg(target_os = "ios")'.dependencies]
 icrate = { version = "0.1.0", features = [
-    "Foundation",
-    "Foundation_NSFileManager",
-    "Foundation_NSString",
-    "Foundation_NSNumber",
+	"Foundation",
+	"Foundation_NSFileManager",
+	"Foundation_NSString",
+	"Foundation_NSNumber",
 ] }
 
 [dev-dependencies]


### PR DESCRIPTION
 - ~Update BLAKE3 to 1.5.1~
 - ~Remove~ Fix usage of BLAKE3 fork https://github.com/brxken128/blake3 as it is not available anymore. A backup was made here: https://github.com/spacedriveapp/blake3. ~However the changes included in the fork were not essential, so it was removed to allow updating to the last version of BLAKE3~. (The changes were required, revert back to using our backup repo)
  - Auto format Cargo.toml's