### PR TITLE
Create SpacedropError enum for spacedrop() errors

### DIFF
--- a/core/src/api/p2p.rs
+++ b/core/src/api/p2p.rs
@@ -153,8 +153,8 @@ pub(crate) fn mount() -> AlphaRouter<Ctx> {
 						.collect::<Vec<_>>(),
 				)
 				.await
-				.map_err(|_err| {
-					rspc::Error::new(ErrorCode::InternalServerError, "todo: error".into())
+				.map_err(|spacedrop_err| {
+					rspc::Error::new(ErrorCode::InternalServerError, spacedrop_err.to_string())
 				})
 			})
 		})

--- a/core/src/p2p/operations/spacedrop.rs
+++ b/core/src/p2p/operations/spacedrop.rs
@@ -12,6 +12,7 @@ use crate::p2p::{Header, P2PEvent, P2PManager};
 use futures::future::join_all;
 use sd_p2p::{RemoteIdentity, UnicastStream};
 use sd_p2p_block::{BlockSize, Range, SpaceblockRequest, SpaceblockRequests, Transfer};
+use thiserror::Error;
 use tokio::{
 	fs::{create_dir_all, File},
 	io::{AsyncReadExt, AsyncWriteExt, BufReader, BufWriter},
@@ -24,14 +25,25 @@ use uuid::Uuid;
 /// The amount of time to wait for a Spacedrop request to be accepted or rejected before it's automatically rejected
 pub(crate) const SPACEDROP_TIMEOUT: Duration = Duration::from_secs(60);
 
-// TODO: Proper error handling
+#[derive(Debug, Error)]
+pub enum SpacedropError {
+	#[error("paths argument is an empty vector")]
+	EmptyPath,
+	#[error("error connecting to peer")]
+	FailedPeerConnection,
+	#[error("error creating stream: {0}")]
+	FailedNewStream(#[from] sd_p2p::NewStreamError),
+	#[error("error opening file: {0}")]
+	FailedFileOpen(#[from] std::io::Error),
+}
+
 pub async fn spacedrop(
 	p2p: Arc<P2PManager>,
 	identity: RemoteIdentity,
 	paths: Vec<PathBuf>,
-) -> Result<Uuid, ()> {
+) -> Result<Uuid, SpacedropError> {
 	if paths.is_empty() {
-		return Err(());
+		return Err(SpacedropError::EmptyPath);
 	}
 
 	let (files, requests): (Vec<_>, Vec<_>) = join_all(paths.into_iter().map(|path| async move {
@@ -55,10 +67,7 @@ pub async fn spacedrop(
 	.await
 	.into_iter()
 	.collect::<Result<Vec<_>, std::io::Error>>()
-	.map_err(|err| {
-		warn!("error opening file: '{err:?}'");
-		// TODO: Proper error type
-	})?
+	.map_err(|err| SpacedropError::FailedFileOpen(err))?
 	.into_iter()
 	.unzip();
 
@@ -72,13 +81,13 @@ pub async fn spacedrop(
 		.get(&identity)
 		.ok_or_else(|| {
 			debug!("({id}): failed to find connection method with '{identity}'");
-			// TODO: Proper error
+			SpacedropError::FailedPeerConnection
 		})?
 		.clone();
 
 	let mut stream = peer.new_stream().await.map_err(|err| {
 		debug!("({id}): failed to connect to '{identity}': {err:?}");
-		// TODO: Proper error
+		SpacedropError::FailedNewStream(err)
 	})?;
 
 	tokio::spawn(async move {

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -20,3 +20,18 @@ pub use smart_guards::SmartWriteGuard;
 pub use stream::UnicastStream;
 
 pub use flume;
+
+use thiserror::Error;
+use tokio::sync::{mpsc, oneshot};
+
+#[derive(Debug, Error)]
+pub enum NewStreamError {
+	#[error("No connection methods available for peer")]
+	NoConnectionMethodsAvailable,
+	#[error("The event loop is offline")]
+	EventLoopOffline(mpsc::error::SendError<ConnectionRequest>),
+	#[error("Failed to establish the connection w/ error: {0}")]
+	ConnectionNeverEstablished(oneshot::error::RecvError),
+	#[error("error connecting to peer: {0}")]
+	Connecting(String),
+}

--- a/crates/p2p/src/peer.rs
+++ b/crates/p2p/src/peer.rs
@@ -4,6 +4,7 @@ use std::{
 	sync::{Arc, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard, Weak},
 };
 
+use crate::NewStreamError;
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
 use tracing::warn;
@@ -297,16 +298,4 @@ impl Peer {
 			});
 		}
 	}
-}
-
-#[derive(Debug, Error)]
-pub enum NewStreamError {
-	#[error("No connection methods available for peer")]
-	NoConnectionMethodsAvailable,
-	#[error("The event loop is offline")]
-	EventLoopOffline(mpsc::error::SendError<ConnectionRequest>),
-	#[error("Failed to establish the connection w/ error: {0}")]
-	ConnectionNeverEstablished(oneshot::error::RecvError),
-	#[error("error connecting to peer: {0}")]
-	Connecting(String),
 }


### PR DESCRIPTION
<!-- Put any information about this PR up here -->
1. Creates an enum for Spacedrop errors called `SpacedropError`
2. Changes the return type of `spacedrop()` from `Result<Uuid, ()>` to `Result<Uuid, SpacedropError>`
3. Uses the error messages in `core/src/api/p2p.rs` instead of `"todo: error"`

<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->

Closes #2468
