### PR TITLE
Improve Tunnel error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9455,6 +9455,7 @@ name = "sd-p2p-tunnel"
 version = "0.1.0"
 dependencies = [
  "sd-p2p",
+ "thiserror",
  "tokio",
 ]
 

--- a/crates/p2p-tunnel/Cargo.toml
+++ b/crates/p2p-tunnel/Cargo.toml
@@ -11,3 +11,4 @@ repository.workspace = true
 sd-p2p = { path = "../p2p" }
 
 tokio = { workspace = true, features = ["io-util"] }
+thiserror = { workspace = true }


### PR DESCRIPTION
<!-- Put any information about this PR up here -->
1. Creates the `TunnelError` enum
2. Modifies `Tunnel.responder()` and `Tunnel.initiator()` to return `Result<Self, TunnelError>` instead of `Result<Self, &'static str>`

<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->

Closes #2478
