### PR TITLE
p2p: improve error handling for QuicTransport

### DIFF
--- a/core/src/p2p/manager.rs
+++ b/core/src/p2p/manager.rs
@@ -67,7 +67,7 @@ impl P2PManager {
 	> {
 		let (tx, rx) = bounded(25);
 		let p2p = P2P::new(SPACEDRIVE_APP_ID, node_config.get().await.identity, tx);
-		let (quic, lp2p_peer_id) = QuicTransport::spawn(p2p.clone())?;
+		let (quic, lp2p_peer_id) = QuicTransport::spawn(p2p.clone()).map_err(|e| e.to_string())?;
 		let libraries_hook_id = libraries_hook(p2p.clone(), libraries);
 		let this = Arc::new(Self {
 			p2p: p2p.clone(),


### PR DESCRIPTION
<!-- Put any information about this PR up here -->
1. Creates the `QuicTransportError` enum
2. Changes the return types of `QuicTransport.spawn()`, `QuicTransport.set_ipv4_enabled()`, `QuicTransport.set_ipv6_enabled()`, and `QuicTransport.setup_listener()` to use `QuicTransportError` instead of `String` as the error variant of their `Result`. 

<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->

Closes #2481
