### PR TITLE
Faster debug builds

### DIFF
--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -34,15 +34,6 @@ runs:
       shell: bash
       run: echo '{}' | npx -y mustache - .cargo/config.toml.mustache .cargo/config.toml
 
-    - name: Turn Off Debuginfo and bump opt-level
-      if: ${{ runner.os == 'Windows' }}
-      shell: powershell
-      run: |
-        (Get-Content Cargo.toml) -replace '\[profile.dev\]', '[profile.dev]
-        debug = 0' | Set-Content Cargo.toml
-        (Get-Content Cargo.toml) -replace '\[profile.dev\]', '[profile.dev]
-        opt-level=1' | Set-Content Cargo.toml
-
     - name: Restore cached Prisma codegen
       id: cache-prisma-restore
       uses: actions/cache/restore@v4

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -35,18 +35,6 @@ runs:
       run: echo '{}' | npx -y mustache - .cargo/config.toml.mustache .cargo/config.toml
 
     - name: Turn Off Debuginfo and bump opt-level
-      shell: bash
-      if: ${{ runner.os != 'Windows' }}
-      run: |
-        sed '/\[profile.dev]/a\
-        debug = 0
-        ' Cargo.toml > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-
-        sed '/\[profile.dev]/a\
-        opt-level=1
-        ' Cargo.toml > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-
-    - name: Turn Off Debuginfo and bump opt-level
       if: ${{ runner.os == 'Windows' }}
       shell: powershell
       run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,12 @@ pdfium-render = { git = "https://github.com/fogodev/pdfium-render.git", rev = "e
 [profile.dev]
 # Make compilation faster on macOS
 split-debuginfo = "unpacked"
+opt-level = 0
+debug = 0
+strip = "none"
+lto = false
+codegen-units = 256
+incremental = true
 
 # Set the settings for build scripts and proc-macros.
 [profile.dev.build-override]


### PR DESCRIPTION
<!-- Put any information about this PR up here -->

Config the dev profile for faster debug builds. That's a simple change, but I found it to be quite good for dev workflow.

A clean `pnpm tauri dev` went from 5m to 3m20s (better, but I'm certain we can improve), and it's even better when during small iterations of changes-and-check, or change-and-test (when the incremental changes start doing its thing).

The downside of these changes is that we lose the debug symbols (**only in debug builds, this does not affect release builds**)

<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->
