### PR TITLE
Make sync ingest setting public

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -19,6 +19,7 @@
 		"dialog:allow-open",
 		"window:allow-close",
 		"window:allow-minimize",
-		"window:allow-toggle-maximize"
+		"window:allow-toggle-maximize",
+		"dialog:allow-confirm"
 	]
 }

--- a/core/crates/sync/src/ingest.rs
+++ b/core/crates/sync/src/ingest.rs
@@ -152,7 +152,7 @@ impl Actor {
 		shared
 			.actors
 			.declare(
-				"Sync Ingester",
+				"Sync Ingest",
 				{
 					let shared = shared.clone();
 					move || async move {

--- a/interface/app/$libraryId/settings/Sidebar.tsx
+++ b/interface/app/$libraryId/settings/Sidebar.tsx
@@ -117,12 +117,10 @@ export default () => {
 						<Icon component={MagnifyingGlass} />
 						Saved Searches
 					</SidebarLink> */}
-					{useFeatureFlag('cloudSync') && (
-						<SidebarLink to="library/sync">
-							<Icon component={ArrowsClockwise} />
-							{t('sync')}
-						</SidebarLink>
-					)}
+					<SidebarLink to="library/sync">
+						<Icon component={ArrowsClockwise} />
+						{t('sync')}
+					</SidebarLink>
 					<SidebarLink disabled to="library/clouds">
 						<Icon component={Cloud} />
 						{t('clouds')}

--- a/interface/app/$libraryId/settings/library/sync.tsx
+++ b/interface/app/$libraryId/settings/library/sync.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import { useEffect, useState } from 'react';
 import {
 	Procedures,
+	useFeatureFlag,
 	useLibraryMutation,
 	useLibraryQuery,
 	useLibrarySubscription,
@@ -35,6 +36,8 @@ export const Component = () => {
 	const [data, setData] = useState<inferSubscriptionResult<Procedures, 'library.actors'>>({});
 
 	useLibrarySubscription(['library.actors'], { onData: setData });
+
+	const cloudSync = useFeatureFlag('cloudSync');
 
 	return (
 		<>
@@ -78,7 +81,8 @@ export const Component = () => {
 							)}
 						</div>
 					</Setting>
-					<CloudSync data={data} />
+
+					{cloudSync && <CloudSync data={data} />}
 				</>
 			)}
 		</>


### PR DESCRIPTION
Only cloud stuff is hidden behind the `cloudSync` feature now. This also fixes the backend feature flag dialog, since the dialog permission wasn't granted.