### PR TITLE
Fix front-end error when selecting multiple files with inspector open

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,7 +1,5 @@
 ; make all engine requirements (e.g. node version) strictly kept
 engine-strict=true
-; tempfix for pnpm#5909: https://github.com/pnpm/pnpm/issues/5909#issuecomment-1397758156
-prefer-symlinked-executables=false
 ; necessary for metro + mobile
 strict-peer-dependencies=false
 node-linker=hoisted

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -63,11 +63,3 @@ default = ["custom-protocol"]
 devtools = ["tauri/devtools"]
 ai-models = ["sd-core/ai"]
 custom-protocol = ["tauri/custom-protocol"]
-
-# Optimize release builds
-[profile.release]
-panic = "abort"   # Strip expensive panic clean-up logic
-codegen-units = 1 # Compile crates one after another so the compiler can optimize better
-lto = true        # Enables link to optimizations
-opt-level = "s"   # Optimize for binary size
-strip = true      # Remove debug symbols

--- a/apps/mobile/src/components/overview/StatCard.tsx
+++ b/apps/mobile/src/components/overview/StatCard.tsx
@@ -25,7 +25,7 @@ const StatCard = ({ icon, name, connectionType, ...stats }: StatCardProps) => {
 		return {
 			totalSpace,
 			freeSpace,
-			usedSpaceSpace: humanizeSize(totalSpace.original - freeSpace.original)
+			usedSpaceSpace: humanizeSize(totalSpace.bytes - freeSpace.bytes)
 		};
 	}, [stats]);
 
@@ -34,7 +34,7 @@ const StatCard = ({ icon, name, connectionType, ...stats }: StatCardProps) => {
 	}, []);
 
 	const progress = useMemo(() => {
-		if (!mounted || totalSpace.original === 0) return 0;
+		if (!mounted || totalSpace.bytes === 0n) return 0;
 		return Math.floor((usedSpaceSpace.value / totalSpace.value) * 100);
 	}, [mounted, totalSpace, usedSpaceSpace]);
 

--- a/interface/app/$libraryId/Explorer/Inspector/index.tsx
+++ b/interface/app/$libraryId/Explorer/Inspector/index.tsx
@@ -483,7 +483,7 @@ const MultiItemMetadata = ({ items }: { items: ExplorerItem[] }) => {
 						getExplorerItemData(item);
 
 					if (item.type !== 'NonIndexedPath' || !item.item.is_dir) {
-						metadata.size = (metadata.size ?? BigInt(0)) + BigInt(size.original);
+						metadata.size = (metadata.size ?? 0n) + size.bytes;
 					}
 
 					if (dateCreated)

--- a/interface/app/$libraryId/overview/StatCard.tsx
+++ b/interface/app/$libraryId/overview/StatCard.tsx
@@ -27,7 +27,7 @@ const StatCard = ({ icon, name, connectionType, ...stats }: StatCardProps) => {
 		return {
 			totalSpace,
 			freeSpace,
-			usedSpaceSpace: humanizeSize(totalSpace.original - freeSpace.original)
+			usedSpaceSpace: humanizeSize(totalSpace.bytes - freeSpace.bytes)
 		};
 	}, [stats]);
 
@@ -36,7 +36,7 @@ const StatCard = ({ icon, name, connectionType, ...stats }: StatCardProps) => {
 	}, []);
 
 	const progress = useMemo(() => {
-		if (!mounted || totalSpace.original === 0) return 0;
+		if (!mounted || totalSpace.bytes === 0n) return 0;
 		return Math.floor((usedSpaceSpace.value / totalSpace.value) * 100);
 	}, [mounted, totalSpace, usedSpaceSpace]);
 

--- a/package.json
+++ b/package.json
@@ -69,6 +69,5 @@
 	"eslintConfig": {
 		"root": true
 	},
-	"packageManager": "pnpm@9.1.0",
-	"engineStrict": false
+	"packageManager": "pnpm@9.1.1"
 }

--- a/packages/client/src/lib/humanizeSize.ts
+++ b/packages/client/src/lib/humanizeSize.ts
@@ -89,7 +89,7 @@ export interface ByteSizeOpts {
 }
 
 /**
- * Returns an object with the spec `{ value: string, unit: string, long: string }`. The returned object defines a `toString` method meaning it can be used in any string context.
+ * Returns an object with the spec `{ unit: string, long: string, bytes: bigint, value: number }`. The returned object defines a `toString` method meaning it can be used in any string context.
  *
  * @param value - The bytes value to convert.
  * @param options - Optional config.
@@ -111,9 +111,16 @@ export const humanizeSize = (
 ) => {
 	if (value == null) value = 0n;
 	if (Array.isArray(value)) value = bytesToNumber(value);
-	else if (typeof value === 'number') value = BigInt(value | 0);
 	else if (typeof value !== 'bigint') value = BigInt(value);
-	const [isNegative, bytes] = value < 0n ? [true, -value] : [false, value];
+	const [isNegative, bytes] =
+		typeof value === 'number'
+			? value < 0
+				? // Note: These magic shift operations internally convert value from f64 to u32
+					[true, BigInt(-value >>> 0)]
+				: [false, BigInt(value >>> 0)]
+			: value < 0n
+				? [true, -value]
+				: [false, value];
 
 	const unit = getBaseUnit(bytes, base_unit === 'decimal' ? DECIMAL_UNITS : BINARY_UNITS);
 	const defaultFormat = new Intl.NumberFormat(locales, {
@@ -126,14 +133,15 @@ export const humanizeSize = (
 		unit.from === 0n
 			? Number(bytes)
 			: Number((bytes * BigInt(precisionFactor)) / unit.from) / precisionFactor;
+	const plural = use_plural && value !== 1 ? 's' : '';
 
 	return {
 		unit: is_bit ? BYTE_TO_BIT[unit.short as keyof typeof BYTE_TO_BIT] : unit.short,
 		long: is_bit ? BYTE_TO_BIT[unit.long as keyof typeof BYTE_TO_BIT] : unit.long,
+		bytes,
 		value: (isNegative ? -1 : 1) * value,
-		original: value,
 		toString() {
-			return `${defaultFormat.format(this.value)} ${this.unit}`;
+			return `${defaultFormat.format(this.value)} ${this.unit}${plural}`;
 		}
 	};
 };

--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -138,7 +138,7 @@ export function insertLibrary(queryClient: QueryClient, library: LibraryConfigWr
 }
 
 export function int32ArrayToBigInt([high, low]: [number, number]) {
-	// Note: These magic shift operations internally convert the high into i32 and the low into u32
+	// Note: These magic shift operations internally convert high into i32 and low into u32
 	return (BigInt(high | 0) << 32n) | BigInt(low >>> 0);
 }
 


### PR DESCRIPTION
 - Fix humanizeSize returning value as original (which was simply plain wrong), replace it with the original bytes
 - Restore plural to humanizeSize, but only when converting object to string
 - Fix float number to BigInt conversion in humanizeSize possibly causing an error (now it truncates the value)
 - Remove unused profile.release from `apps/desktop/src-tauri/Cargo.toml`, repo's main Cargo.toml profile overrides it
 - Update `packageManager` and remove conflicting `engineStrict` entry from package.json
 - Remove `prefer-symlinked-executables` from `.npmrc`, linked bug was fixed