### PR TITLE
Remove unnecessary allocation

### DIFF
--- a/core/crates/indexer-rules/src/lib.rs
+++ b/core/crates/indexer-rules/src/lib.rs
@@ -474,10 +474,6 @@ impl IndexerRuler {
 	pub async fn has_system(&self, rule: &SystemIndexerRule) -> bool {
 		let rules = self.rules.read().await;
 
-		rules
-			.iter()
-			.map(|rule| (rule.id, rule.name.clone()))
-			.collect::<Vec<(Option<i32>, String)>>();
 		rules.iter().any(|inner_rule| rule == inner_rule)
 	}
 }


### PR DESCRIPTION
https://github.com/spacedriveapp/spacedrive/pull/2459 introduced this snippet that does nothing, this allocation isn't used nor is necessary.

