### PR TITLE
Display captured backtrace when available

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -260,6 +260,7 @@ async fn main() -> tauri::Result<()> {
 
 					handle.windows().iter().for_each(|(_, window)| {
 						if should_clear_localstorage {
+							println!("cleaning localStorage");
 							for webview in window.webviews() {
 								webview.eval("localStorage.clear();").ok();
 							}

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -260,7 +260,6 @@ async fn main() -> tauri::Result<()> {
 
 					handle.windows().iter().for_each(|(_, window)| {
 						if should_clear_localstorage {
-							println!("bruh?");
 							for webview in window.webviews() {
 								webview.eval("localStorage.clear();").ok();
 							}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -212,8 +212,6 @@ impl Node {
 				"info"
 			};
 
-			// let level = "debug"; // Exists for now to debug the location manager
-
 			std::env::set_var(
 				"RUST_LOG",
 				format!("info,sd_core={level},sd_p2p=debug,sd_core::location::manager=info,sd_ai={level}"),
@@ -239,12 +237,20 @@ impl Node {
 			.init();
 
 		std::panic::set_hook(Box::new(move |panic| {
+			use std::backtrace::{Backtrace, BacktraceStatus};
+			let backtrace = Backtrace::capture();
 			if let Some(location) = panic.location() {
 				tracing::error!(
 					message = %panic,
 					panic.file = format!("{}:{}", location.file(), location.line()),
 					panic.column = location.column(),
 				);
+				if backtrace.status() == BacktraceStatus::Captured {
+					// NOTE(matheus-consoli): it seems that `tauri` is messing up the stack-trace
+					// and it doesn't capture anything, even when `RUST_BACKTRACE=full`,
+					// so in the current architecture, this is emitting an empty event.
+					tracing::error!(message = %backtrace);
+				}
 			} else {
 				tracing::error!(message = %panic);
 			}


### PR DESCRIPTION
<!-- Put any information about this PR up here -->

Tries to capture and display the backtrace when the system crashes.





Note tho, that in the current state, it seems that tauri is somehow messing with the backtrace, so if the `core` crashes, it only captures an empty backtrace - I'm still not sure why, and I will investigate more later.

But with this added code, we at least start capturing the stacktrace, and when we figure out the tauri issue or move the `core` to a daemon architecture, it will emit the stacktrace.

As an example, if we create `core/src/bin/a.rs`:

```rust
use sd_core::Node;

fn main() {
	let _guard = Node::init_logger("./").unwrap();
	panic!("ops");
}
```


and run the application `RUST_BACKTRACE=1 cargo run`, it will emit the backtrace:

<details>
  <summary>Collapsed</summary>

```sh
2024-05-24T16:53:29.496031Z ERROR sd_core: core/src/lib.rs:243: panicked at core/src/bin/backtrace.rs:5:5:
ops panic.file="core/src/bin/backtrace.rs:5" panic.column=5
2024-05-24T16:53:29.500813Z ERROR sd_core: core/src/lib.rs:252:    0: sd_core::Node::init_logger::{{closure}}
   1: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/alloc/src/boxed.rs:2034:9
   2: std::panicking::rust_panic_with_hook
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panicking.rs:783:13
   3: std::panicking::begin_panic_handler::{{closure}}
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panicking.rs:649:13
   4: std::sys_common::backtrace::__rust_end_short_backtrace
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/sys_common/backtrace.rs:171:18
   5: rust_begin_unwind
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panicking.rs:645:5
   6: core::panicking::panic_fmt
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/panicking.rs:72:14
   7: backtrace::main
   8: core::ops::function::FnOnce::call_once
   9: std::sys_common::backtrace::__rust_begin_short_backtrace
  10: std::rt::lang_start::{{closure}}
  11: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/ops/function.rs:284:13
  12: std::panicking::try::do_call
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panicking.rs:552:40
  13: std::panicking::try
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panicking.rs:516:19
  14: std::panic::catch_unwind
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panic.rs:146:14
  15: std::rt::lang_start_internal::{{closure}}
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/rt.rs:148:48
  16: std::panicking::try::do_call
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panicking.rs:552:40
  17: std::panicking::try
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panicking.rs:516:19
  18: std::panic::catch_unwind
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panic.rs:146:14
  19: std::rt::lang_start_internal
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/rt.rs:148:20
  20: std::rt::lang_start
  21: main
  22: <unknown>
  23: __libc_start_main
  24: _start
```
</details>


<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->
