### PR TITLE
No Duplicating Tags

### DIFF
--- a/core/src/api/tags.rs
+++ b/core/src/api/tags.rs
@@ -89,7 +89,8 @@ pub(crate) fn mount() -> AlphaRouter<Ctx> {
 			R.with2(library())
 				.mutation(|(_, library), args: TagCreateArgs| async move {
 					// Check if tag with the same name already exists
-					let existing_tag = library.db
+					let existing_tag = library
+						.db
 						.tag()
 						.find_many(vec![tag::name::equals(Some(args.name.clone()))])
 						.select(tag::select!({ id }))


### PR DESCRIPTION
This PR makes it so tags cannot be created with the same name, stopping duplicate tags from existing. The front-end doesn't exist and this PR adds backend functionality. 

This is the error now from the backend when trying to create a duplicate tag:

```
Error executing operation: ErrResolverError(Error { code: Conflict, message: "Tag with the same name already exists", cause: None })
 ```
