### PR TITLE
[ENG-1776] Delete cloud ops after they've been ingested

### DIFF
--- a/core/crates/sync/README.md
+++ b/core/crates/sync/README.md
@@ -109,7 +109,7 @@ usually because the scalar fields are local and disconnected from the Sync ID.
 ```rs
 let (sync_params, db_params): (Vec<_>, Vec<_>) = [
 	sync_db_entry!(
-		prisma_sync::object::SyncId { pub_idk: object_pub_id },
+		prisma_sync::object::SyncId { pub_id: object_pub_id },
 		file_path::object
 	)
 ].into_iter().unzip();

--- a/core/crates/sync/README.md
+++ b/core/crates/sync/README.md
@@ -2,8 +2,6 @@
 
 Spacedrive's sync system. Consumes types and helpers from `sd-sync`.
 
-## Using Sync
-
 ### Creating Records
 
 Prepare a sync id by creating or obtaining its value,
@@ -99,5 +97,36 @@ sync.write_ops(
         db_params
     )
   )
+)
+```
+
+### Setting Relation Fields
+
+Setting relation fields requires providing the Sync ID of the relation.
+Setting the relation field's scalar fields instead will not properly sync then relation,
+usually because the scalar fields are local and disconnected from the Sync ID.
+
+```rs
+let (sync_params, db_params): (Vec<_>, Vec<_>) = [
+	sync_db_entry!(
+		prisma_sync::object::SyncId { pub_idk: object_pub_id },
+		file_path::object
+	)
+].into_iter().unzip();
+
+sync.write_ops(
+	db,
+	(
+		sync.shared_update(
+			prisma_sync::file_path::SyncId {
+				pub_id: file_path_pub_id
+			},
+			sync_params
+		),
+		db.file_path().update(
+			file_path::id::equals(file_path_id),
+			db_params
+		)
+	)
 )
 ```

--- a/core/crates/sync/src/db_operation.rs
+++ b/core/crates/sync/src/db_operation.rs
@@ -41,14 +41,17 @@ impl cloud_crdt_include::Data {
 		Uuid::from_slice(&self.instance.pub_id).unwrap()
 	}
 
-	pub fn into_operation(self) -> CRDTOperation {
-		CRDTOperation {
-			instance: self.instance(),
-			timestamp: self.timestamp(),
-			record_id: rmp_serde::from_slice(&self.record_id).unwrap(),
-			model: self.model as u16,
-			data: serde_json::from_slice(&self.data).unwrap(),
-		}
+	pub fn into_operation(self) -> (i32, CRDTOperation) {
+		(
+			self.id,
+			CRDTOperation {
+				instance: self.instance(),
+				timestamp: self.timestamp(),
+				record_id: rmp_serde::from_slice(&self.record_id).unwrap(),
+				model: self.model as u16,
+				data: serde_json::from_slice(&self.data).unwrap(),
+			},
+		)
 	}
 }
 

--- a/core/crates/sync/src/ingest.rs
+++ b/core/crates/sync/src/ingest.rs
@@ -31,7 +31,7 @@ pub enum Request {
 		timestamps: Vec<(Uuid, NTP64)>,
 		tx: oneshot::Sender<()>,
 	},
-	Ingested,
+	// Ingested,
 	FinishedIngesting,
 }
 
@@ -425,7 +425,7 @@ impl Actor {
 
 		self.timestamps.write().await.insert(instance, new_ts);
 
-		self.io.req_tx.send(Request::Ingested).await.ok();
+		// self.io.req_tx.send(Request::Ingested).await.ok();
 
 		Ok(())
 	}

--- a/core/crates/sync/src/ingest.rs
+++ b/core/crates/sync/src/ingest.rs
@@ -129,6 +129,10 @@ impl Actor {
 					}
 				}
 
+				if let Some(tx) = event.wait_tx {
+					tx.send(()).ok();
+				}
+
 				match event.has_more {
 					true => State::RetrievingMessages,
 					false => {
@@ -445,6 +449,7 @@ pub struct MessagesEvent {
 	pub instance_id: Uuid,
 	pub messages: CompressedCRDTOperations,
 	pub has_more: bool,
+	pub wait_tx: Option<oneshot::Sender<()>>,
 }
 
 impl ActorTypes for Actor {

--- a/core/crates/sync/src/manager.rs
+++ b/core/crates/sync/src/manager.rs
@@ -246,7 +246,7 @@ impl Manager {
 	pub async fn get_cloud_ops(
 		&self,
 		args: GetOpsArgs,
-	) -> prisma_client_rust::Result<Vec<CRDTOperation>> {
+	) -> prisma_client_rust::Result<Vec<(i32, CRDTOperation)>> {
 		let db = &self.db;
 
 		macro_rules! db_args {

--- a/core/crates/sync/tests/mock_instance.rs
+++ b/core/crates/sync/tests/mock_instance.rs
@@ -128,6 +128,7 @@ impl Instance {
 										messages: CompressedCRDTOperations::new(messages),
 										has_more: false,
 										instance_id: instance1.id,
+										wait_tx: None,
 									}))
 									.await
 									.unwrap();

--- a/core/crates/sync/tests/mock_instance.rs
+++ b/core/crates/sync/tests/mock_instance.rs
@@ -133,9 +133,9 @@ impl Instance {
 									.await
 									.unwrap();
 							}
-							ingest::Request::Ingested => {
-								instance2.sync.tx.send(SyncMessage::Ingested).ok();
-							}
+							// ingest::Request::Ingested => {
+							// 	instance2.sync.tx.send(SyncMessage::Ingested).ok();
+							// }
 							ingest::Request::FinishedIngesting => {}
 						}
 					}

--- a/core/src/p2p/sync/mod.rs
+++ b/core/src/p2p/sync/mod.rs
@@ -252,7 +252,7 @@ mod responder {
 					instance_id: library.sync.instance,
 					has_more: ops.len() == OPS_PER_REQUEST as usize,
 					messages: ops,
-					wait_tx: None,
+					wait_tx: Some(wait_tx),
 				}))
 				.await
 				.expect("TODO: Handle ingest channel closed, so we don't loose ops");


### PR DESCRIPTION
Cached sync operations from the cloud need to be deleted after they're processed, otherwise they'd build up over time.