### PR TITLE
Disable AppNap for macOS and fix app version in deb

### DIFF
--- a/apps/desktop/crates/macos/src-swift/window.swift
+++ b/apps/desktop/crates/macos/src-swift/window.swift
@@ -1,10 +1,39 @@
 import AppKit
+import SwiftRs
 
 @objc
 public enum AppThemeType: Int {
   case auto = -1
   case light = 0
   case dark = 1
+}
+
+var activity: NSObjectProtocol?
+
+@_cdecl("disable_app_nap")
+public func disableAppNap(reason: SRString) -> Bool {
+    // Check if App Nap is already disabled
+    guard activity == nil else {
+        return false
+    }
+
+    activity = ProcessInfo.processInfo.beginActivity(
+        options: .userInitiatedAllowingIdleSystemSleep,
+        reason: reason.toString()
+    )
+    return true
+}
+
+@_cdecl("enable_app_nap")
+public func enableAppNap() -> Bool {
+    // Check if App Nap is already enabled
+    guard let pinfo = activity else {
+        return false
+    }
+
+    ProcessInfo.processInfo.endActivity(pinfo)
+    activity = nil
+    return true
 }
 
 @_cdecl("lock_app_theme")

--- a/apps/desktop/crates/macos/src/lib.rs
+++ b/apps/desktop/crates/macos/src/lib.rs
@@ -9,10 +9,10 @@ pub enum AppThemeType {
 	Dark = 1 as Int,
 }
 
+swift!(pub fn disable_app_nap(reason: &SRString) -> Bool);
+swift!(pub fn enable_app_nap() -> Bool);
 swift!(pub fn lock_app_theme(theme_type: Int));
 swift!(pub fn set_titlebar_style(window: &NSObject, is_fullscreen: Bool));
-// swift!(pub fn setup_disk_watcher(window: &NSObject, transparent: Bool, large: Bool));
-// swift!(pub fn disk_event_callback(mounted: Bool, path: &SRString));
 swift!(pub fn reload_webview(webview: &NSObject));
 
 #[repr(C)]
@@ -30,20 +30,3 @@ pub fn open_file_paths_with(file_urls: &[String], with_url: &str) {
 	let file_url = file_urls.join("\0");
 	unsafe { open_file_path_with(&file_url.as_str().into(), &with_url.into()) }
 }
-
-// main!(|_| {
-// 	unsafe { setup_disk_watcher() };
-// 	print!("Waiting for disk events... ");
-// 	Ok(())
-// });
-
-// #[no_mangle]
-// pub extern "C" fn disk_event_callback(mounted: Bool, path: *const SRString) {
-// 	let mounted_str = if mounted { "mounted" } else { "unmounted" };
-
-// 	// Convert the raw pointer to a reference
-// 	let path_ref = unsafe { &*path };
-// 	let path_str = path_ref.to_string(); // Assuming SRString has a to_string method
-
-// 	println!("Disk at path {} was {}", path_str, mounted_str);
-// }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -289,7 +289,10 @@ async fn main() -> tauri::Result<()> {
 								sd_desktop_macos::set_titlebar_style(
 									&window.ns_window().expect("NSWindows must exist on macOS"),
 									false,
-								)
+								);
+								sd_desktop_macos::disable_app_nap(
+									&"File indexer needs to run unimpeded".into(),
+								);
 							};
 						}
 					});

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,6 @@
 {
 	"$schema": "https://github.com/tauri-apps/tauri/raw/tauri-v2.0.0-beta.17/core/tauri-config-schema/schema.json",
 	"productName": "Spacedrive",
-	"version": "0.2.13",
 	"identifier": "com.spacedrive.desktop",
 	"build": {
 		"beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
 - Disable app nap on app launch on macOS, as this was negatively affecting file indexer when the app window was in the background
 - Remove version from tauri.conf.json so tauri fallback to the version defined in Cargo.toml
 - Probably fix updater asking to update when you already have (same problem as above)