### PR TITLE
Serve thumbnails over P2P

### DIFF
--- a/apps/desktop/src/platform.ts
+++ b/apps/desktop/src/platform.ts
@@ -45,9 +45,9 @@ function constructServerUrl(urlSuffix: string) {
 
 export const platform = {
 	platform: 'tauri',
-	getThumbnailUrlByThumbKey: (keyParts) =>
+	getThumbnailUrlByThumbKey: (library_id, cas_id) =>
 		constructServerUrl(
-			`/thumbnail/${keyParts.map((i) => encodeURIComponent(i)).join('/')}.webp`
+			`/thumbnail/${encodeURIComponent(library_id)}/${encodeURIComponent(cas_id)}`
 		),
 	getFileUrl: (libraryId, locationLocalId, filePathId) =>
 		constructServerUrl(`/file/${libraryId}/${locationLocalId}/${filePathId}`),

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -42,8 +42,8 @@ const spacedriveURL = (() => {
 
 const platform: Platform = {
 	platform: 'web',
-	getThumbnailUrlByThumbKey: (keyParts) =>
-		`${spacedriveURL}/thumbnail/${keyParts.map((i) => encodeURIComponent(i)).join('/')}.webp`,
+	getThumbnailUrlByThumbKey: (library_id, cas_id) =>
+		`${spacedriveURL}/thumbnail/${encodeURIComponent(library_id)}/${encodeURIComponent(cas_id)}`,
 	getFileUrl: (libraryId, locationLocalId, filePathId) =>
 		`${spacedriveURL}/file/${encodeURIComponent(libraryId)}/${encodeURIComponent(
 			locationLocalId

--- a/core/src/custom_uri/mod.rs
+++ b/core/src/custom_uri/mod.rs
@@ -320,16 +320,6 @@ pub fn base_router() -> Router<LocalState> {
 							.body(body::boxed(Full::from(""))));
 						}
 					};
-
-					let file = File::open(&path).await.map_err(|err| {
-						InfallibleResponse::builder()
-							.status(if err.kind() == io::ErrorKind::NotFound {
-								StatusCode::NOT_FOUND
-							} else {
-								StatusCode::INTERNAL_SERVER_ERROR
-							})
-							.body(body::boxed(Full::from("")))
-					})?;
 					let metadata = file.metadata().await;
 					serve_file(
 						file,

--- a/core/src/p2p/manager.rs
+++ b/core/src/p2p/manager.rs
@@ -441,7 +441,7 @@ async fn start(
 						return;
 					};
 
-					error!("Failed to handling library file request with {remote:?} for {req}: {err:?}");
+					error!("Failed to handling library file request with {remote:?} for {req:?}: {err:?}");
 				}
 			};
 		});

--- a/core/src/p2p/manager.rs
+++ b/core/src/p2p/manager.rs
@@ -433,18 +433,15 @@ async fn start(
 
 					error!("Failed to handling rspc request with '{remote}': {err:?}");
 				}
-				Header::LibraryFile {
-					file_path_id,
-					range,
-				} => {
+				Header::LibraryFile { req, range } => {
 					let remote = stream.remote_identity();
 					let Err(err) =
-						operations::library::receiver(stream, file_path_id, range, &node).await
+						operations::library::receiver(stream, req.clone(), range, &node).await
 					else {
 						return;
 					};
 
-					error!("Failed to handling library file request with {remote:?} for {file_path_id}: {err:?}");
+					error!("Failed to handling library file request with {remote:?} for {req}: {err:?}");
 				}
 			};
 		});

--- a/interface/app/$libraryId/Explorer/FilePath/Thumb.tsx
+++ b/interface/app/$libraryId/Explorer/FilePath/Thumb.tsx
@@ -67,9 +67,9 @@ export const FileThumb = forwardRef<HTMLImageElement, ThumbProps>((props, ref) =
 
 		if (thumbType === 'thumbnail')
 			if (
-				loadState.thumbnail !== 'error' &&
-				itemData.hasLocalThumbnail &&
-				itemData.thumbnailKey.length > 0
+				loadState.thumbnail !== 'error' // &&
+				// itemData.hasLocalThumbnail &&
+				// itemData.thumbnailKey.length > 0
 			)
 				return { variant: 'thumbnail' };
 

--- a/interface/app/$libraryId/Explorer/FilePath/Thumb.tsx
+++ b/interface/app/$libraryId/Explorer/FilePath/Thumb.tsx
@@ -87,8 +87,8 @@ export const FileThumb = forwardRef<HTMLImageElement, ThumbProps>((props, ref) =
 				break;
 
 			case 'thumbnail':
-				if (itemData.thumbnailKey.length > 0)
-					return platform.getThumbnailUrlByThumbKey(itemData.thumbnailKey);
+				if (itemData.casId)
+					return platform.getThumbnailUrlByThumbKey(library.uuid, itemData.casId);
 
 				break;
 			case 'icon':

--- a/interface/app/index.tsx
+++ b/interface/app/index.tsx
@@ -235,10 +235,10 @@ function RemoteLayout() {
 		() =>
 			({
 				...platform,
-				getThumbnailUrlByThumbKey: (thumbKey) =>
+				getThumbnailUrlByThumbKey: (library_id, cas_id) =>
 					platform.constructRemoteRspcPath(
 						params.node,
-						`thumbnail/${thumbKey.map((i) => encodeURIComponent(i)).join('/')}.webp`
+						`thumbnail/${encodeURIComponent(library_id)}/${encodeURIComponent(cas_id)}`
 					),
 				getFileUrl: (libraryId, locationLocalId, filePathId) =>
 					platform.constructRemoteRspcPath(

--- a/interface/util/Platform.tsx
+++ b/interface/util/Platform.tsx
@@ -17,7 +17,7 @@ export type OpenWithApplication = { url: string; name: string };
 // This could be Tauri or web.
 export type Platform = {
 	platform: 'web' | 'tauri'; // This represents the specific platform implementation
-	getThumbnailUrlByThumbKey: (thumbKey: string[]) => string;
+	getThumbnailUrlByThumbKey: (library_id: 'ephemeral' | string, cas_id: string) => string;
 	getFileUrl: (libraryId: string, locationLocalId: number, filePathId: number) => string;
 	getFileUrlByPath: (path: string) => string;
 	getRemoteRspcEndpoint: (remote_identity: string) => {


### PR DESCRIPTION
This PR builds on top of #2523 to allow thumbnails to be served via P2P from the node where the file exists.

Although we will sync preview media, having the ability to serve it over P2P means we can suffice before the first sync and we can also support scenarios were only a portion of the preview media is sunk.