### PR TITLE
Cleanup: remove unnecessary #[allow(dead_code)] and #[allow(unused)] attributes

### DIFF
--- a/core/crates/file-path-helper/src/lib.rs
+++ b/core/crates/file-path-helper/src/lib.rs
@@ -198,7 +198,6 @@ pub fn filter_existing_file_path_params(
 /// With this function we try to do a loose filtering of file paths, to avoid having to do check
 /// twice for directories and for files. This is because directories have a trailing `/` or `\` in
 /// the materialized path
-#[allow(unused)]
 pub fn loose_find_existing_file_path_params(
 	location_id: location::id::Type,
 	location_path: impl AsRef<Path>,

--- a/core/src/api/utils/invalidate.rs
+++ b/core/src/api/utils/invalidate.rs
@@ -55,7 +55,6 @@ impl InvalidateOperationEvent {
 
 /// a request to invalidate a specific resource
 #[derive(Debug)]
-#[allow(dead_code)]
 pub(crate) struct InvalidationRequest {
 	pub key: &'static str,
 	pub arg_ty: Option<DataType>,
@@ -65,13 +64,11 @@ pub(crate) struct InvalidationRequest {
 
 /// invalidation request for a specific resource
 #[derive(Debug, Default)]
-#[allow(dead_code)]
 pub(crate) struct InvalidRequests {
 	pub queries: Vec<InvalidationRequest>,
 }
 
 impl InvalidRequests {
-	#[allow(unused)]
 	const fn new() -> Self {
 		Self {
 			queries: Vec::new(),

--- a/core/src/location/manager/mod.rs
+++ b/core/src/location/manager/mod.rs
@@ -29,14 +29,12 @@ mod watcher;
 mod helpers;
 
 #[derive(Clone, Copy, Debug)]
-#[allow(dead_code)]
 enum ManagementMessageAction {
 	Add,
 	Remove,
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub struct LocationManagementMessage {
 	location_id: location::id::Type,
 	library: Arc<Library>,
@@ -45,7 +43,6 @@ pub struct LocationManagementMessage {
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
 enum WatcherManagementMessageAction {
 	Stop,
 	Reinit,
@@ -53,7 +50,6 @@ enum WatcherManagementMessageAction {
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub struct WatcherManagementMessage {
 	location_id: location::id::Type,
 	library: Arc<Library>,

--- a/core/src/p2p/operations/rspc.rs
+++ b/core/src/p2p/operations/rspc.rs
@@ -9,7 +9,6 @@ use tracing::debug;
 use crate::{p2p::Header, Node};
 
 /// Transfer an rspc query to a remote node.
-#[allow(unused)]
 pub async fn remote_rspc(
 	p2p: Arc<P2P>,
 	identity: RemoteIdentity,

--- a/crates/sync-generator/src/lib.rs
+++ b/crates/sync-generator/src/lib.rs
@@ -17,7 +17,6 @@ enum Error {}
 #[derive(serde::Deserialize)]
 struct SDSyncGenerator {}
 
-#[allow(unused)]
 #[derive(Clone)]
 pub enum ModelSyncType<'a> {
 	Local {


### PR DESCRIPTION
<!-- Put any information about this PR up here -->
I found 4 instances of `#[allow(unused)]` and 6 instances of `#[allow(dead_code)]` across 5 source files, where the code was not actually dead or unused. This PR removes the usage of these unnecessary attributes.

<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->


