### PR TITLE
Streamline conversion from Key to GenericArray

### DIFF
--- a/crates/crypto/src/types.rs
+++ b/crates/crypto/src/types.rs
@@ -326,7 +326,7 @@ where
 	I: ArrayLength<u8>,
 {
 	fn from(value: &Key) -> Self {
-		value.expose().iter().copied().collect() // TODO(brxken128): streamline this?
+		GenericArray::clone_from_slice(value.expose())
 	}
 }
 


### PR DESCRIPTION
This constructs the `GenericArray` directly, instead of using an iterator. 

And resolves a TODO comment.
