### PR TITLE
[MOB-72] Tracing logs not working on Android

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
+name = "android_log-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85965b6739a430150bdd138e2374a98af0c3ee0d030b3bb7fc3bddff58d0102e"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9024,6 +9030,7 @@ dependencies = [
  "tokio-util",
  "tower-service",
  "tracing",
+ "tracing-android",
  "tracing-appender",
  "tracing-subscriber",
  "tracing-test",
@@ -11237,6 +11244,17 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-android"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12612be8f868a09c0ceae7113ff26afe79d81a24473a393cb9120ece162e86c0"
+dependencies = [
+ "android_log-sys",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ tokio = "1.38"
 tokio-stream = "0.1.15"
 tokio-util = "0.7.11"
 tracing = "0.1.40"
+tracing-android = "0.2.0"
 tracing-subscriber = "0.3.18"
 tracing-test = "0.2.5"
 uhlc = "0.6.0"                                        # Must follow version used by specta

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,6 @@ tokio = "1.38"
 tokio-stream = "0.1.15"
 tokio-util = "0.7.11"
 tracing = "0.1.40"
-tracing-android = "0.2.0"
 tracing-subscriber = "0.3.18"
 tracing-test = "0.2.5"
 uhlc = "0.6.0"                                        # Must follow version used by specta

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -102,6 +102,7 @@ tokio = { workspace = true, features = [
 tokio-stream = { workspace = true, features = ["fs"] }
 tokio-util = { workspace = true, features = ["io"] }
 tracing = { workspace = true }
+tracing-android = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 uuid = { workspace = true, features = ["v4", "serde"] }
 webp = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -102,7 +102,6 @@ tokio = { workspace = true, features = [
 tokio-stream = { workspace = true, features = ["fs"] }
 tokio-util = { workspace = true, features = ["io"] }
 tracing = { workspace = true }
-tracing-android = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 uuid = { workspace = true, features = ["v4", "serde"] }
 webp = { workspace = true }
@@ -159,6 +158,9 @@ icrate = { version = "0.1.2", features = [
 	"Foundation_NSString",
 	"Foundation_NSNumber",
 ] }
+
+[target.'cfg(target_os = "android")'.dependencies]
+tracing-android = "0.2.0"
 
 [dev-dependencies]
 # Workspace dependencies

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -262,7 +262,7 @@ impl Node {
 					.with_file(true)
 					.with_line_number(true)
 					.with_ansi(false)
-					.with_target(false)
+					.with_target(true)
 					.with_writer(logfile)
 					.with_filter(EnvFilter::from_default_env()),
 			)

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -258,16 +258,14 @@ impl Node {
 
 		let registry = registry();
 
-		#[cfg(target_os = "android")]
-		let registry = registry.with(tracing_android::layer("com.spacedrive.app").unwrap());
-
 		let registry = registry
 			.with(
 				tracing_subscriber::fmt::layer()
 					.with_file(true)
 					.with_line_number(true)
 					.with_ansi(false)
-					// .with_writer(logfile)
+					.with_target(false)
+					.with_writer(logfile)
 					.with_filter(EnvFilter::from_default_env()),
 			)
 			.with(
@@ -277,6 +275,9 @@ impl Node {
 					.with_writer(std::io::stdout)
 					.with_filter(EnvFilter::from_default_env()),
 			);
+
+		#[cfg(target_os = "android")]
+		let registry = registry.with(tracing_android::layer("com.spacedrive.app").unwrap());
 
 		registry.init();
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -235,13 +235,11 @@ impl Node {
 
 		// Set a default if the user hasn't set an override
 		if std::env::var("RUST_LOG") == Err(std::env::VarError::NotPresent) {
-			// let level = if cfg!(debug_assertions) {
-			// 	"debug"
-			// } else {
-			// 	"info"
-			// };
-
-			let level = "debug";
+			let level = if cfg!(debug_assertions) {
+				"debug"
+			} else {
+				"info"
+			};
 
 			std::env::set_var(
 				"RUST_LOG",


### PR DESCRIPTION
This PR fixes the issue of getting logs from the rust core on Android. Currently, when building for Android, logs will stop showing up after the `Spacedrive Online!` message.

Now, logs will go to `adb logcat` instead of the logfile. Please run `adb logcat | grep -i com.spacedrive.app` when looking at logs, in order to only see logs from the Spacedrive Rust core.