### PR TITLE
[ENG-1808] Fix job manager icons

### DIFF
--- a/interface/app/$libraryId/Explorer/Inspector/index.tsx
+++ b/interface/app/$libraryId/Explorer/Inspector/index.tsx
@@ -12,6 +12,20 @@ import {
 	Icon as PhosphorIcon,
 	Snowflake
 } from '@phosphor-icons/react';
+import clsx from 'clsx';
+import dayjs from 'dayjs';
+import {
+	forwardRef,
+	useCallback,
+	useEffect,
+	useMemo,
+	useState,
+	type HTMLAttributes,
+	type ReactNode
+} from 'react';
+import { useLocation } from 'react-router';
+import { Link as NavLink } from 'react-router-dom';
+import Sticky from 'react-sticky-el';
 import {
 	FilePath,
 	FilePathForFrontend,
@@ -28,20 +42,6 @@ import {
 	type ExplorerItem
 } from '@sd/client';
 import { Button, Divider, DropdownMenu, toast, Tooltip, tw } from '@sd/ui';
-import clsx from 'clsx';
-import dayjs from 'dayjs';
-import {
-	forwardRef,
-	useCallback,
-	useEffect,
-	useMemo,
-	useState,
-	type HTMLAttributes,
-	type ReactNode
-} from 'react';
-import { useLocation } from 'react-router';
-import { Link as NavLink } from 'react-router-dom';
-import Sticky from 'react-sticky-el';
 import { LibraryIdParamsSchema } from '~/app/route-schemas';
 import { Folder, Icon } from '~/components';
 import { useLocale, useZodRouteParams } from '~/hooks';
@@ -102,11 +102,7 @@ export const Inspector = forwardRef<HTMLDivElement, Props>(
 		const { t } = useLocale();
 		return (
 			<div ref={ref} style={{ width: INSPECTOR_WIDTH, ...style }} {...props}>
-				<Sticky
-					scrollElement=".explorer-inspector-scroll"
-					stickyClassName="!top-[40px]"
-					topOffset={-40}
-				>
+				<Sticky stickyClassName="!top-[40px]" topOffset={-40}>
 					{showThumbnail && (
 						<div className="relative mb-2 flex aspect-square items-center justify-center px-2">
 							{isNonEmpty(selectedItems) ? (
@@ -525,7 +521,6 @@ const MultiItemMetadata = ({ items }: { items: ExplorerItem[] }) => {
 
 	const onlyNonIndexed = metadata.types.has('NonIndexedPath') && metadata.types.size === 1;
 	const filesSize = humanizeSize(metadata.size);
-
 
 	return (
 		<>

--- a/interface/app/$libraryId/Layout/Sidebar/JobManager/Job.tsx
+++ b/interface/app/$libraryId/Layout/Sidebar/JobManager/Job.tsx
@@ -24,13 +24,13 @@ interface JobProps {
 }
 
 const JobIcon: Record<string, Icon> = {
-	indexer: Folder,
-	media_processor: Image,
-	file_identifier: Fingerprint,
-	file_copier: Copy,
-	file_deleter: Trash,
-	file_cutter: Scissors,
-	object_validator: Fingerprint
+	Indexer: Folder,
+	MediaProcessor: Image,
+	FileIdentifier: Fingerprint,
+	FileCopier: Copy,
+	FileDeleter: Trash,
+	FileCutter: Scissors,
+	ObjectValidator: Fingerprint
 };
 
 function Job({ job, className, isChild, progress }: JobProps) {


### PR DESCRIPTION
**This PR**: 

- Simply fixes icons of job manager, key names have changed since improving jobs PR was merged.
- Removed un-necessary classname from inspector, after testing, it isn't needed + was giving error messages in console.

![image](https://github.com/spacedriveapp/spacedrive/assets/33054370/7fbdeb80-a676-4f34-bdcc-6b109b20b2a6)
