### PR TITLE
[ENG-1814] Assign objects to directories on File Identifier Job

### DIFF
--- a/core/crates/heavy-lifting/src/file_identifier/job.rs
+++ b/core/crates/heavy-lifting/src/file_identifier/job.rs
@@ -482,6 +482,7 @@ impl FileIdentifier {
 			%task_id,
 			?extract_metadata_time,
 			?save_db_time,
+			file_paths_to_object_processor_count = file_paths_by_cas_id.len(),
 			created_objects_count,
 			total_identified_files,
 			errors_count = errors.len()

--- a/core/crates/heavy-lifting/src/file_identifier/mod.rs
+++ b/core/crates/heavy-lifting/src/file_identifier/mod.rs
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
 use specta::Type;
 use tokio::fs;
 use tracing::trace;
+use uuid::Uuid;
 
 mod cas_id;
 pub mod job;
@@ -71,8 +72,15 @@ pub enum NonCriticalFileIdentifierError {
 	#[cfg(target_os = "windows")]
 	#[error("failed to extract metadata from on-demand file: {0}")]
 	FailedToExtractMetadataFromOnDemandFile(String),
-	#[error("failed to extract isolated file path data: {0}")]
-	FailedToExtractIsolatedFilePathData(String),
+	#[error(
+		"failed to extract isolated file path data: <file_path_id='{file_path_pub_id}'>: {error}"
+	)]
+	FailedToExtractIsolatedFilePathData {
+		file_path_pub_id: Uuid,
+		error: String,
+	},
+	#[error("file path without is_dir field: <file_path_id='{0}'>")]
+	FilePathWithoutIsDirField(file_path::id::Type),
 }
 
 #[derive(Debug, Clone)]
@@ -115,11 +123,15 @@ impl FileMetadata {
 		let cas_id = if fs_metadata.len() != 0 {
 			generate_cas_id(&path, fs_metadata.len())
 				.await
-				.map(Some)
 				.map_err(|e| FileIOError::from((&path, e)))?
 		} else {
 			// We can't do shit with empty files
-			None
+			trace!(path = %path.display(), %kind, "Skipping empty file;");
+			return Ok(Self {
+				cas_id: None,
+				kind,
+				fs_metadata,
+			});
 		};
 
 		trace!(
@@ -130,7 +142,7 @@ impl FileMetadata {
 		);
 
 		Ok(Self {
-			cas_id,
+			cas_id: Some(cas_id),
 			kind,
 			fs_metadata,
 		})
@@ -148,14 +160,12 @@ fn orphan_path_filters_shallow(
 				file_path::object_id::equals(None),
 				file_path::cas_id::equals(None)
 			),
-			file_path::is_dir::equals(Some(false)),
 			file_path::location_id::equals(Some(location_id)),
 			file_path::materialized_path::equals(Some(
 				sub_iso_file_path
 					.materialized_path_for_children()
 					.expect("sub path for shallow identifier must be a directory"),
 			)),
-			file_path::size_in_bytes_bytes::not(Some(0u64.to_be_bytes().to_vec())),
 		],
 		[file_path_id.map(file_path::id::gt)],
 	)
@@ -172,9 +182,7 @@ fn orphan_path_filters_deep(
 				file_path::object_id::equals(None),
 				file_path::cas_id::equals(None)
 			),
-			file_path::is_dir::equals(Some(false)),
 			file_path::location_id::equals(Some(location_id)),
-			file_path::size_in_bytes_bytes::not(Some(0u64.to_be_bytes().to_vec())),
 		],
 		[
 			// this is a workaround for the cursor not working properly

--- a/core/crates/heavy-lifting/src/file_identifier/mod.rs
+++ b/core/crates/heavy-lifting/src/file_identifier/mod.rs
@@ -16,7 +16,7 @@ use std::{
 	sync::Arc,
 };
 
-use prisma_client_rust::{or, QueryError};
+use prisma_client_rust::QueryError;
 use rspc::ErrorCode;
 use serde::{Deserialize, Serialize};
 use specta::Type;
@@ -156,10 +156,7 @@ fn orphan_path_filters_shallow(
 ) -> Vec<file_path::WhereParam> {
 	sd_utils::chain_optional_iter(
 		[
-			or!(
-				file_path::object_id::equals(None),
-				file_path::cas_id::equals(None)
-			),
+			file_path::object_id::equals(None),
 			file_path::location_id::equals(Some(location_id)),
 			file_path::materialized_path::equals(Some(
 				sub_iso_file_path
@@ -178,10 +175,7 @@ fn orphan_path_filters_deep(
 ) -> Vec<file_path::WhereParam> {
 	sd_utils::chain_optional_iter(
 		[
-			or!(
-				file_path::object_id::equals(None),
-				file_path::cas_id::equals(None)
-			),
+			file_path::object_id::equals(None),
 			file_path::location_id::equals(Some(location_id)),
 		],
 		[

--- a/core/crates/heavy-lifting/src/file_identifier/tasks/identifier.rs
+++ b/core/crates/heavy-lifting/src/file_identifier/tasks/identifier.rs
@@ -19,15 +19,15 @@ use sd_task_system::{
 use sd_utils::{error::FileIOError, msgpack};
 
 use std::{
-	collections::HashMap, future::IntoFuture, mem, path::PathBuf, pin::pin, sync::Arc,
-	time::Duration,
+	collections::HashMap, convert::identity, future::IntoFuture, mem, path::PathBuf, pin::pin,
+	sync::Arc, time::Duration,
 };
 
 use futures::stream::{self, FuturesUnordered, StreamExt};
 use futures_concurrency::{future::TryJoin, stream::Merge};
 use serde::{Deserialize, Serialize};
 use tokio::time::Instant;
-use tracing::{error, instrument, trace, Level};
+use tracing::{error, instrument, trace, warn, Level};
 
 use super::{create_objects_and_update_file_paths, FilePathToCreateOrLinkObject};
 
@@ -309,17 +309,61 @@ impl Identifier {
 		db: Arc<PrismaClient>,
 		sync: Arc<SyncManager>,
 	) -> Self {
+		let mut output = Output::default();
+
+		let file_paths_count = file_paths.len();
+		let directories_count = file_paths
+			.iter()
+			.filter(|file_path| file_path.is_dir.is_some_and(identity))
+			.count();
+
+		let (file_paths_by_id, file_paths_without_cas_id) = file_paths.into_iter().fold(
+			(
+				HashMap::with_capacity(file_paths_count - directories_count),
+				Vec::with_capacity(directories_count),
+			),
+			|(mut file_paths_by_id, mut directory_file_paths), file_path| {
+				match file_path.is_dir {
+					Some(true) => {
+						let file_path_for_file_identifier::Data {
+							id,
+							pub_id,
+							date_created,
+							..
+						} = file_path;
+						directory_file_paths.push(FilePathToCreateOrLinkObject {
+							id,
+							file_path_pub_id: pub_id.into(),
+							kind: ObjectKind::Folder,
+							created_at: date_created,
+						});
+					}
+					Some(false) => {
+						file_paths_by_id.insert(file_path.pub_id.as_slice().into(), file_path);
+					}
+					None => {
+						warn!(%file_path.id, "file path without is_dir field, skipping;");
+						output.errors.push(
+						file_identifier::NonCriticalFileIdentifierError::FilePathWithoutIsDirField(
+							file_path.id,
+						)
+						.into(),
+					);
+					}
+				};
+
+				(file_paths_by_id, directory_file_paths)
+			},
+		);
+
 		Self {
 			id: TaskId::new_v4(),
 			location,
 			location_path,
-			identified_files: HashMap::with_capacity(file_paths.len()),
-			file_paths_without_cas_id: Vec::with_capacity(file_paths.len()),
-			file_paths_by_id: file_paths
-				.into_iter()
-				.map(|file_path| (file_path.pub_id.as_slice().into(), file_path))
-				.collect(),
-			output: Output::default(),
+			identified_files: HashMap::with_capacity(file_paths_count - directories_count),
+			file_paths_without_cas_id,
+			file_paths_by_id,
+			output,
 			with_priority,
 			db,
 			sync,
@@ -419,19 +463,19 @@ fn try_iso_file_path_extraction(
 	location_path: Arc<PathBuf>,
 	errors: &mut Vec<NonCriticalError>,
 ) -> Option<(FilePathPubId, IsolatedFilePathData<'static>, Arc<PathBuf>)> {
-	IsolatedFilePathData::try_from((location_id, file_path))
+	match IsolatedFilePathData::try_from((location_id, file_path))
 		.map(IsolatedFilePathData::to_owned)
-		.map_err(|e| {
-			error!(?e, "Failed to extract isolated file path data;");
+	{
+		Ok(iso_file_path) => Some((file_path_pub_id, iso_file_path, location_path)),
+		Err(e) => {
+			error!(?e, %file_path_pub_id, "Failed to extract isolated file path data;");
 			errors.push(
-				file_identifier::NonCriticalFileIdentifierError::FailedToExtractIsolatedFilePathData(format!(
-					"<file_path_pub_id='{file_path_pub_id}', error={e}>"
-				))
-				.into(),
+				file_identifier::NonCriticalFileIdentifierError::FailedToExtractIsolatedFilePathData { file_path_pub_id: file_path_pub_id.into(), error: e.to_string() }.into(),
+
 			);
-		})
-		.map(|iso_file_path| (file_path_pub_id, iso_file_path, location_path))
-		.ok()
+			None
+		}
+	}
 }
 
 #[derive(Serialize, Deserialize)]

--- a/core/crates/heavy-lifting/src/file_identifier/tasks/identifier.rs
+++ b/core/crates/heavy-lifting/src/file_identifier/tasks/identifier.rs
@@ -293,6 +293,23 @@ impl Task<Error> for Identifier {
 			);
 
 			trace!(save_db_time = ?output.save_db_time, "Cas_ids saved to db;");
+		} else if !file_paths_without_cas_id.is_empty() {
+			let start_time = Instant::now();
+
+			// Assign objects to directories
+			let file_path_ids_with_new_object = create_objects_and_update_file_paths(
+				file_paths_without_cas_id.drain(..),
+				&self.db,
+				&self.sync,
+			)
+			.await?;
+
+			output.save_db_time = start_time.elapsed();
+			output.created_objects_count = file_path_ids_with_new_object.len() as u64;
+			output.file_path_ids_with_new_object =
+				file_path_ids_with_new_object.into_keys().collect();
+
+			trace!(save_db_time = ?output.save_db_time, "Directories objects saved to db;");
 		}
 
 		Ok(ExecStatus::Done(mem::take(output).into_output()))

--- a/core/crates/heavy-lifting/src/file_identifier/tasks/object_processor.rs
+++ b/core/crates/heavy-lifting/src/file_identifier/tasks/object_processor.rs
@@ -173,7 +173,8 @@ impl Task<Error> for ObjectProcessor {
 					file_path_ids_with_new_object.extend(more_file_paths_with_new_object);
 					*linked_objects_count += more_linked_objects_count;
 
-					*created_objects_count = file_path_ids_with_new_object.len() as u64;
+					*created_objects_count =
+						file_path_ids_with_new_object.len() as u64 - *linked_objects_count;
 
 					trace!(%created_objects_count, ?create_object_time, "Created new Objects;");
 

--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -496,7 +496,7 @@ name: string; identity: RemoteIdentity; p2p: NodeConfigP2P; features: BackendFea
 
 export type NonCriticalError = { indexer: NonCriticalIndexerError } | { file_identifier: NonCriticalFileIdentifierError } | { media_processor: NonCriticalMediaProcessorError }
 
-export type NonCriticalFileIdentifierError = { failed_to_extract_file_metadata: string } | { failed_to_extract_isolated_file_path_data: string }
+export type NonCriticalFileIdentifierError = { failed_to_extract_file_metadata: string } | { failed_to_extract_isolated_file_path_data: { file_path_pub_id: string; error: string } } | { file_path_without_is_dir_field: number }
 
 export type NonCriticalIndexerError = { failed_directory_entry: string } | { metadata: string } | { indexer_rule: string } | { file_path_metadata: string } | { fetch_already_existing_file_path_ids: string } | { fetch_file_paths_to_remove: string } | { iso_file_path: string } | { dispatch_keep_walking: string } | { missing_file_path_data: string }
 


### PR DESCRIPTION
Now we're properly identifying directories and empty files, assigning objects to both of them, even though we can't process then to generate a cas_id.