### PR TITLE
Revert ENG-1812

### DIFF
--- a/interface/app/$libraryId/Explorer/index.tsx
+++ b/interface/app/$libraryId/Explorer/index.tsx
@@ -1,5 +1,5 @@
 import { FolderNotchOpen } from '@phosphor-icons/react';
-import { CSSProperties, useEffect, type PropsWithChildren, type ReactNode } from 'react';
+import { CSSProperties, type PropsWithChildren, type ReactNode } from 'react';
 import {
 	explorerLayout,
 	useExplorerLayoutStore,

--- a/interface/app/$libraryId/recents.tsx
+++ b/interface/app/$libraryId/recents.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { ObjectOrder, objectOrderingKeysSchema } from '@sd/client';
 import { Icon } from '~/components';
 import { useLocale, useRouteTitle } from '~/hooks';
@@ -16,8 +16,6 @@ import { TopBarPortal } from './TopBar/Portal';
 
 export function Component() {
 	useRouteTitle('Recents');
-
-	const [_, setForceRender] = useState(false);
 
 	const explorerSettings = useExplorerSettings({
 		settings: useMemo(() => {
@@ -49,13 +47,6 @@ export function Component() {
 		isFetchingNextPage: items.query.isFetchingNextPage,
 		settings: explorerSettings
 	});
-
-	//this forces a re-render so that the explorer can update and show the objects
-	//since this is a recents page issue only - this is sufficient unless otherwise
-	useEffect(() => {
-		setForceRender((prev) => !prev);
-	}, [items.query.isFetching]);
-
 	return (
 		<ExplorerContextProvider explorer={explorer}>
 			<SearchContextProvider search={search}>
@@ -76,7 +67,7 @@ export function Component() {
 					)}
 				</TopBarPortal>
 			</SearchContextProvider>
-			<Explorer
+					<Explorer
 				emptyNotice={
 					<EmptyNotice
 						icon={<Icon name="Collection" size={128} />}

--- a/interface/app/$libraryId/recents.tsx
+++ b/interface/app/$libraryId/recents.tsx
@@ -67,7 +67,7 @@ export function Component() {
 					)}
 				</TopBarPortal>
 			</SearchContextProvider>
-					<Explorer
+			<Explorer
 				emptyNotice={
 					<EmptyNotice
 						icon={<Icon name="Collection" size={128} />}


### PR DESCRIPTION
We are reverting 1812 due to the issue existing within all explorer related routes, and not just recents page.