### PR TITLE
[ENG-1816] Fix explorer rendering

### DIFF
--- a/interface/app/$libraryId/Explorer/View/GridView/index.tsx
+++ b/interface/app/$libraryId/Explorer/View/GridView/index.tsx
@@ -1,5 +1,5 @@
 import { Grid, useGrid } from '@virtual-grid/react';
-import { useCallback } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useExplorerLayoutStore } from '@sd/client';
 
 import { useExplorerContext } from '../../Context';

--- a/interface/app/$libraryId/Explorer/View/index.tsx
+++ b/interface/app/$libraryId/Explorer/View/index.tsx
@@ -122,7 +122,7 @@ export const View = ({ emptyNotice, ...contextProps }: ExplorerViewProps) => {
 	// with the correct padding when the tags are toggled
 	// also fixes a bug where grid items would not render initially
 	useEffect(() => {
-		if (forceRender === 0) setForceRender((prev) => prev + 1)
+		if (forceRender === 0) setForceRender((prev) => prev + 1);
 	}, [layoutStore.showTags, explorer.isFetching, forceRender]);
 
 	useEffect(() => {

--- a/interface/app/$libraryId/Explorer/View/index.tsx
+++ b/interface/app/$libraryId/Explorer/View/index.tsx
@@ -5,6 +5,7 @@ import {
 	ExplorerLayout,
 	explorerLayout,
 	getItemObject,
+	useExplorerLayoutStore,
 	useSelector,
 	type Object
 } from '@sd/client';
@@ -51,6 +52,7 @@ export const View = ({ emptyNotice, ...contextProps }: ExplorerViewProps) => {
 
 	const quickPreview = useQuickPreviewContext();
 	const quickPreviewStore = useQuickPreviewStore();
+	const layoutStore = useExplorerLayoutStore();
 
 	const [{ path }] = useExplorerSearchParams();
 
@@ -59,6 +61,7 @@ export const View = ({ emptyNotice, ...contextProps }: ExplorerViewProps) => {
 	const ref = useRef<HTMLDivElement | null>(null);
 
 	const [showLoading, setShowLoading] = useState(false);
+	const [forceRender, setForceRender] = useState(0);
 
 	const selectable =
 		explorer.selectable &&
@@ -114,6 +117,13 @@ export const View = ({ emptyNotice, ...contextProps }: ExplorerViewProps) => {
 			return () => clearTimeout(timer);
 		} else setShowLoading(false);
 	}, [explorer.isFetchingNextPage]);
+
+	// this makes sure that the grid is re-rendered
+	// with the correct padding when the tags are toggled
+	// also fixes a bug where grid items would not render initially
+	useEffect(() => {
+		if (forceRender === 0) setForceRender((prev) => prev + 1)
+	}, [layoutStore.showTags, explorer.isFetching, forceRender]);
 
 	useEffect(() => {
 		if (explorer.layouts[layoutMode]) return;

--- a/interface/app/$libraryId/Explorer/useExplorer.ts
+++ b/interface/app/$libraryId/Explorer/useExplorer.ts
@@ -41,6 +41,7 @@ export interface UseExplorerProps<TOrder extends Ordering> {
 	parent?: ExplorerParent;
 	loadMore?: () => void;
 	isFetchingNextPage?: boolean;
+	isFetching?: boolean;
 	isLoadingPreferences?: boolean;
 	scrollRef?: RefObject<HTMLDivElement>;
 	overscan?: number;

--- a/interface/app/$libraryId/favorites.tsx
+++ b/interface/app/$libraryId/favorites.tsx
@@ -45,6 +45,7 @@ export function Component() {
 	const explorer = useExplorer({
 		...items,
 		isFetchingNextPage: items.query.isFetchingNextPage,
+		isFetching: items.query.isFetching,
 		settings: explorerSettings
 	});
 

--- a/interface/app/$libraryId/location/$id.tsx
+++ b/interface/app/$libraryId/location/$id.tsx
@@ -102,6 +102,7 @@ const LocationExplorer = ({ location }: { location: Location; path?: string }) =
 	const explorer = useExplorer({
 		...items,
 		isFetchingNextPage: items.query.isFetchingNextPage,
+		isFetching: items.query.isFetching,
 		isLoadingPreferences: preferences.isLoading,
 		settings: explorerSettings,
 		parent: { type: 'Location', location }

--- a/interface/app/$libraryId/recents.tsx
+++ b/interface/app/$libraryId/recents.tsx
@@ -44,6 +44,7 @@ export function Component() {
 
 	const explorer = useExplorer({
 		...items,
+		isFetching: items.query.isFetching,
 		isFetchingNextPage: items.query.isFetchingNextPage,
 		settings: explorerSettings
 	});

--- a/interface/app/$libraryId/tag/$id.tsx
+++ b/interface/app/$libraryId/tag/$id.tsx
@@ -43,6 +43,7 @@ export function Component() {
 	const explorer = useExplorer({
 		...items,
 		isFetchingNextPage: items.query.isFetchingNextPage,
+		isFetching: items.query.isFetching,
 		isLoadingPreferences: preferences.isLoading,
 		settings: explorerSettings,
 		parent: { type: 'Tag', tag: tag }


### PR DESCRIPTION
**This PR**:  Fixes initial rendering of explorer by making sure the initial rendering is successful and not blank.

- Also fixes updating gap values when "show tags" is toggled, previously it would take a few toggles for Explorer to update, now it's instant.

