### PR TITLE
Use default props for Top Bar icons

### DIFF
--- a/interface/app/$libraryId/Explorer/TopBarOptions.tsx
+++ b/interface/app/$libraryId/Explorer/TopBarOptions.tsx
@@ -16,7 +16,12 @@ import { useKeyMatcher, useLocale } from '~/hooks';
 
 import { KeyManager } from '../KeyManager';
 import { Spacedrop, SpacedropButton } from '../Spacedrop';
-import TopBarOptions, { ToolOption, TOP_BAR_ICON_CLASSLIST } from '../TopBar/TopBarOptions';
+import TopBarOptions, {
+	ToolOption,
+	TOP_BAR_ICON_CLASSLIST,
+	TOP_BAR_ICON_DEFAULT_PROPS,
+	TOP_BAR_ICON_WEIGHT
+} from '../TopBar/TopBarOptions';
 import { useExplorerContext } from './Context';
 import OptionsPanel from './OptionsPanel';
 import { explorerStore } from './store';
@@ -49,7 +54,7 @@ export const useExplorerTopBarOptions = () => {
 					const option = {
 						layout,
 						toolTipLabel: t(`${layout}_view`),
-						icon: <Icon className={TOP_BAR_ICON_CLASSLIST} />,
+						icon: <Icon {...TOP_BAR_ICON_DEFAULT_PROPS} />,
 						keybinds: [controlIcon, (i + 1).toString()],
 						topBarActive:
 							!explorer.isLoadingPreferences && settings.layoutMode === layout,
@@ -74,7 +79,7 @@ export const useExplorerTopBarOptions = () => {
 	const controlOptions: ToolOption[] = [
 		{
 			toolTipLabel: t('explorer_settings'),
-			icon: <SlidersHorizontal className={TOP_BAR_ICON_CLASSLIST} />,
+			icon: <SlidersHorizontal {...TOP_BAR_ICON_DEFAULT_PROPS} />,
 			popOverComponent: <OptionsPanel />,
 			individual: true,
 			showAtResolution: 'sm:flex'
@@ -87,7 +92,8 @@ export const useExplorerTopBarOptions = () => {
 			},
 			icon: (
 				<SidebarSimple
-					weight={showInspector ? 'fill' : 'regular'}
+					{...TOP_BAR_ICON_DEFAULT_PROPS}
+					weight={showInspector ? 'fill' : TOP_BAR_ICON_WEIGHT}
 					className={clsx(TOP_BAR_ICON_CLASSLIST, '-scale-x-100')}
 				/>
 			),
@@ -120,7 +126,7 @@ export const useExplorerTopBarOptions = () => {
 		},
 		{
 			toolTipLabel: 'Key Manager',
-			icon: <Key className={TOP_BAR_ICON_CLASSLIST} />,
+			icon: <Key {...TOP_BAR_ICON_DEFAULT_PROPS} />,
 			popOverComponent: <KeyManager />,
 			individual: true,
 			showAtResolution: 'xl:flex'
@@ -129,8 +135,8 @@ export const useExplorerTopBarOptions = () => {
 			toolTipLabel: 'Assign tags',
 			icon: (
 				<Tag
-					weight={tagAssignMode ? 'fill' : 'regular'}
-					className={TOP_BAR_ICON_CLASSLIST}
+					{...TOP_BAR_ICON_DEFAULT_PROPS}
+					weight={tagAssignMode ? 'fill' : TOP_BAR_ICON_WEIGHT}
 				/>
 			),
 			// TODO: Assign tag mode is not yet implemented!

--- a/interface/app/$libraryId/Spacedrop/index.tsx
+++ b/interface/app/$libraryId/Spacedrop/index.tsx
@@ -15,7 +15,7 @@ import { useDropzone, useLocale, useOnDndLeave } from '~/hooks';
 import { hardwareModelToIcon } from '~/util/hardware';
 import { usePlatform } from '~/util/Platform';
 
-import { TOP_BAR_ICON_CLASSLIST } from '../TopBar/TopBarOptions';
+import { TOP_BAR_ICON_DEFAULT_PROPS } from '../TopBar/TopBarOptions';
 import { useIncomingSpacedropToast, useSpacedropProgressToast } from './toast';
 
 // TODO: This is super hacky so should probs be rewritten but for now it works.
@@ -57,7 +57,7 @@ export function SpacedropButton({ triggerOpen }: { triggerOpen: () => void }) {
 
 	return (
 		<div ref={ref} className={dndState === 'active' && !isPanelOpen ? 'animate-bounce' : ''}>
-			<Planet className={TOP_BAR_ICON_CLASSLIST} />
+			<Planet {...TOP_BAR_ICON_DEFAULT_PROPS} />
 		</div>
 	);
 }

--- a/interface/app/$libraryId/TopBar/TopBarMobile.tsx
+++ b/interface/app/$libraryId/TopBar/TopBarMobile.tsx
@@ -3,7 +3,7 @@ import React, { forwardRef, HTMLAttributes } from 'react';
 import { Popover, usePopover } from '@sd/ui';
 
 import TopBarButton, { TopBarButtonProps } from './TopBarButton';
-import { ToolOption, TOP_BAR_ICON_CLASSLIST } from './TopBarOptions';
+import { ToolOption, TOP_BAR_ICON_DEFAULT_PROPS } from './TopBarOptions';
 
 const GroupTool = forwardRef<
 	HTMLButtonElement,
@@ -40,7 +40,7 @@ export default ({ toolOptions, className }: Props) => {
 				popover={popover}
 				trigger={
 					<TopBarButton>
-						<DotsThreeCircle className={TOP_BAR_ICON_CLASSLIST} />
+						<DotsThreeCircle {...TOP_BAR_ICON_DEFAULT_PROPS} />
 					</TopBarButton>
 				}
 			>

--- a/interface/app/$libraryId/TopBar/TopBarOptions.tsx
+++ b/interface/app/$libraryId/TopBar/TopBarOptions.tsx
@@ -1,4 +1,4 @@
-import { Cards, Minus, Square, X } from '@phosphor-icons/react';
+import { Cards, IconWeight, Minus, Square, X } from '@phosphor-icons/react';
 import { getCurrent, Window } from '@tauri-apps/api/window';
 import clsx from 'clsx';
 import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
@@ -26,7 +26,14 @@ interface TopBarChildrenProps {
 	options?: ToolOption[][];
 }
 
-export const TOP_BAR_ICON_CLASSLIST = 'm-0.5 w-[18px] h-[18px] text-ink-dull';
+export const TOP_BAR_ICON_CLASSLIST = 'm-0.5 text-ink-dull';
+export const TOP_BAR_ICON_WEIGHT: IconWeight = 'regular';
+export const TOP_BAR_ICON_SIZE = 20;
+export const TOP_BAR_ICON_DEFAULT_PROPS = {
+	weight: TOP_BAR_ICON_WEIGHT,
+	size: TOP_BAR_ICON_SIZE,
+	className: TOP_BAR_ICON_CLASSLIST
+};
 
 export default ({ options }: TopBarChildrenProps) => {
 	const [windowSize, setWindowSize] = useState(0);
@@ -193,7 +200,7 @@ export function WindowsControls({ windowSize }: { windowSize: number }) {
 				active={false}
 				onClick={() => appWindow.minimize()}
 			>
-				<Minus weight="regular" className={clsx(TOP_BAR_ICON_CLASSLIST)} />
+				<Minus {...TOP_BAR_ICON_DEFAULT_PROPS} />
 			</TopBarButton>
 			<TopBarButton
 				rounding="both"
@@ -204,9 +211,9 @@ export function WindowsControls({ windowSize }: { windowSize: number }) {
 				}}
 			>
 				{maximized ? (
-					<Cards weight="regular" className={clsx(TOP_BAR_ICON_CLASSLIST)} />
+					<Cards {...TOP_BAR_ICON_DEFAULT_PROPS} />
 				) : (
-					<Square weight="regular" className={clsx(TOP_BAR_ICON_CLASSLIST)} />
+					<Square {...TOP_BAR_ICON_DEFAULT_PROPS} />
 				)}
 			</TopBarButton>
 			<TopBarButton
@@ -215,7 +222,10 @@ export function WindowsControls({ windowSize }: { windowSize: number }) {
 				active={false}
 				onClick={() => appWindow.close()}
 			>
-				<X weight="regular" className={clsx(TOP_BAR_ICON_CLASSLIST, 'hover:text-white')} />
+				<X
+					{...TOP_BAR_ICON_DEFAULT_PROPS}
+					className={clsx(TOP_BAR_ICON_CLASSLIST, 'hover:text-white')}
+				/>
 			</TopBarButton>
 		</div>
 	);

--- a/interface/app/$libraryId/location/$id.tsx
+++ b/interface/app/$libraryId/location/$id.tsx
@@ -35,7 +35,7 @@ import { SearchContextProvider, SearchOptions, useSearchFromSearchParams } from 
 import SearchBar from '../search/SearchBar';
 import { useSearchExplorerQuery } from '../search/useSearchExplorerQuery';
 import { TopBarPortal } from '../TopBar/Portal';
-import { TOP_BAR_ICON_CLASSLIST } from '../TopBar/TopBarOptions';
+import { TOP_BAR_ICON_DEFAULT_PROPS } from '../TopBar/TopBarOptions';
 import LocationOptions from './LocationOptions';
 
 export const Component = () => {
@@ -152,7 +152,7 @@ const LocationExplorer = ({ location }: { location: Location; path?: string }) =
 								{
 									toolTipLabel: t('reload'),
 									onClick: () => rescan(location.id),
-									icon: <ArrowClockwise className={TOP_BAR_ICON_CLASSLIST} />,
+									icon: <ArrowClockwise {...TOP_BAR_ICON_DEFAULT_PROPS} />,
 									individual: true,
 									showAtResolution: 'xl:flex'
 								}


### PR DESCRIPTION
<!-- Put any information about this PR up here -->

Make changing icon styles in Top Bar easier by including default `size` and `weight` props and introducing a new spreadable `TOP_BAR_ICON_DEFAULT_PROPS` constant.
