### PR TITLE
Disable Vite `clearScreen`

### DIFF
--- a/packages/config/vite/index.ts
+++ b/packages/config/vite/index.ts
@@ -13,6 +13,7 @@ import { narrowSolidPlugin } from './narrowSolidPlugin';
 const url = new URL('../../../interface/locales', import.meta.url);
 
 export default defineConfig({
+	clearScreen: false,
 	plugins: [
 		million.vite({ auto: true }),
 		tsconfigPaths(),


### PR DESCRIPTION
Vite is regularly clearing other development messages when running Rust and Vite dev in parallel. This PR disables Vite's `clearScreen` configuration option entirely.