### PR TITLE
Revamp `.gitattributes` for statistics and better PR diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,20 @@
-pnpm-lock.yaml -diff
-package-lock.json -diff
-Cargo.lock -diff
-.github/actions/publish-artifacts/dist/index.js -diff
+# Mark generated lockfiles as generated code
+Cargo.lock -diff linguist-generated
+pnpm-lock.yaml -diff linguist-generated
+
+# Mark our codegen as generated code
+/.github/actions/publish-artifacts/dist/index.js -diff linguist-generated
+/apps/desktop/src/commands.ts linguist-generated
+/core/prisma/migrations/migration_lock.toml linguist-generated
+/crates/sync/example/web/src/utils/bindings.ts linguist-generated
+/packages/assets/**/index.ts linguist-generated
+/packages/client/src/core.ts linguist-generated
+
+# Mark copied-in code as vendored, removing from language statistics
+/apps/landing/src/plugins/rehype-image-size.js linguist-vendored
+
+# Mark docs and examples as documentation, removing them from language statistics
+/apps/landing/posts/* linguist-documentation
+/docs/* linguist-documentation
+/crates/*/example/**/* linguist-documentation
+/crates/*/examples/**/* linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,7 +5,7 @@ pnpm-lock.yaml -diff linguist-generated
 # Mark our codegen as generated code
 /.github/actions/publish-artifacts/dist/index.js -diff linguist-generated
 /apps/desktop/src/commands.ts linguist-generated
-/core/prisma/migrations/migration_lock.toml linguist-generated
+/core/prisma/migrations/migration_lock.toml -diff linguist-generated
 /crates/sync/example/web/src/utils/bindings.ts linguist-generated
 /packages/assets/**/index.ts linguist-generated
 /packages/client/src/core.ts linguist-generated


### PR DESCRIPTION
This PR revamps our `.gitattributes` file to more properly show language statistics on the repository and hide diffs for files generated by codegen in PRs and commit diffs.

- `linguist-*` attributes are specifically used by GitHub to control how files contribute to its statistics and PR/commit diff views. ([docs](https://github.com/github-linguist/linguist/blob/master/docs/overrides.md#summary))
- `-diff` marks a file as "binary" which further signifies to Git that the diff will tend to be 'messy' and not desirable for human review. In the case of lockfiles and some generated code, I use this attribute on top of Linguist rules. ([docs](https://git-scm.com/docs/gitattributes#_marking_files_as_binary))