### PR TITLE
[ENG-1830] Change sidebar toggle shortcut

### DIFF
--- a/interface/app/$libraryId/Layout/Sidebar/SidebarLayout/index.tsx
+++ b/interface/app/$libraryId/Layout/Sidebar/SidebarLayout/index.tsx
@@ -5,7 +5,14 @@ import { PropsWithChildren, useCallback, useEffect, useRef, useState } from 'rea
 import { useKey } from 'rooks';
 import { Button, Kbd, Resizable, ResizableHandle, Tooltip, useResizableContext } from '@sd/ui';
 import { MacTrafficLights } from '~/components';
-import { useLocale, useOperatingSystem, useShortcut, useShowControls } from '~/hooks';
+import {
+	useKeyMatcher,
+	useKeysMatcher,
+	useLocale,
+	useOperatingSystem,
+	useShortcut,
+	useShowControls
+} from '~/hooks';
 
 import { layoutStore, useLayoutStore } from '../../store';
 import { getSidebarStore } from '../store';
@@ -208,6 +215,7 @@ function SidebarControls() {
 	const { t } = useLocale();
 	const os = useOperatingSystem();
 	const { sidebar } = useLayoutStore();
+	const ctrlmeta = useKeysMatcher(['Meta']).Meta.icon;
 
 	if (os !== 'macOS') return null;
 
@@ -215,7 +223,7 @@ function SidebarControls() {
 		<div className="flex justify-end">
 			<Tooltip
 				label={!sidebar.collapsed ? t('hide_sidebar') : t('lock_sidebar')}
-				keybinds={['[']}
+				keybinds={[ctrlmeta, 'S']}
 			>
 				<Button
 					size="icon"

--- a/interface/hooks/useShortcut.ts
+++ b/interface/hooks/useShortcut.ts
@@ -153,7 +153,8 @@ const shortcuts = {
 		all: ['ArrowRight']
 	},
 	toggleSidebar: {
-		all: ['[']
+		all: ['Control', 'KeyS'],
+		macOS: ['Meta', 'KeyS']
 	}
 } satisfies Record<string, Shortcut>;
 


### PR DESCRIPTION
**This PR**: Fixes shortcuts conflicting with each other of toggling sidebar and navigate back.

- The new shortcut of toggling sidebar is CMD/CTRL + S

<img width="299" alt="Screenshot 2024-07-22 at 5 31 13 PM" src="https://github.com/user-attachments/assets/098652a0-3cfc-452f-ba41-d72291a3b104">
