### PR TITLE
Switch the log message to a prettier and easier to read format

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -32,7 +32,9 @@ use tracing_appender::{
 	non_blocking::{NonBlocking, WorkerGuard},
 	rolling::{RollingFileAppender, Rotation},
 };
-use tracing_subscriber::{filter::FromEnvError, prelude::*, registry, EnvFilter};
+use tracing_subscriber::{
+	filter::FromEnvError, fmt::format::Format, prelude::*, registry, EnvFilter,
+};
 
 pub mod api;
 mod cloud;
@@ -274,6 +276,7 @@ impl Node {
 					.with_file(true)
 					.with_line_number(true)
 					.with_writer(std::io::stdout)
+					.event_format(Format::default().pretty())
 					.with_filter(EnvFilter::from_default_env()),
 			);
 


### PR DESCRIPTION
This changes the log message to an easier-to-read format on the terminal (logging to files was not changed)


Before:

![image](https://github.com/user-attachments/assets/17160a65-6ddf-4fa6-8300-775cf7450423)


After:

![image](https://github.com/user-attachments/assets/c420a5b4-1c48-493e-abcb-fb2a8e5d92ff)
