### PR TITLE
Remove explicit ref in checkout for type and style check CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
-on:
-  pull_request:
-  merge_group:
+on: [ pull_request, merge_group ]
 
 env:
   SPACEDRIVE_CUSTOM_APT_FLAGS: --no-install-recommends
@@ -31,7 +29,6 @@ jobs:
       - name: 'Checkout PR branch and all PR commits'
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: ${{ env.PR_FETCH_DEPTH }}
 
       - name: Setup Node.js, pnpm and dependencies


### PR DESCRIPTION
This is currently breaking checkouts for PRs from forks
