### PR TITLE
Update `rspc-tauri` patch to use updated Tauri API

### DIFF
--- a/patches/@oscartbeaumont-sd__rspc-tauri@0.0.0-main-dc31e5b2.patch
+++ b/patches/@oscartbeaumont-sd__rspc-tauri@0.0.0-main-dc31e5b2.patch
@@ -7,7 +7,7 @@ index df70b20e9381e7bf44f9a35b11174e40ede80376..bc06927b7290891717c48999f79d0705
          // @ts-ignore
          this.requestMap.set(id, resolve);
 -        await window.appWindow.emit("plugin:rspc:transport", {
-+        await window.getCurrent().emit("plugin:rspc:transport", {
++        await window.getCurrentWindow().emit("plugin:rspc:transport", {
              id,
              method: operation,
              params: {
@@ -19,8 +19,8 @@ index a80ac6155a4a920173c442b4d7b458a46ab63624..03b3d9ee6d3691980584c1fd58c17f7c
  import { randomId, RSPCError } from '@oscartbeaumont-sd/rspc-client';
  import { listen } from '@tauri-apps/api/event';
 -import { appWindow } from '@tauri-apps/api/window';
-+import { getCurrent } from '@tauri-apps/api/window';
- 
++import { getCurrentWindow } from '@tauri-apps/api/window';
+
  // @ts-nocheck No one asked
  class TauriTransport {
 @@ -15,7 +15,7 @@ class TauriTransport {
@@ -28,7 +28,7 @@ index a80ac6155a4a920173c442b4d7b458a46ab63624..03b3d9ee6d3691980584c1fd58c17f7c
          // @ts-ignore
          this.requestMap.set(id, resolve);
 -        await appWindow.emit("plugin:rspc:transport", {
-+        await getCurrent().emit("plugin:rspc:transport", {
++        await getCurrentWindow().emit("plugin:rspc:transport", {
              id,
              method: operation,
              params: {
@@ -41,7 +41,7 @@ index e597db7bf00a7e62f32266814345b257b8f8d0da..fa683640a0c0c9f1796ed1af1fd0d04c
                          await listener;
                      }
 -                    await window.appWindow.emit("plugin:rspc:transport", currentBatch);
-+                    await window.getCurrent().emit("plugin:rspc:transport", currentBatch);
++                    await window.getCurrentWindow().emit("plugin:rspc:transport", currentBatch);
                  })();
              });
          }
@@ -53,8 +53,8 @@ index bd7ceb6927d187dd2ff7cf9a9364d7c312a75b88..844495e36aef0c1337e7393685c1a33f
  import { AlphaRSPCError } from '@oscartbeaumont-sd/rspc-client/v2';
  import { listen } from '@tauri-apps/api/event';
 -import { appWindow } from '@tauri-apps/api/window';
-+import { getCurrent } from '@tauri-apps/api/window';
- 
++import { getCurrentWindow } from '@tauri-apps/api/window';
+
  // @ts-nocheck No one asked
  /**
 @@ -42,7 +42,7 @@ import { appWindow } from '@tauri-apps/api/window';
@@ -62,7 +62,7 @@ index bd7ceb6927d187dd2ff7cf9a9364d7c312a75b88..844495e36aef0c1337e7393685c1a33f
                          await listener;
                      }
 -                    await appWindow.emit("plugin:rspc:transport", currentBatch);
-+                    await getCurrent().emit("plugin:rspc:transport", currentBatch);
++                    await getCurrentWindow().emit("plugin:rspc:transport", currentBatch);
                  })();
              });
          }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ patchedDependencies:
     hash: r22rdxqpl6d5mdpkhdt6tw4evu
     path: patches/@contentlayer__cli@0.3.4.patch
   '@oscartbeaumont-sd/rspc-tauri@0.0.0-main-dc31e5b2':
-    hash: 3ozd223mr7o4cioyf7af7qd56a
+    hash: aivg4lv3fcaaigmygku42cefnu
     path: patches/@oscartbeaumont-sd__rspc-tauri@0.0.0-main-dc31e5b2.patch
   '@remix-run/router@1.13.1':
     hash: rgixflaa47ddt4t677o2d275p4
@@ -93,7 +93,7 @@ importers:
         version: 0.0.0-main-dc31e5b2
       '@oscartbeaumont-sd/rspc-tauri':
         specifier: '=0.0.0-main-dc31e5b2'
-        version: 0.0.0-main-dc31e5b2(patch_hash=3ozd223mr7o4cioyf7af7qd56a)(@tauri-apps/api@2.0.0-beta.15)
+        version: 0.0.0-main-dc31e5b2(patch_hash=aivg4lv3fcaaigmygku42cefnu)(@tauri-apps/api@2.0.0-beta.15)
       '@remix-run/router':
         specifier: '=1.13.1'
         version: 1.13.1(patch_hash=rgixflaa47ddt4t677o2d275p4)
@@ -365,7 +365,7 @@ importers:
         version: 6.5.20(@react-navigation/native@6.1.17(react-native@0.73.4(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.8.2(react-native@0.73.4(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(react@18.2.0))(react@18.2.0))(react-native-screens@3.29.0(react-native@0.73.4(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(react@18.2.0))(react@18.2.0))(react-native@0.73.4(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(react@18.2.0))(react@18.2.0)
       '@react-navigation/drawer':
         specifier: ^6.6.14
-        version: 6.6.15(3fzmnfc2je7bh62gn24exmf5uu)
+        version: 6.6.15(@react-navigation/native@6.1.17(react-native@0.73.4(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(react@18.2.0))(react@18.2.0))(react-native-gesture-handler@2.14.1(react-native@0.73.4(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(react@18.2.0))(react@18.2.0))(react-native-reanimated@3.6.3(@babel/core@7.24.0)(@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.24.0))(@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.24.0))(@babel/plugin-transform-arrow-functions@7.23.3(@babel/core@7.24.0))(@babel/plugin-transform-shorthand-properties@7.23.3(@babel/core@7.24.0))(@babel/plugin-transform-template-literals@7.23.3(@babel/core@7.24.0))(react-native@0.73.4(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.8.2(react-native@0.73.4(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(react@18.2.0))(react@18.2.0))(react-native-screens@3.29.0(react-native@0.73.4(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(react@18.2.0))(react@18.2.0))(react-native@0.73.4(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(react@18.2.0))(react@18.2.0)
       '@react-navigation/native':
         specifier: ^6.1.16
         version: 6.1.17(react-native@0.73.4(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(react@18.2.0))(react@18.2.0)
@@ -16403,7 +16403,7 @@ snapshots:
       '@tanstack/react-query': 4.36.1(react-dom@18.2.0(react@18.2.0))(react-native@0.73.4(@babel/core@7.24.0)(react@18.2.0))(react@18.2.0)
       react: 18.2.0
 
-  '@oscartbeaumont-sd/rspc-tauri@0.0.0-main-dc31e5b2(patch_hash=3ozd223mr7o4cioyf7af7qd56a)(@tauri-apps/api@2.0.0-beta.15)':
+  '@oscartbeaumont-sd/rspc-tauri@0.0.0-main-dc31e5b2(patch_hash=aivg4lv3fcaaigmygku42cefnu)(@tauri-apps/api@2.0.0-beta.15)':
     dependencies:
       '@oscartbeaumont-sd/rspc-client': 0.0.0-main-dc31e5b2
       '@tauri-apps/api': 2.0.0-beta.15
@@ -17601,8 +17601,8 @@ snapshots:
       react-is: 16.13.1
       use-latest-callback: 0.1.9(react@18.2.0)
 
-  '@react-navigation/drawer@6.6.15(3fzmnfc2je7bh62gn24exmf5uu)':
-    dependencies:
+  ? '@react-navigation/drawer@6.6.15(@react-navigation/native@6.1.17(react-native@0.73.4(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(react@18.2.0))(react@18.2.0))(react-native-gesture-handler@2.14.1(react-native@0.73.4(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(react@18.2.0))(react@18.2.0))(react-native-reanimated@3.6.3(@babel/core@7.24.0)(@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.24.0))(@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.24.0))(@babel/plugin-transform-arrow-functions@7.23.3(@babel/core@7.24.0))(@babel/plugin-transform-shorthand-properties@7.23.3(@babel/core@7.24.0))(@babel/plugin-transform-template-literals@7.23.3(@babel/core@7.24.0))(react-native@0.73.4(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.8.2(react-native@0.73.4(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(react@18.2.0))(react@18.2.0))(react-native-screens@3.29.0(react-native@0.73.4(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(react@18.2.0))(react@18.2.0))(react-native@0.73.4(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(react@18.2.0))(react@18.2.0)'
+  : dependencies:
       '@react-navigation/elements': 1.3.30(@react-navigation/native@6.1.17(react-native@0.73.4(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.8.2(react-native@0.73.4(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(react@18.2.0))(react@18.2.0))(react-native@0.73.4(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(react@18.2.0))(react@18.2.0)
       '@react-navigation/native': 6.1.17(react-native@0.73.4(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(react@18.2.0))(react@18.2.0)
       color: 4.2.3


### PR DESCRIPTION
Fixes the following issue by updating the API used in the following patch to use the latest API due to the underlying package being updated. 

<img width="728" alt="Screenshot 2024-07-23 at 5 05 34 PM" src="https://github.com/user-attachments/assets/ed8f171d-94a7-4917-a65f-9d35c2568ef7">
