### PR TITLE
[ENG-1806] Add zoom shortcuts and pinch to quick preview 

### DIFF
--- a/interface/app/$libraryId/Explorer/QuickPreview/index.tsx
+++ b/interface/app/$libraryId/Explorer/QuickPreview/index.tsx
@@ -93,6 +93,9 @@ export const QuickPreview = () => {
 	const [thumbnailLoading, setThumbnailLoading] = useState<'notLoaded' | 'loaded' | 'error'>(
 		'notLoaded'
 	);
+	// the purpose of these refs is to prevent "jittering" when zooming with trackpads, as the deltaY value can be very high
+	const deltaYRef = useRef(0);
+	const lastZoomTimeRef = useRef(0);
 
 	const { t } = useLocale();
 
@@ -197,6 +200,55 @@ export const QuickPreview = () => {
 		explorer.resetSelectedItems([newSelectedItem]);
 		getQuickPreviewStore().itemIndex = 0;
 	};
+
+	const handleZoomIn = useCallback(() => {
+		setMagnification((currentMagnification) =>
+			currentMagnification < 2
+				? currentMagnification + currentMagnification * 0.1
+				: currentMagnification
+		);
+	}, []);
+
+	const handleZoomOut = useCallback(() => {
+		setMagnification((currentMagnification) =>
+			currentMagnification > 0.5 ? currentMagnification / (1 + 0.1) : currentMagnification
+		);
+	}, []);
+
+	// pinch support for trackpads
+	const applyZoom = useCallback(() => {
+		if (deltaYRef.current < 0) {
+			handleZoomIn();
+		} else if (deltaYRef.current > 0) {
+			handleZoomOut();
+		}
+		deltaYRef.current = 0;
+	}, [handleZoomIn, handleZoomOut]);
+
+	const handleWheel = useCallback(
+		(event: WheelEvent) => {
+			if (event.ctrlKey) {
+				event.preventDefault();
+				deltaYRef.current += event.deltaY;
+				const now = Date.now();
+				if (now - lastZoomTimeRef.current > 50) {
+					applyZoom();
+					lastZoomTimeRef.current = now;
+				}
+			}
+		},
+		[applyZoom]
+	);
+
+	useEffect(() => {
+		window.addEventListener('wheel', handleWheel, { passive: false });
+		return () => {
+			window.removeEventListener('wheel', handleWheel);
+		};
+	}, [handleWheel]);
+
+	useShortcut('zoomIn', handleZoomIn);
+	useShortcut('zoomOut', handleZoomOut);
 
 	useShortcut('quickPreviewMoveBack', () => {
 		if (isContextMenuOpen || isRenaming) return;
@@ -455,14 +507,7 @@ export const QuickPreview = () => {
 									<div className="flex flex-1 items-center justify-end gap-1">
 										<Tooltip label={t('zoom_in')}>
 											<IconButton
-												onClick={() => {
-													magnification < 2 &&
-														setMagnification(
-															(currentMagnification) =>
-																currentMagnification +
-																currentMagnification * 0.2
-														);
-												}}
+												onClick={handleZoomIn}
 												// this is same formula as interest calculation
 											>
 												<MagnifyingGlassPlus />
@@ -471,13 +516,7 @@ export const QuickPreview = () => {
 
 										<Tooltip label={t('zoom_out')}>
 											<IconButton
-												onClick={() => {
-													magnification > 0.5 &&
-														setMagnification(
-															(currentMagnification) =>
-																currentMagnification / (1 + 0.2)
-														);
-												}}
+												onClick={handleZoomOut}
 												// this is same formula as interest calculation
 											>
 												<MagnifyingGlassMinus />

--- a/interface/app/$libraryId/TopBar/index.tsx
+++ b/interface/app/$libraryId/TopBar/index.tsx
@@ -138,7 +138,7 @@ function Tabs() {
 						else if (e.button === 1) removeTab(index);
 					}}
 					className={clsx(
-						'group relative flex h-full min-w-40 shrink-0 flex-row items-center justify-center px-8 text-center duration-[50ms]',
+						'duration-[50ms] group relative flex h-full min-w-40 shrink-0 flex-row items-center justify-center px-8 text-center',
 						ctx.tabIndex === index
 							? 'text-ink'
 							: 'top-bar-blur border-t border-sidebar-divider bg-sidebar/30 text-ink-faint/60 transition-colors hover:bg-app/50'
@@ -166,7 +166,7 @@ function Tabs() {
 				<Tooltip keybinds={[keybind.icon, 'T']} label={t('new_tab')}>
 					<button
 						onClick={addTab}
-						className="flex flex-row items-center justify-center rounded p-1.5 transition-colors duration-[50ms] hover:bg-app/80"
+						className="duration-[50ms] flex flex-row items-center justify-center rounded p-1.5 transition-colors hover:bg-app/80"
 					>
 						<Plus weight="bold" size={14} />
 					</button>

--- a/interface/app/$libraryId/TopBar/index.tsx
+++ b/interface/app/$libraryId/TopBar/index.tsx
@@ -138,7 +138,7 @@ function Tabs() {
 						else if (e.button === 1) removeTab(index);
 					}}
 					className={clsx(
-						'duration-[50ms] group relative flex h-full min-w-40 shrink-0 flex-row items-center justify-center px-8 text-center',
+						'group relative flex h-full min-w-40 shrink-0 flex-row items-center justify-center px-8 text-center duration-[50ms]',
 						ctx.tabIndex === index
 							? 'text-ink'
 							: 'top-bar-blur border-t border-sidebar-divider bg-sidebar/30 text-ink-faint/60 transition-colors hover:bg-app/50'
@@ -166,7 +166,7 @@ function Tabs() {
 				<Tooltip keybinds={[keybind.icon, 'T']} label={t('new_tab')}>
 					<button
 						onClick={addTab}
-						className="duration-[50ms] flex flex-row items-center justify-center rounded p-1.5 transition-colors hover:bg-app/80"
+						className="flex flex-row items-center justify-center rounded p-1.5 transition-colors duration-[50ms] hover:bg-app/80"
 					>
 						<Plus weight="bold" size={14} />
 					</button>

--- a/interface/hooks/useShortcut.ts
+++ b/interface/hooks/useShortcut.ts
@@ -155,6 +155,14 @@ const shortcuts = {
 	toggleSidebar: {
 		all: ['Control', 'KeyS'],
 		macOS: ['Meta', 'KeyS']
+	},
+	zoomIn: {
+		macOS: ['Meta', '='],
+		all: ['Control', '=']
+	},
+	zoomOut: {
+		macOS: ['Meta', '-'],
+		all: ['Control', '-']
 	}
 } satisfies Record<string, Shortcut>;
 


### PR DESCRIPTION
<!-- Put any information about this PR up here -->
Added QOL shortcuts to quick preview 
- Shortcuts CMD and +/CMD and - added for zoom in/zoom out respectively. 
- Pinch support added for trackpad. 

Closes #(issue)
https://linear.app/spacedriveapp/issue/ENG-1806/quick-preview-add-zoom-shortcuts-and-pinch