### PR TITLE
[ENG-1791] Fix right-click sometimes opening native context menu

### DIFF
--- a/interface/app/$libraryId/Explorer/View/ViewItem.tsx
+++ b/interface/app/$libraryId/Explorer/View/ViewItem.tsx
@@ -1,4 +1,4 @@
-import { useCallback, type HTMLAttributes, type PropsWithChildren } from 'react';
+import { useCallback, useEffect, type HTMLAttributes, type PropsWithChildren } from 'react';
 import {
 	createSearchParams,
 	useNavigate,
@@ -214,6 +214,17 @@ export const ViewItem = ({ data, children, ...props }: ViewItemProps) => {
 	const explorerView = useExplorerViewContext();
 
 	const { doubleClick } = useViewItemDoubleClick();
+
+	useEffect(() => {
+		const handleContextMenu = (e: MouseEvent) => {
+			e.preventDefault();
+		};
+
+		document.addEventListener('contextmenu', handleContextMenu);
+		return () => {
+			document.removeEventListener('contextmenu', handleContextMenu);
+		};
+	}, []);
 
 	return (
 		<ContextMenu.Root


### PR DESCRIPTION
<!-- Put any information about this PR up here -->

Fixes bug where clicking explorer item with a mouse would cause the native context menu to open instead of the Spacedrive context menu. 