### PR TITLE
Bump version to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8721,7 +8721,7 @@ dependencies = [
 
 [[package]]
 name = "sd-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-channel",
  "async-recursion",
@@ -8955,7 +8955,7 @@ dependencies = [
 
 [[package]]
 name = "sd-desktop"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "axum",
  "dbus",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sd-desktop"
-version = "0.4.0"
+version = "0.4.1"
 description = "The universal file manager."
 authors = ["Spacedrive Technology Inc <support@spacedrive.com>"]
 default-run = "sd-desktop"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sd-core"
-version = "0.4.0"
+version = "0.4.1"
 description = "Virtual distributed filesystem engine that powers Spacedrive."
 authors = ["Spacedrive Technology Inc <support@spacedrive.com>"]
 rust-version = "1.78"


### PR DESCRIPTION
We will be releasing 0.4.1, this PR bumps the Spacedrive Core and Desktop versions to match