### PR TITLE
Dim pure white text & increase keybind text size in keybind list

### DIFF
--- a/interface/app/$libraryId/settings/client/keybindings.tsx
+++ b/interface/app/$libraryId/settings/client/keybindings.tsx
@@ -174,7 +174,7 @@ function KeybindTable({ data }: { data: ShortcutCategory['shortcuts'] }) {
 
 					return symbols.map((symbol) => (
 						<div key={symbol} className="inline-flex items-center">
-							<kbd className="ml-2 rounded-lg border border-app-line bg-app-box px-2 py-1 text-[10.5px] tracking-widest shadow">
+							<kbd className="ml-2 rounded-lg border border-app-line bg-app-box px-1.5 py-0.5 text-sm tracking-widest shadow">
 								{symbol}
 							</kbd>
 						</div>

--- a/packages/ui/style/colors.scss
+++ b/packages/ui/style/colors.scss
@@ -17,7 +17,7 @@
 	--color-sidebar: var(--dark-hue), 15%, 7%;
 	--color-sidebar-box: var(--dark-hue), 15%, 16%;
 	--color-sidebar-line: var(--dark-hue), 15%, 23%;
-	--color-sidebar-ink: var(--dark-hue), 0%, 92%;
+	--color-sidebar-ink: var(--dark-hue), 15%, 92%;
 	--color-sidebar-ink-dull: var(--dark-hue), 10%, 70%;
 	--color-sidebar-ink-faint: var(--dark-hue), 10%, 55%;
 	--color-sidebar-divider: var(--dark-hue), 15%, 17%;

--- a/packages/ui/style/colors.scss
+++ b/packages/ui/style/colors.scss
@@ -10,14 +10,14 @@
 	--color-accent-faint: 208, 100%, 64%;
 	--color-accent-deep: 208, 100%, 47%;
 	// text
-	--color-ink: var(--dark-hue), 0%, 100%;
+	--color-ink: var(--dark-hue), 0%, 92%;
 	--color-ink-dull: var(--dark-hue), 10%, 70%;
 	--color-ink-faint: var(--dark-hue), 10%, 55%;
 	// sidebar
 	--color-sidebar: var(--dark-hue), 15%, 7%;
 	--color-sidebar-box: var(--dark-hue), 15%, 16%;
 	--color-sidebar-line: var(--dark-hue), 15%, 23%;
-	--color-sidebar-ink: var(--dark-hue), 0%, 100%;
+	--color-sidebar-ink: var(--dark-hue), 0%, 92%;
 	--color-sidebar-ink-dull: var(--dark-hue), 10%, 70%;
 	--color-sidebar-ink-faint: var(--dark-hue), 10%, 55%;
 	--color-sidebar-divider: var(--dark-hue), 15%, 17%;
@@ -47,7 +47,7 @@
 	// menu
 	--color-menu: var(--dark-hue), 15%, 10%;
 	--color-menu-line: var(--dark-hue), 15%, 14%;
-	--color-menu-ink: var(--dark-hue), 10%, 100%;
+	--color-menu-ink: var(--dark-hue), 10%, 92%;
 	--color-menu-faint: var(--dark-hue), 5%, 80%;
 	--color-menu-hover: var(--dark-hue), 15%, 30%;
 	--color-menu-selected: var(--dark-hue), 5%, 30%;

--- a/packages/ui/style/colors.scss
+++ b/packages/ui/style/colors.scss
@@ -47,7 +47,7 @@
 	// menu
 	--color-menu: var(--dark-hue), 15%, 10%;
 	--color-menu-line: var(--dark-hue), 15%, 14%;
-	--color-menu-ink: var(--dark-hue), 10%, 92%;
+	--color-menu-ink: var(--dark-hue), 25%, 92%;
 	--color-menu-faint: var(--dark-hue), 5%, 80%;
 	--color-menu-hover: var(--dark-hue), 15%, 30%;
 	--color-menu-selected: var(--dark-hue), 5%, 30%;

--- a/packages/ui/style/colors.scss
+++ b/packages/ui/style/colors.scss
@@ -10,7 +10,7 @@
 	--color-accent-faint: 208, 100%, 64%;
 	--color-accent-deep: 208, 100%, 47%;
 	// text
-	--color-ink: var(--dark-hue), 0%, 92%;
+	--color-ink: var(--dark-hue), 35%, 92%;
 	--color-ink-dull: var(--dark-hue), 10%, 70%;
 	--color-ink-faint: var(--dark-hue), 10%, 55%;
 	// sidebar


### PR DESCRIPTION
- Use rgb(235,235,235) for the brightest text color in dark mode (Closes #2417)

- Increase keybind text size in settings for better legibility (before/after):
  <img width="324" alt="before" src="https://github.com/user-attachments/assets/a5cb5184-b028-4a30-a370-f6781c43d7c9"> <img width="323" alt="after" src="https://github.com/user-attachments/assets/d8348c27-bde9-47d4-b131-4c30274d6fbe">


Fixes #2417