### PR TITLE
[ENG-1707] Fix bug causing both quick preview and search closing with esc

### DIFF
--- a/interface/app/$libraryId/Explorer/QuickPreview/index.tsx
+++ b/interface/app/$libraryId/Explorer/QuickPreview/index.tsx
@@ -270,7 +270,11 @@ export const QuickPreview = () => {
 	useShortcut('closeQuickPreview', (e) => {
 		if (explorerStore.isCMDPOpen) return;
 		e.preventDefault();
-		getQuickPreviewStore().open = false;
+		e.stopPropagation();
+		// set timeout is to move the state change to the next event loop
+		setTimeout(() => {
+			getQuickPreviewStore().open = false;
+		}, 0);
 	});
 
 	// Toggle metadata

--- a/interface/app/$libraryId/search/SearchOptions.tsx
+++ b/interface/app/$libraryId/search/SearchOptions.tsx
@@ -1,7 +1,9 @@
 import { FunnelSimple, Icon, Plus } from '@phosphor-icons/react';
 import { IconTypes } from '@sd/assets/util';
 import clsx from 'clsx';
+import { use } from 'i18next';
 import { memo, PropsWithChildren, useDeferredValue, useMemo, useState } from 'react';
+import { get } from 'react-hook-form';
 import { useFeatureFlag, useLibraryMutation } from '@sd/client';
 import {
 	Button,
@@ -10,11 +12,13 @@ import {
 	Input,
 	Popover,
 	RadixCheckbox,
+	toast,
 	tw,
 	usePopover
 } from '@sd/ui';
-import { useIsDark, useKeybind, useLocale } from '~/hooks';
+import { useIsDark, useKeybind, useLocale, useShortcut } from '~/hooks';
 
+import { getQuickPreviewStore, useQuickPreviewStore } from '../Explorer/QuickPreview/store';
 import { AppliedFilters, InteractiveSection } from './AppliedFilters';
 import { useSearchContext } from './context';
 import { filterRegistry, SearchFilterCRUD, useToggleOptionSelected } from './Filters';
@@ -334,6 +338,7 @@ function SaveSearchButton() {
 
 function EscapeButton() {
 	const search = useSearchContext();
+	let { open: isQpOpen } = useQuickPreviewStore();
 
 	function escape() {
 		search.setSearch?.(undefined);
@@ -341,7 +346,16 @@ function EscapeButton() {
 		search.setSearchBarFocused(false);
 	}
 
-	useKeybind(['Escape'], escape);
+	useShortcut('explorerEscape', (e) => {
+		isQpOpen = getQuickPreviewStore().open;
+
+		e.preventDefault();
+		e.stopPropagation();
+		// Check the open state from the store
+		if (!isQpOpen) {
+			escape();
+		}
+	});
 
 	return (
 		<kbd


### PR DESCRIPTION
Co-authored-by: Lynx <iLynxcat@users.noreply.github.com>

Fixes bug where pressing escape with both search and quick preview open causes both to close. 
- now, only quick preview closes 

<!-- Which issue does this PR close? -->
https://linear.app/spacedriveapp/issue/ENG-1707/pressing-esc-closes-quick-preview-search

