### PR TITLE
Fix pdf thumbnails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6168,8 +6168,7 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 [[package]]
 name = "pdfium-render"
 version = "0.8.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf21aa9bd11aa175e8755e0dbc613affe885e149c4b3ee4ac6d2c183260e727"
+source = "git+https://github.com/HeavenVolkoff/pdfium-render.git?rev=dd8118c068#dd8118c0681dcc6a2824b84b67d7537ebd4ea1f0"
 dependencies = [
  "bindgen",
  "bitflags 2.6.0",
@@ -6179,7 +6178,7 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "image",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "js-sys",
  "libloading 0.8.5",
  "log",

--- a/crates/images/Cargo.toml
+++ b/crates/images/Cargo.toml
@@ -23,7 +23,12 @@ tracing   = { workspace = true }
 # Specific Images dependencies
 bincode = { version = "=2.0.0-rc.3", features = ["alloc", "derive"], optional = true }
 # Disable defaults for libheif* to avoid bindgen and use pre-compiled headers
-libheif-rs    = { version = "1.0", default-features = false, optional = true }
-libheif-sys   = { version = "2.1", default-features = false, optional = true }
-pdfium-render = { version = "0.8.24", features = ["image", "sync", "thread_safe"] }
-resvg         = "0.43.0"
+libheif-rs  = { version = "1.0", default-features = false, optional = true }
+libheif-sys = { version = "2.1", default-features = false, optional = true }
+resvg       = "0.43.0"
+
+[dependencies.pdfium-render]
+default-features = false
+features         = ["image", "pdfium_6259", "sync", "thread_safe"]
+git              = "https://github.com/HeavenVolkoff/pdfium-render.git"
+rev              = "dd8118c068"


### PR DESCRIPTION
Use a fork of pdfium-renderer including the required fix while a new version isn't released

Related:
https://github.com/ajrcarey/pdfium-render/pull/155