### PR TITLE
Fix 0.4.2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8068,7 +8068,7 @@ dependencies = [
 
 [[package]]
 name = "sd-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "async-channel",
  "async-recursion",
@@ -8306,7 +8306,7 @@ dependencies = [
 
 [[package]]
 name = "sd-desktop"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "axum",
  "dbus",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "sd-desktop"
-version = "0.4.1"
+version = "0.4.2"
 
 authors              = ["Spacedrive Technology Inc <support@spacedrive.com>"]
 default-run          = "sd-desktop"

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -206,6 +206,7 @@ async fn main() -> tauri::Result<()> {
 		])
 		.events(collect_events![DragAndDropEvent]);
 
+	#[cfg(debug_assertions)]
 	builder
 		.export(
 			Typescript::default()

--- a/apps/server/docker/Dockerfile
+++ b/apps/server/docker/Dockerfile
@@ -74,7 +74,7 @@ RUN curl -L# 'https://github.com/rui314/mold/releases/download/v2.4.0/mold-2.4.0
 RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
 	env CI=true ./scripts/setup.sh
 
-RUN cd ./scripts; npm i --production
+RUN cd ./scripts; npm i --omit=dev && npm i -g prisma
 
 RUN --mount=type=cache,target=/root/.cache/prisma/binaries/cli/ \
 	pnpm prep

--- a/apps/server/docker/Dockerfile
+++ b/apps/server/docker/Dockerfile
@@ -3,7 +3,7 @@ ARG REPO_REF=main
 
 #--
 
-FROM debian:bookworm as base
+FROM debian:bookworm AS base
 
 ADD --chmod=644 --checksum=sha256:8bea540b2cd1a47c94555e746c75fd41a42847a46d8c8c36c7ab6dd9c8526ab4 \
 	https://gist.githubusercontent.com/HeavenVolkoff/ff7b77b9087f956b8df944772e93c071/raw \
@@ -18,7 +18,7 @@ RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/
 
 #--
 
-FROM base as build-base
+FROM base AS build-base
 
 RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
 	apt-get install build-essential git sudo unzip wget curl python3 python-is-python3
@@ -44,7 +44,7 @@ WORKDIR /srv/spacedrive
 
 #--
 
-FROM build-base as web
+FROM build-base AS web
 
 # Run pnpm install with docker cache
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store --mount=type=cache,target=/root/.cache/pnpm/metadata \
@@ -56,7 +56,7 @@ RUN pnpm web build
 
 #--
 
-FROM build-base as server
+FROM build-base AS server
 
 RUN wget -qO- https://sh.rustup.rs | sh -s -- -yq --profile minimal
 
@@ -77,7 +77,7 @@ RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/
 RUN cd ./scripts; npm i --omit=dev && npm i -g prisma
 
 RUN --mount=type=cache,target=/root/.cache/prisma/binaries/cli/ \
-	pnpm prep
+	env PATH="$(npm prefix -g)/bin:$PATH" pnpm prep
 
 COPY --from=web /srv/spacedrive/apps/web/dist /srv/spacedrive/apps/web/dist
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "sd-core"
-version = "0.4.1"
+version = "0.4.2"
 
 authors              = ["Spacedrive Technology Inc <support@spacedrive.com>"]
 description          = "Virtual distributed filesystem engine that powers Spacedrive."


### PR DESCRIPTION
 - Change version to 0.4.2
 - Don't call specta export on prod releases
 - Install prisma before trying to use it when building server