### PR TITLE
[ENG-1860] News banner with latest alpha version & changelog link

### DIFF
--- a/apps/landing/src/app/page.tsx
+++ b/apps/landing/src/app/page.tsx
@@ -40,9 +40,9 @@ export default async function Page() {
 				<div className="mt-22 lg:mt-28" id="content" aria-hidden="true" />
 				<div className="mt-24 lg:mt-8" />
 				<NewBanner
-					headline="Alpha 0.4 is out!"
+					headline={`Alpha ${release.tag_name} is out!`}
 					className="mt-[50px] lg:mt-0"
-					href="/docs/changelog/alpha/0.4.0"
+					href={`/docs/changelog/alpha/${release.tag_name}`}
 				/>
 				<h1 className="fade-in-heading z-30 mb-3 bg-clip-text px-2 text-center text-4xl font-bold leading-tight text-white md:text-5xl lg:text-7xl">
 					One Explorer. All Your Files.


### PR DESCRIPTION
**This PR**:

- Shows latest alpha version dynamically instead of hard coding.
- Changelog link based on the version.

**Image**:

<img width="1482" alt="Screenshot 2024-08-19 at 1 30 51 PM" src="https://github.com/user-attachments/assets/0aba9b79-cce9-4c6b-bb75-618b3e8c9001">
