### PR TITLE
[ENG-1874] Always show windows top bar options

### DIFF
--- a/interface/app/$libraryId/TopBar/TopBarOptions.tsx
+++ b/interface/app/$libraryId/TopBar/TopBarOptions.tsx
@@ -66,7 +66,6 @@ export default ({ options }: TopBarChildrenProps) => {
 						/>
 					))
 				)}
-				{os === 'windows' && <WindowsControls windowSize={windowSize} />}
 			</div>
 			<TopBarMobile
 				toolOptions={options}
@@ -74,6 +73,7 @@ export default ({ options }: TopBarChildrenProps) => {
 					windowSize <= 1279 && (toolsNotSmFlex?.length as number) > 0 ? 'flex' : 'hidden'
 				}
 			/>
+			{os === 'windows' && <WindowsControls windowSize={windowSize} />}
 		</div>
 	);
 };
@@ -193,7 +193,7 @@ export function WindowsControls({ windowSize }: { windowSize: number }) {
 		getWindowState().catch(console.error);
 	}, [getWindowState, windowSize]);
 	return (
-		<div className="mx-1 hidden items-center xl:flex">
+		<div className="mx-1 ml-4 flex items-center">
 			<TopBarButton
 				className="mx-2"
 				rounding="both"

--- a/interface/app/$libraryId/overview/index.tsx
+++ b/interface/app/$libraryId/overview/index.tsx
@@ -49,36 +49,7 @@ export const Component = () => {
 						</div>
 					}
 					center={<SearchBar redirectToSearch />}
-					right={
-						os === 'windows' && <TopBarOptions />
-						// <TopBarOptions
-						// options={[
-						// 	[
-						// 		{
-						// 			toolTipLabel: 'Spacedrop',
-						// 			onClick: () => {},
-						// 			icon: <Broadcast className={TOP_BAR_ICON_STYLE} />,
-						// 			individual: true,
-						// 			showAtResolution: 'sm:flex'
-						// 		},
-						// 		{
-						// 			toolTipLabel: 'Key Manager',
-						// 			onClick: () => {},
-						// 			icon: <Key className={TOP_BAR_ICON_STYLE} />,
-						// 			individual: true,
-						// 			showAtResolution: 'sm:flex'
-						// 		},
-						// 		{
-						// 			toolTipLabel: 'Overview Display Settings',
-						// 			onClick: () => {},
-						// 			icon: <SlidersHorizontal className={TOP_BAR_ICON_STYLE} />,
-						// 			individual: true,
-						// 			showAtResolution: 'sm:flex'
-						// 		}
-						// 	]
-						// ]}
-						// 	/>
-					}
+					right={os === 'windows' && <TopBarOptions />}
 				/>
 				<div className="mt-4 flex flex-col gap-3 pt-3">
 					<OverviewSection>


### PR DESCRIPTION
**This PR addresses this issue**: https://github.com/spacedriveapp/spacedrive/issues/2689

- Resizing the window, should no longer hide the Windows OS window options.