### PR TITLE
Update pdfium-render version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6168,7 +6168,8 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 [[package]]
 name = "pdfium-render"
 version = "0.8.24"
-source = "git+https://github.com/HeavenVolkoff/pdfium-render.git?rev=dd8118c068#dd8118c0681dcc6a2824b84b67d7537ebd4ea1f0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf21aa9bd11aa175e8755e0dbc613affe885e149c4b3ee4ac6d2c183260e727"
 dependencies = [
  "bindgen",
  "bitflags 2.6.0",
@@ -6178,7 +6179,7 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "image",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "js-sys",
  "libloading 0.8.5",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,15 +654,12 @@ dependencies = [
  "itertools 0.10.5",
  "lazy_static",
  "lazycell",
- "log",
- "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.74",
- "which",
 ]
 
 [[package]]
@@ -3627,7 +3624,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core 0.51.1",
 ]
 
 [[package]]
@@ -6167,11 +6164,9 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pdfium-render"
-version = "0.8.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf21aa9bd11aa175e8755e0dbc613affe885e149c4b3ee4ac6d2c183260e727"
+version = "0.8.25"
+source = "git+https://github.com/HeavenVolkoff/pdfium-render.git?rev=7518e39c1b#7518e39c1b0f5bdede0e6e920f28d20415317352"
 dependencies = [
- "bindgen",
  "bitflags 2.6.0",
  "bytemuck",
  "bytes",
@@ -6607,16 +6602,6 @@ name = "presser"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
-
-[[package]]
-name = "prettyplease"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
-dependencies = [
- "proc-macro2",
- "syn 2.0.74",
-]
 
 [[package]]
 name = "prisma-cli"
@@ -11306,18 +11291,6 @@ dependencies = [
  "bitflags 2.6.0",
  "js-sys",
  "web-sys",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
 ]
 
 [[package]]

--- a/crates/images/Cargo.toml
+++ b/crates/images/Cargo.toml
@@ -23,12 +23,7 @@ tracing   = { workspace = true }
 # Specific Images dependencies
 bincode = { version = "=2.0.0-rc.3", features = ["alloc", "derive"], optional = true }
 # Disable defaults for libheif* to avoid bindgen and use pre-compiled headers
-libheif-rs  = { version = "1.0", default-features = false, optional = true }
-libheif-sys = { version = "2.1", default-features = false, optional = true }
-resvg       = "0.43.0"
-
-[dependencies.pdfium-render]
-default-features = false
-features         = ["image", "pdfium_6259", "sync", "thread_safe"]
-git              = "https://github.com/HeavenVolkoff/pdfium-render.git"
-rev              = "dd8118c068"
+libheif-rs    = { version = "1.0", default-features = false, optional = true }
+libheif-sys   = { version = "2.1", default-features = false, optional = true }
+pdfium-render = { version = "0.8.24", features = ["image", "sync", "thread_safe"] }
+resvg         = "0.43.0"

--- a/crates/images/Cargo.toml
+++ b/crates/images/Cargo.toml
@@ -25,5 +25,5 @@ bincode = { version = "=2.0.0-rc.3", features = ["alloc", "derive"], optional = 
 # Disable defaults for libheif* to avoid bindgen and use pre-compiled headers
 libheif-rs    = { version = "1.0", default-features = false, optional = true }
 libheif-sys   = { version = "2.1", default-features = false, optional = true }
-pdfium-render = { version = "0.8.24", features = ["image", "sync", "thread_safe"] }
+pdfium-render = { version = "0.8", features = ["image", "sync", "thread_safe"] }
 resvg         = "0.43.0"

--- a/crates/images/Cargo.toml
+++ b/crates/images/Cargo.toml
@@ -23,7 +23,12 @@ tracing   = { workspace = true }
 # Specific Images dependencies
 bincode = { version = "=2.0.0-rc.3", features = ["alloc", "derive"], optional = true }
 # Disable defaults for libheif* to avoid bindgen and use pre-compiled headers
-libheif-rs    = { version = "1.0", default-features = false, optional = true }
-libheif-sys   = { version = "2.1", default-features = false, optional = true }
-pdfium-render = { version = "0.8", features = ["image", "sync", "thread_safe"] }
-resvg         = "0.43.0"
+libheif-rs  = { version = "1.0", default-features = false, optional = true }
+libheif-sys = { version = "2.1", default-features = false, optional = true }
+resvg       = "0.43.0"
+
+[dependencies.pdfium-render]
+default-features = false
+features         = ["image", "pdfium_6666", "sync", "thread_safe"]
+git              = "https://github.com/HeavenVolkoff/pdfium-render.git"
+rev              = "7518e39c1b"


### PR DESCRIPTION
R̶e̶v̶e̶r̶t̶ ̶#̶2̶6̶6̶6̶ ̶a̶n̶d̶ ̶b̶u̶m̶p̶ ̶p̶d̶f̶i̶u̶m̶-̶r̶e̶n̶d̶e̶r̶ ̶v̶e̶r̶s̶i̶o̶n̶.̶

W̶i̶t̶h̶ ̶o̶u̶r̶ ̶c̶u̶r̶r̶e̶n̶t̶ ̶f̶o̶r̶k̶,̶ ̶w̶e̶ ̶r̶e̶c̶e̶i̶v̶e̶ ̶a̶ ̶l̶o̶t̶ ̶o̶f̶ ̶e̶r̶r̶o̶r̶s̶ ̶r̶e̶l̶a̶t̶e̶d̶ ̶t̶o̶ ̶l̶i̶n̶k̶i̶n̶g̶,̶ ̶a̶n̶d̶ ̶t̶h̶e̶ ̶o̶r̶i̶g̶i̶n̶a̶l̶ ̶c̶r̶a̶t̶e̶ ̶m̶e̶r̶g̶e̶d̶ ̶o̶u̶r̶ ̶c̶h̶a̶n̶g̶e̶s̶ ̶(̶t̶h̶a̶n̶k̶s̶ ̶@̶H̶e̶a̶v̶e̶n̶V̶o̶l̶k̶o̶f̶f̶!̶)̶

@HeavenVolkoff: Updated custom fork and increased the minimum required pdfium api, now that native_deps ships the latest pdfium lib. Unfortunately, we still need a custom fork due to upstream [adding a hard limit on chono version <= 0.4.31](https://github.com/ajrcarey/pdfium-render/blob/bc1195b23a777325afea96a5fc895e9f3db381c6/Cargo.toml#L26), which is incompatible with some of our dependencies which require newer versions