### PR TITLE
fix windows multiple tab spacing

### DIFF
--- a/interface/app/$libraryId/settings/Layout.tsx
+++ b/interface/app/$libraryId/settings/Layout.tsx
@@ -3,6 +3,7 @@ import { Outlet } from 'react-router';
 import { useRouteTitle } from '~/hooks';
 import { useOperatingSystem } from '~/hooks/useOperatingSystem';
 import { useWindowState } from '~/hooks/useWindowState';
+import { useTabsContext } from '~/TabsContext';
 
 import DragRegion from '../../../components/DragRegion';
 import { TopBarPortal } from '../TopBar/Portal';
@@ -12,11 +13,14 @@ import Sidebar from './Sidebar';
 export const Component = () => {
 	const os = useOperatingSystem();
 	const windowState = useWindowState();
+	const ctx = useTabsContext()!;
 
 	useRouteTitle('Settings');
 
 	return (
-		<div className={`flex w-full flex-row bg-app ${os === 'windows' && 'mt-6'}`}>
+		<div
+			className={`flex w-full flex-row bg-app ${os === 'windows' && 'mt-6'} ${os === 'windows' && ctx.tabs.length > 1 && 'pt-9'}`}
+		>
 			{os === 'windows' && <TopBarPortal right={<TopBarOptions />} />}
 			<Sidebar />
 			<div className="relative w-full">


### PR DESCRIPTION
Closes #2529 

Simple fix, was a bit harder figuring out just *where* to put this logic lol. But it just takes the same height of the topbar and puts it as top-padding for the settings selection window's. Checks to see if it's windows os and more than 1 tab (as that's where the bug happens)

I'm not fully sure if these two logics can be combined. I don't think it can? But would love to be told I'm wrong, and learn that it can be. :)
```${os === 'windows' && 'mt-6'} ${os === 'windows' && ctx.tabs.length > 1 && 'pt-9'}```

The result of the fix.
![image](https://github.com/user-attachments/assets/1d9ddd6b-c23f-46d7-a628-f59d9ab1464d)
