### PR TITLE
[MOB-123,122,121] Fix & improve navigation issues

### DIFF
--- a/apps/mobile/src/hooks/useEnableDrawer.ts
+++ b/apps/mobile/src/hooks/useEnableDrawer.ts
@@ -1,0 +1,28 @@
+import { useNavigation } from "@react-navigation/native";
+import { useEffect } from "react";
+
+
+/**
+ * This hook enables the drawer swipe gesture when the screen is focused and disables it when the screen is blurred.
+ */
+
+export function useEnableDrawer(): void {
+	const navigation = useNavigation();
+	useEffect(() => {
+		const tabNavigator = navigation.getParent(); // This is the TabNavigator
+		const drawerNavigator = tabNavigator?.getParent(); // This is the DrawerNavigator
+
+		const unsubscribeFocus = navigation.addListener('focus', () => {
+				drawerNavigator?.setOptions({ swipeEnabled: true });
+		});
+
+		const unsubscribeBlur = navigation.addListener('blur', () => {
+				drawerNavigator?.setOptions({ swipeEnabled: false });
+		});
+
+		return () => {
+			unsubscribeFocus();
+			unsubscribeBlur();
+		};
+	}, [navigation]);
+}

--- a/apps/mobile/src/hooks/useEnableDrawer.ts
+++ b/apps/mobile/src/hooks/useEnableDrawer.ts
@@ -1,6 +1,5 @@
-import { useNavigation } from "@react-navigation/native";
-import { useEffect } from "react";
-
+import { useNavigation } from '@react-navigation/native';
+import { useEffect } from 'react';
 
 /**
  * This hook enables the drawer swipe gesture when the screen is focused and disables it when the screen is blurred.
@@ -13,11 +12,11 @@ export function useEnableDrawer(): void {
 		const drawerNavigator = tabNavigator?.getParent(); // This is the DrawerNavigator
 
 		const unsubscribeFocus = navigation.addListener('focus', () => {
-				drawerNavigator?.setOptions({ swipeEnabled: true });
+			drawerNavigator?.setOptions({ swipeEnabled: true });
 		});
 
 		const unsubscribeBlur = navigation.addListener('blur', () => {
-				drawerNavigator?.setOptions({ swipeEnabled: false });
+			drawerNavigator?.setOptions({ swipeEnabled: false });
 		});
 
 		return () => {

--- a/apps/mobile/src/navigation/DrawerNavigator.tsx
+++ b/apps/mobile/src/navigation/DrawerNavigator.tsx
@@ -16,6 +16,7 @@ export default function DrawerNavigator() {
 			initialRouteName="Home"
 			screenOptions={{
 				headerShown: false,
+				swipeEnabled: false,
 				drawerStyle: {
 					backgroundColor: tw.color('app-darkBox'),
 					width: '70%',

--- a/apps/mobile/src/navigation/SearchStack.tsx
+++ b/apps/mobile/src/navigation/SearchStack.tsx
@@ -10,7 +10,12 @@ const Stack = createNativeStackNavigator<SearchStackParamList>();
 
 export default function SearchStack() {
 	return (
-		<Stack.Navigator initialRouteName="Search">
+		<Stack.Navigator
+			screenOptions={{
+				fullScreenGestureEnabled: true
+			}}
+			initialRouteName="Search"
+		>
 			<Stack.Screen
 				name="Search"
 				component={SearchScreen}

--- a/apps/mobile/src/navigation/TabNavigator.tsx
+++ b/apps/mobile/src/navigation/TabNavigator.tsx
@@ -118,40 +118,42 @@ export default function TabNavigator() {
 				tabBarInactiveTintColor: tw.color('ink/50')
 			}}
 		>
-			{TabScreens.map((screen, index) => (
-				<Tab.Screen
-					key={screen.name + index}
-					name={screen.name}
-					component={screen.component}
-					options={({ navigation }) => ({
-						tabBarLabel: screen.label,
-						tabBarLabelStyle: screen.labelStyle,
-						/**
-						 * TouchableWithoutFeedback is used to prevent Android ripple effect
-						 * State is being used to control the animation and make Rive work
-						 * Tab.Screen listeners are needed because if a user taps on the tab text only, the animation won't play
-						 * This may be revisited in the future to update accordingly
-						 */
-						tabBarIcon: () => (
-							<TouchableWithoutFeedback
-								onPress={() => {
-									navigation.navigate(screen.name);
-									setActiveIndex(index);
-								}}
-							>
-								{screen.icon}
-							</TouchableWithoutFeedback>
-						),
-						tabBarTestID: screen.testID
-					})}
-					listeners={() => ({
-						focus: () => {
-							Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-							setActiveIndex(index);
-						}
-					})}
-				/>
-			))}
+			{TabScreens.map((screen, index) => {
+				return (
+					<Tab.Screen
+						key={screen.name + index}
+						name={screen.name}
+						component={screen.component}
+						options={({ navigation }) => ({
+							tabBarLabel: screen.label,
+							tabBarLabelStyle: screen.labelStyle,
+							/**
+							 * TouchableWithoutFeedback is used to prevent Android ripple effect
+							 * State is being used to control the animation and make Rive work
+							 * Tab.Screen listeners are needed because if a user taps on the tab text only, the animation won't play
+							 * This may be revisited in the future to update accordingly
+							 */
+							tabBarIcon: () => (
+								<TouchableWithoutFeedback
+									onPress={() => {
+										navigation.navigate(screen.name);
+										setActiveIndex(index);
+									}}
+								>
+									{screen.icon}
+								</TouchableWithoutFeedback>
+							),
+							tabBarTestID: screen.testID
+						})}
+						listeners={() => ({
+							focus: () => {
+								Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+								setActiveIndex(index);
+							}
+						})}
+					/>
+				);
+			})}
 		</Tab.Navigator>
 	);
 }

--- a/apps/mobile/src/navigation/tabs/BrowseStack.tsx
+++ b/apps/mobile/src/navigation/tabs/BrowseStack.tsx
@@ -16,7 +16,12 @@ const Stack = createNativeStackNavigator<BrowseStackParamList>();
 
 export default function BrowseStack() {
 	return (
-		<Stack.Navigator initialRouteName="Browse">
+		<Stack.Navigator
+			screenOptions={{
+				fullScreenGestureEnabled: true
+			}}
+			initialRouteName="Browse"
+		>
 			<Stack.Screen
 				name="Browse"
 				component={BrowseScreen}

--- a/apps/mobile/src/navigation/tabs/OverviewStack.tsx
+++ b/apps/mobile/src/navigation/tabs/OverviewStack.tsx
@@ -11,7 +11,12 @@ const Stack = createNativeStackNavigator<OverviewStackParamList>();
 
 export default function OverviewStack() {
 	return (
-		<Stack.Navigator initialRouteName="Overview">
+		<Stack.Navigator
+			screenOptions={{
+				fullScreenGestureEnabled: true
+			}}
+			initialRouteName="Overview"
+		>
 			<Stack.Screen
 				name="Overview"
 				component={OverviewScreen}

--- a/apps/mobile/src/navigation/tabs/SettingsStack.tsx
+++ b/apps/mobile/src/navigation/tabs/SettingsStack.tsx
@@ -27,7 +27,12 @@ const Stack = createNativeStackNavigator<SettingsStackParamList>();
 
 export default function SettingsStack() {
 	return (
-		<Stack.Navigator initialRouteName="Settings">
+		<Stack.Navigator
+			screenOptions={{
+				fullScreenGestureEnabled: true
+			}}
+			initialRouteName="Settings"
+		>
 			<Stack.Screen
 				name="Settings"
 				component={SettingsScreen}

--- a/apps/mobile/src/screens/browse/Browse.tsx
+++ b/apps/mobile/src/screens/browse/Browse.tsx
@@ -1,8 +1,10 @@
 import BrowseLocations from '~/components/browse/BrowseLocations';
 import BrowseTags from '~/components/browse/BrowseTags';
 import ScreenContainer from '~/components/layout/ScreenContainer';
+import { useEnableDrawer } from '~/hooks/useEnableDrawer';
 
 export default function BrowseScreen() {
+	useEnableDrawer();
 	return (
 		<ScreenContainer>
 			{/* <BrowseCategories /> */}

--- a/apps/mobile/src/screens/browse/Locations.tsx
+++ b/apps/mobile/src/screens/browse/Locations.tsx
@@ -16,9 +16,10 @@ import { useSearchStore } from '~/stores/searchStore';
 
 interface Props {
 	viewStyle?: 'grid' | 'list';
+	navToSettings?: boolean; // on press, navigate to settings
 }
 
-export default function LocationsScreen({ viewStyle }: Props) {
+export default function LocationsScreen({ viewStyle, navToSettings }: Props) {
 	const locationsQuery = useLibraryQuery(['locations.list']);
 	const locations = locationsQuery.data;
 	const { search } = useSearchStore();
@@ -39,7 +40,7 @@ export default function LocationsScreen({ viewStyle }: Props) {
 	return (
 		<ScreenContainer scrollview={false} style={tw`relative px-6 py-0`}>
 			<Pressable
-				style={tw`absolute bottom-7 right-7 z-10 h-12 w-12 items-center justify-center rounded-full bg-accent`}
+				style={tw`absolute z-10 items-center justify-center w-12 h-12 rounded-full bottom-7 right-7 bg-accent`}
 				onPress={() => {
 					modalRef.current?.present();
 				}}
@@ -67,12 +68,18 @@ export default function LocationsScreen({ viewStyle }: Props) {
 					numColumns={viewStyle === 'grid' ? 3 : 1}
 					renderItem={({ item }) => (
 						<LocationItem
-							onPress={() =>
+							onPress={() => {
+								if (navToSettings) {
+									return navigation.navigate('SettingsStack', {
+										screen: 'EditLocationSettings',
+										params: { id: item.id }
+									});
+								}
 								navigation.navigate('BrowseStack', {
 									screen: 'Location',
 									params: { id: item.id }
-								})
-							}
+								});
+							}}
 							editLocation={() =>
 								navigation.navigate('SettingsStack', {
 									screen: 'EditLocationSettings',

--- a/apps/mobile/src/screens/browse/Locations.tsx
+++ b/apps/mobile/src/screens/browse/Locations.tsx
@@ -40,7 +40,7 @@ export default function LocationsScreen({ viewStyle, navToSettings }: Props) {
 	return (
 		<ScreenContainer scrollview={false} style={tw`relative px-6 py-0`}>
 			<Pressable
-				style={tw`absolute z-10 items-center justify-center w-12 h-12 rounded-full bottom-7 right-7 bg-accent`}
+				style={tw`absolute bottom-7 right-7 z-10 h-12 w-12 items-center justify-center rounded-full bg-accent`}
 				onPress={() => {
 					modalRef.current?.present();
 				}}

--- a/apps/mobile/src/screens/network/Network.tsx
+++ b/apps/mobile/src/screens/network/Network.tsx
@@ -1,15 +1,17 @@
 import { Text } from 'react-native';
 import { Icon } from '~/components/icons/Icon';
 import ScreenContainer from '~/components/layout/ScreenContainer';
+import { useEnableDrawer } from '~/hooks/useEnableDrawer';
 import { tw } from '~/lib/tailwind';
 import { NetworkStackScreenProps } from '~/navigation/tabs/NetworkStack';
 
 export default function NetworkScreen({ navigation }: NetworkStackScreenProps<'Network'>) {
+	useEnableDrawer();
 	return (
 		<ScreenContainer scrollview={false} style={tw`items-center justify-center gap-0`}>
 			<Icon name="Globe" size={128} />
 			<Text style={tw`mt-4 text-lg font-bold text-white`}>Your Local Network</Text>
-			<Text style={tw`mt-1 max-w-sm text-center text-sm text-ink-dull`}>
+			<Text style={tw`max-w-sm mt-1 text-sm text-center text-ink-dull`}>
 				Other Spacedrive nodes on your LAN will appear here, along with your default OS
 				network mounts.
 			</Text>

--- a/apps/mobile/src/screens/network/Network.tsx
+++ b/apps/mobile/src/screens/network/Network.tsx
@@ -11,7 +11,7 @@ export default function NetworkScreen({ navigation }: NetworkStackScreenProps<'N
 		<ScreenContainer scrollview={false} style={tw`items-center justify-center gap-0`}>
 			<Icon name="Globe" size={128} />
 			<Text style={tw`mt-4 text-lg font-bold text-white`}>Your Local Network</Text>
-			<Text style={tw`max-w-sm mt-1 text-sm text-center text-ink-dull`}>
+			<Text style={tw`mt-1 max-w-sm text-center text-sm text-ink-dull`}>
 				Other Spacedrive nodes on your LAN will appear here, along with your default OS
 				network mounts.
 			</Text>

--- a/apps/mobile/src/screens/overview/Overview.tsx
+++ b/apps/mobile/src/screens/overview/Overview.tsx
@@ -5,6 +5,7 @@ import Cloud from '~/components/overview/Cloud';
 import Devices from '~/components/overview/Devices';
 import Locations from '~/components/overview/Locations';
 import OverviewStats from '~/components/overview/OverviewStats';
+import { useEnableDrawer } from '~/hooks/useEnableDrawer';
 
 const EMPTY_STATISTICS = {
 	id: 0,
@@ -26,6 +27,7 @@ export default function OverviewScreen() {
 
 	// Running the query here so the data is already available for settings screen
 	useLibraryQuery(['sync.enabled']);
+	useEnableDrawer();
 
 	return (
 		<ScreenContainer>

--- a/apps/mobile/src/screens/settings/Settings.tsx
+++ b/apps/mobile/src/screens/settings/Settings.tsx
@@ -19,6 +19,7 @@ import { Platform, SectionList, Text, TouchableWithoutFeedback, View } from 'rea
 import { DebugState, useDebugState, useDebugStateEnabler, useLibraryQuery } from '@sd/client';
 import ScreenContainer from '~/components/layout/ScreenContainer';
 import { SettingsItem } from '~/components/settings/SettingsItem';
+import { useEnableDrawer } from '~/hooks/useEnableDrawer';
 import { tw, twStyle } from '~/lib/tailwind';
 import { SettingsStackParamList, SettingsStackScreenProps } from '~/navigation/tabs/SettingsStack';
 
@@ -157,6 +158,7 @@ function renderSectionHeader({ section }: { section: { title: string } }) {
 export default function SettingsScreen({ navigation }: SettingsStackScreenProps<'Settings'>) {
 	const debugState = useDebugState();
 	const syncEnabled = useLibraryQuery(['sync.enabled']);
+	useEnableDrawer();
 	return (
 		<ScreenContainer tabHeight={false} style={tw`gap-0 px-5 py-0`}>
 			<SectionList

--- a/apps/mobile/src/screens/settings/library/LocationSettings.tsx
+++ b/apps/mobile/src/screens/settings/library/LocationSettings.tsx
@@ -1,7 +1,7 @@
 import LocationsScreen from '~/screens/browse/Locations';
 
 const LocationSettingsScreen = () => {
-	return <LocationsScreen viewStyle="list" />;
+	return <LocationsScreen navToSettings viewStyle="list" />;
 };
 
 export default LocationSettingsScreen;


### PR DESCRIPTION
- You can now swipe from inner screens of stacks to navigate back to the initial route of that stack or the previous screen of that stack.

- The Drawer will now only open on the initial screens of the stacks, i'm using a hook which has been applied to 4 of those screens that enables Drawer Swiping (this can be improved).

- Pressing on a location in settings will take you to edit location page instead.