### PR TITLE
[ENG-1897,1900,1901] Quick add tag fix & more

### DIFF
--- a/interface/app/$libraryId/Explorer/ContextMenu/SharedItems.tsx
+++ b/interface/app/$libraryId/Explorer/ContextMenu/SharedItems.tsx
@@ -63,7 +63,7 @@ export const OpenQuickView = () => {
 
 	return (
 		<ContextMenu.Item
-			label={t('quick_view')}
+			label={t('quick_preview')}
 			keybind={keybind([], [' '])}
 			onClick={() => (getQuickPreviewStore().open = true)}
 		/>

--- a/interface/app/$libraryId/Explorer/Inspector/index.tsx
+++ b/interface/app/$libraryId/Explorer/Inspector/index.tsx
@@ -395,6 +395,7 @@ export const SingleItemMetadata = ({ item }: { item: ExplorerItem }) => {
 						<DropdownMenu.Root
 							trigger={<PlaceholderPill>{t('add_tag')}</PlaceholderPill>}
 							side="left"
+							className="z-[101]"
 							sideOffset={5}
 							alignOffset={-10}
 						>

--- a/interface/components/ColorPicker.tsx
+++ b/interface/components/ColorPicker.tsx
@@ -19,7 +19,7 @@ export const ColorPicker = <T extends FieldValues>({ className, ...props }: Prop
 					style={{ backgroundColor: field.value }}
 				/>
 			}
-			className="p-3"
+			className="relative z-[110] p-3"
 			sideOffset={5}
 		>
 			<HexColorPicker color={field.value} onChange={field.onChange} />

--- a/packages/ui/src/Dialog.tsx
+++ b/packages/ui/src/Dialog.tsx
@@ -261,14 +261,14 @@ export function Dialog<S extends FieldValues>({
 				show ? (
 					<RDialog.Portal forceMount>
 						<AnimatedDialogOverlay
-							className="z-49 fixed inset-0 m-px grid place-items-center overflow-y-auto rounded-xl bg-app/50"
+							className="fixed inset-0 z-[102] m-px grid place-items-center overflow-y-auto rounded-xl bg-app/50"
 							style={{
 								opacity: styles.opacity
 							}}
 						/>
 
 						<AnimatedDialogContent
-							className="!pointer-events-none fixed inset-0 z-50 grid place-items-center overflow-y-auto"
+							className="!pointer-events-none fixed inset-0 z-[103] grid place-items-center overflow-y-auto"
 							style={styles}
 							onInteractOutside={(e) =>
 								props.ignoreClickOutside && e.preventDefault()


### PR DESCRIPTION
**This PR does the following**:

- Add tag context menu shows in quick preview.
- Pressing + New Tag will now show the dialog properly while quick preview is open.
- Quick view -> Quick Preview in context menu.

**images**:

![Screenshot 2024-09-24 at 6 53 24 PM](https://github.com/user-attachments/assets/a18a09d4-575f-4307-baa4-02d3a6056c3c)

![Screenshot 2024-09-24 at 6 53 11 PM](https://github.com/user-attachments/assets/c82e4a3f-89ad-41e3-acb5-c0fdf933abe6)

![Screenshot 2024-09-24 at 6 54 03 PM](https://github.com/user-attachments/assets/44f68ea7-8d5a-40d3-b331-36e031373cf3)

