### PR TITLE
Use mimalloc as the global memory allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3624,7 +3624,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core 0.51.1",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -4260,7 +4260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4268,6 +4268,16 @@ name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "libmimalloc-sys"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "libp2p"
@@ -5112,6 +5122,15 @@ dependencies = [
  "parking_lot 0.11.2",
  "quanta",
  "sketches-ddsketch",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -8299,6 +8318,7 @@ dependencies = [
  "futures",
  "http 0.2.12",
  "hyper 0.14.30",
+ "mimalloc",
  "opener",
  "prisma-client-rust",
  "rand 0.9.0-alpha.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ image               = "0.24.9"                                       # Update bl
 itertools           = "0.13.0"
 lending-stream      = "1.0"
 libc                = "0.2"
+mimalloc            = "0.1.43"
 normpath            = "1.2"
 once_cell           = "1.19"
 pin-project-lite    = "0.2.14"
@@ -63,8 +64,7 @@ tracing-test        = "0.2.5"
 uhlc                = "0.8.0"                                        # Must follow version used by specta
 uuid                = "1.10"                                         # Must follow version used by specta
 webp                = "0.2.6"                                        # Update blocked by image
-mimalloc = "0.1.43"
-																#
+
 [workspace.dependencies.prisma-client-rust]
 default-features = false
 features         = ["migrations", "specta", "sqlite", "sqlite-create-many"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,8 @@ tracing-test        = "0.2.5"
 uhlc                = "0.8.0"                                        # Must follow version used by specta
 uuid                = "1.10"                                         # Must follow version used by specta
 webp                = "0.2.6"                                        # Update blocked by image
-
+mimalloc = "0.1.43"
+																#
 [workspace.dependencies.prisma-client-rust]
 default-features = false
 features         = ["migrations", "specta", "sqlite", "sqlite-create-many"]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -41,6 +41,9 @@ tauri-plugin-os      = "=2.0.0-rc.0"
 tauri-plugin-shell   = "=2.0.0-rc.0"
 tauri-plugin-updater = "=2.0.0-rc.0"
 
+# memory allocator
+mimalloc = { workspace = true }
+
 [dependencies.tauri]
 features = ["linux-libxdo", "macos-private-api", "native-tls-vendored", "unstable"]
 version  = "=2.0.0-rc.2"

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -3,6 +3,9 @@
 	windows_subsystem = "windows"
 )]
 
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use std::{fs, path::PathBuf, process::Command, sync::Arc, time::Duration};
 
 use menu::{set_enabled, MenuEvent};


### PR DESCRIPTION
This PR changes the global allocator to mimalloc. In our tests, it performed better than the default allocator, making Spacedrive less intense in memory terms.

Note tho, that this PR doesn't fix our current issue with memory leaking, but it contributes to a better experience overall.