### PR TITLE
Handle thumbnail encoder error

### DIFF
--- a/core/crates/heavy-lifting/src/media_processor/helpers/thumbnailer.rs
+++ b/core/crates/heavy-lifting/src/media_processor/helpers/thumbnailer.rs
@@ -363,7 +363,7 @@ fn inner_generate_image_thumbnail(
 		)
 	})?;
 
-	let thumb = encoder.encode_advanced(&*WEBP_CONFIG).map_err(|reason| {
+	let thumb = encoder.encode_advanced(&WEBP_CONFIG).map_err(|reason| {
 		thumbnailer::NonCriticalThumbnailerError::WebPEncoding(
 			file_path.clone(),
 			format!("{reason:?}"),

--- a/core/crates/heavy-lifting/src/media_processor/helpers/thumbnailer.rs
+++ b/core/crates/heavy-lifting/src/media_processor/helpers/thumbnailer.rs
@@ -354,10 +354,19 @@ fn inner_generate_image_thumbnail(
 		)
 	})?;
 
+	let thumb = encoder
+		.encode_simple(false, TARGET_QUALITY)
+		.map_err(|reason| {
+			thumbnailer::NonCriticalThumbnailerError::WebPEncoding(
+				file_path.clone(),
+				format!("{reason:?}"),
+			)
+		})?;
+
 	// Type `WebPMemory` is !Send, which makes the `Future` in this function `!Send`,
 	// this make us `deref` to have a `&[u8]` and then `to_owned` to make a `Vec<u8>`
 	// which implies on a unwanted clone...
-	Ok(encoder.encode(TARGET_QUALITY).deref().to_owned())
+	Ok(thumb.deref().to_owned())
 }
 
 #[instrument(


### PR DESCRIPTION
When generating thumbnails, we may crash if the file is invalid, e.g. has an invalid width or height.

The application shouldn't crash, but report the invalid file as a non-critical error and keep processing the remaining files.

This PR does that by not calling the [`Encoder::encode`](https://github.com/jaredforth/webp/blob/4e7616a0a62bc4a78a9c63cfd3040fdd6757f92b/src/encoder.rs#L70), which `.unwrap`s, but rather calling `Encoder::encode_simple` and handling its result.

Closes #2736
