### PR TITLE
Fix Inspector notes

### DIFF
--- a/interface/app/$libraryId/Explorer/Inspector/MediaData.tsx
+++ b/interface/app/$libraryId/Explorer/Inspector/MediaData.tsx
@@ -67,147 +67,6 @@ const UrlMetadataValue = (props: { text: string; url: string; platform: Platform
 	</a>
 );
 
-const ExifMediaData = (data: ExifMetadata) => {
-	const platform = usePlatform();
-	const { t } = useLocale();
-	const coordinatesFormat = useUnitFormatStore().coordinatesFormat;
-
-	return (
-		<>
-			<MetaData
-				label={t('date')}
-				tooltipValue={data.date_taken ?? null} // should show full raw value
-				// should show localised, utc-offset value or plain value with tooltip mentioning that we don't have the timezone metadata
-				value={data.date_taken ?? null}
-			/>
-			<MetaData label={t('type')} value={t('image')} />
-			<MetaData
-				label={t('location')}
-				tooltipValue={data.location && formatLocation(data.location, coordinatesFormat)}
-				value={
-					data.location && (
-						<UrlMetadataValue
-							url={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
-								formatLocation(data.location, 'dd')
-							)}`}
-							text={formatLocation(
-								data.location,
-								coordinatesFormat,
-								coordinatesFormat === 'dd' ? 4 : 0
-							)}
-							platform={platform}
-						/>
-					)
-				}
-			/>
-			<MetaData
-				label="Plus Code"
-				value={
-					data.location?.pluscode && (
-						<UrlMetadataValue
-							url={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
-								data.location.pluscode
-							)}`}
-							text={data.location.pluscode}
-							platform={platform}
-						/>
-					)
-				}
-			/>
-			<MetaData
-				label={t('resolution')}
-				value={`${data.resolution.width} x ${data.resolution.height}`}
-			/>
-			<MetaData label={t('device')} value={data.camera_data.device_make} />
-			<MetaData label={t('model')} value={data.camera_data.device_model} />
-			<MetaData label={t('color_profile')} value={data.camera_data.color_profile} />
-			<MetaData label={t('color_space')} value={data.camera_data.color_space} />
-			<MetaData
-				label={t('flash')}
-				value={t(`${data.camera_data.flash?.mode.toLowerCase()}`)}
-			/>
-			<MetaData
-				label={t('zoom')}
-				value={
-					data.camera_data &&
-					data.camera_data.zoom &&
-					!Number.isNaN(data.camera_data.zoom)
-						? `${data.camera_data.zoom.toFixed(2) + 'x'}`
-						: '--'
-				}
-			/>
-			<MetaData label="ISO" value={data.camera_data.iso} />
-			<MetaData label={t('software')} value={data.camera_data.software} />
-		</>
-	);
-};
-
-const FFmpegMediaData = (data: FFmpegMetadata) => {
-	const { t } = useLocale();
-
-	const streamKinds = new Set(
-		data.programs.flatMap((program) => program.streams.map((stream) => stream.codec?.kind))
-	);
-	const type = streamKinds.has('video')
-		? 'Video'
-		: streamKinds.has('audio')
-			? 'Audio'
-			: (capitalize(streamKinds.values().next().value) ?? 'Unknown');
-
-	const bit_rate = humanizeSize(int32ArrayToBigInt(data.bit_rate), {
-		is_bit: true,
-		base_unit: 'binary',
-		use_plural: false
-	});
-
-	const duration_ms = data.duration ? int32ArrayToBigInt(data.duration) / 1000n : null;
-	const duration = duration_ms
-		? dayjs.duration(
-				Number(duration_ms / 1000n) + Number(duration_ms % 1000n) / 1000,
-				'seconds'
-			)
-		: null;
-
-	const start_time_ms = data.start_time ? int32ArrayToBigInt(data.start_time) / 1000n : null;
-	const start_time = start_time_ms
-		? dayjs.duration(
-				Number(start_time_ms / 1000n) + Number(start_time_ms % 1000n) / 1000,
-				'seconds'
-			)
-		: null;
-
-	const chapters = data.chapters
-		.map((chapter) => {
-			const num = BigInt(chapter.time_base_num);
-			const den = BigInt(chapter.time_base_den);
-
-			const start = dayjs.duration(
-				Number((int32ArrayToBigInt(chapter.start) * num) / den),
-				'seconds'
-			);
-
-			const end = dayjs.duration(
-				Number((int32ArrayToBigInt(chapter.end) * num) / den),
-				'seconds'
-			);
-
-			return `${start.format('HH:mm:ss')} - ${end.format('HH:mm:ss')}`;
-		})
-		.join('\n');
-
-	return (
-		<>
-			<MetaData label={t('type')} value={type} />
-			<MetaData label={t('bitrate')} value={`${bit_rate.value} ${bit_rate.unit}/s`} />
-			{duration && <MetaData label={t('duration')} value={duration.format('HH:mm:ss.SSS')} />}
-			{start_time && (
-				<MetaData label={t('start_time')} value={start_time.format('HH:mm:ss.SSS')} />
-			)}
-			{chapters && <MetaData label={t('chapters')} value={chapters} />}
-		</>
-	);
-};
-
 interface Props {
 	data: RemoteMediaData;
 }
@@ -215,6 +74,161 @@ interface Props {
 export const MediaData = ({ data }: Props) => {
 	const { t } = useLocale();
 	const showMoreInfo = useSelector(explorerStore, (s) => s.showMoreInfo);
+	const platform = usePlatform();
+	const coordinatesFormat = useUnitFormatStore().coordinatesFormat;
+
+	const renderMetadata = () => {
+		if ('Exif' in data) {
+			return (
+				<>
+					<MetaData
+						label={t('date')}
+						tooltipValue={data.Exif.date_taken ?? null} // should show full raw value
+						// should show localised, utc-offset value or plain value with tooltip mentioning that we don't have the timezone metadata
+						value={data.Exif.date_taken ?? null}
+					/>
+					<MetaData label={t('type')} value={t('image')} />
+					<MetaData
+						label={t('location')}
+						tooltipValue={
+							data.Exif.location &&
+							formatLocation(data.Exif.location, coordinatesFormat)
+						}
+						value={
+							data.Exif.location && (
+								<UrlMetadataValue
+									url={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
+										formatLocation(data.Exif.location, 'dd')
+									)}`}
+									text={formatLocation(
+										data.Exif.location,
+										coordinatesFormat,
+										coordinatesFormat === 'dd' ? 4 : 0
+									)}
+									platform={platform}
+								/>
+							)
+						}
+					/>
+					<MetaData
+						label="Plus Code"
+						value={
+							data.Exif.location?.pluscode && (
+								<UrlMetadataValue
+									url={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
+										data.Exif.location.pluscode
+									)}`}
+									text={data.Exif.location.pluscode}
+									platform={platform}
+								/>
+							)
+						}
+					/>
+					<MetaData
+						label={t('resolution')}
+						value={`${data.Exif.resolution.width} x ${data.Exif.resolution.height}`}
+					/>
+					<MetaData label={t('device')} value={data.Exif.camera_data.device_make} />
+					<MetaData label={t('model')} value={data.Exif.camera_data.device_model} />
+					<MetaData
+						label={t('color_profile')}
+						value={data.Exif.camera_data.color_profile}
+					/>
+					<MetaData label={t('color_space')} value={data.Exif.camera_data.color_space} />
+					<MetaData
+						label={t('flash')}
+						value={t(`${data.Exif.camera_data.flash?.mode.toLowerCase()}`)}
+					/>
+					<MetaData
+						label={t('zoom')}
+						value={
+							data.Exif.camera_data &&
+							data.Exif.camera_data.zoom &&
+							!Number.isNaN(data.Exif.camera_data.zoom)
+								? `${data.Exif.camera_data.zoom.toFixed(2) + 'x'}`
+								: '--'
+						}
+					/>
+					<MetaData label="ISO" value={data.Exif.camera_data.iso} />
+					<MetaData label={t('software')} value={data.Exif.camera_data.software} />
+				</>
+			);
+		} else if ('FFmpeg' in data) {
+			const streamKinds = new Set(
+				data.FFmpeg.programs.flatMap((program) =>
+					program.streams.map((stream) => stream.codec?.kind)
+				)
+			);
+			const type = streamKinds.has('video')
+				? 'Video'
+				: streamKinds.has('audio')
+					? 'Audio'
+					: (capitalize(streamKinds.values().next().value) ?? 'Unknown');
+
+			const bit_rate = humanizeSize(int32ArrayToBigInt(data.FFmpeg.bit_rate), {
+				is_bit: true,
+				base_unit: 'binary',
+				use_plural: false
+			});
+
+			const duration_ms = data.FFmpeg.duration
+				? int32ArrayToBigInt(data.FFmpeg.duration) / 1000n
+				: null;
+			const duration = duration_ms
+				? dayjs.duration(
+						Number(duration_ms / 1000n) + Number(duration_ms % 1000n) / 1000,
+						'seconds'
+					)
+				: null;
+
+			const start_time_ms = data.FFmpeg.start_time
+				? int32ArrayToBigInt(data.FFmpeg.start_time) / 1000n
+				: null;
+			const start_time = start_time_ms
+				? dayjs.duration(
+						Number(start_time_ms / 1000n) + Number(start_time_ms % 1000n) / 1000,
+						'seconds'
+					)
+				: null;
+
+			const chapters = data.FFmpeg.chapters
+				.map((chapter) => {
+					const num = BigInt(chapter.time_base_num);
+					const den = BigInt(chapter.time_base_den);
+
+					const start = dayjs.duration(
+						Number((int32ArrayToBigInt(chapter.start) * num) / den),
+						'seconds'
+					);
+
+					const end = dayjs.duration(
+						Number((int32ArrayToBigInt(chapter.end) * num) / den),
+						'seconds'
+					);
+
+					return `${start.format('HH:mm:ss')} - ${end.format('HH:mm:ss')}`;
+				})
+				.join('\n');
+
+			return (
+				<>
+					<MetaData label={t('type')} value={type} />
+					<MetaData label={t('bitrate')} value={`${bit_rate.value} ${bit_rate.unit}/s`} />
+					{duration && (
+						<MetaData label={t('duration')} value={duration.format('HH:mm:ss.SSS')} />
+					)}
+					{start_time && (
+						<MetaData
+							label={t('start_time')}
+							value={start_time.format('HH:mm:ss.SSS')}
+						/>
+					)}
+					{chapters && <MetaData label={t('chapters')} value={chapters} />}
+				</>
+			);
+		}
+		return null;
+	};
 
 	return (
 		<div className="flex flex-col gap-0 py-2">
@@ -224,7 +238,7 @@ export const MediaData = ({ data }: Props) => {
 				variant="apple"
 				title={t('more_info')}
 			>
-				{'Exif' in data ? ExifMediaData(data.Exif) : FFmpegMediaData(data.FFmpeg)}
+				{renderMetadata()}
 			</Accordion>
 		</div>
 	);

--- a/interface/app/$libraryId/Explorer/Inspector/Note.tsx
+++ b/interface/app/$libraryId/Explorer/Inspector/Note.tsx
@@ -1,33 +1,46 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
+import { useSnapshot } from 'valtio';
 import { Object as SDObject, useLibraryMutation } from '@sd/client';
 import { Divider, TextArea } from '@sd/ui';
 import { useLocale } from '~/hooks';
 
 import { MetaContainer, MetaTitle } from '../Inspector';
+import { noteCacheStore } from './store';
 
 interface Props {
 	data: SDObject;
 }
 
-export default function Note(props: Props) {
+export default function Note({ data }: Props) {
 	const setNote = useLibraryMutation('files.setNote');
 
 	const flush = useRef<() => void>();
 	const debouncedSetNote = useDebouncedCallback((note: string) => {
 		setNote.mutate({
-			id: props.data.id,
+			id: data.id,
 			note
 		});
 	}, 500);
 
-	// Don't need to wrap in a arrow func because flush is not a method
+	// Flush debounced note change when component unmounts
 	flush.current = debouncedSetNote.flush;
 
-	// Force update when component unmounts
+	// Cleanup on unmount
 	useEffect(() => () => flush.current?.(), []);
 
-	const [cachedNote, setCachedNote] = useState(props.data.note);
+	// Use Valtio snapshot to manage cached notes
+	const noteSnapshot = useSnapshot(noteCacheStore);
+
+	// Prioritize cached value unless backend value is different, then update
+	useEffect(() => {
+		const cachedNote = noteCacheStore[data.id];
+		if (cachedNote === undefined || cachedNote === data.note) {
+			// If no cached value or cached value equals backend value, update store with backend value
+			noteCacheStore[data.id] = data.note ?? undefined;
+		}
+	}, [data]);
+
 	const { t } = useLocale();
 
 	return (
@@ -37,9 +50,9 @@ export default function Note(props: Props) {
 				<MetaTitle>{t('note')}</MetaTitle>
 				<TextArea
 					className="mb-1 mt-2 !py-2 text-xs leading-snug"
-					value={cachedNote ?? ''}
+					value={noteSnapshot[data.id] ?? ''}
 					onChange={(e) => {
-						setCachedNote(e.target.value);
+						noteCacheStore[data.id] = e.target.value;
 						debouncedSetNote(e.target.value);
 					}}
 				/>

--- a/interface/app/$libraryId/Explorer/Inspector/store.tsx
+++ b/interface/app/$libraryId/Explorer/Inspector/store.tsx
@@ -1,0 +1,4 @@
+import { proxy } from 'valtio';
+
+// Store to cache notes for multiple files
+export const noteCacheStore = proxy<{ [id: string]: string | undefined }>({});


### PR DESCRIPTION
Notes in the Inspector work now... not that anyone noticed they didn't 🥲
- Ensure note value updates when prop data changes.
- Fixed a rendering bug in MediaData caused by separate metadata functions leading to inconsistent updates. Replaced them with a single renderMetadata function for better consistency.
- Added a Valtio store in Note.tsx to cache note values across files, prioritizing cached values unless the backend value changes. 