### PR TITLE
Change sample date

### DIFF
--- a/interface/app/$libraryId/Explorer/util.ts
+++ b/interface/app/$libraryId/Explorer/util.ts
@@ -73,11 +73,16 @@ export function loadDayjsLocale(language: string) {
 // Generate list of localized formats available in the app
 export function generateLocaleDateFormats(language: string) {
 	language = language.replace('_', '-');
-	const defaultDate = '01/01/2024 23:19';
+	// this is a good example date because:
+	// - day segment is greater than 12, no confusion about the month
+	// - month segment is below 10, no confusion about zero-padding
+	// - hours segment is below 10, no confusion about zero-padding
+	// - is a Monday, just a good day of week for examples
+	const defaultDate = '2024-01-15 08:51';
 	const DATE_FORMATS = [
 		{
 			value: 'L',
-			label: dayjs(defaultDate).locale(language).format('L')
+			label: dayjs().locale(language).format('L')
 		},
 		{
 			value: 'L, LT',

--- a/interface/app/$libraryId/Explorer/util.ts
+++ b/interface/app/$libraryId/Explorer/util.ts
@@ -82,7 +82,7 @@ export function generateLocaleDateFormats(language: string) {
 	const DATE_FORMATS = [
 		{
 			value: 'L',
-			label: dayjs().locale(language).format('L')
+			label: dayjs(defaultDate).locale(language).format('L')
 		},
 		{
 			value: 'L, LT',


### PR DESCRIPTION
<!-- Put any information about this PR up here -->

This PR switches the date format example from 1 Jan 2024 (where 01/01/2024 could mean MM-DD-YYYY or DD-MM-YYYY) to one less confusable (15 Jan 2024)

08:51 was chosen because 08 allows explicit visibility of zero-padding, 51 was just random and felt right

<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->

Closes ENG-1931
