### PR TITLE
Fix Android builds failing to compile

### DIFF
--- a/apps/mobile/modules/sd-core/core/Cargo.toml
+++ b/apps/mobile/modules/sd-core/core/Cargo.toml
@@ -7,9 +7,8 @@ license.workspace      = true
 repository.workspace   = true
 rust-version.workspace = true
 
-[target.'cfg(target_os = "android")'.dependencies]
-sd-core = { default-features = false, features = ["mobile"], path = "../../../../../core" }
 
+# Spacedrive Sub-crates
 [target.'cfg(target_os = "ios")'.dependencies]
 sd-core = { default-features = false, features = [
 	"ffmpeg",
@@ -17,6 +16,10 @@ sd-core = { default-features = false, features = [
 	"mobile"
 ], path = "../../../../../core" }
 
+[target.'cfg(target_os = "android")'.dependencies]
+sd-core = { path = "../../../../../core", features = ["mobile"], default-features = false }
+
+[dependencies]
 # Workspace dependencies
 futures    = { workspace = true }
 rspc       = { workspace = true }


### PR DESCRIPTION
Android builds fail to compile due to weird dependency linking issues. This PR fixes that, and we now have working Android builds again.