### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9574,7 +9574,7 @@ dependencies = [
 
 [[package]]
 name = "sd-core"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "async-channel",
  "async-recursion",
@@ -9862,7 +9862,7 @@ dependencies = [
 
 [[package]]
 name = "sd-desktop"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "axum",
  "axum-extra",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "sd-desktop"
-version = "0.4.2"
+version = "0.5.0"
 
 authors              = ["Spacedrive Technology Inc <support@spacedrive.com>"]
 default-run          = "sd-desktop"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "sd-core"
-version = "0.4.2"
+version = "0.5.0"
 
 authors                = ["Spacedrive Technology Inc <support@spacedrive.com>"]
 description            = "Virtual distributed filesystem engine that powers Spacedrive."


### PR DESCRIPTION
This PR bumps the version to 0.5.0 since that's officially the version being worked on in `main`.
