### PR TITLE
Fix issue with Node 23

### DIFF
--- a/apps/desktop/.eslintrc.mjs
+++ b/apps/desktop/.eslintrc.mjs
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
 	extends: [require.resolve('@sd/config/eslint/web.js')],
 	parserOptions: {
 		tsconfigRootDir: __dirname,

--- a/apps/desktop/postcss.config.cjs
+++ b/apps/desktop/postcss.config.cjs
@@ -1,1 +1,0 @@
-module.exports = require('@sd/ui/postcss');

--- a/apps/desktop/postcss.config.mjs
+++ b/apps/desktop/postcss.config.mjs
@@ -1,0 +1,1 @@
+export { default } from '@sd/ui/postcss';

--- a/apps/desktop/tailwind.config.js
+++ b/apps/desktop/tailwind.config.js
@@ -1,1 +1,0 @@
-module.exports = require('@sd/ui/tailwind')('desktop');

--- a/apps/desktop/tailwind.config.mjs
+++ b/apps/desktop/tailwind.config.mjs
@@ -1,0 +1,3 @@
+import tailwind from '@sd/ui/tailwind';
+
+export default tailwind('desktop');

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -8,7 +8,7 @@
 		},
 		"moduleResolution": "bundler"
 	},
-	"include": ["src"],
+	"include": ["src", "tailwind.config.mjs", "postcss.config.mjs", ".eslintrc.mjs"],
 	"references": [
 		{
 			"path": "../../interface"


### PR DESCRIPTION
I was having issues trying to launch spacedrive in dev mode due to updating my Node to version 23. So I tried to fix it, changing the desktop app to use ES Modules instead of CommonJS. 

I'm not too sure as TS isn't much my thing, so this PR needs a proper reviewing from some TS guys.