### PR TITLE
Implement empty menu for Windows to prevent menu bar display

### DIFF
--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -1991,6 +1991,17 @@ fn main() {
 			if let Err(e) = setup_menu(app.handle()) {
 				tracing::warn!("Failed to setup menu: {}", e);
 			}
+
+			// Explicitly remove menu on Windows
+			#[cfg(target_os = "windows")]
+			{
+				use tauri::menu::MenuBuilder;
+				// Create an empty menu to ensure no menu bar is shown on Windows
+				if let Ok(empty_menu) = MenuBuilder::new(app.handle()).build() {
+					let _ = app.handle().set_menu(empty_menu);
+				}
+			}
+
 			tracing::info!("Spacedrive Tauri app starting...");
 
 			// Apply macOS-specific window customizations


### PR DESCRIPTION
- Added logic to explicitly set an empty menu on Windows to ensure no menu bar is shown.
- Utilized Tauri's MenuBuilder to create and apply the empty menu during app initialization.

Before

<img width="1394" height="106" alt="Screenshot 2025-12-26 171631" src="https://github.com/user-attachments/assets/a8104d3b-7e12-41ad-90e6-eff05d4aadf4" />


After

<img width="1292" height="100" alt="after" src="https://github.com/user-attachments/assets/0c856ee1-f83d-444e-bfc3-4087ca5363cf" />

