### PR TITLE
fix(setup): update GitHub connectivity check to use HTTPS port 443

### DIFF
--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -110,7 +110,7 @@ https://learn.microsoft.com/windows/package-manager/winget/
 
     # Check connectivity to GitHub
     $ProgressPreference = 'SilentlyContinue'
-    if (-not ((Test-NetConnection -ComputerName 'github.com' -Port 80).TcpTestSucceeded)) {
+    if (-not ((Test-NetConnection -ComputerName 'github.com' -Port 443 -WarningAction SilentlyContinue).TcpTestSucceeded)) {
         Exit-WithError "Can't connect to github, check your internet connection and run this script again"
     }
     $ProgressPreference = 'Continue'


### PR DESCRIPTION
This commit modifies the connectivity check in the setup script to use port 443 instead of port 80 for GitHub, ensuring a more secure connection. The change enhances the script's reliability in verifying internet connectivity before proceeding with further setup steps.