### PR TITLE
UseNormalizedQuery direct query input

### DIFF
--- a/apps/mobile/src/screens/browse/BrowseScreen.tsx
+++ b/apps/mobile/src/screens/browse/BrowseScreen.tsx
@@ -80,7 +80,7 @@ function CreateSpaceScreen() {
 export function BrowseScreen() {
 	const insets = useSafeAreaInsets();
 	const { data: spacesData } = useNormalizedQuery({
-		wireMethod: "query:spaces.list",
+		query: "spaces.list",
 		input: null,
 		resourceType: "space",
 	});

--- a/apps/mobile/src/screens/browse/components/DevicesGroup.tsx
+++ b/apps/mobile/src/screens/browse/components/DevicesGroup.tsx
@@ -9,7 +9,7 @@ import { SettingsGroup, SettingsLink } from "../../../components/primitive";
 export function DevicesGroup() {
 	const router = useRouter();
 	const { data: devices, isLoading } = useNormalizedQuery<any, Device[]>({
-		wireMethod: "query:devices.list",
+		query: "devices.list",
 		input: {
 			include_offline: true,
 			include_details: false,

--- a/apps/mobile/src/screens/browse/components/LocationsGroup.tsx
+++ b/apps/mobile/src/screens/browse/components/LocationsGroup.tsx
@@ -9,13 +9,13 @@ import type { Device } from "@sd/ts-client";
 export function LocationsGroup() {
 	const router = useRouter();
 	const { data: locationsData } = useNormalizedQuery({
-		wireMethod: "query:locations.list",
+		query: "locations.list",
 		input: null,
 		resourceType: "location",
 	});
 
 	const { data: devices } = useNormalizedQuery<any, Device[]>({
-		wireMethod: "query:devices.list",
+		query: "devices.list",
 		input: {
 			include_offline: true,
 			include_details: false,

--- a/apps/mobile/src/screens/browse/components/VolumesGroup.tsx
+++ b/apps/mobile/src/screens/browse/components/VolumesGroup.tsx
@@ -10,14 +10,14 @@ export function VolumesGroup() {
 	const router = useRouter();
 	const { data: volumesData } = useNormalizedQuery<any, { volumes: Volume[] }>(
 		{
-			wireMethod: "query:volumes.list",
+			query: "volumes.list",
 			input: { filter: "All" },
 			resourceType: "volume",
 		}
 	);
 
 	const { data: devices } = useNormalizedQuery<any, Device[]>({
-		wireMethod: "query:devices.list",
+		query: "devices.list",
 		input: {
 			include_offline: true,
 			include_details: false,

--- a/apps/mobile/src/screens/explorer/ExplorerScreen.tsx
+++ b/apps/mobile/src/screens/explorer/ExplorerScreen.tsx
@@ -41,7 +41,7 @@ export function ExplorerScreen() {
 
 	// Fetch device for path display
 	const { data: devices } = useNormalizedQuery<any, Device[]>({
-		wireMethod: "query:devices.list",
+		query: "devices.list",
 		input: {
 			include_offline: true,
 			include_details: false,

--- a/apps/mobile/src/screens/explorer/hooks/useExplorerFiles.ts
+++ b/apps/mobile/src/screens/explorer/hooks/useExplorerFiles.ts
@@ -42,7 +42,7 @@ export function useExplorerFiles(
 
 	// Directory query
 	const directoryQuery = useNormalizedQuery({
-		wireMethod: "query:files.directory_listing",
+		query: "files.directory_listing",
 		input: currentPath
 			? {
 					path: currentPath,

--- a/apps/mobile/src/screens/explorer/hooks/useVirtualListing.ts
+++ b/apps/mobile/src/screens/explorer/hooks/useVirtualListing.ts
@@ -44,7 +44,7 @@ export function useVirtualListing(
 		any,
 		Device[]
 	>({
-		wireMethod: "query:devices.list",
+		query: "devices.list",
 		input: {
 			include_offline: true,
 			include_details: false,
@@ -57,7 +57,7 @@ export function useVirtualListing(
 	// Fetch locations
 	const { data: locationsData, isLoading: locationsLoading } =
 		useNormalizedQuery({
-			wireMethod: "query:locations.list",
+			query: "locations.list",
 			input: null,
 			resourceType: "location",
 			enabled: isVirtualView && view === "device",
@@ -68,7 +68,7 @@ export function useVirtualListing(
 		any,
 		{ volumes: Volume[] }
 	>({
-		wireMethod: "query:volumes.list",
+		query: "volumes.list",
 		input: { filter: "All" },
 		resourceType: "volume",
 		enabled: isVirtualView && view === "device",

--- a/apps/mobile/src/screens/overview/OverviewScreen.tsx
+++ b/apps/mobile/src/screens/overview/OverviewScreen.tsx
@@ -43,14 +43,14 @@ export function OverviewScreen() {
 		isLoading,
 		error,
 	} = useNormalizedQuery<null, Library>({
-		wireMethod: "query:libraries.info",
+		query: "libraries.info",
 		input: null,
 		resourceType: "library",
 	});
 
 	// Fetch locations list to get the selected location reactively
 	const { data: locationsData } = useNormalizedQuery<any, any>({
-		wireMethod: "query:locations.list",
+		query: "locations.list",
 		input: null,
 		resourceType: "location",
 	});

--- a/apps/mobile/src/screens/overview/components/DevicePanel.tsx
+++ b/apps/mobile/src/screens/overview/components/DevicePanel.tsx
@@ -65,7 +65,7 @@ export function DevicePanel({ onLocationSelect }: DevicePanelProps = {}) {
 		any,
 		any
 	>({
-		wireMethod: "query:volumes.list",
+		query: "volumes.list",
 		input: { filter: "All" },
 		resourceType: "volume",
 	});
@@ -75,7 +75,7 @@ export function DevicePanel({ onLocationSelect }: DevicePanelProps = {}) {
 		any,
 		DeviceWithConnection[]
 	>({
-		wireMethod: "query:devices.list",
+		query: "devices.list",
 		input: { include_offline: true, include_details: false },
 		resourceType: "device",
 	});
@@ -83,7 +83,7 @@ export function DevicePanel({ onLocationSelect }: DevicePanelProps = {}) {
 	// Fetch all locations
 	const { data: locationsData, isLoading: locationsLoading } =
 		useNormalizedQuery<any, any>({
-			wireMethod: "query:locations.list",
+			query: "locations.list",
 			input: null,
 			resourceType: "location",
 		});

--- a/core/tests/normalized_cache_fixtures_test.rs
+++ b/core/tests/normalized_cache_fixtures_test.rs
@@ -406,7 +406,7 @@ async fn capture_event_fixtures_for_typescript() -> Result<(), Box<dyn std::erro
 		"name": "directory_view_exact_mode",
 		"description": "Directory view should only show direct children, filtering out subdirectory files",
 		"query": {
-			"wireMethod": "query:files.directory_listing",
+			"query": "files.directory_listing",
 			"input": {
 				"path": test_location_path,
 				"limit": null,
@@ -439,7 +439,7 @@ async fn capture_event_fixtures_for_typescript() -> Result<(), Box<dyn std::erro
 		"name": "media_view_recursive_mode",
 		"description": "Media view should show all files recursively including subdirectories",
 		"query": {
-			"wireMethod": "query:files.media_listing",
+			"query": "files.media_listing",
 			"input": {
 				"path": test_location_path,
 				"include_descendants": true,
@@ -473,7 +473,7 @@ async fn capture_event_fixtures_for_typescript() -> Result<(), Box<dyn std::erro
 		"name": "location_updates",
 		"description": "Location list should update when locations are created or modified",
 		"query": {
-			"wireMethod": "query:locations.list",
+			"query": "locations.list",
 			"input": null,
 			"resourceType": "location",
 			"pathScope": null,

--- a/docs/core/testing.mdx
+++ b/docs/core/testing.mdx
@@ -1146,7 +1146,7 @@ describe("Cache Update Tests", () => {
 		const { result } = renderHook(
 			() =>
 				useNormalizedQuery({
-					wireMethod: "query:files.directory_listing",
+					query: "files.directory_listing",
 					input: { path: { Physical: { path: folderPath } } },
 					resourceType: "file",
 					pathScope: { Physical: { path: folderPath } },
@@ -1211,7 +1211,7 @@ The primary use case for bridge tests is verifying that `useNormalizedQuery` cac
 const { result } = renderHook(
 	() =>
 		useNormalizedQuery({
-			wireMethod: "query:files.directory_listing",
+			query: "files.directory_listing",
 			input: {
 				/* ... */
 			},

--- a/docs/react/ui/hooks.mdx
+++ b/docs/react/ui/hooks.mdx
@@ -135,7 +135,7 @@ import { useNormalizedCache } from '@sd/interface';
 
 function LocationsList() {
   const { data: locations } = useNormalizedCache({
-    wireMethod: 'query:locations.list',
+    query: 'locations.list',
     input: {},
     resourceType: 'location',
     isGlobalList: true,
@@ -566,7 +566,7 @@ const { data: nodeInfo } = useCoreQuery(
 
 // Dynamic data - short stale time or use useNormalizedCache
 const { data: files } = useNormalizedCache({
-  wireMethod: 'query:files.directory_listing',
+  query: 'files.directory_listing',
   input: { path },
   resourceType: 'file',
 });

--- a/docs/react/ui/normalized-cache.mdx
+++ b/docs/react/ui/normalized-cache.mdx
@@ -70,7 +70,7 @@ import { useNormalizedQuery } from "@sd/ts-client";
 
 function DirectoryView({ path }: { path: SdPath }) {
 	const { data, isLoading } = useNormalizedQuery({
-		wireMethod: "query:files.directory_listing",
+		query: "files.directory_listing",
 		input: { path },
 		resourceType: "file",
 		pathScope: path,
@@ -100,7 +100,7 @@ function DirectoryView({ path }: { path: SdPath }) {
 ```tsx
 function MediaGallery({ path }: { path: SdPath }) {
 	const { data } = useNormalizedQuery({
-		wireMethod: "query:files.media_listing",
+		query: "files.media_listing",
 		input: { path, include_descendants: true },
 		resourceType: "file",
 		pathScope: path,
@@ -120,7 +120,7 @@ function MediaGallery({ path }: { path: SdPath }) {
 ```tsx
 function LocationsList() {
 	const { data } = useNormalizedQuery({
-		wireMethod: "query:locations.list",
+		query: "locations.list",
 		input: null,
 		resourceType: "location",
 		// No pathScope - locations are global resources
@@ -137,7 +137,7 @@ function LocationsList() {
 ```tsx
 function FileInspector({ fileId }: { fileId: string }) {
 	const { data: file } = useNormalizedQuery({
-		wireMethod: "query:files.by_id",
+		query: "files.by_id",
 		input: { file_id: fileId },
 		resourceType: "file",
 		resourceId: fileId, // Only events for this file
@@ -161,8 +161,8 @@ function FileInspector({ fileId }: { fileId: string }) {
 
 ```tsx
 interface UseNormalizedQueryOptions<I> {
-	// Wire method to call (e.g., "query:files.directory_listing")
-	wireMethod: string;
+	// Query method to call (e.g., "files.directory_listing")
+	query: string;
 
 	// Input for the query
 	input: I;
@@ -425,7 +425,7 @@ Multiple hooks with identical filters automatically share a single backend subsc
 // Component A
 function LocationsList() {
   useNormalizedQuery({
-    wireMethod: 'query:locations.list',
+    query: 'locations.list',
     resourceType: 'location',
   });
 }
@@ -433,7 +433,7 @@ function LocationsList() {
 // Component B (mounted at same time)
 function LocationsDropdown() {
   useNormalizedQuery({
-    wireMethod: 'query:locations.list',
+    query: 'locations.list',
     resourceType: 'location',
   });
 }
@@ -549,7 +549,7 @@ cargo test --test normalized_cache_fixtures_test
 ```tsx
 // Good
 const { data } = useNormalizedQuery({
-	wireMethod: "query:files.directory_listing",
+	query: "files.directory_listing",
 	input: { path },
 	resourceType: "file",
 	pathScope: path, // Server filters efficiently
@@ -557,7 +557,7 @@ const { data } = useNormalizedQuery({
 
 // Bad - will skip subscription
 const { data } = useNormalizedQuery({
-	wireMethod: "query:files.directory_listing",
+	query: "files.directory_listing",
 	input: { path },
 	resourceType: "file",
 	// Missing pathScope! Subscription skipped to prevent overload
@@ -581,7 +581,7 @@ includeDescendants: true; // All matching files
 
 ```tsx
 const { data } = useNormalizedQuery({
-	wireMethod: "query:files.directory_listing",
+	query: "files.directory_listing",
 	input: { path },
 	resourceType: "file",
 	pathScope: path,
@@ -691,7 +691,7 @@ const { data } = useLibraryQuery({
 
 // After (instant updates)
 const { data } = useNormalizedQuery({
-	wireMethod: "query:locations.list",
+	query: "locations.list",
 	input: null,
 	resourceType: "location",
 });
@@ -764,7 +764,7 @@ import {
 
 ```tsx
 const { data: items } = useNormalizedQuery({
-	wireMethod: "query:items.list",
+	query: "items.list",
 	input: filters,
 	resourceType: "item",
 });
@@ -779,7 +779,7 @@ const { data: items } = useNormalizedQuery({
 
 ```tsx
 const { data: files } = useNormalizedQuery({
-	wireMethod: "query:files.directory_listing",
+	query: "files.directory_listing",
 	input: { path },
 	resourceType: "file",
 	pathScope: path,
@@ -795,7 +795,7 @@ const { data: files } = useNormalizedQuery({
 
 ```tsx
 const { data: file } = useNormalizedQuery({
-	wireMethod: "query:files.by_id",
+	query: "files.by_id",
 	input: { file_id },
 	resourceType: "file",
 	resourceId: file_id,

--- a/packages/interface/src/ShellLayout.tsx
+++ b/packages/interface/src/ShellLayout.tsx
@@ -45,7 +45,7 @@ function ShellLayoutContent() {
 
 	// Fetch locations to get current location info
 	const locationsQuery = useNormalizedQuery<null, {locations: Location[]}>({
-		wireMethod: 'query:locations.list',
+		query: 'locations.list',
 		input: null,
 		resourceType: 'location'
 	});

--- a/packages/interface/src/components/Inspector/variants/FileInspector.tsx
+++ b/packages/interface/src/components/Inspector/variants/FileInspector.tsx
@@ -88,7 +88,7 @@ export function FileInspector({file}: FileInspectorProps) {
 	};
 
 	const fileQuery = useNormalizedQuery<{file_id: string}, File>({
-		wireMethod: 'query:files.by_id',
+		query: 'files.by_id',
 		input: {file_id: file?.id || ''},
 		resourceType: 'file',
 		resourceId: file?.id,
@@ -1554,7 +1554,7 @@ function InstancesTab({file}: {file: File}) {
 		{entry_uuid: string},
 		{instances: File[]; total_count: number}
 	>({
-		wireMethod: 'query:files.alternate_instances',
+		query: 'files.alternate_instances',
 		input: {entry_uuid: file?.id || ''},
 		enabled: !!file?.id && !!file?.content_identity
 	});
@@ -1563,7 +1563,7 @@ function InstancesTab({file}: {file: File}) {
 
 	// Query devices to get proper names and icons
 	const devicesQuery = useNormalizedQuery<any, any[]>({
-		wireMethod: 'query:devices.list',
+		query: 'devices.list',
 		input: {
 			include_offline: true,
 			include_details: false,

--- a/packages/interface/src/components/JobManager/renderers/FileCopyRenderer.tsx
+++ b/packages/interface/src/components/JobManager/renderers/FileCopyRenderer.tsx
@@ -123,7 +123,7 @@ function FileCopyCardContent({
 
 	// Fetch devices to determine if destination is remote
 	const { data: devices } = useNormalizedQuery<any, Device[]>({
-		wireMethod: "query:devices.list",
+		query: "devices.list",
 		input: { include_offline: true, include_details: false },
 		resourceType: "device",
 	});

--- a/packages/interface/src/components/QuickPreview/DirectoryPreview.tsx
+++ b/packages/interface/src/components/QuickPreview/DirectoryPreview.tsx
@@ -10,7 +10,7 @@ interface DirectoryPreviewProps {
 
 export function DirectoryPreview({ file }: DirectoryPreviewProps) {
 	const directoryQuery = useNormalizedQuery({
-		wireMethod: "query:files.directory_listing",
+		query: "files.directory_listing",
 		input: {
 			path: file.sd_path,
 			limit: null,

--- a/packages/interface/src/components/QuickPreview/QuickPreview.tsx
+++ b/packages/interface/src/components/QuickPreview/QuickPreview.tsx
@@ -89,7 +89,7 @@ export function QuickPreview() {
 		isLoading,
 		error,
 	} = useNormalizedQuery<{ file_id: string }, File>({
-		wireMethod: "query:files.by_id",
+		query: "files.by_id",
 		input: { file_id: fileId! },
 		resourceType: "file",
 		resourceId: fileId!,

--- a/packages/interface/src/components/QuickPreview/QuickPreviewOverlay.tsx
+++ b/packages/interface/src/components/QuickPreview/QuickPreviewOverlay.tsx
@@ -25,7 +25,7 @@ export function QuickPreviewOverlay({
 	hasNext
 }: QuickPreviewOverlayProps) {
 	const { data: file, isLoading, error } = useNormalizedQuery<{ file_id: string }, File>({
-		wireMethod: 'query:files.by_id',
+		query: 'files.by_id',
 		input: { file_id: fileId },
 		resourceType: 'file',
 		resourceId: fileId,

--- a/packages/interface/src/components/SpacesSidebar/DevicesGroup.tsx
+++ b/packages/interface/src/components/SpacesSidebar/DevicesGroup.tsx
@@ -25,7 +25,7 @@ export function DevicesGroup({
 		ListLibraryDevicesInput,
 		Device[]
 	>({
-		wireMethod: "query:devices.list",
+		query: "devices.list",
 		input: {
 			include_offline: true,
 			include_details: false,

--- a/packages/interface/src/components/SpacesSidebar/LocationsGroup.tsx
+++ b/packages/interface/src/components/SpacesSidebar/LocationsGroup.tsx
@@ -19,7 +19,7 @@ export function LocationsGroup({
   const navigate = useNavigate();
 
   const { data: locationsData } = useNormalizedQuery({
-    wireMethod: "query:locations.list",
+    query: "locations.list",
     input: null, // Unit struct serializes as null, not {}
     resourceType: "location",
   });

--- a/packages/interface/src/components/SpacesSidebar/TagsGroup.tsx
+++ b/packages/interface/src/components/SpacesSidebar/TagsGroup.tsx
@@ -100,7 +100,7 @@ export function TagsGroup({
 	// Fetch tags with real-time updates using search with empty query
 	// Using select to normalize TagSearchResult[] to Tag[] for consistent cache structure
 	const { data: tags = [], isLoading } = useNormalizedQuery({
-		wireMethod: 'query:tags.search',
+		query: 'tags.search',
 		input: { query: '' },
 		resourceType: 'tag',
 		select: (data: any) => data?.tags?.map((result: any) => result.tag || result).filter(Boolean) ?? []

--- a/packages/interface/src/components/SpacesSidebar/VolumesGroup.tsx
+++ b/packages/interface/src/components/SpacesSidebar/VolumesGroup.tsx
@@ -67,7 +67,7 @@ export function VolumesGroup({
 	sortableListeners
 }: VolumesGroupProps) {
 	const {data: volumesData} = useNormalizedQuery({
-		wireMethod: 'query:volumes.list',
+		query: 'volumes.list',
 		input: {filter},
 		resourceType: 'volume'
 	});

--- a/packages/interface/src/components/SpacesSidebar/hooks/useSpaces.ts
+++ b/packages/interface/src/components/SpacesSidebar/hooks/useSpaces.ts
@@ -6,7 +6,7 @@ import type { Event } from '@sd/ts-client';
 
 export function useSpaces() {
 	return useNormalizedQuery({
-		wireMethod: 'query:spaces.list',
+		query: 'spaces.list',
 		input: null, // Unit struct serializes as null, not {}
 		resourceType: 'space',
 	});
@@ -18,7 +18,7 @@ export function useSpaceLayout(spaceId: string | null) {
 	const libraryId = client.getCurrentLibraryId();
 
 	const query = useNormalizedQuery({
-		wireMethod: 'query:spaces.get_layout',
+		query: 'spaces.get_layout',
 		input: spaceId ? { space_id: spaceId } : null,
 		resourceType: 'space_layout',
 		resourceId: spaceId || undefined,

--- a/packages/interface/src/components/TabManager/TabDefaultsSync.tsx
+++ b/packages/interface/src/components/TabManager/TabDefaultsSync.tsx
@@ -17,7 +17,7 @@ export function TabDefaultsSync() {
 		ListLibraryDevicesInput,
 		Device[]
 	>({
-		wireMethod: "query:devices.list",
+		query: "devices.list",
 		input: { include_offline: true, include_details: false },
 		resourceType: "device",
 	});

--- a/packages/interface/src/components/Tags/TagSelector.tsx
+++ b/packages/interface/src/components/Tags/TagSelector.tsx
@@ -38,7 +38,7 @@ export function TagSelector({
 	// Fetch all tags using search with empty query
 	// Using select to normalize TagSearchResult[] to Tag[] for consistent cache structure
 	const { data: allTags = [] } = useNormalizedQuery({
-		wireMethod: 'query:tags.search',
+		query: 'tags.search',
 		input: { query: '' },
 		resourceType: 'tag',
 		select: (data: any) => data?.tags?.map((result: any) => result.tag || result).filter(Boolean) ?? []

--- a/packages/interface/src/routes/explorer/TagAssignmentMode.tsx
+++ b/packages/interface/src/routes/explorer/TagAssignmentMode.tsx
@@ -34,7 +34,7 @@ export function TagAssignmentMode({ isActive, onExit }: TagAssignmentModeProps) 
 		{ query: string },
 		{ tags: Array<{ tag: Tag } | Tag> }
 	>({
-		wireMethod: 'query:tags.search',
+		query: 'tags.search',
 		input: { query: '' },
 		resourceType: 'tag'
 	});

--- a/packages/interface/src/routes/explorer/components/LocationsSection.tsx
+++ b/packages/interface/src/routes/explorer/components/LocationsSection.tsx
@@ -17,7 +17,7 @@ export function LocationsSection() {
   const previousLocationIdsRef = useRef<Set<string>>(new Set());
 
   const locationsQuery = useNormalizedQuery<null, Location>({
-    wireMethod: "query:locations.list",
+    query: "locations.list",
     input: null,
     resourceType: "location",
   });

--- a/packages/interface/src/routes/explorer/components/PathBar.tsx
+++ b/packages/interface/src/routes/explorer/components/PathBar.tsx
@@ -122,7 +122,7 @@ function IndexIndicator({ path }: { path: SdPath }) {
 
 	// Fetch all locations
 	const { data: locationsData } = useNormalizedQuery({
-		wireMethod: "query:locations.list",
+		query: "locations.list",
 		input: null,
 		resourceType: "location",
 	});

--- a/packages/interface/src/routes/explorer/context.tsx
+++ b/packages/interface/src/routes/explorer/context.tsx
@@ -535,7 +535,7 @@ export function ExplorerProvider({
 	}, [currentTarget]);
 
 	const devicesQuery = useNormalizedQuery<ListLibraryDevicesInput, Device[]>({
-		wireMethod: "query:devices.list",
+		query: "devices.list",
 		input: { include_offline: true, include_details: false },
 		resourceType: "device",
 	});

--- a/packages/interface/src/routes/explorer/hooks/useExplorerFiles.ts
+++ b/packages/interface/src/routes/explorer/hooks/useExplorerFiles.ts
@@ -112,7 +112,7 @@ export function useExplorerFiles(): ExplorerFilesResult {
 
 	// Search query
 	const searchQuery = useNormalizedQuery<FileSearchInput, FileSearchOutput>({
-		wireMethod: "query:search.files",
+		query: "search.files",
 		input: searchQueryInput!,
 		resourceType: "file",
 		pathScope:
@@ -124,7 +124,7 @@ export function useExplorerFiles(): ExplorerFilesResult {
 
 	// Recents query
 	const recentsQuery = useNormalizedQuery<FileSearchInput, FileSearchOutput>({
-		wireMethod: "query:search.files",
+		query: "search.files",
 		input: recentsQueryInput!,
 		resourceType: "file",
 		enabled: isRecentsMode && !!recentsQueryInput,
@@ -132,7 +132,7 @@ export function useExplorerFiles(): ExplorerFilesResult {
 
 	// Directory query
 	const directoryQuery = useNormalizedQuery({
-		wireMethod: "query:files.directory_listing",
+		query: "files.directory_listing",
 		input: currentPath
 			? {
 					path: currentPath,

--- a/packages/interface/src/routes/explorer/hooks/useExplorerKeyboard.ts
+++ b/packages/interface/src/routes/explorer/hooks/useExplorerKeyboard.ts
@@ -42,7 +42,7 @@ export function useExplorerKeyboard() {
 
 	// Query files for keyboard operations
 	const directoryQuery = useNormalizedQuery({
-		wireMethod: "query:files.directory_listing",
+		query: "files.directory_listing",
 		input: currentPath
 			? {
 					path: currentPath,

--- a/packages/interface/src/routes/explorer/hooks/useVirtualListing.ts
+++ b/packages/interface/src/routes/explorer/hooks/useVirtualListing.ts
@@ -37,7 +37,7 @@ export function useVirtualListing(): VirtualListingResult {
 	// Fetch locations
 	const { data: locationsData, isLoading: locationsLoading } =
 		useNormalizedQuery({
-			wireMethod: "query:locations.list",
+			query: "locations.list",
 			input: null,
 			resourceType: "location",
 			enabled: view === "device",
@@ -46,7 +46,7 @@ export function useVirtualListing(): VirtualListingResult {
 	// Fetch volumes
 	const { data: volumesData, isLoading: volumesLoading } = useNormalizedQuery(
 		{
-			wireMethod: "query:volumes.list",
+			query: "volumes.list",
 			input: { filter: "All" },
 			resourceType: "volume",
 			enabled: view === "device",
@@ -56,7 +56,7 @@ export function useVirtualListing(): VirtualListingResult {
 	// Fetch devices
 	const { data: devicesData, isLoading: devicesLoading } = useNormalizedQuery(
 		{
-			wireMethod: "query:devices.list",
+			query: "devices.list",
 			input: { include_offline: true, include_details: false },
 			resourceType: "device",
 			enabled: view === "devices" || view === "device",

--- a/packages/interface/src/routes/explorer/views/ColumnView/Column.tsx
+++ b/packages/interface/src/routes/explorer/views/ColumnView/Column.tsx
@@ -132,7 +132,7 @@ export const Column = memo(function Column({
 	const { selectedFiles } = useSelection();
 
 	const directoryQuery = useNormalizedQuery({
-		wireMethod: "query:files.directory_listing",
+		query: "files.directory_listing",
 		input: {
 			path: path!,
 			limit: null,

--- a/packages/interface/src/routes/explorer/views/ColumnView/ColumnView.tsx
+++ b/packages/interface/src/routes/explorer/views/ColumnView/ColumnView.tsx
@@ -184,7 +184,7 @@ export function ColumnView() {
 
 	// Query files for the active column (for keyboard navigation)
 	const activeColumnQuery = useNormalizedQuery({
-		wireMethod: "query:files.directory_listing",
+		query: "files.directory_listing",
 		input: activeColumnPath
 			? {
 					path: activeColumnPath,
@@ -234,7 +234,7 @@ export function ColumnView() {
 	// Query the next column for right arrow navigation
 	const nextColumnPath = columnStack[activeColumnIndex + 1];
 	const nextColumnQuery = useNormalizedQuery({
-		wireMethod: "query:files.directory_listing",
+		query: "files.directory_listing",
 		input: nextColumnPath
 			? {
 					path: nextColumnPath,

--- a/packages/interface/src/routes/explorer/views/KnowledgeView.tsx
+++ b/packages/interface/src/routes/explorer/views/KnowledgeView.tsx
@@ -82,7 +82,7 @@ export function KnowledgeView() {
 		useExplorer();
 
 	const directoryQuery = useNormalizedQuery({
-		wireMethod: "query:files.directory_listing",
+		query: "files.directory_listing",
 		input: currentPath
 			? {
 					path: currentPath,

--- a/packages/interface/src/routes/explorer/views/MediaView/MediaView.tsx
+++ b/packages/interface/src/routes/explorer/views/MediaView/MediaView.tsx
@@ -132,7 +132,7 @@ export function MediaView() {
 
 	// Query for all media files from current path with descendants (only when NOT in search mode)
 	const mediaQuery = useNormalizedQuery({
-		wireMethod: "query:files.media_listing",
+		query: "files.media_listing",
 		input: currentPath
 			? {
 					path: currentPath,

--- a/packages/interface/src/routes/explorer/views/SizeView/SizeView.tsx
+++ b/packages/interface/src/routes/explorer/views/SizeView/SizeView.tsx
@@ -340,7 +340,7 @@ export function SizeView() {
 	} | null>(null);
 
 	const directoryQuery = useNormalizedQuery({
-		wireMethod: 'query:files.directory_listing',
+		query: 'files.directory_listing',
 		input: currentPath
 			? {
 					path: currentPath,

--- a/packages/interface/src/routes/file-kinds/index.tsx
+++ b/packages/interface/src/routes/file-kinds/index.tsx
@@ -70,7 +70,7 @@ export function FileKindsView() {
 		Record<string, never>,
 		ContentKindStatsOutput
 	>({
-		wireMethod: "query:files.content_kind_stats",
+		query: "files.content_kind_stats",
 		input: {},
 		resourceType: "content_kind",
 	});

--- a/packages/interface/src/routes/overview/DevicePanel.tsx
+++ b/packages/interface/src/routes/overview/DevicePanel.tsx
@@ -83,7 +83,7 @@ export function DevicePanel({onLocationSelect}: DevicePanelProps = {}) {
 		VolumeListQueryInput,
 		VolumeListOutput
 	>({
-		wireMethod: 'query:volumes.list',
+		query: 'volumes.list',
 		input: {filter: 'All'},
 		resourceType: 'volume'
 	});
@@ -93,7 +93,7 @@ export function DevicePanel({onLocationSelect}: DevicePanelProps = {}) {
 		ListLibraryDevicesInput,
 		DeviceWithConnection[]
 	>({
-		wireMethod: 'query:devices.list',
+		query: 'devices.list',
 		input: {include_offline: true, include_details: false},
 		resourceType: 'device'
 	});
@@ -101,7 +101,7 @@ export function DevicePanel({onLocationSelect}: DevicePanelProps = {}) {
 	// Fetch all locations using normalized cache
 	const {data: locationsData, isLoading: locationsLoading} =
 		useNormalizedQuery<LocationsListQueryInput, LocationsListOutput>({
-			wireMethod: 'query:locations.list',
+			query: 'locations.list',
 			input: null,
 			resourceType: 'location'
 		});

--- a/packages/interface/src/routes/overview/VolumeBar.tsx
+++ b/packages/interface/src/routes/overview/VolumeBar.tsx
@@ -139,7 +139,7 @@ export function VolumeBar({volume, index}: VolumeBarProps) {
 
 	// Get current device to check if this volume is local
 	const devicesQuery = useNormalizedQuery<any, Device[]>({
-		wireMethod: 'query:devices.list',
+		query: 'devices.list',
 		input: {include_offline: true, include_details: false},
 		resourceType: 'device'
 	});

--- a/packages/interface/src/routes/overview/index.tsx
+++ b/packages/interface/src/routes/overview/index.tsx
@@ -30,7 +30,7 @@ export function Overview() {
 		isLoading,
 		error,
 	} = useNormalizedQuery<null, Library>({
-		wireMethod: "query:libraries.info",
+		query: "libraries.info",
 		input: null,
 		resourceType: "library",
 	});
@@ -40,7 +40,7 @@ export function Overview() {
 		LocationsListQueryInput,
 		LocationsListOutput
 	>({
-		wireMethod: "query:locations.list",
+		query: "locations.list",
 		input: null,
 		resourceType: "location",
 	});

--- a/packages/interface/src/routes/tag/index.tsx
+++ b/packages/interface/src/routes/tag/index.tsx
@@ -14,7 +14,7 @@ export function TagView() {
 
 	// Fetch the tag details
 	const {data: tagData, isLoading: tagLoading} = useNormalizedQuery({
-		wireMethod: 'query:tags.by_id',
+		query: 'tags.by_id',
 		input: {tag_id: tagId},
 		resourceType: 'tag',
 		resourceId: tagId,
@@ -23,7 +23,7 @@ export function TagView() {
 
 	// Fetch tag ancestors for breadcrumb
 	const {data: ancestorsData} = useNormalizedQuery({
-		wireMethod: 'query:tags.ancestors',
+		query: 'tags.ancestors',
 		input: {tag_id: tagId},
 		resourceType: 'tag',
 		resourceId: tagId,
@@ -32,7 +32,7 @@ export function TagView() {
 
 	// Fetch tag children for quick filters
 	const {data: childrenData} = useNormalizedQuery({
-		wireMethod: 'query:tags.children',
+		query: 'tags.children',
 		input: {tag_id: tagId},
 		resourceType: 'tag',
 		resourceId: tagId,
@@ -41,7 +41,7 @@ export function TagView() {
 
 	// Fetch related tags for suggestions
 	const {data: relatedData} = useNormalizedQuery({
-		wireMethod: 'query:tags.related',
+		query: 'tags.related',
 		input: {tag_id: tagId},
 		resourceType: 'tag',
 		resourceId: tagId,
@@ -50,7 +50,7 @@ export function TagView() {
 
 	// Fetch files with this tag
 	const {data: filesData, isLoading: filesLoading} = useNormalizedQuery({
-		wireMethod: 'query:files.by_tag',
+		query: 'files.by_tag',
 		input: {
 			tag_id: tagId,
 			include_children: false, // TODO: Make this toggleable

--- a/packages/ts-client/src/hooks/__tests__/useNormalizedQuery.test.tsx
+++ b/packages/ts-client/src/hooks/__tests__/useNormalizedQuery.test.tsx
@@ -73,7 +73,7 @@ describe("useNormalizedQuery - Event Replay Tests", () => {
 		// Now apply the filtered resources to a cache using the ACTUAL production function
 		const testQueryClient = new QueryClient();
 		const queryKey = [
-			testCase.query.wireMethod,
+			`query:${testCase.query.query}`,
 			"test-library-id",
 			testCase.query.input,
 		];

--- a/packages/ts-client/src/hooks/useNormalizedQuery.ts
+++ b/packages/ts-client/src/hooks/useNormalizedQuery.ts
@@ -13,7 +13,7 @@
  *
  * ```tsx
  * const { data: files } = useNormalizedQuery({
- *   wireMethod: 'query:files.directory_listing',
+ *   query: "files.directory_listing",
  *   input: { path: currentPath },
  *   resourceType: 'file',
  *   pathScope: currentPath,
@@ -34,8 +34,8 @@ import type { Simplify } from "type-fest";
 // Types
 
 export type UseNormalizedQueryOptions<I, O = any, TSelected = O> = Simplify<{
-	/** Wire method to call (e.g., "query:files.directory_listing") */
-	wireMethod: string;
+	/** Query method to call (e.g., "files.directory_listing") */
+	query: string;
 	/** Input for the query */
 	input: I;
 	/** Resource type for event filtering (e.g., "file", "location") */
@@ -117,10 +117,15 @@ export function useNormalizedQuery<I, O = any, TSelected = O>(
 		};
 	}, [client]);
 
+	const wireMethod = useMemo(
+		() => toWireMethod(options.query),
+		[options.query],
+	);
+
 	// Query key
 	const queryKey = useMemo(
-		() => [options.wireMethod, libraryId, options.input],
-		[options.wireMethod, libraryId, JSON.stringify(options.input)],
+		() => [wireMethod, libraryId, options.input],
+		[wireMethod, libraryId, JSON.stringify(options.input)],
 	);
 
 	// Standard TanStack Query
@@ -128,10 +133,7 @@ export function useNormalizedQuery<I, O = any, TSelected = O>(
 		queryKey,
 		queryFn: async () => {
 			invariant(libraryId, "Library ID must be set before querying");
-			return await client.execute<I, O>(
-				options.wireMethod,
-				options.input,
-			);
+			return await client.execute<I, O>(wireMethod, options.input);
 		},
 		enabled: (options.enabled ?? true) && !!libraryId,
 		select: options.select,
@@ -243,6 +245,7 @@ export function handleResourceEvent(
 	queryClient: QueryClient,
 	debug?: boolean,
 ) {
+	const wireMethod = toWireMethod(options.query);
 	// Skip string events (like "CoreStarted", "CoreShutdown")
 	if (typeof event === "string") {
 		return;
@@ -252,7 +255,7 @@ export function handleResourceEvent(
 	if ("Refresh" in event) {
 		if (debug) {
 			console.log(
-				`[useNormalizedQuery] ${options.wireMethod} processing Refresh`,
+				`[useNormalizedQuery] ${wireMethod} processing Refresh`,
 				event,
 			);
 		}
@@ -272,7 +275,7 @@ export function handleResourceEvent(
 		if (resource_type === options.resourceType) {
 			if (debug) {
 				console.log(
-					`[useNormalizedQuery] ${options.wireMethod} processing ResourceChanged`,
+					`[useNormalizedQuery] ${wireMethod} processing ResourceChanged`,
 					event,
 				);
 			}
@@ -302,7 +305,7 @@ export function handleResourceEvent(
 		) {
 			if (debug) {
 				console.log(
-					`[useNormalizedQuery] ${options.wireMethod} processing ResourceChangedBatch`,
+					`[useNormalizedQuery] ${wireMethod} processing ResourceChangedBatch`,
 					event,
 				);
 			}
@@ -327,13 +330,28 @@ export function handleResourceEvent(
 		if (resource_type === options.resourceType) {
 			if (debug) {
 				console.log(
-					`[useNormalizedQuery] ${options.wireMethod} processing ResourceDeleted`,
+					`[useNormalizedQuery] ${wireMethod} processing ResourceDeleted`,
 					event,
 				);
 			}
 			deleteResource(resource_id, queryKey, queryClient);
 		}
 	}
+}
+
+function toWireMethod(query: string): string {
+	invariant(query, "useNormalizedQuery requires a query method");
+
+	if (query.startsWith("query:")) {
+		return query;
+	}
+
+	invariant(
+		!query.startsWith("action:"),
+		"useNormalizedQuery only supports queries, remove the action prefix",
+	);
+
+	return `query:${query}`;
 }
 
 // Batch Filtering

--- a/packages/ts-client/tests/integration/README.md
+++ b/packages/ts-client/tests/integration/README.md
@@ -151,7 +151,7 @@ await client.setLibrary(bridgeConfig.library_id);
 
 // Now use hooks normally!
 const { data } = useNormalizedQuery({
-	wireMethod: "query:files.directory_listing",
+  query: "files.directory_listing",
 	input: { path: { Physical: { path: "/some/path" } } },
 	resourceType: "file",
 	// ...

--- a/packages/ts-client/tests/integration/useNormalizedQuery.bulk-moves.test.ts
+++ b/packages/ts-client/tests/integration/useNormalizedQuery.bulk-moves.test.ts
@@ -111,7 +111,7 @@ describe("useNormalizedQuery - Bulk Moves Integration", () => {
 		const { result: rootResult } = renderHook(
 			() =>
 				useNormalizedQuery({
-					wireMethod: "query:files.directory_listing",
+					query: "files.directory_listing",
 					input: {
 						path: {
 							Physical: {
@@ -138,7 +138,7 @@ describe("useNormalizedQuery - Bulk Moves Integration", () => {
 		const { result: subfolderResult } = renderHook(
 			() =>
 				useNormalizedQuery({
-					wireMethod: "query:files.directory_listing",
+					query: "files.directory_listing",
 					input: {
 						path: {
 							Physical: {

--- a/packages/ts-client/tests/integration/useNormalizedQuery.file-delete.test.ts
+++ b/packages/ts-client/tests/integration/useNormalizedQuery.file-delete.test.ts
@@ -126,7 +126,7 @@ describe("useNormalizedQuery - File Deletion Integration", () => {
 		const { result: folderResult } = renderHook(
 			() =>
 				useNormalizedQuery({
-					wireMethod: "query:files.directory_listing",
+					query: "files.directory_listing",
 					input: {
 						path: {
 							Physical: {

--- a/packages/ts-client/tests/integration/useNormalizedQuery.folder-rename.test.ts
+++ b/packages/ts-client/tests/integration/useNormalizedQuery.folder-rename.test.ts
@@ -128,7 +128,7 @@ describe("useNormalizedQuery - Folder Rename Integration", () => {
 		const { result: rootResult } = renderHook(
 			() =>
 				useNormalizedQuery({
-					wireMethod: "query:files.directory_listing",
+					query: "files.directory_listing",
 					input: {
 						path: {
 							Physical: {
@@ -155,7 +155,7 @@ describe("useNormalizedQuery - Folder Rename Integration", () => {
 		const { result: folderResult } = renderHook(
 			() =>
 				useNormalizedQuery({
-					wireMethod: "query:files.directory_listing",
+					query: "files.directory_listing",
 					input: {
 						path: {
 							Physical: {

--- a/packages/ts-client/tests/integration/useNormalizedQuery.test.ts
+++ b/packages/ts-client/tests/integration/useNormalizedQuery.test.ts
@@ -127,7 +127,7 @@ describe("useNormalizedQuery - File Moves Integration", () => {
 		const { result: folderAResult } = renderHook(
 			() =>
 				useNormalizedQuery({
-					wireMethod: "query:files.directory_listing",
+					query: "files.directory_listing",
 					input: {
 						path: {
 							Physical: {
@@ -154,7 +154,7 @@ describe("useNormalizedQuery - File Moves Integration", () => {
 		const { result: folderBResult } = renderHook(
 			() =>
 				useNormalizedQuery({
-					wireMethod: "query:files.directory_listing",
+					query: "files.directory_listing",
 					input: {
 						path: {
 							Physical: {


### PR DESCRIPTION
<!-- Put any information about this PR up here -->
Refactors `useNormalizedQuery` to accept a `query` string (e.g., "files.directory_listing") instead of a `wireMethod` (e.g., "query:files.directory_listing"). The "query:" prefix is now automatically added internally.

This change simplifies the API for `useNormalizedQuery`, making it more intuitive and less verbose for consumers. All call sites, documentation, and relevant tests have been updated to reflect this new usage.

<!-- Which issue does this PR close? -->
<!-- If this PR does not have a corresponding issue,
     make sure one gets created before you create this PR.
     You can create a bug report or feature request at
     https://github.com/spacedriveapp/spacedrive/issues/new/choose -->

Closes #(issue)

---
<a href="https://cursor.com/background-agent?bcId=bc-27b6ece5-6962-4c08-bd5d-0425c899a58e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-27b6ece5-6962-4c08-bd5d-0425c899a58e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

