### PR TITLE
feat(core): make STT deps optional via feature flags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
 
   #     - name: Build CLI binaries
   #       run: |
-  #         cargo build --release --bin sd-cli --bin sd-daemon --features heif,ffmpeg --target ${{ matrix.target }}
+  #         cargo build --release --bin sd-cli --bin sd-daemon --features heif,ffmpeg,ai --target ${{ matrix.target }}
   #       env:
   #         # Set linker for cross-compilation
   #         CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
@@ -144,7 +144,7 @@ jobs:
 
       - name: Build server binary
         run: |
-          cargo build --release --bin sd-server --features sd-core/heif,sd-core/ffmpeg --target ${{ matrix.settings.target }}
+          cargo build --release --bin sd-server --features sd-core/heif,sd-core/ffmpeg,sd-core/ai --target ${{ matrix.settings.target }}
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
 

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -7,6 +7,9 @@ version = "2.0.0-pre.1"
 default = []
 heif = ["sd-core/heif"]
 ffmpeg = ["sd-core/ffmpeg"]
+whisper = ["sd-core/whisper"]
+speech-to-text = ["sd-core/speech-to-text"]
+ai = ["sd-core/ai"]
 
 [dependencies]
 anyhow      = "1"

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 default = []
 heif = ["sd-core/heif"]
 ffmpeg = ["sd-core/ffmpeg"]
+whisper = ["sd-core/whisper"]
+speech-to-text = ["sd-core/speech-to-text"]
+ai = ["sd-core/ai"]
 
 [dependencies]
 # Spacedrive core

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,10 +6,14 @@ autobins = true
 
 [features]
 default = ["wasm"]
-# FFmpeg support for video thumbnails and audio transcription
+# FFmpeg support for video thumbnails and audio extraction
 ffmpeg = ["dep:sd-ffmpeg"]
-# AI models support
-ai = []
+# Whisper speech recognition engine (internal dependency)
+whisper = ["dep:whisper-rs", "dep:hound", "dep:rubato"]
+# Speech-to-text transcription (requires audio extraction + recognition)
+speech-to-text = ["ffmpeg", "whisper"]
+# AI features umbrella (heavy deps, can be disabled for lite builds or mobile)
+ai = ["speech-to-text"]
 # HEIF image support (extends sd-images with HEIF format)
 heif = ["sd-images/heif"]
 # Mobile platform support (excludes wasm which doesn't work on iOS)
@@ -124,10 +128,10 @@ sd-media-metadata = { path = "../crates/media-metadata" }
 tokio-rustls     = "0.26"
 webp             = "0.3"
 
-# Speech-to-text dependencies (always included)
-whisper-rs = "0.15.1"
-hound      = "3.5"  # WAV file reading
-rubato     = "0.16" # Audio resampling to 16kHz
+# Speech-to-text dependencies (optional, behind whisper feature)
+whisper-rs = { version = "0.15.1", optional = true }
+hound      = { version = "3.5", optional = true }   # WAV file reading
+rubato     = { version = "0.16", optional = true }  # Audio resampling to 16kHz
 
 # Networking
 # Iroh P2P networking
@@ -216,7 +220,7 @@ libc = "0.2"
 windows-sys = { version = "0.52", features = ["Win32_Storage_FileSystem", "Win32_Foundation", "Win32_Security"] }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-whisper-rs = { version = "0.15.1", features = ["metal"] }
+whisper-rs = { version = "0.15.1", features = ["metal"], optional = true }
 
 # iOS-specific dependencies for volume detection via Objective-C FFI
 [target.'cfg(target_os = "ios")'.dependencies]

--- a/core/src/domain/location.rs
+++ b/core/src/domain/location.rs
@@ -539,7 +539,7 @@ impl Default for SpeechPolicy {
 
 impl SpeechPolicy {
 	/// Convert this policy to a SpeechToTextJobConfig for job dispatch
-	#[cfg(feature = "ffmpeg")]
+	#[cfg(feature = "speech-to-text")]
 	pub fn to_job_config(
 		&self,
 		location_id: Option<Uuid>,

--- a/core/src/ops/indexing/change_detection/persistent.rs
+++ b/core/src/ops/indexing/change_detection/persistent.rs
@@ -408,9 +408,10 @@ impl ChangeHandler for DatabaseAdapter {
 		use crate::ops::media::{ocr::OcrProcessor, proxy::ProxyProcessor};
 		#[cfg(feature = "ffmpeg")]
 		use crate::ops::media::{
-			speech::SpeechToTextProcessor, thumbnail::ThumbnailProcessor,
-			thumbstrip::ThumbstripProcessor,
+			thumbnail::ThumbnailProcessor, thumbstrip::ThumbstripProcessor,
 		};
+		#[cfg(feature = "speech-to-text")]
+		use crate::ops::media::speech::SpeechToTextProcessor;
 
 		if entry.is_directory() {
 			return Ok(());
@@ -584,7 +585,7 @@ impl ChangeHandler for DatabaseAdapter {
 		}
 
 		// Speech-to-text
-		#[cfg(feature = "ffmpeg")]
+		#[cfg(feature = "speech-to-text")]
 		if proc_config
 			.watcher_processors
 			.iter()

--- a/core/src/ops/locations/trigger_job/action.rs
+++ b/core/src/ops/locations/trigger_job/action.rs
@@ -168,7 +168,7 @@ impl LibraryAction for LocationTriggerJobAction {
 				})?
 			}
 
-			#[cfg(feature = "ffmpeg")]
+			#[cfg(feature = "speech-to-text")]
 			JobType::SpeechToText => {
 				if !job_policies.speech_to_text.enabled && !self.input.force {
 					return Err(ActionError::Validation {
@@ -188,13 +188,21 @@ impl LibraryAction for LocationTriggerJobAction {
 			}
 
 			#[cfg(not(feature = "ffmpeg"))]
-			JobType::Thumbnail | JobType::Thumbstrip | JobType::SpeechToText => {
+			JobType::Thumbnail | JobType::Thumbstrip => {
 				return Err(ActionError::Validation {
 					field: "job_type".to_string(),
 					message: format!(
 						"{} requires FFmpeg support which is not enabled",
 						self.input.job_type
 					),
+				});
+			}
+
+			#[cfg(not(feature = "speech-to-text"))]
+			JobType::SpeechToText => {
+				return Err(ActionError::Validation {
+					field: "job_type".to_string(),
+					message: "Speech-to-text requires FFmpeg and Whisper support which is not enabled".to_string(),
 				});
 			}
 

--- a/core/src/ops/media/mod.rs
+++ b/core/src/ops/media/mod.rs
@@ -30,7 +30,7 @@ pub use ocr::{OcrJob, OcrProcessor};
 pub use proxy::{ProxyJob, ProxyProcessor};
 pub use splat::{GaussianSplatJob, GaussianSplatProcessor};
 
-#[cfg(feature = "ffmpeg")]
+#[cfg(feature = "speech-to-text")]
 pub use speech::{SpeechToTextJob, SpeechToTextProcessor};
 #[cfg(feature = "ffmpeg")]
 pub use thumbnail::ThumbnailJob;

--- a/core/src/ops/media/speech/action.rs
+++ b/core/src/ops/media/speech/action.rs
@@ -54,7 +54,7 @@ impl LibraryAction for TranscribeAudioAction {
 		library: Arc<crate::library::Library>,
 		_context: Arc<CoreContext>,
 	) -> Result<Self::Output, ActionError> {
-		#[cfg(feature = "ffmpeg")]
+		#[cfg(feature = "speech-to-text")]
 		{
 			tracing::info!(
 				"Dispatching speech-to-text job for entry: {}",
@@ -89,10 +89,10 @@ impl LibraryAction for TranscribeAudioAction {
 			})
 		}
 
-		#[cfg(not(feature = "ffmpeg"))]
+		#[cfg(not(feature = "speech-to-text"))]
 		{
 			Err(ActionError::InvalidInput(
-				"Speech-to-text feature is not enabled. Please rebuild the daemon with --features ffmpeg".to_string()
+				"Speech-to-text feature is not enabled. Please rebuild with --features ffmpeg,whisper".to_string()
 			))
 		}
 	}

--- a/core/src/ops/media/speech/mod.rs
+++ b/core/src/ops/media/speech/mod.rs
@@ -2,19 +2,21 @@
 //!
 //! Transcribes audio/video to text using whisper.rs.
 //! Generates .srt subtitle files as sidecars.
+//!
+//! Requires the `speech-to-text` feature (enables `ffmpeg` + `whisper`).
 
 pub mod action;
 
-#[cfg(feature = "ffmpeg")]
+#[cfg(feature = "speech-to-text")]
 pub mod job;
-#[cfg(feature = "ffmpeg")]
+#[cfg(feature = "speech-to-text")]
 pub mod processor;
 
 pub use action::{TranscribeAudioAction, TranscribeAudioInput, TranscribeAudioOutput};
 
-#[cfg(feature = "ffmpeg")]
+#[cfg(feature = "speech-to-text")]
 pub use job::{SpeechToTextJob, SpeechToTextJobConfig};
-#[cfg(feature = "ffmpeg")]
+#[cfg(feature = "speech-to-text")]
 pub use processor::SpeechToTextProcessor;
 
 use anyhow::{Context, Result};
@@ -22,7 +24,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 /// Transcribe audio/video to text using whisper
-#[cfg(feature = "ffmpeg")]
+#[cfg(feature = "speech-to-text")]
 pub async fn transcribe_audio_file(
 	source_path: &Path,
 	model: &str,
@@ -97,7 +99,7 @@ pub async fn transcribe_audio_file(
 
 /// Load audio file and convert to 16kHz mono f32 samples required by Whisper
 /// Uses FFmpeg libraries directly (no subprocess)
-#[cfg(feature = "ffmpeg")]
+#[cfg(feature = "speech-to-text")]
 fn load_audio_samples(path: &Path) -> Result<Vec<f32>> {
 	// Use sd-ffmpeg to extract audio samples directly
 	// This returns 16kHz mono f32 PCM samples, exactly what Whisper needs
@@ -105,7 +107,7 @@ fn load_audio_samples(path: &Path) -> Result<Vec<f32>> {
 }
 
 /// Format a single SRT subtitle segment
-#[cfg(feature = "ffmpeg")]
+#[cfg(feature = "speech-to-text")]
 fn format_srt_segment(index: usize, start: f64, end: f64, text: &str) -> String {
 	let start_time = format_srt_timestamp(start);
 	let end_time = format_srt_timestamp(end);
@@ -120,7 +122,7 @@ fn format_srt_segment(index: usize, start: f64, end: f64, text: &str) -> String 
 }
 
 /// Format timestamp in SRT format (HH:MM:SS,mmm)
-#[cfg(feature = "ffmpeg")]
+#[cfg(feature = "speech-to-text")]
 fn format_srt_timestamp(seconds: f64) -> String {
 	let hours = (seconds / 3600.0).floor() as u32;
 	let minutes = ((seconds % 3600.0) / 60.0).floor() as u32;
@@ -144,7 +146,7 @@ pub fn is_speech_supported(mime_type: &str, registry: &crate::filetype::FileType
 }
 
 /// Get audio duration in seconds using ffprobe (public for job progress estimation)
-#[cfg(feature = "ffmpeg")]
+#[cfg(feature = "speech-to-text")]
 pub async fn get_audio_duration_public(path: &Path) -> Result<f32> {
 	use std::process::Command;
 


### PR DESCRIPTION
Makes whisper-rs, hound, and rubato optional behind a `whisper` feature. Adds a `speech-to-text` feature that combines `whisper` + `ffmpeg`, less config changes to switch to another STT engine later. Updates `#[cfg]` guards to use `speech-to-text`.

I've been disabling whisper-rs on my Android branch using a less complete feature flag setup which I think might've caused issues if merged to main. Here's a, hopefully, more proper setup which should be easier to extend to other features in the future.

## Changes

- Made whisper-rs, hound, rubato optional deps
- Added `whisper` and `speech-to-text` features under `ai`
- Updated `#[cfg]` guards to use `speech-to-text`
- Added `ai` to release workflow to maintain existing behavior
- Re-exported features in server/cli crates