### PR TITLE
Fix: Windows user directories incorrectly flagged as high risk paths

### DIFF
--- a/core/src/ops/locations/validate/query.rs
+++ b/core/src/ops/locations/validate/query.rs
@@ -85,7 +85,9 @@ impl LibraryQuery for ValidateLocationPathQuery {
 		let is_system_dir = system_dirs.iter().any(|d| {
 			// Special case: "/" should only match if path IS "/", not if it starts with "/"
 			// Otherwise every absolute path would be considered a system directory
-			let matches = if d.to_string_lossy() == "/" {
+			// Same for Windows drive roots like "C:\" - only match if path IS the drive root
+			let d_str = d.to_string_lossy();
+			let matches = if d_str == "/" || (cfg!(target_os = "windows") && d_str.ends_with(":\\")) {
 				path == d
 			} else {
 				path.starts_with(d)


### PR DESCRIPTION
## Fix: Windows user directories incorrectly flagged as high risk paths

Fixes #3017

### Changes

- Modified `core/src/ops/locations/validate/query.rs` to detect Windows drive roots (paths ending with `:\\`)
- Drive roots now use exact matching (`path == d`) instead of prefix matching (`path.starts_with(d)`)
- Other system directories like `C:\Windows` and `C:\Program Files` continue to use prefix matching as before

<img width="475" height="408" alt="image" src="https://github.com/user-attachments/assets/867f9dd0-61ea-4ca3-b004-88c62b09611a" />

Now able to add /downloads with out warning

<img width="472" height="527" alt="image" src="https://github.com/user-attachments/assets/846c6f5b-d887-4553-b273-9af3b918e061" />

Correct high risk paths keep the warning 



