### PR TITLE
refactor: replace button+navigate() with React Router NavLink in sidebar

### DIFF
--- a/packages/interface/src/components/Inspector/variants/LocationInspector.tsx
+++ b/packages/interface/src/components/Inspector/variants/LocationInspector.tsx
@@ -24,6 +24,7 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useQueryClient } from "@tanstack/react-query";
 import { useLocation, useNavigate } from "react-router-dom";
+import { shouldNavigate } from "../../../util/navigation";
 import {
 	InfoRow,
 	Section,
@@ -172,7 +173,8 @@ function OverviewTab({ location }: { location: Location }) {
 				{isOverview && (
 					<TopBarButton
 						icon={FolderOpen}
-						onClick={() => {
+						onClick={(e: React.MouseEvent) => {
+							if (!shouldNavigate(e)) return;
 							const encodedPath = encodeURIComponent(JSON.stringify(location.sd_path));
 							navigate(`/explorer?path=${encodedPath}`);
 						}}

--- a/packages/interface/src/components/JobManager/JobManagerPopover.tsx
+++ b/packages/interface/src/components/JobManager/JobManagerPopover.tsx
@@ -3,6 +3,7 @@ import { Popover, usePopover, TopBarButton } from "@sd/ui";
 import clsx from "clsx";
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import { shouldNavigate } from "../../util/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import { JobList } from "./components/JobList";
 import { useJobsContext } from "./hooks/JobsContext";
@@ -75,7 +76,7 @@ export function JobManagerPopover({ className }: JobManagerPopoverProps) {
           {/* Expand to full screen button */}
           <TopBarButton
             icon={ArrowsOut}
-            onClick={() => navigate("/jobs")}
+            onClick={(e: React.MouseEvent) => { if (!shouldNavigate(e)) return; navigate("/jobs"); }}
             title="Open full jobs screen"
           />
 

--- a/packages/interface/src/components/JobManager/JobsScreen/index.tsx
+++ b/packages/interface/src/components/JobManager/JobsScreen/index.tsx
@@ -2,6 +2,7 @@ import { X, FunnelSimple } from "@phosphor-icons/react";
 import { TopBarButton } from "@sd/ui";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { shouldNavigate } from "../../../util/navigation";
 import { useJobsContext } from "../hooks/JobsContext";
 import { JobRow } from "./JobRow";
 
@@ -58,7 +59,7 @@ export function JobsScreen() {
 						{/* Back button */}
 						<TopBarButton
 							icon={X}
-							onClick={() => navigate(-1)}
+							onClick={(e: React.MouseEvent) => { if (!shouldNavigate(e)) return; navigate(-1); }}
 							title="Go back"
 						/>
 					</div>

--- a/packages/interface/src/components/SpacesSidebar/SpaceItem.tsx
+++ b/packages/interface/src/components/SpacesSidebar/SpaceItem.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "react-router-dom";
+import { shouldNavigate } from "../../util/navigation";
 import clsx from "clsx";
 import type { SpaceItem as SpaceItemType } from "@sd/ts-client";
 import { Thumb } from "../../routes/explorer/File/Thumb";
@@ -236,6 +237,7 @@ export function SpaceItem({
 
 	// Event handlers
 	const handleClick = (e: React.MouseEvent) => {
+		if (!shouldNavigate(e)) return;
 		if (effectiveOverrides.onClick) {
 			effectiveOverrides.onClick(e);
 		} else if (path) {

--- a/packages/interface/src/components/SpacesSidebar/TagsGroup.tsx
+++ b/packages/interface/src/components/SpacesSidebar/TagsGroup.tsx
@@ -1,6 +1,6 @@
 import { Tag as TagIcon, Plus, CaretRight } from '@phosphor-icons/react';
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { NavLink, useNavigate } from 'react-router-dom';
 import clsx from 'clsx';
 import { useNormalizedQuery, useLibraryMutation } from '../../contexts/SpacedriveContext';
 import type { Tag } from '@sd/ts-client';
@@ -20,7 +20,6 @@ interface TagItemProps {
 }
 
 function TagItem({ tag, depth = 0 }: TagItemProps) {
-	const navigate = useNavigate();
 	const { loadPreferencesForSpaceItem } = useExplorer();
 	const [isExpanded, setIsExpanded] = useState(false);
 
@@ -28,17 +27,16 @@ function TagItem({ tag, depth = 0 }: TagItemProps) {
 	const children: Tag[] = [];
 	const hasChildren = children.length > 0;
 
-	const handleClick = () => {
-		loadPreferencesForSpaceItem(`tag:${tag.id}`);
-		navigate(`/tag/${tag.id}`);
-	};
-
 	return (
 		<div>
-			<button
-				onClick={handleClick}
-				className={clsx(
-					'flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-sm font-medium text-sidebar-ink-dull hover:bg-sidebar-box hover:text-sidebar-ink transition-colors',
+			<NavLink
+				to={`/tag/${tag.id}`}
+				onClick={() => loadPreferencesForSpaceItem(`tag:${tag.id}`)}
+				className={({ isActive }) => clsx(
+					'flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-sm font-medium transition-colors',
+					isActive
+						? 'bg-sidebar-selected/30 text-sidebar-ink'
+						: 'text-sidebar-ink-dull hover:bg-sidebar-box hover:text-sidebar-ink',
 					tag.privacy_level === 'Archive' && 'opacity-50',
 					tag.privacy_level === 'Hidden' && 'opacity-25'
 				)}
@@ -54,6 +52,7 @@ function TagItem({ tag, depth = 0 }: TagItemProps) {
 							isExpanded && 'rotate-90'
 						)}
 						onClick={(e) => {
+							e.preventDefault();
 							e.stopPropagation();
 							setIsExpanded(!isExpanded);
 						}}
@@ -75,7 +74,7 @@ function TagItem({ tag, depth = 0 }: TagItemProps) {
 
 				{/* File count badge (if available) */}
 				{/* TODO: Add file count when available from backend */}
-			</button>
+			</NavLink>
 
 			{/* Children (recursive) */}
 			{isExpanded &&

--- a/packages/interface/src/components/SpacesSidebar/index.tsx
+++ b/packages/interface/src/components/SpacesSidebar/index.tsx
@@ -25,6 +25,7 @@ import { useDroppable, useDndContext } from "@dnd-kit/core";
 import { SortableContext, verticalListSortingStrategy, useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useNavigate } from "react-router-dom";
+import { shouldNavigate } from "../../util/navigation";
 
 // Wrapper that adds a space-level drop zone before each group and makes it sortable
 function SpaceGroupWithDropZone({
@@ -157,7 +158,7 @@ const SyncButton = memo(function SyncButton() {
 
           <TopBarButton
             icon={ArrowsOut}
-            onClick={() => navigate("/sync")}
+            onClick={(e: React.MouseEvent) => { if (!shouldNavigate(e)) return; navigate("/sync"); }}
             title="Open full sync monitor"
           />
 
@@ -263,7 +264,7 @@ const JobsButton = memo(function JobsButton({
 
           <TopBarButton
             icon={ArrowsOut}
-            onClick={() => navigate("/jobs")}
+            onClick={(e: React.MouseEvent) => { if (!shouldNavigate(e)) return; navigate("/jobs"); }}
             title="Open full jobs screen"
           />
 

--- a/packages/interface/src/components/SyncMonitor/SyncMonitorPopover.tsx
+++ b/packages/interface/src/components/SyncMonitor/SyncMonitorPopover.tsx
@@ -8,6 +8,7 @@ import { Popover, usePopover, TopBarButton } from "@sd/ui";
 import clsx from "clsx";
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import { shouldNavigate } from "../../util/navigation";
 import { motion } from "framer-motion";
 import { PeerList } from "./components/PeerList";
 import { ActivityFeed } from "./components/ActivityFeed";
@@ -79,7 +80,7 @@ export function SyncMonitorPopover({ className }: SyncMonitorPopoverProps) {
 
 					<TopBarButton
 						icon={ArrowsOut}
-						onClick={() => navigate("/sync")}
+						onClick={(e: React.MouseEvent) => { if (!shouldNavigate(e)) return; navigate("/sync"); }}
 						title="Open full sync monitor"
 					/>
 

--- a/packages/interface/src/routes/explorer/Sidebar.tsx
+++ b/packages/interface/src/routes/explorer/Sidebar.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
 import clsx from "clsx";
 import {
   House,
@@ -26,13 +25,9 @@ export function Sidebar() {
   const client = useSpacedriveClient();
   const platform = usePlatform();
   const { data: libraries } = useLibraries();
-  const navigate = useNavigate();
-  const location = useLocation();
   const [currentLibraryId, setCurrentLibraryId] = useState<string | null>(
     () => client.getCurrentLibraryId(),
   );
-
-  const isActive = (path: string) => location.pathname === path;
 
   // Listen for library changes from client and update local state
   useEffect(() => {
@@ -141,25 +136,9 @@ export function Sidebar() {
 
           <div className="no-scrollbar mask-fade-out flex grow flex-col space-y-5 overflow-x-hidden overflow-y-scroll pb-10">
             <div className="space-y-0.5">
-              <SidebarItem
-                icon={Planet}
-                label="Overview"
-                active={isActive("/")}
-                weight={isActive("/") ? "fill" : "bold"}
-                onClick={() => navigate("/")}
-              />
-              <SidebarItem
-                icon={Clock}
-                label="Recents"
-                active={isActive("/recents")}
-                onClick={() => navigate("/recents")}
-              />
-              <SidebarItem
-                icon={Heart}
-                label="Favorites"
-                active={isActive("/favorites")}
-                onClick={() => navigate("/favorites")}
-              />
+              <SidebarItem icon={Planet} label="Overview" to="/" end />
+              <SidebarItem icon={Clock} label="Recents" to="/recents" />
+              <SidebarItem icon={Heart} label="Favorites" to="/favorites" />
             </div>
 
             <LocationsSection />

--- a/packages/interface/src/routes/explorer/components/LocationsSection.tsx
+++ b/packages/interface/src/routes/explorer/components/LocationsSection.tsx
@@ -1,132 +1,119 @@
-import { useNavigate, useParams } from "react-router-dom";
-import { useRef, useEffect } from "react";
-import { Plus } from "@phosphor-icons/react";
-import clsx from "clsx";
-import type { Location } from "@sd/ts-client";
-import { useNormalizedQuery } from "../../../contexts/SpacedriveContext";
-import { Section } from "./Section";
-import { SidebarItem } from "./SidebarItem";
-import { useAddLocationDialog } from "./AddLocationModal";
-import { Location } from "@sd/assets/icons";
-import { useEvent } from "../../../hooks/useEvent";
-import { useDroppable } from "@dnd-kit/core";
+import {useDroppable} from '@dnd-kit/core';
+import {Plus} from '@phosphor-icons/react';
+import {Location} from '@sd/assets/icons';
+import type {Location} from '@sd/ts-client';
+import clsx from 'clsx';
+import {useEffect, useRef} from 'react';
+import {useNavigate} from 'react-router-dom';
+import {useNormalizedQuery} from '../../../contexts/SpacedriveContext';
+import {useEvent} from '../../../hooks/useEvent';
+import {useAddLocationDialog} from './AddLocationModal';
+import {Section} from './Section';
+import {SidebarItem} from './SidebarItem';
 
 export function LocationsSection() {
-  const navigate = useNavigate();
-  const { locationId } = useParams();
-  const previousLocationIdsRef = useRef<Set<string>>(new Set());
+	const navigate = useNavigate();
+	const previousLocationIdsRef = useRef<Set<string>>(new Set());
 
-  const locationsQuery = useNormalizedQuery<null, Location>({
-    query: "locations.list",
-    input: null,
-    resourceType: "location",
-  });
+	const locationsQuery = useNormalizedQuery<null, Location>({
+		query: 'locations.list',
+		input: null,
+		resourceType: 'location'
+	});
 
-  const locations = locationsQuery.data?.locations || [];
+	const locations = locationsQuery.data?.locations || [];
 
-  // Track location IDs to detect new locations
-  useEffect(() => {
-    previousLocationIdsRef.current = new Set(locations.map((loc) => loc.id));
-  }, [locations]);
+	// Track location IDs to detect new locations
+	useEffect(() => {
+		previousLocationIdsRef.current = new Set(
+			locations.map((loc) => loc.id)
+		);
+	}, [locations]);
 
-  // Listen for new location creation events and navigate to them
-  useEvent("ResourceChanged", (event) => {
-    if ("ResourceChanged" in event) {
-      const { resource_type, resource } = event.ResourceChanged;
+	// Listen for new location creation events and navigate to them
+	useEvent('ResourceChanged', (event) => {
+		if ('ResourceChanged' in event) {
+			const {resource_type, resource} = event.ResourceChanged;
 
-      if (resource_type === "location" && typeof resource === "object" && resource !== null) {
-        const newLocation = resource as Location;
+			if (
+				resource_type === 'location' &&
+				typeof resource === 'object' &&
+				resource !== null
+			) {
+				const newLocation = resource as Location;
 
-        // Check if this is a new location (not in our previous set)
-        if (!previousLocationIdsRef.current.has(newLocation.id)) {
-          navigate(`/location/${newLocation.id}`);
-        }
-      }
-    }
-  });
+				// Check if this is a new location (not in our previous set)
+				if (!previousLocationIdsRef.current.has(newLocation.id)) {
+					navigate(`/location/${newLocation.id}`);
+				}
+			}
+		}
+	});
 
-  const handleLocationClick = (location: Location) => {
-    navigate(`/location/${location.id}`);
-  };
+	const handleAddLocation = async () => {
+		// Navigation now happens automatically via ResourceChanged event
+		await useAddLocationDialog();
+	};
 
-  const handleAddLocation = async () => {
-    // Navigation now happens automatically via ResourceChanged event
-    await useAddLocationDialog();
-  };
+	return (
+		<Section title="Locations">
+			{locationsQuery.isLoading && (
+				<div className="text-sidebar-inkFaint px-2 py-1 text-xs">
+					Loading...
+				</div>
+			)}
 
-  return (
-    <Section title="Locations">
-      {locationsQuery.isLoading && (
-        <div className="px-2 py-1 text-xs text-sidebar-inkFaint">
-          Loading...
-        </div>
-      )}
+			{locationsQuery.error && (
+				<div className="px-2 py-1 text-xs text-red-400">
+					Error: {(locationsQuery.error as Error).message}
+				</div>
+			)}
 
-      {locationsQuery.error && (
-        <div className="px-2 py-1 text-xs text-red-400">
-          Error: {(locationsQuery.error as Error).message}
-        </div>
-      )}
+			{locations.length === 0 &&
+				!locationsQuery.isLoading &&
+				!locationsQuery.error && (
+					<div className="text-sidebar-inkFaint px-2 py-1 text-xs">
+						No locations yet
+					</div>
+				)}
 
-      {locations.length === 0 &&
-        !locationsQuery.isLoading &&
-        !locationsQuery.error && (
-          <div className="px-2 py-1 text-xs text-sidebar-inkFaint">
-            No locations yet
-          </div>
-        )}
+			{locations.map((location) => (
+				<LocationDropZone key={location.id} location={location} />
+			))}
 
-      {locations.map((location) => (
-        <LocationDropZone
-          key={location.id}
-          location={location}
-          active={locationId === location.id}
-          onClick={() => handleLocationClick(location)}
-        />
-      ))}
-
-      <SidebarItem
-        icon={Plus}
-        label="Add Location"
-        onClick={handleAddLocation}
-        className="text-ink-faint hover:text-ink"
-      />
-    </Section>
-  );
+			<SidebarItem
+				icon={Plus}
+				label="Add Location"
+				onClick={handleAddLocation}
+				className="text-ink-faint hover:text-ink"
+			/>
+		</Section>
+	);
 }
 
 // Location item with drop zone support
-function LocationDropZone({
-  location,
-  active,
-  onClick,
-}: {
-  location: Location;
-  active: boolean;
-  onClick: () => void;
-}) {
-  const { setNodeRef, isOver } = useDroppable({
-    id: `location-drop-${location.id}`,
-    data: {
-      action: "move-into",
-      targetType: "location",
-      targetId: location.id,
-      targetPath: location.sd_path, // Use the proper sd_path from the location
-    },
-  });
+function LocationDropZone({location}: {location: Location}) {
+	const {setNodeRef, isOver} = useDroppable({
+		id: `location-drop-${location.id}`,
+		data: {
+			action: 'move-into',
+			targetType: 'location',
+			targetId: location.id,
+			targetPath: location.sd_path // Use the proper sd_path from the location
+		}
+	});
 
-  return (
-    <div ref={setNodeRef} className="relative">
-      {isOver && (
-        <div className="absolute inset-0 rounded-lg ring-2 ring-accent ring-inset pointer-events-none z-10" />
-      )}
-      <SidebarItem
-        icon={Location}
-        label={location.name || "Unnamed"}
-        active={active}
-        onClick={onClick}
-        className={clsx(isOver && "bg-accent/10")}
-      />
-    </div>
-  );
+	return (
+		<div ref={setNodeRef} className="relative">
+			{isOver && (
+				<div className="ring-accent pointer-events-none absolute inset-0 z-10 rounded-lg ring-2 ring-inset" />
+			)}
+			<SidebarItem
+				icon={Location}
+				label={location.name || 'Unnamed'}
+				to={`/location/${location.id}`}
+				className={clsx(isOver && 'bg-accent/10')}
+			/>
+		</div>
+	);
 }

--- a/packages/interface/src/routes/explorer/components/SidebarItem.tsx
+++ b/packages/interface/src/routes/explorer/components/SidebarItem.tsx
@@ -1,39 +1,48 @@
 import clsx from "clsx";
+import { NavLink } from "react-router-dom";
 
-interface SidebarItemProps {
+interface SidebarItemBaseProps {
   icon: React.ElementType | string;
   label: string;
-  active?: boolean;
   weight?: "regular" | "fill" | "bold";
   color?: string;
-  onClick?: () => void;
   className?: string;
 }
 
-export function SidebarItem({
+interface SidebarItemLinkProps extends SidebarItemBaseProps {
+  to: string;
+  end?: boolean;
+  onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
+  active?: never;
+}
+
+interface SidebarItemButtonProps extends SidebarItemBaseProps {
+  to?: never;
+  end?: never;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  active?: boolean;
+}
+
+type SidebarItemProps = SidebarItemLinkProps | SidebarItemButtonProps;
+
+function SidebarItemContent({
   icon,
   label,
-  active,
+  isActive,
   weight = "bold",
   color,
-  onClick,
-  className,
-}: SidebarItemProps) {
+}: {
+  icon: React.ElementType | string;
+  label: string;
+  isActive: boolean;
+  weight?: "regular" | "fill" | "bold";
+  color?: string;
+}) {
   const isImageUrl = typeof icon === "string";
   const Icon = isImageUrl ? null : icon;
 
   return (
-    <button
-      onClick={onClick}
-      className={clsx(
-        "w-full flex flex-row items-center gap-0.5 truncate rounded-lg px-2 py-1.5 text-sm font-medium tracking-wide outline-none",
-        "ring-inset ring-transparent focus:ring-1 focus:ring-accent",
-        active
-          ? "bg-sidebar-selected/40 text-sidebar-ink"
-          : "text-sidebar-inkDull hover:text-sidebar-ink",
-        className
-      )}
-    >
+    <>
       {color ? (
         <span
           className="mr-2 size-4 rounded-full"
@@ -42,9 +51,60 @@ export function SidebarItem({
       ) : isImageUrl ? (
         <img src={icon} alt="" className="mr-2 size-4" />
       ) : (
-        Icon && <Icon className="mr-2 size-4" weight={active ? "fill" : weight} />
+        Icon && <Icon className="mr-2 size-4" weight={isActive ? "fill" : weight} />
       )}
       <span className="truncate">{label}</span>
+    </>
+  );
+}
+
+function getItemClassName(isActive: boolean, className?: string) {
+  return clsx(
+    "w-full flex flex-row items-center gap-0.5 truncate rounded-lg px-2 py-1.5 text-sm font-medium tracking-wide outline-none",
+    "ring-inset ring-transparent focus:ring-1 focus:ring-accent",
+    isActive
+      ? "bg-sidebar-selected/40 text-sidebar-ink"
+      : "text-sidebar-inkDull hover:text-sidebar-ink",
+    className
+  );
+}
+
+export function SidebarItem(props: SidebarItemProps) {
+  const { icon, label, weight = "bold", color, className } = props;
+
+  if (props.to != null) {
+    return (
+      <NavLink
+        to={props.to}
+        end={props.end}
+        onClick={props.onClick}
+        className={({ isActive }) => getItemClassName(isActive, className)}
+      >
+        {({ isActive }) => (
+          <SidebarItemContent
+            icon={icon}
+            label={label}
+            isActive={isActive}
+            weight={weight}
+            color={color}
+          />
+        )}
+      </NavLink>
+    );
+  }
+
+  return (
+    <button
+      onClick={props.onClick}
+      className={getItemClassName(props.active ?? false, className)}
+    >
+      <SidebarItemContent
+        icon={icon}
+        label={label}
+        isActive={props.active ?? false}
+        weight={weight}
+        color={color}
+      />
     </button>
   );
 }

--- a/packages/interface/src/util/navigation.ts
+++ b/packages/interface/src/util/navigation.ts
@@ -1,0 +1,5 @@
+export function shouldNavigate(e: React.MouseEvent): boolean {
+	if (e.button !== 0) return false;
+	if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return false;
+	return true;
+}


### PR DESCRIPTION

Fixes #3008

> **Draft — untested on macOS and Windows.** Opening early for visibility and approach feedback.

Replaces the `<button onClick={() => navigate(path)}>` pattern with React Router `<NavLink>` for sidebar navigation. The current pattern uses buttons for what are semantically links — screen readers announce "button" instead of "link", there's no right-click "Copy Link" or status bar URL preview, and every component manually reimplements active-state detection and click filtering.

## Changes

**`SidebarItem` is now polymorphic** — pass a `to` prop and it renders as `<NavLink>` with automatic active state and `<a>` tag semantics. Omit `to` and it renders as `<button>` for action items like "Add Location". This is the core of the refactor; everything else follows from it.

**Explorer sidebar, LocationsSection, and TagItem** now use `to` prop / `<NavLink>` directly, eliminating `useNavigate()`, `useLocation()`, `isActive()` helpers, and manual click guards from these components.

**`shouldNavigate()` utility** for navigation that can't use `<NavLink>` — SpaceItem (dnd-kit sortable listeners on the element), TopBarButton expand/back actions, "Open Location" in the inspector. Replaces the incomplete `e.button !== 0` guard with full modifier key checks (meta, ctrl, shift, alt).

## Not yet tested

I need to check several things on macOS and Windows such as:

- [ ] Left-click sidebar NavLinks navigates, active state highlights
- [ ] Overview NavLink active only on `/` (tests `end` prop)
- [ ] Middle-click / Ctrl+click doesn't navigate in-app
- [ ] "Add Location" button still works (button mode)
- [ ] SpaceItem click + DnD still works
- [ ] TopBarButton expand/back in Sync/Jobs popovers still navigates
- [ ] DOM inspection: nav items render as `<a>`, action items as `<button>`
