### PR TITLE
fix(windows,ui): dark titlebar via DWM API and sidebar hover effects

### DIFF
--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -1970,6 +1970,14 @@ fn main() {
 
 			tracing::info!("Spacedrive Tauri app starting...");
 
+			// Apply Windows-specific window customizations (dark titlebar)
+			#[cfg(target_os = "windows")]
+			{
+				if let Some(window) = app.get_webview_window("main") {
+					crate::windows::apply_dark_titlebar_pub(&window);
+				}
+			}
+
 			// Apply macOS-specific window customizations
 			#[cfg(target_os = "macos")]
 			{

--- a/apps/tauri/src-tauri/src/windows.rs
+++ b/apps/tauri/src-tauri/src/windows.rs
@@ -353,6 +353,9 @@ impl SpacedriveWindow {
 					.build()
 					.map_err(|e| format!("Failed to create context menu: {}", e))?;
 
+				#[cfg(target_os = "windows")]
+				apply_dark_titlebar(&window);
+
 				Ok(window)
 			}
 		}
@@ -551,31 +554,39 @@ fn apply_dark_titlebar(window: &WebviewWindow) {
 	let hwnd = hwnd.0 as isize;
 
 	unsafe {
+		let set_attr =
+			|attr: u32, value: *const std::ffi::c_void, size: u32, name: &'static str| {
+				let hr = dwm::DwmSetWindowAttribute(hwnd, attr, value, size);
+				if hr < 0 {
+					tracing::warn!(attribute = name, hr, "Failed to apply DWM window attribute");
+				}
+			};
+
 		// Enable immersive dark mode (dark close/minimize/maximize icons)
 		let dark_mode: i32 = 1;
-		dwm::DwmSetWindowAttribute(
-			hwnd,
+		set_attr(
 			dwm::DWMWA_USE_IMMERSIVE_DARK_MODE,
 			&dark_mode as *const _ as *const std::ffi::c_void,
 			std::mem::size_of::<i32>() as u32,
+			"DWMWA_USE_IMMERSIVE_DARK_MODE",
 		);
 
 		// Force caption color to dark gray — overrides user's accent color
 		// COLORREF format is 0x00BBGGRR
 		let caption_color: u32 = 0x00_1E_1E_1E; // #1E1E1E in BGR
-		dwm::DwmSetWindowAttribute(
-			hwnd,
+		set_attr(
 			dwm::DWMWA_CAPTION_COLOR,
 			&caption_color as *const _ as *const std::ffi::c_void,
 			std::mem::size_of::<u32>() as u32,
+			"DWMWA_CAPTION_COLOR",
 		);
 
 		// Match border color to caption
-		dwm::DwmSetWindowAttribute(
-			hwnd,
+		set_attr(
 			dwm::DWMWA_BORDER_COLOR,
 			&caption_color as *const _ as *const std::ffi::c_void,
 			std::mem::size_of::<u32>() as u32,
+			"DWMWA_BORDER_COLOR",
 		);
 	}
 }

--- a/apps/tauri/src-tauri/src/windows.rs
+++ b/apps/tauri/src-tauri/src/windows.rs
@@ -398,6 +398,10 @@ fn create_window(
 		.build()
 		.map_err(|e| format!("Failed to create window: {}", e))?;
 
+	// Windows: force dark titlebar + override accent color
+	#[cfg(target_os = "windows")]
+	apply_dark_titlebar(&window);
+
 	window.show().ok();
 	window.set_focus().ok();
 
@@ -509,4 +513,69 @@ pub async fn position_context_menu(
 	window.set_focus().map_err(|e| e.to_string())?;
 
 	Ok(())
+}
+
+/// Apply dark titlebar on Windows using DWM API.
+///
+/// Sets both `DWMWA_USE_IMMERSIVE_DARK_MODE` (dark window chrome) and
+/// `DWMWA_CAPTION_COLOR` (explicit titlebar color) to override the user's
+/// Windows accent color setting which would otherwise tint the titlebar.
+#[cfg(target_os = "windows")]
+pub fn apply_dark_titlebar_pub(window: &WebviewWindow) {
+	apply_dark_titlebar(window);
+}
+
+#[cfg(target_os = "windows")]
+fn apply_dark_titlebar(window: &WebviewWindow) {
+	#[allow(non_snake_case)]
+	mod dwm {
+		// DWM attribute constants
+		pub const DWMWA_USE_IMMERSIVE_DARK_MODE: u32 = 20;
+		pub const DWMWA_CAPTION_COLOR: u32 = 35;
+		pub const DWMWA_BORDER_COLOR: u32 = 34;
+
+		extern "system" {
+			pub fn DwmSetWindowAttribute(
+				hwnd: isize,
+				attr: u32,
+				value: *const std::ffi::c_void,
+				size: u32,
+			) -> i32;
+		}
+	}
+
+	let Ok(hwnd) = window.hwnd() else {
+		tracing::warn!("Failed to get HWND for dark titlebar");
+		return;
+	};
+	let hwnd = hwnd.0 as isize;
+
+	unsafe {
+		// Enable immersive dark mode (dark close/minimize/maximize icons)
+		let dark_mode: i32 = 1;
+		dwm::DwmSetWindowAttribute(
+			hwnd,
+			dwm::DWMWA_USE_IMMERSIVE_DARK_MODE,
+			&dark_mode as *const _ as *const std::ffi::c_void,
+			std::mem::size_of::<i32>() as u32,
+		);
+
+		// Force caption color to dark gray — overrides user's accent color
+		// COLORREF format is 0x00BBGGRR
+		let caption_color: u32 = 0x00_1E_1E_1E; // #1E1E1E in BGR
+		dwm::DwmSetWindowAttribute(
+			hwnd,
+			dwm::DWMWA_CAPTION_COLOR,
+			&caption_color as *const _ as *const std::ffi::c_void,
+			std::mem::size_of::<u32>() as u32,
+		);
+
+		// Match border color to caption
+		dwm::DwmSetWindowAttribute(
+			hwnd,
+			dwm::DWMWA_BORDER_COLOR,
+			&caption_color as *const _ as *const std::ffi::c_void,
+			std::mem::size_of::<u32>() as u32,
+		);
+	}
 }

--- a/packages/interface/src/components/SpacesSidebar/SpaceItem.tsx
+++ b/packages/interface/src/components/SpacesSidebar/SpaceItem.tsx
@@ -302,10 +302,10 @@ export function SpaceItem({
 						? { ...sortableAttributes, ...sortableListeners }
 						: {})}
 					className={clsx(
-						"flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium transition-colors relative cursor-default",
+						"flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium transition-colors relative cursor-pointer",
 						isActive
 							? "bg-sidebar-selected/30 text-sidebar-ink"
-							: className || "text-sidebar-inkDull",
+							: [className || "text-sidebar-inkDull", "hover:text-sidebar-ink hover:bg-sidebar-selected/20"],
 						showDropHighlight && "bg-accent/10",
 					)}
 				>

--- a/packages/interface/src/routes/explorer/components/SidebarItem.tsx
+++ b/packages/interface/src/routes/explorer/components/SidebarItem.tsx
@@ -26,11 +26,11 @@ export function SidebarItem({
     <button
       onClick={onClick}
       className={clsx(
-        "w-full flex flex-row items-center gap-0.5 truncate rounded-lg px-2 py-1.5 text-sm font-medium tracking-wide outline-none",
+        "w-full flex flex-row items-center gap-0.5 truncate rounded-lg px-2 py-1.5 text-sm font-medium tracking-wide outline-none cursor-pointer",
         "ring-inset ring-transparent focus:ring-1 focus:ring-accent",
         active
           ? "bg-sidebar-selected/40 text-sidebar-ink"
-          : "text-sidebar-inkDull hover:text-sidebar-ink",
+          : "text-sidebar-inkDull hover:text-sidebar-ink hover:bg-sidebar-selected/20",
         className
       )}
     >


### PR DESCRIPTION
## Summary

- **Windows titlebar**: Use `DwmSetWindowAttribute` to force dark caption color (`#1E1E1E`), dark mode icons, and matching border color on all windows. This overrides the user's Windows accent color that would otherwise tint the titlebar, ensuring consistent dark appearance.
- **Sidebar hover**: Add `cursor-pointer` and `hover:bg-sidebar-selected/20` to `SpaceItem` and `SidebarItem` for non-active items, improving interactive feedback.

## Details

### Windows dark titlebar (`#[cfg(target_os = "windows")]` only)
<img width="1403" height="104" alt="image" src="https://github.com/user-attachments/assets/30c18439-17ef-420a-bc57-88c791b58c5b" />



Sets three DWM attributes on every window (main + dynamically created):
- `DWMWA_USE_IMMERSIVE_DARK_MODE` — dark close/minimize/maximize icons
- `DWMWA_CAPTION_COLOR` — explicit `#1E1E1E` background, overrides accent color
- `DWMWA_BORDER_COLOR` — matches caption for clean look

Applied in two places:
1. `main.rs` setup hook — for the config-created main window
2. `create_window()` helper — for all code-created windows

### Sidebar hover (cross-platform CSS)

- `SpaceItem.tsx`: `cursor-default` → `cursor-pointer`, added hover styles for inactive items
- `SidebarItem.tsx`: added `cursor-pointer` and `hover:bg-sidebar-selected/20` for inactive items

## Cross-platform safety

- All Rust DWM code is behind `#[cfg(target_os = "windows")]` — zero impact on macOS/Linux builds
- Frontend changes are pure Tailwind classes using semantic color tokens — no platform dependency

## Test plan

- [x] Windows: verify dark titlebar on main window and dynamically created windows (e.g. Settings, Explorer)
- [x] Windows: verify titlebar stays dark regardless of Windows accent color setting
- [ ] macOS/Linux: verify no regression (sidebar hover works, no build errors)
- [x] Sidebar: verify hover effect on inactive items (SpaceItem + SidebarItem)