### PR TITLE
fix(locations): register watcher on location add, canonicalize paths

### DIFF
--- a/core/src/common/utils.rs
+++ b/core/src/common/utils.rs
@@ -17,9 +17,17 @@
 pub fn strip_windows_extended_prefix(path: std::path::PathBuf) -> std::path::PathBuf {
 	if let Some(s) = path.to_str() {
 		if s.starts_with(r"\\?\UNC\") {
+			// \\?\UNC\server\share\... → \\server\share\...
 			std::path::PathBuf::from(format!(r"\\{}", &s[8..]))
 		} else if let Some(stripped) = s.strip_prefix(r"\\?\") {
-			std::path::PathBuf::from(stripped)
+			// Only strip \\?\ when followed by a drive letter (e.g. C:\).
+			// Leave volume GUIDs (\\?\Volume{...}\) and other verbatim
+			// forms untouched — they are invalid without the prefix.
+			if stripped.as_bytes().get(1) == Some(&b':') {
+				std::path::PathBuf::from(stripped)
+			} else {
+				path
+			}
 		} else {
 			path
 		}

--- a/core/src/common/utils.rs
+++ b/core/src/common/utils.rs
@@ -3,3 +3,33 @@
 // Note: Device ID management has been moved to device::manager for better
 // module organization. Import from there instead:
 // use crate::device::manager::{get_current_device_id, set_current_device_id};
+
+/// Strip Windows extended path prefixes produced by `std::fs::canonicalize()`.
+///
+/// On Windows, `canonicalize()` returns paths like `\\?\C:\...` (local) or
+/// `\\?\UNC\server\share\...` (network). These prefixes break `starts_with()`
+/// matching throughout the codebase and must be normalized.
+///
+/// - `\\?\UNC\server\share\...` → `\\server\share\...`
+/// - `\\?\C:\...` → `C:\...`
+/// - All other paths are returned unchanged.
+#[cfg(windows)]
+pub fn strip_windows_extended_prefix(path: std::path::PathBuf) -> std::path::PathBuf {
+	if let Some(s) = path.to_str() {
+		if s.starts_with(r"\\?\UNC\") {
+			std::path::PathBuf::from(format!(r"\\{}", &s[8..]))
+		} else if let Some(stripped) = s.strip_prefix(r"\\?\") {
+			std::path::PathBuf::from(stripped)
+		} else {
+			path
+		}
+	} else {
+		path
+	}
+}
+
+/// No-op on non-Windows platforms.
+#[cfg(not(windows))]
+pub fn strip_windows_extended_prefix(path: std::path::PathBuf) -> std::path::PathBuf {
+	path
+}

--- a/core/src/location/manager.rs
+++ b/core/src/location/manager.rs
@@ -58,13 +58,21 @@ impl LocationManager {
 						e
 					))
 				})?;
-				// On Windows, canonicalize() returns UNC paths (\\?\C:\...) which break
-				// starts_with() matching throughout the codebase. Strip the prefix.
+				// On Windows, canonicalize() returns extended path prefixes that break
+				// starts_with() matching throughout the codebase.
+				// \\?\UNC\server\share\... → \\server\share\... (network UNC)
+				// \\?\C:\... → C:\... (local drive)
+				// Same normalization as volume/fs/refs.rs:contains_path()
 				#[cfg(windows)]
 				let canonical = {
-					let s = canonical.to_string_lossy();
-					if let Some(stripped) = s.strip_prefix(r"\\?\") {
-						std::path::PathBuf::from(stripped)
+					if let Some(s) = canonical.to_str() {
+						if s.starts_with(r"\\?\UNC\") {
+							std::path::PathBuf::from(format!(r"\\{}", &s[8..]))
+						} else if let Some(stripped) = s.strip_prefix(r"\\?\") {
+							std::path::PathBuf::from(stripped)
+						} else {
+							canonical
+						}
 					} else {
 						canonical
 					}

--- a/core/src/location/manager.rs
+++ b/core/src/location/manager.rs
@@ -58,25 +58,7 @@ impl LocationManager {
 						e
 					))
 				})?;
-				// On Windows, canonicalize() returns extended path prefixes that break
-				// starts_with() matching throughout the codebase.
-				// \\?\UNC\server\share\... → \\server\share\... (network UNC)
-				// \\?\C:\... → C:\... (local drive)
-				// Same normalization as volume/fs/refs.rs:contains_path()
-				#[cfg(windows)]
-				let canonical = {
-					if let Some(s) = canonical.to_str() {
-						if s.starts_with(r"\\?\UNC\") {
-							std::path::PathBuf::from(format!(r"\\{}", &s[8..]))
-						} else if let Some(stripped) = s.strip_prefix(r"\\?\") {
-							std::path::PathBuf::from(stripped)
-						} else {
-							canonical
-						}
-					} else {
-						canonical
-					}
-				};
+				let canonical = crate::common::utils::strip_windows_extended_prefix(canonical);
 				crate::domain::addressing::SdPath::Physical {
 					device_slug,
 					path: canonical,

--- a/core/src/location/manager.rs
+++ b/core/src/location/manager.rs
@@ -46,6 +46,40 @@ impl LocationManager {
 		job_policies: Option<String>,
 		volume_manager: &crate::volume::VolumeManager,
 	) -> LocationResult<(Uuid, String)> {
+		// Canonicalize local physical paths to absolute form before storing.
+		// Relative paths break the watcher, volume resolution, and indexer.
+		// Only for local device — remote paths can't be resolved locally.
+		let sd_path = if sd_path.is_local() {
+			if let crate::domain::addressing::SdPath::Physical { device_slug, path } = sd_path {
+				let canonical = tokio::fs::canonicalize(&path).await.map_err(|e| {
+					LocationError::InvalidPath(format!(
+						"Failed to resolve path {}: {}",
+						path.display(),
+						e
+					))
+				})?;
+				// On Windows, canonicalize() returns UNC paths (\\?\C:\...) which break
+				// starts_with() matching throughout the codebase. Strip the prefix.
+				#[cfg(windows)]
+				let canonical = {
+					let s = canonical.to_string_lossy();
+					if let Some(stripped) = s.strip_prefix(r"\\?\") {
+						std::path::PathBuf::from(stripped)
+					} else {
+						canonical
+					}
+				};
+				crate::domain::addressing::SdPath::Physical {
+					device_slug,
+					path: canonical,
+				}
+			} else {
+				sd_path
+			}
+		} else {
+			sd_path
+		};
+
 		info!("Adding location: {}", sd_path);
 
 		// Validate the path based on type

--- a/core/src/ops/locations/add/action.rs
+++ b/core/src/ops/locations/add/action.rs
@@ -110,10 +110,25 @@ impl LibraryAction for LocationAddAction {
 				use crate::ops::indexing::handlers::LocationMeta;
 				use crate::ops::indexing::RuleToggles;
 
-				// Use canonical path to match what add_location stored in DB
+				// Use canonical path to match what add_location stored in DB,
+				// with the same Windows prefix normalization as manager.rs
 				let root_path = tokio::fs::canonicalize(local_path)
 					.await
 					.unwrap_or_else(|_| local_path.to_path_buf());
+				#[cfg(windows)]
+				let root_path = {
+					if let Some(s) = root_path.to_str() {
+						if s.starts_with(r"\\?\UNC\") {
+							std::path::PathBuf::from(format!(r"\\{}", &s[8..]))
+						} else if let Some(stripped) = s.strip_prefix(r"\\?\") {
+							std::path::PathBuf::from(stripped)
+						} else {
+							root_path
+						}
+					} else {
+						root_path
+					}
+				};
 
 				let meta = LocationMeta {
 					id: location_id,

--- a/core/src/ops/locations/add/action.rs
+++ b/core/src/ops/locations/add/action.rs
@@ -102,6 +102,31 @@ impl LibraryAction for LocationAddAction {
 			.await
 			.map_err(|e| ActionError::Internal(e.to_string()))?;
 
+		// Register the new location with the filesystem watcher so changes
+		// (creates, deletes, renames) are detected in real-time.
+		// Without this, the watcher only learns about locations at startup.
+		if let Some(local_path) = self.input.path.as_local_path() {
+			if let Some(fs_watcher) = context.get_fs_watcher().await {
+				use crate::ops::indexing::handlers::LocationMeta;
+				use crate::ops::indexing::RuleToggles;
+
+				// Use canonical path to match what add_location stored in DB
+				let root_path = tokio::fs::canonicalize(local_path)
+					.await
+					.unwrap_or_else(|_| local_path.to_path_buf());
+
+				let meta = LocationMeta {
+					id: location_id,
+					library_id: library.id(),
+					root_path,
+					rule_toggles: RuleToggles::default(),
+				};
+				if let Err(e) = fs_watcher.watch_location(meta).await {
+					tracing::warn!("Failed to register location with watcher: {}", e);
+				}
+			}
+		}
+
 		// Parse the job ID from the string returned by add_location
 		let job_id = if !job_id_string.is_empty() {
 			Some(

--- a/core/src/ops/locations/add/action.rs
+++ b/core/src/ops/locations/add/action.rs
@@ -110,25 +110,10 @@ impl LibraryAction for LocationAddAction {
 				use crate::ops::indexing::handlers::LocationMeta;
 				use crate::ops::indexing::RuleToggles;
 
-				// Use canonical path to match what add_location stored in DB,
-				// with the same Windows prefix normalization as manager.rs
 				let root_path = tokio::fs::canonicalize(local_path)
 					.await
 					.unwrap_or_else(|_| local_path.to_path_buf());
-				#[cfg(windows)]
-				let root_path = {
-					if let Some(s) = root_path.to_str() {
-						if s.starts_with(r"\\?\UNC\") {
-							std::path::PathBuf::from(format!(r"\\{}", &s[8..]))
-						} else if let Some(stripped) = s.strip_prefix(r"\\?\") {
-							std::path::PathBuf::from(stripped)
-						} else {
-							root_path
-						}
-					} else {
-						root_path
-					}
-				};
+				let root_path = crate::common::utils::strip_windows_extended_prefix(root_path);
 
 				let meta = LocationMeta {
 					id: location_id,

--- a/core/src/ops/locations/remove/action.rs
+++ b/core/src/ops/locations/remove/action.rs
@@ -43,12 +43,23 @@ impl LibraryAction for LocationRemoveAction {
 		library: std::sync::Arc<crate::library::Library>,
 		context: Arc<CoreContext>,
 	) -> Result<Self::Output, ActionError> {
-		// Remove the location
+		// Remove the location from DB
 		let location_manager = LocationManager::new(context.events.as_ref().clone());
 		location_manager
 			.remove_location(&library, self.input.location_id)
 			.await
 			.map_err(|e| ActionError::Internal(e.to_string()))?;
+
+		// Unwatch the location from the filesystem watcher
+		if let Some(watcher) = context.get_fs_watcher().await {
+			if let Err(e) = watcher.unwatch_location(self.input.location_id).await {
+				tracing::warn!(
+					"Failed to unwatch location {}: {}",
+					self.input.location_id,
+					e
+				);
+			}
+		}
 
 		Ok(LocationRemoveOutput::new(self.input.location_id, None))
 	}

--- a/core/src/volume/fs/refs.rs
+++ b/core/src/volume/fs/refs.rs
@@ -293,18 +293,7 @@ impl super::FilesystemHandler for RefsHandler {
 	}
 
 	fn contains_path(&self, volume: &Volume, path: &std::path::Path) -> bool {
-		// Strip Windows extended path prefix (\\?\) produced by canonicalize()
-		let normalized_path = if let Some(path_str) = path.to_str() {
-			if path_str.starts_with("\\\\?\\UNC\\") {
-				PathBuf::from(format!("\\\\{}", &path_str[8..]))
-			} else if let Some(stripped) = path_str.strip_prefix("\\\\?\\") {
-				PathBuf::from(stripped)
-			} else {
-				path.to_path_buf()
-			}
-		} else {
-			path.to_path_buf()
-		};
+		let normalized_path = crate::common::utils::strip_windows_extended_prefix(path.to_path_buf());
 
 		if normalized_path.starts_with(&volume.mount_point) {
 			return true;


### PR DESCRIPTION
## Summary

Locations added at runtime are never registered with the `FsWatcherService`. The watcher only discovers locations at startup via `load_library_locations()`. This means **no filesystem events (creates, deletes, renames) are detected** for any location added through the UI until the app is restarted.

Additionally, `LocationManager::add_location()` stores paths without canonicalization, so relative paths (from cwd-dependent contexts) break the watcher, volume manager, and indexer.

## Changes

### 1. Register watcher on location add (`locations/add/action.rs`)

After `LocationManager::add_location()` succeeds, call `fs_watcher.watch_location(meta)` to start OS-level filesystem monitoring immediately. This mirrors what `load_library_locations()` does at startup.

- Only registers local physical paths (remote/cloud skipped)
- Graceful fallback if watcher not available (warns, doesn't fail)
- Uses canonical path to match DB storage

### 2. Canonicalize paths before storing (`location/manager.rs`)

Call `tokio::fs::canonicalize()` on local physical paths before storing in DB.

- Converts relative paths to absolute
- Resolves symlinks and `..` components
- Strips `\?\` UNC prefix on Windows (same pattern as `volume/manager.rs`)
- Only for local device paths — remote paths pass through unchanged

## Test plan

- [x] Add a location via the UI, then copy/delete/rename a file inside it — changes should appear in the UI immediately without restart
- [x] Verify the watcher log shows `Watching location <id> at <path>` after adding
- [ ] macOS/Linux: verify no regression (location add + file operations)
- [ ] Remote locations (if testable): verify no canonicalization attempted on remote paths

## Related

- PR #3041 fixes the delete pipeline itself (Content path resolution, keybinds, progress). This PR fixes the watcher not detecting FS changes after those operations complete.