### PR TITLE
fix(ts-client): prevent Overview crash from single-resource cache seeding

### DIFF
--- a/packages/ts-client/src/hooks/useNormalizedQuery.ts
+++ b/packages/ts-client/src/hooks/useNormalizedQuery.ts
@@ -507,7 +507,9 @@ export function updateSingleResource<O>(
 
 	queryClient.setQueryData<O>(queryKey, (oldData: any) => {
 		if (!oldData) {
-			return { files: resourcesToUpdate, total_count: resourcesToUpdate.length, has_more: false } as O;
+			// queryFn will deliver correct data. The { files: [...] } fallback assumes
+			// list shape, which crashes single-resource queries like libraries.info.
+			return undefined;
 		}
 
 		// Handle array responses


### PR DESCRIPTION
## Summary

- `updateSingleResource` seeded the TanStack cache with `{ files: [...], total_count, has_more }` when `oldData` was null (buffer replay race). This list-shaped fallback broke single-resource queries like `libraries.info` where the response is a plain `Library` object, causing `TypeError: Cannot read properties of undefined (reading 'total_capacity')` on the Overview page.
- Returns `undefined` instead (TanStack no-op) so the `queryFn` delivers the correct shape. Batch seeding in `updateBatchResources` is preserved for file listings.

## Root Cause

The subscription manager pre-registers the listener before `transport.subscribe()` (correct for capturing buffer replay). When the daemon has a recent `ResourceChanged` for `library` (from `recalculate_statistics()`), the buffer replay delivers it before the `queryFn` resolves. With `oldData` null, the fallback creates `{ files: [Library] }` which has no `statistics` key, crashing the Overview component.

## Why only `updateSingleResource`

`updateBatchResources` keeps its `{ files: [...] }` seeding because `ResourceChangedBatch` events are only emitted by the file indexing pipeline, where the list shape is correct. Single `ResourceChanged` events affect all resource types (library, device, volume, location, tag), most of which don't use list-shaped responses.