### PR TITLE
fix: update tests/examples for upstream API changes and fix sync loop busy-loop

### DIFF
--- a/core/examples/create_memory.rs
+++ b/core/examples/create_memory.rs
@@ -7,7 +7,7 @@ use sd_core::domain::memory::{DocumentType, FactType, MemoryFile, MemoryScope};
 use std::path::PathBuf;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	// Initialize logging
 	tracing_subscriber::fmt().with_env_filter("info").init();
 

--- a/core/examples/file_type_demo.rs
+++ b/core/examples/file_type_demo.rs
@@ -3,7 +3,7 @@
 use sd_core::filetype::FileTypeRegistry;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	// Create registry with built-in types
 	let registry = FileTypeRegistry::new();
 

--- a/core/examples/indexing_demo.rs
+++ b/core/examples/indexing_demo.rs
@@ -24,7 +24,7 @@ use std::path::PathBuf;
 use tokio::time::{sleep, Duration};
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	// Initialize logging with more detail
 	tracing_subscriber::fmt()
 		.with_env_filter("sd_core=debug,desktop_indexing_demo=info")

--- a/core/examples/job_logging_test.rs
+++ b/core/examples/job_logging_test.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 use tokio::time::{sleep, Duration};
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	// Initialize logging
 	tracing_subscriber::fmt()
 		.with_env_filter("sd_core=debug")

--- a/core/examples/library_demo.rs
+++ b/core/examples/library_demo.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use uuid::Uuid;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	// Initialize logging
 	tracing_subscriber::fmt()
 		.with_env_filter("sd_core=debug")
@@ -125,8 +125,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 			accessed_at: Set(None),
 			indexed_at: Set(None),
 			permissions: Set(None),
-			device_id: Set(Some(inserted_device.id)),
 			inode: Set(None),
+			volume_id: Set(None),
 		};
 		let entry_record = entry.insert(db.conn()).await?;
 
@@ -143,6 +143,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 			error_message: Set(None),
 			total_file_count: Set(0),
 			total_byte_size: Set(0),
+			volume_id: Set(None),
 			job_policies: Set(None),
 			created_at: Set(chrono::Utc::now()),
 			updated_at: Set(chrono::Utc::now()),

--- a/core/examples/pause_resume_demo.rs
+++ b/core/examples/pause_resume_demo.rs
@@ -14,7 +14,7 @@ use tempfile::TempDir;
 use tokio::time::sleep;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	// Initialize logging
 	tracing_subscriber::fmt::init();
 

--- a/core/examples/shutdown_demo.rs
+++ b/core/examples/shutdown_demo.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use tokio::time::sleep;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	// Initialize logging
 	tracing_subscriber::fmt::init();
 

--- a/core/examples/simple_pause_resume.rs
+++ b/core/examples/simple_pause_resume.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use tokio::time::sleep;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	// Initialize logging
 	tracing_subscriber::fmt::init();
 

--- a/core/examples/test_migration.rs
+++ b/core/examples/test_migration.rs
@@ -5,7 +5,7 @@ use sea_orm::{ConnectionTrait, Database, Statement};
 use sea_orm_migration::MigratorTrait;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	// Initialize logging
 	tracing_subscriber::fmt()
 		.with_max_level(tracing::Level::DEBUG)

--- a/core/examples/volume_demo.rs
+++ b/core/examples/volume_demo.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use tokio::time::timeout;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	// Initialize logging
 	tracing_subscriber::fmt()
 		.with_env_filter("sd_core=info")

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -10,7 +10,8 @@ pub mod app_config;
 pub mod migration;
 
 pub use app_config::{
-	AppConfig, JobLoggingConfig, LogStreamConfig, LoggingConfig, ServiceConfig, SpacebotConfig,
+	AppConfig, JobLoggingConfig, LogStreamConfig, LoggingConfig, ProxyPairingConfig, ServiceConfig,
+	SpacebotConfig,
 };
 pub use migration::Migrate;
 

--- a/core/src/service/sync/mod.rs
+++ b/core/src/service/sync/mod.rs
@@ -398,14 +398,11 @@ impl SyncService {
 								peer_sync.db(),
 							).await {
 								Ok(partners) if !partners.is_empty() => {
-									// Check if real-time sync is active (lock mechanism)
-									// If real-time broadcasts are happening, skip catch-up to prevent duplication
-									let realtime_active = peer_sync.is_realtime_active().await;
-									if realtime_active {
+									// If real-time broadcasts are happening, skip catch-up to prevent duplication.
+									// Falls through to sleep rather than `continue` to avoid busy-looping.
+									if peer_sync.is_realtime_active().await {
 										debug!("Skipping catch-up - real-time sync is active (lock mechanism)");
-										continue;
-									}
-
+									} else {
 									// Iterate each partner individually (FIX: was only checking partners[0])
 									for partner_id in partners {
 										// Query per-peer watermarks from sync.db
@@ -554,6 +551,7 @@ impl SyncService {
 										// Other peers will be caught up in subsequent loop iterations
 										break;
 									}
+									} // else !realtime_active
 								}
 								Ok(_) => {}
 								Err(e) => {

--- a/core/tests/ephemeral_watcher_test.rs
+++ b/core/tests/ephemeral_watcher_test.rs
@@ -371,7 +371,7 @@ struct TestHarness {
 
 impl TestHarness {
 	/// Setup the test environment with core and ephemeral watching
-	async fn setup() -> Result<Self, Box<dyn std::error::Error>> {
+	async fn setup() -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
 		// Setup logging
 		let _ = tracing_subscriber::fmt()
 			.with_env_filter("sd_core=debug,ephemeral_watcher_test=debug")
@@ -487,7 +487,7 @@ impl TestHarness {
 		&self,
 		name: &str,
 		content: &str,
-	) -> Result<(), Box<dyn std::error::Error>> {
+	) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		let path = self.path(name);
 		tokio::fs::write(&path, content).await?;
 		println!("Created file: {}", name);
@@ -499,7 +499,7 @@ impl TestHarness {
 		&self,
 		name: &str,
 		new_content: &str,
-	) -> Result<(), Box<dyn std::error::Error>> {
+	) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		let path = self.path(name);
 		tokio::fs::write(&path, new_content).await?;
 		println!("Modified file: {}", name);
@@ -507,7 +507,10 @@ impl TestHarness {
 	}
 
 	/// Delete a file
-	async fn delete_file(&self, name: &str) -> Result<(), Box<dyn std::error::Error>> {
+	async fn delete_file(
+		&self,
+		name: &str,
+	) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		let path = self.path(name);
 		tokio::fs::remove_file(&path).await?;
 		println!("Deleted file: {}", name);
@@ -515,7 +518,11 @@ impl TestHarness {
 	}
 
 	/// Rename/move a file
-	async fn rename_file(&self, from: &str, to: &str) -> Result<(), Box<dyn std::error::Error>> {
+	async fn rename_file(
+		&self,
+		from: &str,
+		to: &str,
+	) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		let from_path = self.path(from);
 		let to_path = self.path(to);
 		tokio::fs::rename(&from_path, &to_path).await?;
@@ -524,7 +531,7 @@ impl TestHarness {
 	}
 
 	/// Create a directory
-	async fn create_dir(&self, name: &str) -> Result<(), Box<dyn std::error::Error>> {
+	async fn create_dir(&self, name: &str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		let path = self.path(name);
 		tokio::fs::create_dir_all(&path).await?;
 		println!("Created directory: {}", name);
@@ -532,7 +539,7 @@ impl TestHarness {
 	}
 
 	/// Delete a directory recursively
-	async fn delete_dir(&self, name: &str) -> Result<(), Box<dyn std::error::Error>> {
+	async fn delete_dir(&self, name: &str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		let path = self.path(name);
 		tokio::fs::remove_dir_all(&path).await?;
 		println!("Deleted directory recursively: {}", name);
@@ -540,7 +547,10 @@ impl TestHarness {
 	}
 
 	/// Create multiple files at the top level (batch creation test)
-	async fn create_batch_files(&self, files: &[&str]) -> Result<(), Box<dyn std::error::Error>> {
+	async fn create_batch_files(
+		&self,
+		files: &[&str],
+	) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		for file in files {
 			let full_path = self.path(file);
 			tokio::fs::write(&full_path, format!("Content of {}", file)).await?;
@@ -554,7 +564,7 @@ impl TestHarness {
 		&self,
 		name: &str,
 		trash_dir: &std::path::Path,
-	) -> Result<(), Box<dyn std::error::Error>> {
+	) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		let from_path = self.path(name);
 		let to_path = trash_dir.join(name);
 		tokio::fs::rename(&from_path, &to_path).await?;
@@ -567,7 +577,7 @@ impl TestHarness {
 		&self,
 		name: &str,
 		trash_dir: &std::path::Path,
-	) -> Result<(), Box<dyn std::error::Error>> {
+	) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		let from_path = trash_dir.join(name);
 		let to_path = self.path(name);
 		tokio::fs::rename(&from_path, &to_path).await?;
@@ -576,7 +586,10 @@ impl TestHarness {
 	}
 
 	/// Create multiple directories at the top level
-	async fn create_batch_dirs(&self, dirs: &[&str]) -> Result<(), Box<dyn std::error::Error>> {
+	async fn create_batch_dirs(
+		&self,
+		dirs: &[&str],
+	) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		for dir in dirs {
 			self.create_dir(dir).await?;
 		}
@@ -584,7 +597,10 @@ impl TestHarness {
 	}
 
 	/// Verify entry exists in ephemeral index
-	async fn verify_entry_exists(&self, name: &str) -> Result<(), Box<dyn std::error::Error>> {
+	async fn verify_entry_exists(
+		&self,
+		name: &str,
+	) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		let path = self.path(name);
 
 		// Poll for the entry to appear (with timeout)
@@ -610,7 +626,10 @@ impl TestHarness {
 	}
 
 	/// Verify entry does NOT exist in ephemeral index
-	async fn verify_entry_not_exists(&self, name: &str) -> Result<(), Box<dyn std::error::Error>> {
+	async fn verify_entry_not_exists(
+		&self,
+		name: &str,
+	) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		let path = self.path(name);
 
 		// Poll for the entry to be removed (with timeout)
@@ -636,7 +655,10 @@ impl TestHarness {
 	}
 
 	/// Verify entry is a directory
-	async fn verify_is_directory(&self, name: &str) -> Result<(), Box<dyn std::error::Error>> {
+	async fn verify_is_directory(
+		&self,
+		name: &str,
+	) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		let path = self.path(name);
 		let index = self.context.ephemeral_cache().get_global_index();
 		let mut index_lock = index.write().await;
@@ -657,7 +679,10 @@ impl TestHarness {
 	}
 
 	/// Verify entry is a file (not directory)
-	async fn verify_is_file(&self, name: &str) -> Result<(), Box<dyn std::error::Error>> {
+	async fn verify_is_file(
+		&self,
+		name: &str,
+	) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		let path = self.path(name);
 		let index = self.context.ephemeral_cache().get_global_index();
 		let mut index_lock = index.write().await;
@@ -703,7 +728,7 @@ impl TestHarness {
 	async fn verify_children_count(
 		&self,
 		expected: usize,
-	) -> Result<(), Box<dyn std::error::Error>> {
+	) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		let count = self.get_children_count().await;
 		if count == expected {
 			println!("✓ Children count (list_directory) matches: {}", expected);
@@ -718,7 +743,10 @@ impl TestHarness {
 	}
 
 	/// Verify expected entry count
-	async fn verify_entry_count(&self, expected: usize) -> Result<(), Box<dyn std::error::Error>> {
+	async fn verify_entry_count(
+		&self,
+		expected: usize,
+	) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		let count = self.get_entry_count().await;
 		if count == expected {
 			println!("✓ Entry count matches: {}", expected);
@@ -804,7 +832,7 @@ impl TestHarness {
 	}
 
 	/// Clean up test resources
-	async fn cleanup(self) -> Result<(), Box<dyn std::error::Error>> {
+	async fn cleanup(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		// Dump events before cleanup
 		self.dump_events().await;
 
@@ -830,7 +858,9 @@ impl TestHarness {
 }
 
 /// Inner test logic that can fail
-async fn run_test_scenarios(harness: &TestHarness) -> Result<(), Box<dyn std::error::Error>> {
+async fn run_test_scenarios(
+	harness: &TestHarness,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	// Note: Entry counts include +1 for the root directory itself which is indexed
 
 	// ========================================================================
@@ -1206,7 +1236,7 @@ async fn run_test_scenarios(harness: &TestHarness) -> Result<(), Box<dyn std::er
 
 /// Comprehensive "story" test demonstrating ephemeral watcher functionality
 #[tokio::test]
-async fn test_ephemeral_watcher() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_ephemeral_watcher() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	println!("\n=== Ephemeral Watcher Full Story Test ===\n");
 
 	let harness = TestHarness::setup().await?;

--- a/core/tests/event_system_test.rs
+++ b/core/tests/event_system_test.rs
@@ -25,7 +25,7 @@ use tokio::sync::Mutex;
 use tokio::time::{timeout, Duration};
 
 #[tokio::test]
-async fn test_core_and_library_events() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_core_and_library_events() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	let temp_dir = TempDir::new()?;
 
 	// Set up event collection
@@ -122,7 +122,7 @@ async fn test_core_and_library_events() -> Result<(), Box<dyn std::error::Error>
 }
 
 #[tokio::test]
-async fn test_location_and_job_events() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_location_and_job_events() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	let temp_dir = TempDir::new()?;
 	let core = Core::new(temp_dir.path().to_path_buf()).await?;
 
@@ -241,7 +241,7 @@ async fn test_location_and_job_events() -> Result<(), Box<dyn std::error::Error>
 }
 
 #[tokio::test]
-async fn test_event_filtering() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_event_filtering() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	let temp_dir = TempDir::new()?;
 	let core = Core::new(temp_dir.path().to_path_buf()).await?;
 
@@ -308,7 +308,8 @@ async fn test_event_filtering() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[tokio::test]
-async fn test_concurrent_event_subscribers() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_concurrent_event_subscribers() -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+{
 	let temp_dir = TempDir::new()?;
 	let core = Core::new(temp_dir.path().to_path_buf()).await?;
 
@@ -391,7 +392,7 @@ async fn test_concurrent_event_subscribers() -> Result<(), Box<dyn std::error::E
 }
 
 #[tokio::test]
-async fn test_custom_events() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_custom_events() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	let temp_dir = TempDir::new()?;
 	let core = Core::new(temp_dir.path().to_path_buf()).await?;
 

--- a/core/tests/file_structure_test.rs
+++ b/core/tests/file_structure_test.rs
@@ -13,7 +13,7 @@ use std::{sync::Arc, time::Duration};
 use tempfile::TempDir;
 
 #[tokio::test]
-async fn map_file_structure_per_phase() -> Result<(), Box<dyn std::error::Error>> {
+async fn map_file_structure_per_phase() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	tracing_subscriber::fmt::init();
 	eprintln!("\nMAPPING FILE STRUCTURE AT EACH PHASE\n");
 	eprintln!("{}", "=".repeat(80));

--- a/core/tests/file_sync_simple_test.rs
+++ b/core/tests/file_sync_simple_test.rs
@@ -38,6 +38,8 @@ impl FileSyncTestSetup {
 				statistics_listener_enabled: false,
 			},
 			logging: sd_core::config::LoggingConfig::default(),
+			proxy_pairing: sd_core::config::ProxyPairingConfig::default(),
+			spacebot: sd_core::config::SpacebotConfig::default(),
 		};
 		config.save()?;
 

--- a/core/tests/file_sync_test.rs
+++ b/core/tests/file_sync_test.rs
@@ -64,7 +64,8 @@ impl FileSyncTestSetup {
 				statistics_listener_enabled: false,
 			},
 			logging: sd_core::config::LoggingConfig::default(),
-			proxy_pairing: sd_core::config::app_config::ProxyPairingConfig::default(),
+			proxy_pairing: sd_core::config::ProxyPairingConfig::default(),
+			spacebot: sd_core::config::SpacebotConfig::default(),
 		};
 		config.save()?;
 

--- a/core/tests/fs_watcher_test.rs
+++ b/core/tests/fs_watcher_test.rs
@@ -357,7 +357,7 @@ impl CoreEventCollector {
 async fn count_location_entries(
 	library: &Arc<Library>,
 	location_id: Uuid,
-) -> Result<usize, Box<dyn std::error::Error>> {
+) -> Result<usize, Box<dyn std::error::Error + Send + Sync>> {
 	let location_record = entities::location::Entity::find()
 		.filter(entities::location::Column::Uuid.eq(location_id))
 		.one(library.db().conn())
@@ -381,7 +381,7 @@ async fn count_location_entries(
 async fn get_location_entries(
 	library: &Arc<Library>,
 	location_id: Uuid,
-) -> Result<Vec<entities::entry::Model>, Box<dyn std::error::Error>> {
+) -> Result<Vec<entities::entry::Model>, Box<dyn std::error::Error + Send + Sync>> {
 	let location_record = entities::location::Entity::find()
 		.filter(entities::location::Column::Uuid.eq(location_id))
 		.one(library.db().conn())
@@ -414,7 +414,7 @@ async fn get_location_entries(
 async fn get_directory_children(
 	library: &Arc<Library>,
 	parent_entry_id: i32,
-) -> Result<Vec<entities::entry::Model>, Box<dyn std::error::Error>> {
+) -> Result<Vec<entities::entry::Model>, Box<dyn std::error::Error + Send + Sync>> {
 	let children = entities::entry::Entity::find()
 		.filter(entities::entry::Column::ParentId.eq(parent_entry_id))
 		.all(library.db().conn())
@@ -440,7 +440,7 @@ struct TestHarness {
 
 impl TestHarness {
 	/// Setup the test environment with core, library, and watched location
-	async fn setup() -> Result<Self, Box<dyn std::error::Error>> {
+	async fn setup() -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
 		// Setup logging
 		let _ = tracing_subscriber::fmt()
 			.with_env_filter("sd_core=debug,fs_watcher_test=debug")
@@ -582,7 +582,7 @@ impl TestHarness {
 		&self,
 		name: &str,
 		content: &str,
-	) -> Result<(), Box<dyn std::error::Error>> {
+	) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		let path = self.path(name);
 		tokio::fs::write(&path, content).await?;
 		println!("Created file: {}", name);
@@ -594,7 +594,7 @@ impl TestHarness {
 		&self,
 		name: &str,
 		new_content: &str,
-	) -> Result<(), Box<dyn std::error::Error>> {
+	) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		let path = self.path(name);
 		tokio::fs::write(&path, new_content).await?;
 		println!("Modified file: {}", name);
@@ -602,7 +602,10 @@ impl TestHarness {
 	}
 
 	/// Delete a file
-	async fn delete_file(&self, name: &str) -> Result<(), Box<dyn std::error::Error>> {
+	async fn delete_file(
+		&self,
+		name: &str,
+	) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		let path = self.path(name);
 		tokio::fs::remove_file(&path).await?;
 		println!("Deleted file: {}", name);
@@ -610,7 +613,11 @@ impl TestHarness {
 	}
 
 	/// Rename/move a file
-	async fn rename_file(&self, from: &str, to: &str) -> Result<(), Box<dyn std::error::Error>> {
+	async fn rename_file(
+		&self,
+		from: &str,
+		to: &str,
+	) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		let from_path = self.path(from);
 		let to_path = self.path(to);
 		tokio::fs::rename(&from_path, &to_path).await?;
@@ -619,7 +626,7 @@ impl TestHarness {
 	}
 
 	/// Create a directory
-	async fn create_dir(&self, name: &str) -> Result<(), Box<dyn std::error::Error>> {
+	async fn create_dir(&self, name: &str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		let path = self.path(name);
 		tokio::fs::create_dir_all(&path).await?;
 		println!("Created directory: {}", name);
@@ -627,7 +634,7 @@ impl TestHarness {
 	}
 
 	/// Delete a directory recursively
-	async fn delete_dir(&self, name: &str) -> Result<(), Box<dyn std::error::Error>> {
+	async fn delete_dir(&self, name: &str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		let path = self.path(name);
 		tokio::fs::remove_dir_all(&path).await?;
 		println!("Deleted directory recursively: {}", name);
@@ -635,7 +642,10 @@ impl TestHarness {
 	}
 
 	/// Create multiple files at the top level (batch creation test)
-	async fn create_batch_files(&self, files: &[&str]) -> Result<(), Box<dyn std::error::Error>> {
+	async fn create_batch_files(
+		&self,
+		files: &[&str],
+	) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		for file in files {
 			let full_path = self.path(file);
 			tokio::fs::write(&full_path, format!("Content of {}", file)).await?;
@@ -649,7 +659,7 @@ impl TestHarness {
 		&self,
 		name: &str,
 		trash_dir: &std::path::Path,
-	) -> Result<(), Box<dyn std::error::Error>> {
+	) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		let from_path = self.path(name);
 		let to_path = trash_dir.join(name);
 		tokio::fs::rename(&from_path, &to_path).await?;
@@ -662,7 +672,7 @@ impl TestHarness {
 		&self,
 		name: &str,
 		trash_dir: &std::path::Path,
-	) -> Result<(), Box<dyn std::error::Error>> {
+	) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		let from_path = trash_dir.join(name);
 		let to_path = self.path(name);
 		tokio::fs::rename(&from_path, &to_path).await?;
@@ -671,7 +681,10 @@ impl TestHarness {
 	}
 
 	/// Create multiple directories at the top level
-	async fn create_batch_dirs(&self, dirs: &[&str]) -> Result<(), Box<dyn std::error::Error>> {
+	async fn create_batch_dirs(
+		&self,
+		dirs: &[&str],
+	) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		for dir in dirs {
 			self.create_dir(dir).await?;
 		}
@@ -679,7 +692,10 @@ impl TestHarness {
 	}
 
 	/// Verify entry exists in database (by name, without extension)
-	async fn verify_entry_exists(&self, name: &str) -> Result<(), Box<dyn std::error::Error>> {
+	async fn verify_entry_exists(
+		&self,
+		name: &str,
+	) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		// Poll for the entry to appear (with timeout)
 		let start = std::time::Instant::now();
 		let timeout_duration = Duration::from_secs(10);
@@ -697,7 +713,10 @@ impl TestHarness {
 	}
 
 	/// Verify entry does NOT exist in database
-	async fn verify_entry_not_exists(&self, name: &str) -> Result<(), Box<dyn std::error::Error>> {
+	async fn verify_entry_not_exists(
+		&self,
+		name: &str,
+	) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		// Poll for the entry to be removed (with timeout)
 		let start = std::time::Instant::now();
 		let timeout_duration = Duration::from_secs(5);
@@ -719,7 +738,10 @@ impl TestHarness {
 	}
 
 	/// Verify entry is a directory (kind = 1 for directory)
-	async fn verify_is_directory(&self, name: &str) -> Result<(), Box<dyn std::error::Error>> {
+	async fn verify_is_directory(
+		&self,
+		name: &str,
+	) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		let entries = get_location_entries(&self.library, self.location_id).await?;
 
 		if let Some(entry) = entries.iter().find(|e| e.name == name) {
@@ -739,7 +761,10 @@ impl TestHarness {
 	}
 
 	/// Verify entry is a file (kind = 0 for file)
-	async fn verify_is_file(&self, name: &str) -> Result<(), Box<dyn std::error::Error>> {
+	async fn verify_is_file(
+		&self,
+		name: &str,
+	) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		let entries = get_location_entries(&self.library, self.location_id).await?;
 
 		if let Some(entry) = entries.iter().find(|e| e.name == name) {
@@ -776,7 +801,7 @@ impl TestHarness {
 	async fn verify_children_count(
 		&self,
 		expected: usize,
-	) -> Result<(), Box<dyn std::error::Error>> {
+	) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		let count = self.get_children_count().await;
 		if count == expected {
 			println!("✓ Children count matches: {}", expected);
@@ -791,7 +816,10 @@ impl TestHarness {
 	}
 
 	/// Verify expected entry count (total entries in location)
-	async fn verify_entry_count(&self, expected: usize) -> Result<(), Box<dyn std::error::Error>> {
+	async fn verify_entry_count(
+		&self,
+		expected: usize,
+	) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		let count = self.get_entry_count().await;
 		if count == expected {
 			println!("✓ Entry count matches: {}", expected);
@@ -879,7 +907,7 @@ impl TestHarness {
 	}
 
 	/// Clean up test resources
-	async fn cleanup(self) -> Result<(), Box<dyn std::error::Error>> {
+	async fn cleanup(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		// Dump events before cleanup
 		self.dump_events().await;
 
@@ -905,7 +933,9 @@ impl TestHarness {
 }
 
 /// Inner test logic that can fail
-async fn run_test_scenarios(harness: &TestHarness) -> Result<(), Box<dyn std::error::Error>> {
+async fn run_test_scenarios(
+	harness: &TestHarness,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	// Note: Entry counts include the root directory itself which is indexed
 
 	// Scenario 1: Initial State
@@ -1263,7 +1293,7 @@ async fn run_test_scenarios(harness: &TestHarness) -> Result<(), Box<dyn std::er
 
 /// Comprehensive "story" test demonstrating location watcher functionality
 #[tokio::test]
-async fn test_location_watcher() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_location_watcher() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	println!("\n=== Location Watcher Full Story Test ===\n");
 
 	let harness = TestHarness::setup().await?;

--- a/core/tests/job_resumption_integration_test.rs
+++ b/core/tests/job_resumption_integration_test.rs
@@ -121,7 +121,7 @@ async fn test_job_resumption_at_various_points() {
 }
 
 /// Generate test data using Spacedrive source code for deterministic testing
-async fn generate_test_data() -> Result<PathBuf, Box<dyn std::error::Error>> {
+async fn generate_test_data() -> Result<PathBuf, Box<dyn std::error::Error + Send + Sync>> {
 	// Use Spacedrive core/src directory for deterministic cross-platform testing
 	let indexing_data_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 		.parent()
@@ -252,7 +252,7 @@ async fn start_and_interrupt_job(
 	test_setup: &IntegrationTestSetup,
 	indexing_data_path: &PathBuf,
 	interruption_point: &InterruptionPoint,
-) -> Result<(Uuid, Uuid), Box<dyn std::error::Error>> {
+) -> Result<(Uuid, Uuid), Box<dyn std::error::Error + Send + Sync>> {
 	info!(
 		"Starting job and waiting for interruption point: {:?}",
 		interruption_point
@@ -486,7 +486,7 @@ async fn resume_and_complete_job(
 	_indexing_data_path: &PathBuf,
 	job_id: Uuid,
 	library_id: Uuid,
-) -> Result<(PathBuf, PathBuf), Box<dyn std::error::Error>> {
+) -> Result<(PathBuf, PathBuf), Box<dyn std::error::Error + Send + Sync>> {
 	info!("Resuming job {} and waiting for completion", job_id);
 
 	// Create core again (simulating daemon restart)

--- a/core/tests/job_shutdown_test.rs
+++ b/core/tests/job_shutdown_test.rs
@@ -12,7 +12,7 @@ use tempfile::TempDir;
 use tokio::time::sleep;
 
 #[tokio::test]
-async fn test_jobs_paused_on_shutdown() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_jobs_paused_on_shutdown() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	// Setup test environment
 	let temp_dir = TempDir::new()?;
 	let core_dir = temp_dir.path().join("core");
@@ -103,7 +103,8 @@ async fn test_jobs_paused_on_shutdown() -> Result<(), Box<dyn std::error::Error>
 }
 
 #[tokio::test]
-async fn test_shutdown_with_no_running_jobs() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_shutdown_with_no_running_jobs() -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+{
 	// This test ensures shutdown works correctly when no jobs are running
 	let temp_dir = TempDir::new()?;
 	let core = Core::new(temp_dir.path().to_path_buf()).await?;

--- a/core/tests/normalized_cache_fixtures_test.rs
+++ b/core/tests/normalized_cache_fixtures_test.rs
@@ -100,7 +100,7 @@ impl EventCollector {
 /// Wait for indexing job to complete
 async fn wait_for_indexing_completion(
 	library: &Arc<Library>,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	let mut job_seen = false;
 	let timeout = Duration::from_secs(30);
 	let start = tokio::time::Instant::now();
@@ -151,7 +151,8 @@ async fn wait_for_indexing_completion(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn capture_event_fixtures_for_typescript() -> Result<(), Box<dyn std::error::Error>> {
+async fn capture_event_fixtures_for_typescript(
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	// Initialize tracing
 	let _ = tracing_subscriber::fmt()
 		.with_env_filter(

--- a/core/tests/phase_snapshot_test.rs
+++ b/core/tests/phase_snapshot_test.rs
@@ -15,7 +15,7 @@ use std::{sync::Arc, time::Duration};
 use tempfile::TempDir;
 
 #[tokio::test]
-async fn capture_phase_snapshots() -> Result<(), Box<dyn std::error::Error>> {
+async fn capture_phase_snapshots() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	tracing_subscriber::fmt::init();
 	eprintln!("\nPHASE SNAPSHOT TEST - Indexing Desktop\n");
 	eprintln!("{}", "=".repeat(80));

--- a/core/tests/proxy_pairing_protocol_test.rs
+++ b/core/tests/proxy_pairing_protocol_test.rs
@@ -176,11 +176,12 @@ fn test_vouch_payload_structure() {
 		device_id: vouchee_device_id,
 		device_name: "Test Device".to_string(),
 		device_slug: "test-device".to_string(),
+		device_type: sd_core::service::network::device::DeviceType::Desktop,
 		os_version: "Test OS 1.0".to_string(),
 		app_version: "1.0.0".to_string(),
 		network_fingerprint: sd_core::service::network::utils::identity::NetworkFingerprint {
 			node_id: "test_node_id".to_string(),
-			public_key: vouchee_public_key.clone(),
+			public_key_hash: "abcdef1234567890".to_string(),
 		},
 		last_seen: Utc::now(),
 	};

--- a/core/tests/relay_pairing_test.rs
+++ b/core/tests/relay_pairing_test.rs
@@ -153,8 +153,12 @@ async fn test_relay_discovery_flow() {
 #[tokio::test]
 async fn test_pairing_code_with_qr_json_and_relay_info() {
 	use iroh::SecretKey;
+	use rand::RngCore;
 
-	let secret_key = SecretKey::generate(&mut rand::thread_rng());
+	// Use from_bytes to avoid CryptoRng trait bound mismatch between rand 0.8 and iroh's rand_core
+	let mut seed = [0u8; 32];
+	rand::thread_rng().fill_bytes(&mut seed);
+	let secret_key = SecretKey::from_bytes(&seed);
 	let node_id = secret_key.public();
 
 	// Create pairing code with node_id for remote pairing via pkarr

--- a/core/tests/resource_events_test.rs
+++ b/core/tests/resource_events_test.rs
@@ -192,7 +192,8 @@ impl EventStats {
 }
 
 #[tokio::test]
-async fn test_resource_events_during_indexing() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_resource_events_during_indexing(
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	tracing_subscriber::fmt::init();
 	eprintln!("\nStarting resource events test\n");
 

--- a/core/tests/transitive_sync_backfill_test.rs
+++ b/core/tests/transitive_sync_backfill_test.rs
@@ -247,8 +247,13 @@ async fn alice_transitive_sync_scenario() {
 
 	// Initialize and start sync service with real networking
 	println!("Alice: Starting sync service...");
+	let networking = core
+		.services
+		.networking
+		.clone()
+		.expect("networking service required for sync");
 	library
-		.init_sync_service(device_id, core.services.networking.clone())
+		.init_sync_service(device_id, networking)
 		.await
 		.unwrap();
 	library.sync_service().unwrap().start().await.unwrap();
@@ -410,8 +415,13 @@ async fn bob_transitive_sync_scenario() {
 	}
 
 	println!("Bob: Starting sync service...");
+	let networking = core
+		.services
+		.networking
+		.clone()
+		.expect("networking service required for sync");
 	library
-		.init_sync_service(device_id, core.services.networking.clone())
+		.init_sync_service(device_id, networking)
 		.await
 		.unwrap();
 	library.sync_service().unwrap().start().await.unwrap();
@@ -645,8 +655,13 @@ async fn carol_transitive_sync_scenario() {
 	println!("Carol: Bob registered in library");
 
 	println!("Carol: Starting sync service...");
+	let networking = core
+		.services
+		.networking
+		.clone()
+		.expect("networking service required for sync");
 	library
-		.init_sync_service(device_id, core.services.networking.clone())
+		.init_sync_service(device_id, networking)
 		.await
 		.unwrap();
 	library.sync_service().unwrap().start().await.unwrap();

--- a/core/tests/volume_fingerprint_stability_test.rs
+++ b/core/tests/volume_fingerprint_stability_test.rs
@@ -1,30 +1,32 @@
 //! Tests for volume fingerprint stability
 //!
 //! These tests verify that volume fingerprints remain stable across different scenarios:
-//! - Reboots (disk IDs may change: disk3 → disk4)
-//! - File operations (consumed space changes)
-//! - Mount/unmount cycles
+//! - Reboots (disk IDs may change but mount points stay the same)
+//! - Different volume types produce different fingerprints
+//! - Same inputs always produce identical fingerprints (determinism)
 //!
 //! Run with: cargo test --test volume_fingerprint_stability_test -- --nocapture
 
+use sd_core::domain::volume::VolumeFingerprint;
+use uuid::Uuid;
+
+#[cfg(target_os = "macos")]
 use sd_core::{
-	domain::volume::VolumeFingerprint,
 	infra::event::EventBus,
 	volume::{types::VolumeDetectionConfig, VolumeManager},
 };
+#[cfg(target_os = "macos")]
 use std::{collections::HashMap, sync::Arc, thread, time::Duration};
-use uuid::Uuid;
 
 /// Test that identical volume properties produce identical fingerprints
 #[test]
 fn test_fingerprint_deterministic() {
-	let uuid_str = "12345678-1234-5678-1234-567812345678";
-	let capacity = 1_000_000_000_000u64; // 1TB
+	let mount_point = std::path::Path::new("/Volumes/Macintosh HD");
+	let device_id = Uuid::parse_str("12345678-1234-5678-1234-567812345678").unwrap();
 
-	// Generate fingerprint multiple times with same inputs
-	let fp1 = VolumeFingerprint::new(uuid_str, capacity, "APFS");
-	let fp2 = VolumeFingerprint::new(uuid_str, capacity, "APFS");
-	let fp3 = VolumeFingerprint::new(uuid_str, capacity, "APFS");
+	let fp1 = VolumeFingerprint::from_primary_volume(mount_point, device_id);
+	let fp2 = VolumeFingerprint::from_primary_volume(mount_point, device_id);
+	let fp3 = VolumeFingerprint::from_primary_volume(mount_point, device_id);
 
 	assert_eq!(fp1, fp2, "Fingerprints should be identical for same inputs");
 	assert_eq!(fp2, fp3, "Fingerprints should be deterministic");
@@ -32,92 +34,102 @@ fn test_fingerprint_deterministic() {
 	println!("Fingerprint is deterministic: {}", fp1.short_id());
 }
 
-/// Test that capacity changes produce different fingerprints (expected)
+/// Test that different inputs produce different fingerprints
 #[test]
-fn test_fingerprint_changes_with_capacity() {
-	let uuid_str = "12345678-1234-5678-1234-567812345678";
+fn test_fingerprint_differs_with_different_inputs() {
+	let device_id = Uuid::parse_str("12345678-1234-5678-1234-567812345678").unwrap();
 
-	let fp_1tb = VolumeFingerprint::new(uuid_str, 1_000_000_000_000, "APFS");
-	let fp_2tb = VolumeFingerprint::new(uuid_str, 2_000_000_000_000, "APFS");
+	let fp_vol1 =
+		VolumeFingerprint::from_primary_volume(std::path::Path::new("/Volumes/HD1"), device_id);
+	let fp_vol2 =
+		VolumeFingerprint::from_primary_volume(std::path::Path::new("/Volumes/HD2"), device_id);
 
 	assert_ne!(
-		fp_1tb, fp_2tb,
-		"Different capacities should produce different fingerprints"
+		fp_vol1, fp_vol2,
+		"Different mount points should produce different fingerprints"
 	);
 
-	println!("1TB fingerprint: {}", fp_1tb.short_id());
-	println!("2TB fingerprint: {}", fp_2tb.short_id());
+	let device_id2 = Uuid::parse_str("abcdefab-cdef-abcd-efab-cdefabcdefab").unwrap();
+	let fp_dev2 =
+		VolumeFingerprint::from_primary_volume(std::path::Path::new("/Volumes/HD1"), device_id2);
+
+	assert_ne!(
+		fp_vol1, fp_dev2,
+		"Different device IDs should produce different fingerprints"
+	);
+
+	println!("HD1 fingerprint: {}", fp_vol1.short_id());
+	println!("HD2 fingerprint: {}", fp_vol2.short_id());
 }
 
-/// Test that consumed space changes DON'T affect fingerprint (if we use total capacity)
+/// Test that fingerprints are stable because they use mount point (not consumed space or disk IDs)
 #[test]
-fn test_fingerprint_stable_despite_consumed_changes() {
-	// Simulate same volume with different consumed space
-	let container_uuid = "ABCD1234-5678-90AB-CDEF-1234567890AB";
-	let volume_uuid = "VOLUME12-3456-7890-ABCD-EF1234567890";
-	let container_total = 1_000_000_000_000u64; // 1TB total (stable)
+fn test_fingerprint_stable_across_volume_types() {
+	let device_id = Uuid::parse_str("12345678-1234-5678-1234-567812345678").unwrap();
+	let spacedrive_id = Uuid::parse_str("abcd1234-5678-90ab-cdef-1234567890ab").unwrap();
 
-	let identifier = format!("{}:{}", container_uuid, volume_uuid);
+	// Primary volume fingerprint uses mount point + device (both stable across reboots)
+	let fp_primary = VolumeFingerprint::from_primary_volume(std::path::Path::new("/"), device_id);
 
-	// Fingerprint should use TOTAL capacity (stable)
-	let fp1 = VolumeFingerprint::new(&identifier, container_total, "APFS");
-	let fp2 = VolumeFingerprint::new(&identifier, container_total, "APFS");
+	// External volume fingerprint uses dotfile UUID + device (both stable)
+	let fp_external = VolumeFingerprint::from_external_volume(spacedrive_id, device_id);
 
+	// Network volume fingerprint uses backend ID + URI (both stable)
+	let fp_network = VolumeFingerprint::from_network_volume("smb", "//nas.local/share");
+
+	// All volume types should produce different fingerprints
+	assert_ne!(
+		fp_primary, fp_external,
+		"Primary and external should differ"
+	);
+	assert_ne!(fp_primary, fp_network, "Primary and network should differ");
+	assert_ne!(
+		fp_external, fp_network,
+		"External and network should differ"
+	);
+
+	// Same inputs should always produce same fingerprints (stability)
+	let fp_primary2 = VolumeFingerprint::from_primary_volume(std::path::Path::new("/"), device_id);
 	assert_eq!(
-		fp1, fp2,
-		"Fingerprints should be identical when using stable total capacity"
+		fp_primary, fp_primary2,
+		"Primary volume fingerprint should be stable"
 	);
 
-	println!("Fingerprint stable with total capacity: {}", fp1.short_id());
-
-	// But if someone mistakenly uses consumed capacity, it would change
-	let consumed_50gb = 50_000_000_000u64;
-	let consumed_100gb = 100_000_000_000u64;
-
-	let fp_consumed_50 = VolumeFingerprint::new(&identifier, consumed_50gb, "APFS");
-	let fp_consumed_100 = VolumeFingerprint::new(&identifier, consumed_100gb, "APFS");
-
-	assert_ne!(
-		fp_consumed_50, fp_consumed_100,
-		"Using consumed capacity WOULD create different fingerprints (BAD!)"
-	);
-
-	println!(
-		"️  WARNING: If consumed capacity used, fingerprint would change: {} vs {}",
-		fp_consumed_50.short_id(),
-		fp_consumed_100.short_id()
-	);
+	println!("Primary: {}", fp_primary.short_id());
+	println!("External: {}", fp_external.short_id());
+	println!("Network: {}", fp_network.short_id());
 }
 
-/// Test that UUID-based identifiers are stable even if disk IDs change
+/// Test that mount-point-based fingerprints are reboot-safe
+/// (disk IDs like disk3/disk4 change on reboot, but mount points don't)
 #[test]
 fn test_fingerprint_stable_despite_disk_id_changes() {
-	let container_uuid = "ABCD1234-5678-90AB-CDEF-1234567890AB";
-	let volume_uuid = "VOLUME12-3456-7890-ABCD-EF1234567890";
-	let capacity = 1_000_000_000_000u64;
+	let device_id = Uuid::parse_str("12345678-1234-5678-1234-567812345678").unwrap();
 
-	// UUID-based identifier (stable across reboots)
-	let uuid_identifier = format!("{}:{}", container_uuid, volume_uuid);
-	let fp_uuid = VolumeFingerprint::new(&uuid_identifier, capacity, "APFS");
+	// Mount point is stable across reboots even if underlying disk IDs change
+	let mount_point = std::path::Path::new("/Volumes/Macintosh HD");
+	let fp_before = VolumeFingerprint::from_primary_volume(mount_point, device_id);
+	let fp_after = VolumeFingerprint::from_primary_volume(mount_point, device_id);
 
-	// Disk ID-based identifier (changes on reboot)
-	let disk_id_before_reboot = "disk3:disk3s5";
-	let disk_id_after_reboot = "disk4:disk4s5"; // Same volume, different disk number
-
-	let fp_disk3 = VolumeFingerprint::new(disk_id_before_reboot, capacity, "APFS");
-	let fp_disk4 = VolumeFingerprint::new(disk_id_after_reboot, capacity, "APFS");
-
-	// Disk ID-based fingerprints would be different (BAD)
-	assert_ne!(
-		fp_disk3, fp_disk4,
-		"Disk ID-based fingerprints change on reboot (demonstrating the bug)"
+	assert_eq!(
+		fp_before, fp_after,
+		"Fingerprint should be stable across reboots (mount point doesn't change)"
 	);
 
-	println!("UUID-based fingerprint (stable): {}", fp_uuid.short_id());
+	// External volume with dotfile UUID is also stable across reboots
+	let spacedrive_id = Uuid::parse_str("aabbccdd-1234-5678-9012-aabbccddeeff").unwrap();
+	let fp_ext_before = VolumeFingerprint::from_external_volume(spacedrive_id, device_id);
+	let fp_ext_after = VolumeFingerprint::from_external_volume(spacedrive_id, device_id);
+
+	assert_eq!(
+		fp_ext_before, fp_ext_after,
+		"External volume fingerprint stable when dotfile UUID is preserved"
+	);
+
+	println!("Primary fingerprint (stable): {}", fp_before.short_id());
 	println!(
-		"️  disk3-based fingerprint: {} (would change to {} on reboot)",
-		fp_disk3.short_id(),
-		fp_disk4.short_id()
+		"External fingerprint (stable): {}",
+		fp_ext_before.short_id()
 	);
 }
 
@@ -208,7 +220,7 @@ async fn test_real_volume_fingerprints_remain_stable() {
 				changed_count += 1;
 			}
 		} else {
-			println!("    ️  New volume (not in first detection)");
+			println!("    New volume (not in first detection)");
 		}
 	}
 
@@ -258,7 +270,7 @@ async fn test_what_properties_change_on_real_volumes() {
 		if let Some(container) = &volume.apfs_container {
 			println!("\n  APFS Container:");
 			println!(
-				"    container_id: {} (CHANGES: disk3 → disk4 on reboot)",
+				"    container_id: {} (CHANGES: disk3 -> disk4 on reboot)",
 				container.container_id
 			);
 			println!("    uuid: {} (STABLE: always same)", container.uuid);
@@ -271,7 +283,7 @@ async fn test_what_properties_change_on_real_volumes() {
 			for vol in &container.volumes {
 				println!("\n    Volume {} in container:", vol.name);
 				println!(
-					"      disk_id: {} (CHANGES: disk3s5 → disk4s5 on reboot)",
+					"      disk_id: {} (CHANGES: disk3s5 -> disk4s5 on reboot)",
 					vol.disk_id
 				);
 				println!("      uuid: {} (STABLE)", vol.uuid);

--- a/crates/sd-client/examples/test_connection.rs
+++ b/crates/sd-client/examples/test_connection.rs
@@ -31,7 +31,7 @@ async fn main() -> anyhow::Result<()> {
 		.media_listing(
 			SdPath::Physical {
 				device_slug: "james-s-macbook-pro".to_string(),
-				path: "/Users/jamespine/Desktop".to_string(),
+				path: "/Users/jamespine/Desktop".into(),
 			},
 			Some(100),
 		)
@@ -55,7 +55,11 @@ async fn main() -> anyhow::Result<()> {
 			if !thumbnails.is_empty() {
 				println!("  Thumbnails:");
 				for thumb in thumbnails {
-					let url = client.thumbnail_url(&content_id.uuid, &thumb.variant, &thumb.format);
+					let url = client.thumbnail_url(
+						&content_id.uuid.to_string(),
+						&thumb.variant,
+						&thumb.format,
+					);
 					println!("    - {} ({})", thumb.variant, thumb.status);
 					println!("      {}", url);
 				}


### PR DESCRIPTION
## Summary

- Align error types in all examples and tests to match `Core::new()` / `Core::shutdown()` signatures (`Box<dyn Error + Send + Sync>`)
- Update `entry::ActiveModel` field `device_id` to `volume_id` and add missing `volume_id` to `location::ActiveModel` in `library_demo.rs`
- Add missing `proxy_pairing` and `spacebot` fields to `AppConfig` initializers in sync tests
- Fix `VolumeFingerprint` tests to use new constructors (`from_primary_volume`, `from_external_volume`, `from_network_volume`)
- Fix `SecretKey::generate()` in relay pairing test to use `from_bytes` pattern (rand_core 0.9 compatibility)
- Fix `SdPath::Physical.path` type (PathBuf, not String) and `thumbnail_url` parameter type in sd-client example
- Add `ProxyPairingConfig` re-export from `config/mod.rs`
- Fix `DeviceInfo` and `NetworkFingerprint` struct fields in proxy pairing protocol test
- Fix `init_sync_service` calls to unwrap `Option<Arc<NetworkingService>>`
- **Fix busy-loop in sync loop**: `continue` in the `Ready` state skipped the sleep when `is_realtime_active()` was true, causing CPU-saturating spin. Replaced with `if/else` to fall through to sleep.

## Root Cause

The core library (`cargo build --lib -p sd-core`) compiles fine, but API changes weren't propagated to examples and tests. Key changes: `Core::new()`/`shutdown()` error type gained `Send + Sync`, `entry::Model` renamed `device_id` to `volume_id`, `VolumeFingerprint::new()` removed in favor of purpose-specific constructors, `AppConfig` gained `proxy_pairing` and `spacebot` fields, and `iroh` upgraded `rand_core` breaking `SecretKey::generate()` with `ThreadRng`.

Additionally, a production bug in `run_sync_loop()` caused a busy-loop when real-time sync was active: `continue` skipped the sleep at the bottom of the loop.

## Changes

- 28 files changed across `core/examples/`, `core/tests/`, `core/src/config/`, `core/src/service/sync/`, and `crates/sd-client/examples/`
- All fixes align callers with current API signatures, no hacks or workarounds
