### PR TITLE
fix(cli): implement transparent serialization for JobId and fix receipt parsing

### DIFF
--- a/.tasks/core/CLI-001-fix-jobid-serialization-and-receipts.md
+++ b/.tasks/core/CLI-001-fix-jobid-serialization-and-receipts.md
@@ -1,0 +1,54 @@
+---
+id: CLI-001
+title: "Fix JobId transparent serialization and CLI receipt parsing"
+status: "Done"
+assignee: "jamiepine"
+priority: "High"
+tags: ["core", "cli", "jobs"]
+---
+
+## Description
+
+CLI commands that interact with the daemon's job system (such as indexing a library or copying files) were failing with JSON deserialization errors. The CLI submitted the job, but crashed when parsing the response. 
+
+The underlying cause was a mismatch between the serialization format of the `JobId` struct and the daemon's response shape. The daemon returns a `JobReceipt` (which includes the job ID and name), while the CLI was trying to parse a bare `JobId`. Furthermore, `JobId` was serializing as a newtype struct (e.g., `{"JobId": "..."}`) instead of a raw UUID string.
+
+## The Why
+
+In a CQRS architecture, the CLI and daemon must strictly agree on the RPC input and output shapes. 
+1. `JobId` is a newtype wrapper around `Uuid`. By default, Serde serializes this as a tuple struct. By marking it `#[serde(transparent)]`, we force it to serialize as a standard string UUID, ensuring compatibility over the wire.
+2. The daemon's `execute_action!` macro returns the full `JobReceipt`, not just the `JobId`. The CLI parsing logic must be updated to expect this receipt to avoid dropping the connection.
+
+## The How (Implementation Steps)
+
+1.  **Transparent Serialization**:
+    We applied the `#[serde(transparent)]` macro to `core::infra::job::types::JobId`.
+    ```rust
+    /// Unique identifier for a job
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Type)]
+    #[serde(transparent)]
+    pub struct JobId(pub Uuid);
+    ```
+2.  **CLI Receipt Parsing**:
+    We updated `apps/cli/src/domains/index/mod.rs` and `apps/cli/src/domains/file/mod.rs` to expect a `JobReceipt` instead of `JobId`.
+
+### Example Diff
+
+```diff
+- let out: JobId = execute_action!(ctx, input);
+- print_output!(ctx, out, |_| {
+-     println!("Browse request submitted");
+- });
++ let out: JobReceipt = execute_action!(ctx, input);
++ print_output!(ctx, &out, |r: &JobReceipt| {
++     println!("Browse job submitted: {} (job: {})", r.id, r.job_name);
++ });
+```
+
+## Acceptance Criteria
+- Submitting an indexing or file copy job via CLI parses the receipt successfully.
+- The `JobId` standardizes to a transparent UUID format across the JSON-RPC boundary.
+- The CLI outputs both the Job ID and Job Name upon successful submission.
+
+## Review Refinements
+- **Import Organization:** Reordered imports in `apps/cli/src/domains/file/mod.rs` and `apps/cli/src/domains/index/mod.rs` to ensure external `sd_core` dependencies are grouped properly with other external crates, separated from local `crate::` imports by a blank line.

--- a/apps/cli/src/domains/file/mod.rs
+++ b/apps/cli/src/domains/file/mod.rs
@@ -3,13 +3,13 @@ mod args;
 use anyhow::Result;
 use clap::Subcommand;
 use comfy_table::presets::UTF8_BORDERS_ONLY;
+use sd_core::infra::job::handle::JobReceipt;
+use sd_core::infra::query::LibraryQuery;
 
 use crate::format_bytes;
 use crate::util::prelude::*;
 
 use crate::context::Context;
-use sd_core::infra::job::types::JobId;
-use sd_core::infra::query::LibraryQuery;
 
 use self::args::*;
 
@@ -32,9 +32,9 @@ pub async fn run(ctx: &Context, cmd: FileCmd) -> Result<()> {
 			}
 
 			// Handle confirmation for file copy operations
-			let job_id: JobId = run_copy_with_confirmation(ctx, input).await?;
-			print_output!(ctx, &job_id, |id: &JobId| {
-				println!("Dispatched copy job {}", id);
+			let receipt: JobReceipt = run_copy_with_confirmation(ctx, input).await?;
+			print_output!(ctx, &receipt, |r: &JobReceipt| {
+				println!("Dispatched copy job {} ({})", r.id, r.job_name);
 			});
 		}
 		FileCmd::Info(args) => {
@@ -110,7 +110,7 @@ pub async fn run(ctx: &Context, cmd: FileCmd) -> Result<()> {
 async fn run_copy_with_confirmation(
 	ctx: &Context,
 	mut input: sd_core::ops::files::copy::input::FileCopyInput,
-) -> Result<JobId> {
+) -> Result<JobReceipt> {
 	use crate::util::confirm::prompt_for_choice;
 	use sd_core::infra::action::LibraryAction;
 	use sd_core::ops::files::copy::action::FileCopyAction;
@@ -166,8 +166,8 @@ async fn run_copy_with_confirmation(
 	}
 
 	// Execute the action using the input
-	let job_id: JobId = execute_action!(ctx, input);
-	Ok(job_id)
+	let receipt: JobReceipt = execute_action!(ctx, input);
+	Ok(receipt)
 }
 
 /// Simple conflict detection for CLI

--- a/apps/cli/src/domains/index/mod.rs
+++ b/apps/cli/src/domains/index/mod.rs
@@ -3,11 +3,11 @@ pub mod args;
 use anyhow::Result;
 use clap::Subcommand;
 use comfy_table::{presets::UTF8_BORDERS_ONLY, Attribute, Cell, Table};
+use sd_core::{infra::job::handle::JobReceipt, ops::libraries::list::query::ListLibrariesQuery};
 
 use crate::util::prelude::*;
 
 use crate::{context::Context, util::error::CliError};
-use sd_core::{infra::job::types::JobId, ops::libraries::list::query::ListLibrariesQuery};
 
 use self::args::*;
 
@@ -51,9 +51,9 @@ pub async fn run(ctx: &Context, cmd: IndexCmd) -> Result<()> {
 				anyhow::bail!(errors.join("; "));
 			}
 
-			let out: JobId = execute_action!(ctx, input);
-			print_output!(ctx, out, |_| {
-				println!("Indexing request submitted");
+			let out: JobReceipt = execute_action!(ctx, input);
+			print_output!(ctx, &out, |r: &JobReceipt| {
+				println!("Indexing job submitted: {} (job: {})", r.id, r.job_name);
 			});
 		}
 		IndexCmd::QuickScan(args) => {
@@ -71,9 +71,9 @@ pub async fn run(ctx: &Context, cmd: IndexCmd) -> Result<()> {
 			};
 
 			let input = args.to_input(library_id)?;
-			let out: JobId = execute_action!(ctx, input);
-			print_output!(ctx, out, |_| {
-				println!("Quick scan request submitted");
+			let out: JobReceipt = execute_action!(ctx, input);
+			print_output!(ctx, &out, |r: &JobReceipt| {
+				println!("Quick scan job submitted: {} (job: {})", r.id, r.job_name);
 			});
 		}
 		IndexCmd::Browse(args) => {
@@ -89,9 +89,9 @@ pub async fn run(ctx: &Context, cmd: IndexCmd) -> Result<()> {
 			};
 
 			let input = args.to_input(library_id)?;
-			let out: JobId = execute_action!(ctx, input);
-			print_output!(ctx, out, |_| {
-				println!("Browse request submitted");
+			let out: JobReceipt = execute_action!(ctx, input);
+			print_output!(ctx, &out, |r: &JobReceipt| {
+				println!("Browse job submitted: {} (job: {})", r.id, r.job_name);
 			});
 		}
 		IndexCmd::Verify(args) => {

--- a/core/src/infra/job/types.rs
+++ b/core/src/infra/job/types.rs
@@ -7,6 +7,7 @@ use uuid::Uuid;
 
 /// Unique identifier for a job
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Type)]
+#[serde(transparent)]
 pub struct JobId(pub Uuid);
 
 impl JobId {


### PR DESCRIPTION
This PR resolves CLI communication failures caused by improper JSON deserialization of Job identifiers.

Key changes:
- Enables #[serde(transparent)] on JobId to ensure it serializes as a plain UUID string.
- Updates index and file CLI domains to correctly parse JobReceipt objects returned by the daemon.

**Task File:** [.tasks/core/CLI-001-fix-jobid-serialization-and-receipts.md](https://github.com/brbrainerd/spacedrive/blob/fix/cli-job-serialization/.tasks/core/CLI-001-fix-jobid-serialization-and-receipts.md)

Closes CLI-001