### PR TITLE
fix(tauri): resolve dev blank UI from Bun CJS/ESM interop failures

### DIFF
--- a/apps/tauri/src/stubs/debug.ts
+++ b/apps/tauri/src/stubs/debug.ts
@@ -1,0 +1,10 @@
+/** No-op debug stub for CJS packages that import `debug` in the browser. */
+function debug(_namespace: string) {
+	return (..._args: unknown[]) => {};
+}
+
+debug.enable = () => {};
+debug.disable = () => {};
+debug.enabled = () => false;
+
+export default debug;

--- a/apps/tauri/src/stubs/spacebot-api-client.ts
+++ b/apps/tauri/src/stubs/spacebot-api-client.ts
@@ -1,0 +1,88 @@
+/**
+ * Stub for @spacebot/api-client when the spacebot repo is not checked out locally.
+ * Spacebot UI features are disabled; core Spacedrive remains usable.
+ */
+
+export type InboundMessageEvent = Record<string, unknown>;
+export type OutboundMessageDeltaEvent = Record<string, unknown>;
+export type OutboundMessageEvent = Record<string, unknown>;
+export type PortalConversationResponse = {
+	conversation: { id: string; title?: string | null };
+};
+export type PortalConversationSummary = {
+	id: string;
+	title?: string | null;
+	updated_at?: string;
+};
+export type PortalHistoryMessage = Record<string, unknown>;
+export type TypingStateEvent = Record<string, unknown>;
+export type TimelineItem = {
+	type: string;
+	id: string;
+	[key: string]: unknown;
+};
+export type WorkerListItem = {
+	id: string;
+	channel_id?: string | null;
+	status: string;
+	worker_type?: string;
+	task?: string;
+	[key: string]: unknown;
+};
+export type Task = Record<string, unknown>;
+export type UpdateTaskRequest = Record<string, unknown>;
+export type TtsProfile = { id: string; name?: string; [key: string]: unknown };
+
+let serverUrl = 'http://127.0.0.1:19898';
+
+export function setServerUrl(url: string): void {
+	serverUrl = url;
+}
+
+export function getEventsUrl(): string {
+	return `${serverUrl}/api/events`;
+}
+
+const emptyBuffer = new ArrayBuffer(0);
+
+export const apiClient = {
+	listPortalConversations: async (_agentId: string, _includeArchived: boolean, _limit: number) => ({
+		conversations: [] as PortalConversationSummary[],
+	}),
+	portalHistory: async (_agentId: string, _conversationId: string, _limit: number) => [],
+	createPortalConversation: async (_req: {
+		agentId: string;
+		title?: string | null;
+	}): Promise<PortalConversationResponse> => ({
+		conversation: { id: 'stub-conversation', title: null },
+	}),
+	portalSend: async (_req: Record<string, unknown>) => undefined,
+	channelMessages: async (_channelId: string, _limit: number) => ({
+		items: [] as TimelineItem[],
+	}),
+	listWorkers: async (_req: { agentId: string; limit?: number }) => ({
+		workers: [] as WorkerListItem[],
+	}),
+	workerDetail: async (_agentId: string, _workerId: string) => ({
+		id: 'stub-worker',
+		task: 'Spacebot not available',
+		status: 'completed',
+		started_at: new Date().toISOString(),
+		transcript: [],
+	}),
+	cancelProcess: async (_req: Record<string, unknown>) => undefined,
+	listTasks: async (_agentId: string, _limit: number) => ({
+		tasks: [] as Task[],
+	}),
+	updateTask: async (_taskNumber: number, _req: UpdateTaskRequest) => undefined,
+	deleteTask: async (_taskNumber: number) => undefined,
+	ttsProfiles: async (_agentId: string) => [] as TtsProfile[],
+	ttsGenerate: async (_text: string, _opts?: Record<string, unknown>) => emptyBuffer,
+	webChatSendAudio: async (
+		_agentId: string,
+		_sessionId: string,
+		_blob: Blob,
+	) => ({ ok: false, status: 503 }),
+};
+
+export default apiClient;

--- a/apps/tauri/vite.config.ts
+++ b/apps/tauri/vite.config.ts
@@ -4,10 +4,67 @@ import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react-swc';
 import {defineConfig} from 'vite';
 
+/** Resolve a Bun-hoisted transitive dependency to its CJS entry. */
+function resolveBunPackageDir(packageName: string): string {
+	const bunDir = path.resolve(__dirname, '../../node_modules/.bun');
+	const match = fs
+		.readdirSync(bunDir)
+		.find((entry) => entry.startsWith(`${packageName}@`));
+	if (!match) {
+		throw new Error(`Could not find bun package: ${packageName}`);
+	}
+	return path.resolve(bunDir, match, 'node_modules', packageName);
+}
+
+function resolveBunEntry(packageName: string): string {
+	const pkgDir = resolveBunPackageDir(packageName);
+	const pkgJson = JSON.parse(
+		fs.readFileSync(path.join(pkgDir, 'package.json'), 'utf8')
+	) as {main?: string; browser?: string};
+	const entry = pkgJson.browser ?? pkgJson.main ?? 'index.js';
+	const candidates = [
+		path.resolve(pkgDir, entry),
+		path.resolve(pkgDir, `${entry}.js`),
+		path.resolve(pkgDir, entry, 'index.js'),
+	];
+	for (const candidate of candidates) {
+		if (fs.existsSync(candidate)) {
+			return candidate;
+		}
+	}
+	throw new Error(`Could not resolve entry for ${packageName}`);
+}
+
+// CJS packages loaded via Bun's .bun store need pre-bundling for ESM default imports.
+const CJS_INTEROP_PACKAGES = [
+	'style-to-js',
+	'style-to-object',
+	'inline-style-parser',
+	'extend',
+	'is-plain-obj',
+	'bail',
+	'trough',
+	'ms',
+] as const;
+
+const cjsInteropEntries = CJS_INTEROP_PACKAGES.flatMap((packageName) => {
+	try {
+		return [{packageName, entry: resolveBunEntry(packageName)}];
+	} catch {
+		return [];
+	}
+});
+
+const debugStub = path.resolve(__dirname, './src/stubs/debug.ts');
+
 const spaceui = path.resolve(__dirname, '../../../spaceui/packages');
 const hasSpaceui = fs.existsSync(spaceui);
 const spacebot = path.resolve(__dirname, '../../../spacebot/packages');
 const hasSpacebot = fs.existsSync(spacebot);
+const spacebotStub = path.resolve(
+	__dirname,
+	'./src/stubs/spacebot-api-client.ts'
+);
 
 export default defineConfig(() => ({
 	plugins: [react(), tailwindcss()],
@@ -86,14 +143,12 @@ export default defineConfig(() => ({
 						},
 					]
 				: []),
-			...(hasSpacebot
-				? [
-						{
-							find: /^@spacebot\/api-client$/,
-							replacement: `${spacebot}/api-client/src`,
-						},
-					]
-				: []),
+			{
+				find: /^@spacebot\/api-client$/,
+				replacement: hasSpacebot
+					? `${spacebot}/api-client/src`
+					: spacebotStub,
+			},
 			{
 				find: '@sd/interface',
 				replacement: path.resolve(
@@ -107,12 +162,19 @@ export default defineConfig(() => ({
 					__dirname,
 					'../../packages/ts-client/src'
 				)
-			}
+			},
+			// react-markdown/unified CJS deps imported as ESM defaults
+			...cjsInteropEntries.map(({packageName, entry}) => ({
+				find: packageName,
+				replacement: entry,
+			})),
+			{find: 'debug', replacement: debugStub},
 		]
 	},
 
 	optimizeDeps: {
-		exclude: ['@spacedrive/ai', '@spacedrive/primitives', '@spacedrive/tokens']
+		exclude: ['@spacedrive/ai', '@spacedrive/primitives', '@spacedrive/tokens'],
+		include: cjsInteropEntries.map(({entry}) => entry),
 	},
 
 	clearScreen: false,
@@ -134,10 +196,6 @@ export default defineConfig(() => ({
 		target: ['es2021', 'chrome100', 'safari13'],
 		minify: !process.env.TAURI_ENV_DEBUG ? ('esbuild' as const) : false,
 		sourcemap: !!process.env.TAURI_ENV_DEBUG,
-		rollupOptions: {
-			external: [
-				...(!hasSpacebot ? ['@spacebot/api-client'] : []),
-			],
-		}
+		rollupOptions: {}
 	}
 }));


### PR DESCRIPTION
## Summary
- Fix blank Tauri UI on dev launch caused by Bun-hoisted CJS packages breaking Vite ESM imports (`style-to-js` and related deps)
- Add Vite resolve aliases and `optimizeDeps.include` entries for affected packages
- Stub optional `@spacebot/api-client` when the spacebot repo is not cloned locally

## Test plan
- [x] `cd apps/tauri && bun run build`
- [ ] `cd apps/tauri && bun run tauri:dev` — app mounts React and connects to daemon
- [ ] Verify explorer/overview renders instead of a blank window