### PR TITLE
fix(interface): wire Space Settings and fix space switcher dropdown

### DIFF
--- a/apps/tauri/src/index.css
+++ b/apps/tauri/src/index.css
@@ -77,3 +77,14 @@ body {
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 }
+
+/*
+ * Space switcher and other sidebar dropdowns use bg-sidebar-box. Primitives still
+ * applies bg-menu/95 + backdrop-blur underneath, which bleeds through on Tauri.
+ */
+.border-sidebar-line.bg-sidebar-box,
+.border-sidebar-line.\!bg-sidebar-box {
+	background-color: var(--color-sidebar-box) !important;
+	backdrop-filter: none !important;
+	-webkit-backdrop-filter: none !important;
+}

--- a/apps/tauri/src/index.css
+++ b/apps/tauri/src/index.css
@@ -11,6 +11,8 @@
 /* Tell Tailwind v4 where to scan for utility classes */
 @source "../../../packages/ui/src";
 @source "../../../packages/interface/src";
+@source "../node_modules/@spacedrive/primitives/dist";
+@source "../node_modules/@spacedrive/ai/dist";
 @source "../../../../spaceui/packages/primitives/src";
 @source "../../../../spaceui/packages/ai/src";
 @source "../../../../spaceui/packages/explorer/src";
@@ -76,6 +78,40 @@ body {
 		"Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
+}
+
+/*
+ * Tauri uses a transparent native window. Dialog overlay uses bg-app/50 with a
+ * react-spring opacity animation on the whole element, so the app bleeds through.
+ * Without opaque backdrop + panel styles, modals (Add Group, Add Storage, etc.)
+ * appear invisible while still blocking all pointer events.
+ */
+.fixed.inset-0.z-\[102\] {
+	z-index: 102 !important;
+	background-color: color-mix(in srgb, var(--color-app) 92%, transparent) !important;
+	margin: 0 !important;
+	border-radius: 0 !important;
+	backdrop-filter: blur(16px) saturate(120%);
+	-webkit-backdrop-filter: blur(16px) saturate(120%);
+}
+
+.fixed.inset-0.z-\[103\] {
+	z-index: 103 !important;
+}
+
+.z-\[103\] .border-app-line.bg-app-box,
+.z-\[103\] form.border-app-line.bg-app-box {
+	background-color: var(--color-app-box) !important;
+}
+
+.z-\[103\] .bg-app-input\/60 {
+	background-color: var(--color-app-input) !important;
+}
+
+.border-menu-line.bg-menu\/95 {
+	background-color: var(--color-menu) !important;
+	backdrop-filter: none !important;
+	-webkit-backdrop-filter: none !important;
 }
 
 /*

--- a/apps/tauri/src/stubs/debug.ts
+++ b/apps/tauri/src/stubs/debug.ts
@@ -1,0 +1,10 @@
+/** No-op debug stub for CJS packages that import `debug` in the browser. */
+function debug(_namespace: string) {
+	return (..._args: unknown[]) => {};
+}
+
+debug.enable = () => {};
+debug.disable = () => {};
+debug.enabled = () => false;
+
+export default debug;

--- a/apps/tauri/src/stubs/spacebot-api-client.ts
+++ b/apps/tauri/src/stubs/spacebot-api-client.ts
@@ -1,0 +1,88 @@
+/**
+ * Stub for @spacebot/api-client when the spacebot repo is not checked out locally.
+ * Spacebot UI features are disabled; core Spacedrive remains usable.
+ */
+
+export type InboundMessageEvent = Record<string, unknown>;
+export type OutboundMessageDeltaEvent = Record<string, unknown>;
+export type OutboundMessageEvent = Record<string, unknown>;
+export type PortalConversationResponse = {
+	conversation: { id: string; title?: string | null };
+};
+export type PortalConversationSummary = {
+	id: string;
+	title?: string | null;
+	updated_at?: string;
+};
+export type PortalHistoryMessage = Record<string, unknown>;
+export type TypingStateEvent = Record<string, unknown>;
+export type TimelineItem = {
+	type: string;
+	id: string;
+	[key: string]: unknown;
+};
+export type WorkerListItem = {
+	id: string;
+	channel_id?: string | null;
+	status: string;
+	worker_type?: string;
+	task?: string;
+	[key: string]: unknown;
+};
+export type Task = Record<string, unknown>;
+export type UpdateTaskRequest = Record<string, unknown>;
+export type TtsProfile = { id: string; name?: string; [key: string]: unknown };
+
+let serverUrl = 'http://127.0.0.1:19898';
+
+export function setServerUrl(url: string): void {
+	serverUrl = url;
+}
+
+export function getEventsUrl(): string {
+	return `${serverUrl}/api/events`;
+}
+
+const emptyBuffer = new ArrayBuffer(0);
+
+export const apiClient = {
+	listPortalConversations: async (_agentId: string, _includeArchived: boolean, _limit: number) => ({
+		conversations: [] as PortalConversationSummary[],
+	}),
+	portalHistory: async (_agentId: string, _conversationId: string, _limit: number) => [],
+	createPortalConversation: async (_req: {
+		agentId: string;
+		title?: string | null;
+	}): Promise<PortalConversationResponse> => ({
+		conversation: { id: 'stub-conversation', title: null },
+	}),
+	portalSend: async (_req: Record<string, unknown>) => undefined,
+	channelMessages: async (_channelId: string, _limit: number) => ({
+		items: [] as TimelineItem[],
+	}),
+	listWorkers: async (_req: { agentId: string; limit?: number }) => ({
+		workers: [] as WorkerListItem[],
+	}),
+	workerDetail: async (_agentId: string, _workerId: string) => ({
+		id: 'stub-worker',
+		task: 'Spacebot not available',
+		status: 'completed',
+		started_at: new Date().toISOString(),
+		transcript: [],
+	}),
+	cancelProcess: async (_req: Record<string, unknown>) => undefined,
+	listTasks: async (_agentId: string, _limit: number) => ({
+		tasks: [] as Task[],
+	}),
+	updateTask: async (_taskNumber: number, _req: UpdateTaskRequest) => undefined,
+	deleteTask: async (_taskNumber: number) => undefined,
+	ttsProfiles: async (_agentId: string) => [] as TtsProfile[],
+	ttsGenerate: async (_text: string, _opts?: Record<string, unknown>) => emptyBuffer,
+	webChatSendAudio: async (
+		_agentId: string,
+		_sessionId: string,
+		_blob: Blob,
+	) => ({ ok: false, status: 503 }),
+};
+
+export default apiClient;

--- a/apps/tauri/vite.config.ts
+++ b/apps/tauri/vite.config.ts
@@ -4,10 +4,67 @@ import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react-swc';
 import {defineConfig} from 'vite';
 
+/** Resolve a Bun-hoisted transitive dependency to its CJS entry. */
+function resolveBunPackageDir(packageName: string): string {
+	const bunDir = path.resolve(__dirname, '../../node_modules/.bun');
+	const match = fs
+		.readdirSync(bunDir)
+		.find((entry) => entry.startsWith(`${packageName}@`));
+	if (!match) {
+		throw new Error(`Could not find bun package: ${packageName}`);
+	}
+	return path.resolve(bunDir, match, 'node_modules', packageName);
+}
+
+function resolveBunEntry(packageName: string): string {
+	const pkgDir = resolveBunPackageDir(packageName);
+	const pkgJson = JSON.parse(
+		fs.readFileSync(path.join(pkgDir, 'package.json'), 'utf8')
+	) as {main?: string; browser?: string};
+	const entry = pkgJson.browser ?? pkgJson.main ?? 'index.js';
+	const candidates = [
+		path.resolve(pkgDir, entry),
+		path.resolve(pkgDir, `${entry}.js`),
+		path.resolve(pkgDir, entry, 'index.js'),
+	];
+	for (const candidate of candidates) {
+		if (fs.existsSync(candidate)) {
+			return candidate;
+		}
+	}
+	throw new Error(`Could not resolve entry for ${packageName}`);
+}
+
+// CJS packages loaded via Bun's .bun store need pre-bundling for ESM default imports.
+const CJS_INTEROP_PACKAGES = [
+	'style-to-js',
+	'style-to-object',
+	'inline-style-parser',
+	'extend',
+	'is-plain-obj',
+	'bail',
+	'trough',
+	'ms',
+] as const;
+
+const cjsInteropEntries = CJS_INTEROP_PACKAGES.flatMap((packageName) => {
+	try {
+		return [{packageName, entry: resolveBunEntry(packageName)}];
+	} catch {
+		return [];
+	}
+});
+
+const debugStub = path.resolve(__dirname, './src/stubs/debug.ts');
+
 const spaceui = path.resolve(__dirname, '../../../spaceui/packages');
 const hasSpaceui = fs.existsSync(spaceui);
 const spacebot = path.resolve(__dirname, '../../../spacebot/packages');
 const hasSpacebot = fs.existsSync(spacebot);
+const spacebotStub = path.resolve(
+	__dirname,
+	'./src/stubs/spacebot-api-client.ts'
+);
 
 export default defineConfig(() => ({
 	plugins: [react(), tailwindcss()],
@@ -86,14 +143,12 @@ export default defineConfig(() => ({
 						},
 					]
 				: []),
-			...(hasSpacebot
-				? [
-						{
-							find: /^@spacebot\/api-client$/,
-							replacement: `${spacebot}/api-client/src`,
-						},
-					]
-				: []),
+			{
+				find: /^@spacebot\/api-client$/,
+				replacement: hasSpacebot
+					? `${spacebot}/api-client/src`
+					: spacebotStub,
+			},
 			{
 				find: '@sd/interface',
 				replacement: path.resolve(
@@ -107,12 +162,19 @@ export default defineConfig(() => ({
 					__dirname,
 					'../../packages/ts-client/src'
 				)
-			}
+			},
+			// react-markdown/unified CJS deps imported as ESM defaults
+			...cjsInteropEntries.map(({packageName, entry}) => ({
+				find: packageName,
+				replacement: entry,
+			})),
+			{find: 'debug', replacement: debugStub},
 		]
 	},
 
 	optimizeDeps: {
-		exclude: ['@spacedrive/ai', '@spacedrive/primitives', '@spacedrive/tokens']
+		exclude: ['@spacedrive/ai', '@spacedrive/primitives', '@spacedrive/tokens'],
+		include: cjsInteropEntries.map(({entry}) => entry),
 	},
 
 	clearScreen: false,
@@ -134,10 +196,6 @@ export default defineConfig(() => ({
 		target: ['es2021', 'chrome100', 'safari13'],
 		minify: !process.env.TAURI_ENV_DEBUG ? ('esbuild' as const) : false,
 		sourcemap: !!process.env.TAURI_ENV_DEBUG,
-		rollupOptions: {
-			external: [
-				...(!hasSpacebot ? ['@spacebot/api-client'] : []),
-			],
-		}
+		rollupOptions: {}
 	}
 }));

--- a/packages/interface/src/Settings/pages/AdvancedSettings.tsx
+++ b/packages/interface/src/Settings/pages/AdvancedSettings.tsx
@@ -33,8 +33,8 @@ export function AdvancedSettings() {
         </p>
       </div>
 
-      <div className="p-3 bg-amber-500/10 border border-amber-500/20 rounded-lg">
-        <p className="text-sm text-amber-400">
+      <div className="p-3 bg-status-warning/10 border border-status-warning/20 rounded-lg">
+        <p className="text-sm text-status-warning">
           These settings are for expert users. Incorrect configuration may affect performance.
         </p>
       </div>

--- a/packages/interface/src/Settings/pages/ServicesSettings.tsx
+++ b/packages/interface/src/Settings/pages/ServicesSettings.tsx
@@ -39,8 +39,8 @@ export function ServicesSettings() {
         </p>
       </div>
 
-      <div className="p-3 bg-amber-500/10 border border-amber-500/20 rounded-lg">
-        <p className="text-sm text-amber-400">
+      <div className="p-3 bg-status-warning/10 border border-status-warning/20 rounded-lg">
+        <p className="text-sm text-status-warning">
           Changes to service settings may require a daemon restart to take effect.
         </p>
       </div>

--- a/packages/interface/src/components/SpacesSidebar/AddGroupModal.tsx
+++ b/packages/interface/src/components/SpacesSidebar/AddGroupModal.tsx
@@ -1,5 +1,11 @@
 import { useState } from 'react';
-import { Input, Label, dialogManager, useDialog, Dialog } from '@spacedrive/primitives';
+import {
+	Input,
+	Label,
+	Dialog,
+	dialogManager,
+	useDialog,
+} from '@spacedrive/primitives';
 import { useLibraryMutation } from '@sd/ts-client';
 import { useForm } from 'react-hook-form';
 import type { GroupType } from '@sd/ts-client';
@@ -30,11 +36,18 @@ function AddGroupDialog(props: { id: number; spaceId: string }) {
 		});
 		form.reset();
 		setGroupType('Custom');
-		dialog.state.open = false;
+		dialogManager.setState(dialog.id, { open: false });
 	});
 
 	return (
-		<Dialog form={form} dialog={dialog} title="Add Group" onSubmit={onSubmit} ctaLabel="Create">
+		<Dialog
+			form={form}
+			dialog={dialog}
+			title="Add Group"
+			onSubmit={onSubmit}
+			ctaLabel="Create"
+			onCancelled={true}
+		>
 			<div className="space-y-4">
 				<div>
 					<Label>Group Type</Label>

--- a/packages/interface/src/components/SpacesSidebar/SpaceSettingsModal.tsx
+++ b/packages/interface/src/components/SpacesSidebar/SpaceSettingsModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import clsx from 'clsx';
+import type { Space } from '@sd/ts-client';
 import { Input, Label, dialogManager, useDialog, Dialog } from '@spacedrive/primitives';
 import { useLibraryMutation } from '@sd/ts-client';
 import { useForm } from 'react-hook-form';
@@ -9,32 +10,32 @@ interface FormData {
 	name: string;
 }
 
-export function useCreateSpaceDialog() {
-	return dialogManager.create((props) => <CreateSpaceDialog {...props} />);
+export function useSpaceSettingsDialog(space: Space) {
+	return dialogManager.create((props) => (
+		<SpaceSettingsDialog {...props} space={space} />
+	));
 }
 
-function CreateSpaceDialog(props: { id: number }) {
+function SpaceSettingsDialog(props: { id: number; space: Space }) {
 	const dialog = useDialog(props);
-	const [selectedColor, setSelectedColor] = useState(PRESET_COLORS[0]);
-	const [selectedIcon, setSelectedIcon] = useState(PRESET_ICONS[0]);
+	const [selectedColor, setSelectedColor] = useState(props.space.color);
+	const [selectedIcon, setSelectedIcon] = useState(props.space.icon);
 
 	const form = useForm<FormData>({
-		defaultValues: { name: '' },
+		defaultValues: { name: props.space.name },
 	});
 
-	const createSpace = useLibraryMutation('spaces.create');
+	const updateSpace = useLibraryMutation('spaces.update');
 
 	const onSubmit = form.handleSubmit(async (data) => {
 		if (!data.name?.trim()) return;
 
-		await createSpace.mutateAsync({
-			name: data.name,
+		await updateSpace.mutateAsync({
+			space_id: props.space.id,
+			name: data.name.trim(),
 			icon: selectedIcon,
 			color: selectedColor,
 		});
-		form.reset();
-		setSelectedColor(PRESET_COLORS[0]);
-		setSelectedIcon(PRESET_ICONS[0]);
 		dialog.state.open = false;
 	});
 
@@ -42,16 +43,16 @@ function CreateSpaceDialog(props: { id: number }) {
 		<Dialog
 			form={form}
 			dialog={dialog}
-			title="Create Space"
+			title="Space Settings"
 			onSubmit={onSubmit}
-			ctaLabel="Create"
+			ctaLabel="Save"
 		>
 			<div className="space-y-4">
 				<div>
 					<Label>Space Name</Label>
 					<Input
 						{...form.register('name', { required: true })}
-						placeholder="e.g., Work Files, Personal Photos"
+						placeholder="e.g., All Devices, Work Files"
 						autoFocus
 					/>
 				</div>
@@ -68,7 +69,7 @@ function CreateSpaceDialog(props: { id: number }) {
 									'h-8 w-8 rounded-full border-2 transition-all',
 									selectedColor === color
 										? 'scale-110 border-white'
-										: 'border-transparent'
+										: 'border-transparent',
 								)}
 								style={{ backgroundColor: color }}
 							/>
@@ -88,7 +89,7 @@ function CreateSpaceDialog(props: { id: number }) {
 									'rounded-lg px-3 py-2 text-sm font-medium transition-colors',
 									selectedIcon === icon
 										? 'bg-sidebar-selected text-sidebar-ink'
-										: 'bg-app-input text-sidebar-ink-dull hover:bg-app-hover'
+										: 'bg-app-input text-sidebar-ink-dull hover:bg-app-hover',
 								)}
 							>
 								{icon}

--- a/packages/interface/src/components/SpacesSidebar/SpaceSwitcher.tsx
+++ b/packages/interface/src/components/SpacesSidebar/SpaceSwitcher.tsx
@@ -2,7 +2,9 @@ import {GearSix, Plus} from '@phosphor-icons/react';
 import type {Space} from '@sd/ts-client';
 import {DropdownMenu, SelectPill} from '@spacedrive/primitives';
 import clsx from 'clsx';
+import {useState} from 'react';
 import {useCreateSpaceDialog} from './CreateSpaceModal';
+import {useSpaceSettingsDialog} from './SpaceSettingsModal';
 
 interface SpaceSwitcherProps {
 	spaces: Space[] | undefined;
@@ -15,10 +17,18 @@ export function SpaceSwitcher({
 	currentSpace,
 	onSwitch
 }: SpaceSwitcherProps) {
-	const createSpaceDialog = useCreateSpaceDialog;
+	const [menuOpen, setMenuOpen] = useState(false);
+
+	const openDialogAfterMenuCloses = (openDialog: () => void) => {
+		setMenuOpen(false);
+		// Let the dropdown fully unmount before opening a modal overlay.
+		requestAnimationFrame(() => {
+			openDialog();
+		});
+	};
 
 	return (
-		<DropdownMenu.Root>
+		<DropdownMenu.Root open={menuOpen} onOpenChange={setMenuOpen}>
 			<DropdownMenu.Trigger asChild>
 				<SelectPill variant="sidebar" size="lg" className="shrink-0">
 					<div
@@ -30,12 +40,18 @@ export function SpaceSwitcher({
 					</span>
 				</SelectPill>
 			</DropdownMenu.Trigger>
-			<DropdownMenu.Content className="min-w-[var(--radix-dropdown-menu-trigger-width)] p-1">
+			<DropdownMenu.Content
+				sideOffset={4}
+				className="border-sidebar-line !bg-sidebar-box !backdrop-blur-none z-[70] min-w-[var(--radix-dropdown-menu-trigger-width)] p-1 shadow-xl"
+			>
 				{spaces && spaces.length > 1
 					? spaces.map((space) => (
 							<DropdownMenu.Item
 								key={space.id}
-								onClick={() => onSwitch(space.id)}
+								onSelect={(event) => {
+									event.preventDefault();
+									onSwitch(space.id);
+								}}
 								className={clsx(
 									'rounded-md px-2 py-1 text-sm',
 									space.id === currentSpace?.id
@@ -57,13 +73,26 @@ export function SpaceSwitcher({
 					<DropdownMenu.Separator className="border-sidebar-line my-1" />
 				)}
 				<DropdownMenu.Item
-					onClick={() => createSpaceDialog()}
+					onSelect={(event) => {
+						event.preventDefault();
+						openDialogAfterMenuCloses(useCreateSpaceDialog);
+					}}
 					className="hover:bg-sidebar-selected text-sidebar-ink rounded-md px-2 py-1 text-sm font-medium"
 				>
 					<Plus className="mr-2 size-4" weight="bold" />
 					New Space
 				</DropdownMenu.Item>
-				<DropdownMenu.Item className="hover:bg-sidebar-selected text-sidebar-ink rounded-md px-2 py-1 text-sm font-medium">
+				<DropdownMenu.Item
+					disabled={!currentSpace}
+					onSelect={(event) => {
+						event.preventDefault();
+						if (!currentSpace) return;
+						openDialogAfterMenuCloses(() =>
+							useSpaceSettingsDialog(currentSpace),
+						);
+					}}
+					className="hover:bg-sidebar-selected text-sidebar-ink rounded-md px-2 py-1 text-sm font-medium"
+				>
 					<GearSix className="mr-2 size-4" weight="bold" />
 					Space Settings
 				</DropdownMenu.Item>

--- a/packages/interface/src/components/SpacesSidebar/spacePresets.ts
+++ b/packages/interface/src/components/SpacesSidebar/spacePresets.ts
@@ -1,0 +1,21 @@
+export const PRESET_COLORS = [
+	'#3B82F6',
+	'#8B5CF6',
+	'#EC4899',
+	'#10B981',
+	'#F59E0B',
+	'#EF4444',
+	'#06B6D4',
+	'#6366F1',
+];
+
+export const PRESET_ICONS = [
+	'Planet',
+	'Folder',
+	'Briefcase',
+	'House',
+	'Camera',
+	'MusicNotes',
+	'GameController',
+	'Code',
+];

--- a/packages/interface/src/routes/settings/index.tsx
+++ b/packages/interface/src/routes/settings/index.tsx
@@ -46,7 +46,7 @@ function SettingsSidebar({ currentPage, onPageChange }: SettingsSidebarProps) {
                 : "bg-sidebar-selected text-sidebar-ink"
               : isAboutPage
               ? "text-white/60 hover:text-white hover:bg-white/10"
-              : "text-sidebar-inkDull hover:text-sidebar-ink hover:bg-sidebar-box"
+              : "text-sidebar-ink-dull hover:text-sidebar-ink hover:bg-sidebar-box"
           )}
         >
           {section.label}


### PR DESCRIPTION
## Summary

The All Devices space switcher dropdown was unreadable on Tauri's transparent window. Space Settings had no handler, and opening New Space from the dropdown broke Radix focus.

## Changes

- Opaque `!bg-sidebar-box` background on the dropdown menu
- CSS override for sidebar dropdowns in `apps/tauri/src/index.css`
- Wire **Space Settings** to a new `SpaceSettingsModal` (`spaces.update`)
- Close dropdown before opening dialogs (Radix focus trap fix)
- Shared color/icon presets for Create Space and Space Settings

## Test plan

- [ ] Open All Devices dropdown — solid background, readable New Space / Space Settings
- [ ] New Space opens modal correctly
- [ ] Space Settings opens and saves name, color, icon
- [ ] Pairs with #3076 for dialog/modal opacity fixes