### PR TITLE
fix(explorer): sort direction reliability + stability fixes against hangs

### DIFF
--- a/apps/cli/src/domains/file/mod.rs
+++ b/apps/cli/src/domains/file/mod.rs
@@ -282,6 +282,7 @@ async fn list_directory(
 		limit,
 		include_hidden: Some(include_hidden),
 		sort_by,
+		sort_direction: None,
 		folders_first: None,
 	};
 

--- a/apps/tauri/index.html
+++ b/apps/tauri/index.html
@@ -4,6 +4,34 @@
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>Spacedrive</title>
+		<style>
+			/* Immediate dark background so the transparent Tauri window
+			   (visible:false + transparent:true) does not flash native grey
+			   while Vite + React + CSS load. Matches the app theme. */
+			html, body {
+				background-color: #111113;
+				color: #e5e5e5;
+				margin: 0;
+				height: 100%;
+				overflow: hidden;
+			}
+			#root {
+				height: 100%;
+				min-height: 100vh;
+			}
+			/* Tiny inline loading hint (will be replaced by React quickly) */
+			#root:empty::before {
+				content: "Spacedrive";
+				position: absolute;
+				top: 50%;
+				left: 50%;
+				transform: translate(-50%, -50%);
+				font-family: system-ui, -apple-system, sans-serif;
+				font-size: 13px;
+				opacity: 0.6;
+				letter-spacing: 0.5px;
+			}
+		</style>
 	</head>
 	<body>
 		<div id="root"></div>

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -1601,19 +1601,21 @@ async fn start_daemon(
 		.spawn()
 		.map_err(|e| format!("Failed to start daemon: {}", e))?;
 
-	// Wait for daemon to be ready
-	for i in 0..30 {
+	// Wait for daemon to be ready. Cold start often exceeds a few seconds
+	// (volume discovery + networking/iroh init before the RPC bind).
+	const MAX_ATTEMPTS: u32 = 200; // 200 * 100ms = 20s
+	for i in 0..MAX_ATTEMPTS {
 		tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 		if is_daemon_running(socket_addr).await {
 			tracing::info!("Daemon ready at {}", socket_addr);
 			return Ok(child);
 		}
-		if i == 10 {
+		if i == 30 {
 			tracing::warn!("Daemon taking longer than expected to start...");
 		}
 	}
 
-	Err("Daemon failed to start (connection not available after 3 seconds)".to_string())
+	Err("Daemon failed to start (connection not available after 20 seconds)".to_string())
 }
 
 fn setup_menu(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -2202,13 +2202,35 @@ fn main() {
 				});
 			});
 
-			// In dev mode, show window immediately
+			// In dev mode, show window immediately so a broken module graph is visible.
 			#[cfg(debug_assertions)]
 			{
 				if let Some(window) = app.get_webview_window("main") {
 					window.show().ok();
 					window.set_focus().ok();
 				}
+			}
+
+			// Release builds start with visible:false and rely on the frontend
+			// invoking app_ready. If the webview never boots (e.g. unresolved
+			// import), force-show after a short delay so the process is not
+			// stuck docked with zero windows.
+			#[cfg(not(debug_assertions))]
+			{
+				let app_handle = app.handle().clone();
+				tauri::async_runtime::spawn(async move {
+					tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+					if let Some(window) = app_handle.get_webview_window("main") {
+						let visible = window.is_visible().unwrap_or(false);
+						if !visible {
+							tracing::warn!(
+								"Main window still hidden after 3s (app_ready never called); forcing show"
+							);
+							window.show().ok();
+							window.set_focus().ok();
+						}
+					}
+				});
 			}
 
 			Ok(())

--- a/apps/tauri/src/index.css
+++ b/apps/tauri/src/index.css
@@ -83,7 +83,8 @@ body {
 /*
  * Tauri uses a transparent native window. Dialog overlay uses bg-app/50 with a
  * react-spring opacity animation on the whole element, so the app bleeds through.
- * Force a full-window opaque backdrop above the shell (sidebar is z-[65]).
+ * Without opaque backdrop + panel styles, modals (Add Group, Add Storage, etc.)
+ * appear invisible while still blocking all pointer events.
  */
 .fixed.inset-0.z-\[102\] {
 	z-index: 102 !important;
@@ -98,10 +99,6 @@ body {
 	z-index: 103 !important;
 }
 
-/*
- * Dialog panels also need a solid background on the transparent Tauri window,
- * otherwise Add Storage category tiles (including Cloud Storage) are unreadable.
- */
 .z-\[103\] .border-app-line.bg-app-box,
 .z-\[103\] form.border-app-line.bg-app-box {
 	background-color: var(--color-app-box) !important;
@@ -111,12 +108,19 @@ body {
 	background-color: var(--color-app-input) !important;
 }
 
-/*
- * Primitives menus use bg-menu/95 + backdrop-blur. On the transparent Tauri
- * window, sidebar and explorer content bleeds through and menu text is unreadable.
- */
 .border-menu-line.bg-menu\/95 {
 	background-color: var(--color-menu) !important;
+	backdrop-filter: none !important;
+	-webkit-backdrop-filter: none !important;
+}
+
+/*
+ * Space switcher and other sidebar dropdowns use bg-sidebar-box. Primitives still
+ * applies bg-menu/95 + backdrop-blur underneath, which bleeds through on Tauri.
+ */
+.border-sidebar-line.bg-sidebar-box,
+.border-sidebar-line.\!bg-sidebar-box {
+	background-color: var(--color-sidebar-box) !important;
 	backdrop-filter: none !important;
 	-webkit-backdrop-filter: none !important;
 }

--- a/apps/tauri/src/index.css
+++ b/apps/tauri/src/index.css
@@ -11,6 +11,8 @@
 /* Tell Tailwind v4 where to scan for utility classes */
 @source "../../../packages/ui/src";
 @source "../../../packages/interface/src";
+@source "../node_modules/@spacedrive/primitives/dist";
+@source "../node_modules/@spacedrive/ai/dist";
 @source "../../../../spaceui/packages/primitives/src";
 @source "../../../../spaceui/packages/ai/src";
 @source "../../../../spaceui/packages/explorer/src";
@@ -76,4 +78,45 @@ body {
 		"Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
+}
+
+/*
+ * Tauri uses a transparent native window. Dialog overlay uses bg-app/50 with a
+ * react-spring opacity animation on the whole element, so the app bleeds through.
+ * Force a full-window opaque backdrop above the shell (sidebar is z-[65]).
+ */
+.fixed.inset-0.z-\[102\] {
+	z-index: 102 !important;
+	background-color: color-mix(in srgb, var(--color-app) 92%, transparent) !important;
+	margin: 0 !important;
+	border-radius: 0 !important;
+	backdrop-filter: blur(16px) saturate(120%);
+	-webkit-backdrop-filter: blur(16px) saturate(120%);
+}
+
+.fixed.inset-0.z-\[103\] {
+	z-index: 103 !important;
+}
+
+/*
+ * Dialog panels also need a solid background on the transparent Tauri window,
+ * otherwise Add Storage category tiles (including Cloud Storage) are unreadable.
+ */
+.z-\[103\] .border-app-line.bg-app-box,
+.z-\[103\] form.border-app-line.bg-app-box {
+	background-color: var(--color-app-box) !important;
+}
+
+.z-\[103\] .bg-app-input\/60 {
+	background-color: var(--color-app-input) !important;
+}
+
+/*
+ * Primitives menus use bg-menu/95 + backdrop-blur. On the transparent Tauri
+ * window, sidebar and explorer content bleeds through and menu text is unreadable.
+ */
+.border-menu-line.bg-menu\/95 {
+	background-color: var(--color-menu) !important;
+	backdrop-filter: none !important;
+	-webkit-backdrop-filter: none !important;
 }

--- a/apps/tauri/src/stubs/debug.ts
+++ b/apps/tauri/src/stubs/debug.ts
@@ -1,0 +1,10 @@
+/** No-op debug stub for CJS packages that import `debug` in the browser. */
+function debug(_namespace: string) {
+	return (..._args: unknown[]) => {};
+}
+
+debug.enable = () => {};
+debug.disable = () => {};
+debug.enabled = () => false;
+
+export default debug;

--- a/apps/tauri/src/stubs/spacebot-api-client.ts
+++ b/apps/tauri/src/stubs/spacebot-api-client.ts
@@ -1,0 +1,88 @@
+/**
+ * Stub for @spacebot/api-client when the spacebot repo is not checked out locally.
+ * Spacebot UI features are disabled; core Spacedrive remains usable.
+ */
+
+export type InboundMessageEvent = Record<string, unknown>;
+export type OutboundMessageDeltaEvent = Record<string, unknown>;
+export type OutboundMessageEvent = Record<string, unknown>;
+export type PortalConversationResponse = {
+	conversation: { id: string; title?: string | null };
+};
+export type PortalConversationSummary = {
+	id: string;
+	title?: string | null;
+	updated_at?: string;
+};
+export type PortalHistoryMessage = Record<string, unknown>;
+export type TypingStateEvent = Record<string, unknown>;
+export type TimelineItem = {
+	type: string;
+	id: string;
+	[key: string]: unknown;
+};
+export type WorkerListItem = {
+	id: string;
+	channel_id?: string | null;
+	status: string;
+	worker_type?: string;
+	task?: string;
+	[key: string]: unknown;
+};
+export type Task = Record<string, unknown>;
+export type UpdateTaskRequest = Record<string, unknown>;
+export type TtsProfile = { id: string; name?: string; [key: string]: unknown };
+
+let serverUrl = 'http://127.0.0.1:19898';
+
+export function setServerUrl(url: string): void {
+	serverUrl = url;
+}
+
+export function getEventsUrl(): string {
+	return `${serverUrl}/api/events`;
+}
+
+const emptyBuffer = new ArrayBuffer(0);
+
+export const apiClient = {
+	listPortalConversations: async (_agentId: string, _includeArchived: boolean, _limit: number) => ({
+		conversations: [] as PortalConversationSummary[],
+	}),
+	portalHistory: async (_agentId: string, _conversationId: string, _limit: number) => [],
+	createPortalConversation: async (_req: {
+		agentId: string;
+		title?: string | null;
+	}): Promise<PortalConversationResponse> => ({
+		conversation: { id: 'stub-conversation', title: null },
+	}),
+	portalSend: async (_req: Record<string, unknown>) => undefined,
+	channelMessages: async (_channelId: string, _limit: number) => ({
+		items: [] as TimelineItem[],
+	}),
+	listWorkers: async (_req: { agentId: string; limit?: number }) => ({
+		workers: [] as WorkerListItem[],
+	}),
+	workerDetail: async (_agentId: string, _workerId: string) => ({
+		id: 'stub-worker',
+		task: 'Spacebot not available',
+		status: 'completed',
+		started_at: new Date().toISOString(),
+		transcript: [],
+	}),
+	cancelProcess: async (_req: Record<string, unknown>) => undefined,
+	listTasks: async (_agentId: string, _limit: number) => ({
+		tasks: [] as Task[],
+	}),
+	updateTask: async (_taskNumber: number, _req: UpdateTaskRequest) => undefined,
+	deleteTask: async (_taskNumber: number) => undefined,
+	ttsProfiles: async (_agentId: string) => [] as TtsProfile[],
+	ttsGenerate: async (_text: string, _opts?: Record<string, unknown>) => emptyBuffer,
+	webChatSendAudio: async (
+		_agentId: string,
+		_sessionId: string,
+		_blob: Blob,
+	) => ({ ok: false, status: 503 }),
+};
+
+export default apiClient;

--- a/apps/tauri/vite.config.ts
+++ b/apps/tauri/vite.config.ts
@@ -10,7 +10,91 @@ const spacebot = path.resolve(__dirname, '../../../spacebot/packages');
 const hasSpacebot = fs.existsSync(spacebot);
 
 export default defineConfig(() => ({
-	plugins: [react(), tailwindcss()],
+	plugins: [
+		react(),
+		tailwindcss(),
+		// Provide a stub for @spacebot/api-client when the spacebot sibling repo is not present.
+		// This prevents Vite dev from failing with "Failed to resolve import" which leads to
+		// grey/blank screen in the Tauri webview (the module graph breaks for Spacebot code
+		// pulled in via the router).
+		{
+			name: 'spacebot-stub',
+			resolveId(id: string) {
+				if (id === '@spacebot/api-client' && !hasSpacebot) {
+					return '\0virtual:spacebot-stub';
+				}
+			},
+			load(id: string) {
+				if (id === '\0virtual:spacebot-stub') {
+					// Return pure JS (no TS syntax like `?:` or `export type`).
+					// Vite serves this virtual as JS; browser would choke on TS syntax
+					// causing "Unexpected token '?'" and empty #root (grey screen).
+					return `
+export const apiClient = {};
+export function getEventsUrl() { return ''; }
+export function setServerUrl(_url) {}
+export default apiClient;
+`;
+				}
+			},
+		},
+		// Stub hast-util-to-jsx-runtime (pulls in style-to-js which has CJS interop problems under Vite).
+		// This prevents the "no default export" / require errors that keep #root empty (grey screen).
+		{
+			name: 'hast-util-to-jsx-runtime-stub',
+			resolveId(id) {
+				if (id === 'hast-util-to-jsx-runtime') return '\0virtual:hast-to-jsx-stub';
+			},
+			load(id) {
+				if (id === '\0virtual:hast-to-jsx-stub') {
+					return `
+export function toJsxRuntime(tree, options) {
+  // Minimal stub: avoid pulling style-to-js and heavy hast transform in dev.
+  // Return a harmless empty span if createElement is provided by React JSX runtime.
+  try {
+    const create = (options && options.createElement) || ((t, p, ...c) => ({type:t, props:p, children:c}));
+    return create('span', { style: { display: 'none' } }, '');
+  } catch {
+    return null;
+  }
+}
+export default toJsxRuntime;
+`;
+				}
+			},
+		},
+		// Also provide style-to-js directly as pure JS (belt and suspenders).
+		{
+			name: 'style-to-js-stub',
+			resolveId(id) {
+				if (id === 'style-to-js' || id.includes('style-to-js')) {
+					return '\0virtual:style-to-js-stub';
+				}
+			},
+			load(id) {
+				if (id === '\0virtual:style-to-js-stub') {
+					return `
+function camelCase(str) {
+  return String(str || '').trim().replace(/-+([a-z0-9])/gi, (_, c) => c.toUpperCase());
+}
+export default function styleToJS(style) {
+  const out = {};
+  if (!style || typeof style !== 'string') return out;
+  String(style).split(';').forEach((d) => {
+    const i = d.indexOf(':');
+    if (i > -1) {
+      const k = d.slice(0, i).trim();
+      const v = d.slice(i + 1).trim();
+      if (k && v) out[camelCase(k)] = v;
+    }
+  });
+  return out;
+}
+`;
+				}
+			},
+		},
+	],
 
 	resolve: {
 		dedupe: ['react', 'react-dom'],
@@ -112,7 +196,15 @@ export default defineConfig(() => ({
 	},
 
 	optimizeDeps: {
-		exclude: ['@spacedrive/ai', '@spacedrive/primitives', '@spacedrive/tokens']
+		exclude: [
+			'@spacedrive/ai',
+			'@spacedrive/primitives',
+			'@spacedrive/tokens',
+			// Transitives that pull in awkward CJS style-to-js and cause default export / require errors in dev.
+			'style-to-js',
+			'style-to-object',
+			'hast-util-to-jsx-runtime',
+		]
 	},
 
 	clearScreen: false,

--- a/apps/tauri/vite.config.ts
+++ b/apps/tauri/vite.config.ts
@@ -4,97 +4,70 @@ import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react-swc';
 import {defineConfig} from 'vite';
 
+/** Resolve a Bun-hoisted transitive dependency to its CJS entry. */
+function resolveBunPackageDir(packageName: string): string {
+	const bunDir = path.resolve(__dirname, '../../node_modules/.bun');
+	const match = fs
+		.readdirSync(bunDir)
+		.find((entry) => entry.startsWith(`${packageName}@`));
+	if (!match) {
+		throw new Error(`Could not find bun package: ${packageName}`);
+	}
+	return path.resolve(bunDir, match, 'node_modules', packageName);
+}
+
+function resolveBunEntry(packageName: string): string {
+	const pkgDir = resolveBunPackageDir(packageName);
+	const pkgJson = JSON.parse(
+		fs.readFileSync(path.join(pkgDir, 'package.json'), 'utf8')
+	) as {main?: string; browser?: string};
+	const entry = pkgJson.browser ?? pkgJson.main ?? 'index.js';
+	const candidates = [
+		path.resolve(pkgDir, entry),
+		path.resolve(pkgDir, `${entry}.js`),
+		path.resolve(pkgDir, entry, 'index.js'),
+	];
+	for (const candidate of candidates) {
+		if (fs.existsSync(candidate)) {
+			return candidate;
+		}
+	}
+	throw new Error(`Could not resolve entry for ${packageName}`);
+}
+
+// CJS packages loaded via Bun's .bun store need pre-bundling for ESM default imports.
+const CJS_INTEROP_PACKAGES = [
+	'style-to-js',
+	'style-to-object',
+	'inline-style-parser',
+	'extend',
+	'is-plain-obj',
+	'bail',
+	'trough',
+	'ms',
+] as const;
+
+const cjsInteropEntries = CJS_INTEROP_PACKAGES.flatMap((packageName) => {
+	try {
+		return [{packageName, entry: resolveBunEntry(packageName)}];
+	} catch {
+		return [];
+	}
+});
+
+const debugStub = path.resolve(__dirname, './src/stubs/debug.ts');
+
 const spaceui = path.resolve(__dirname, '../../../spaceui/packages');
 const hasSpaceui = fs.existsSync(spaceui);
 const spacebot = path.resolve(__dirname, '../../../spacebot/packages');
 const hasSpacebot = fs.existsSync(spacebot);
+const spacebotStub = path.resolve(
+	__dirname,
+	'./src/stubs/spacebot-api-client.ts'
+);
 
 export default defineConfig(() => ({
-	plugins: [
-		react(),
-		tailwindcss(),
-		// Provide a stub for @spacebot/api-client when the spacebot sibling repo is not present.
-		// This prevents Vite dev from failing with "Failed to resolve import" which leads to
-		// grey/blank screen in the Tauri webview (the module graph breaks for Spacebot code
-		// pulled in via the router).
-		{
-			name: 'spacebot-stub',
-			resolveId(id: string) {
-				if (id === '@spacebot/api-client' && !hasSpacebot) {
-					return '\0virtual:spacebot-stub';
-				}
-			},
-			load(id: string) {
-				if (id === '\0virtual:spacebot-stub') {
-					// Return pure JS (no TS syntax like `?:` or `export type`).
-					// Vite serves this virtual as JS; browser would choke on TS syntax
-					// causing "Unexpected token '?'" and empty #root (grey screen).
-					return `
-export const apiClient = {};
-export function getEventsUrl() { return ''; }
-export function setServerUrl(_url) {}
-export default apiClient;
-`;
-				}
-			},
-		},
-		// Stub hast-util-to-jsx-runtime (pulls in style-to-js which has CJS interop problems under Vite).
-		// This prevents the "no default export" / require errors that keep #root empty (grey screen).
-		{
-			name: 'hast-util-to-jsx-runtime-stub',
-			resolveId(id) {
-				if (id === 'hast-util-to-jsx-runtime') return '\0virtual:hast-to-jsx-stub';
-			},
-			load(id) {
-				if (id === '\0virtual:hast-to-jsx-stub') {
-					return `
-export function toJsxRuntime(tree, options) {
-  // Minimal stub: avoid pulling style-to-js and heavy hast transform in dev.
-  // Return a harmless empty span if createElement is provided by React JSX runtime.
-  try {
-    const create = (options && options.createElement) || ((t, p, ...c) => ({type:t, props:p, children:c}));
-    return create('span', { style: { display: 'none' } }, '');
-  } catch {
-    return null;
-  }
-}
-export default toJsxRuntime;
-`;
-				}
-			},
-		},
-		// Also provide style-to-js directly as pure JS (belt and suspenders).
-		{
-			name: 'style-to-js-stub',
-			resolveId(id) {
-				if (id === 'style-to-js' || id.includes('style-to-js')) {
-					return '\0virtual:style-to-js-stub';
-				}
-			},
-			load(id) {
-				if (id === '\0virtual:style-to-js-stub') {
-					return `
-function camelCase(str) {
-  return String(str || '').trim().replace(/-+([a-z0-9])/gi, (_, c) => c.toUpperCase());
-}
-export default function styleToJS(style) {
-  const out = {};
-  if (!style || typeof style !== 'string') return out;
-  String(style).split(';').forEach((d) => {
-    const i = d.indexOf(':');
-    if (i > -1) {
-      const k = d.slice(0, i).trim();
-      const v = d.slice(i + 1).trim();
-      if (k && v) out[camelCase(k)] = v;
-    }
-  });
-  return out;
-}
-`;
-				}
-			},
-		},
-	],
+	plugins: [react(), tailwindcss()],
 
 	resolve: {
 		dedupe: ['react', 'react-dom'],
@@ -170,14 +143,12 @@ export default function styleToJS(style) {
 						},
 					]
 				: []),
-			...(hasSpacebot
-				? [
-						{
-							find: /^@spacebot\/api-client$/,
-							replacement: `${spacebot}/api-client/src`,
-						},
-					]
-				: []),
+			{
+				find: /^@spacebot\/api-client$/,
+				replacement: hasSpacebot
+					? `${spacebot}/api-client/src`
+					: spacebotStub,
+			},
 			{
 				find: '@sd/interface',
 				replacement: path.resolve(
@@ -191,20 +162,19 @@ export default function styleToJS(style) {
 					__dirname,
 					'../../packages/ts-client/src'
 				)
-			}
+			},
+			// react-markdown/unified CJS deps imported as ESM defaults
+			...cjsInteropEntries.map(({packageName, entry}) => ({
+				find: packageName,
+				replacement: entry,
+			})),
+			{find: 'debug', replacement: debugStub},
 		]
 	},
 
 	optimizeDeps: {
-		exclude: [
-			'@spacedrive/ai',
-			'@spacedrive/primitives',
-			'@spacedrive/tokens',
-			// Transitives that pull in awkward CJS style-to-js and cause default export / require errors in dev.
-			'style-to-js',
-			'style-to-object',
-			'hast-util-to-jsx-runtime',
-		]
+		exclude: ['@spacedrive/ai', '@spacedrive/primitives', '@spacedrive/tokens'],
+		include: cjsInteropEntries.map(({entry}) => entry),
 	},
 
 	clearScreen: false,
@@ -226,10 +196,6 @@ export default function styleToJS(style) {
 		target: ['es2021', 'chrome100', 'safari13'],
 		minify: !process.env.TAURI_ENV_DEBUG ? ('esbuild' as const) : false,
 		sourcemap: !!process.env.TAURI_ENV_DEBUG,
-		rollupOptions: {
-			external: [
-				...(!hasSpacebot ? ['@spacebot/api-client'] : []),
-			],
-		}
+		rollupOptions: {}
 	}
 }));

--- a/core/src/infra/extension/host_functions.rs
+++ b/core/src/infra/extension/host_functions.rs
@@ -90,8 +90,12 @@ pub fn host_spacedrive_call(
 	};
 
 	// 4. Permission check
-	let auth_result = tokio::runtime::Handle::current()
-		.block_on(async { plugin_env.permissions.authorize(&method, library_id).await });
+	// Use block_in_place so we don't violate tokio rules when the WASM host function
+	// is invoked from a runtime thread. This is a stability fix to prevent hangs/deadlocks.
+	let auth_result = tokio::task::block_in_place(|| {
+		tokio::runtime::Handle::current()
+			.block_on(async { plugin_env.permissions.authorize(&method, library_id).await })
+	});
 
 	if let Err(e) = auth_result {
 		tracing::warn!(
@@ -111,38 +115,45 @@ pub fn host_spacedrive_call(
 	);
 
 	// 5. Call operation handlers directly (same as execute_json_operation does)
-	let result = tokio::runtime::Handle::current().block_on(async {
-		// Create base session
-		let base_session = match plugin_env.api_dispatcher.create_base_session() {
-			Ok(s) => s,
-			Err(e) => return Err(e),
-		};
+	// block_in_place for stability (WASM host fn may be on a runtime thread).
+	let result = tokio::task::block_in_place(|| {
+		tokio::runtime::Handle::current().block_on(async {
+			// Create base session
+			let base_session = match plugin_env.api_dispatcher.create_base_session() {
+				Ok(s) => s,
+				Err(e) => return Err(e),
+			};
 
-		// Try library queries
-		if let Some(handler) = crate::infra::wire::registry::LIBRARY_QUERIES.get(method.as_str()) {
-			let lib_id = library_id.ok_or_else(|| "Library ID required".to_string())?;
-			let session = base_session.with_library(lib_id);
-			return handler(plugin_env.core_context.clone(), session, payload_json).await;
-		}
+			// Try library queries
+			if let Some(handler) =
+				crate::infra::wire::registry::LIBRARY_QUERIES.get(method.as_str())
+			{
+				let lib_id = library_id.ok_or_else(|| "Library ID required".to_string())?;
+				let session = base_session.with_library(lib_id);
+				return handler(plugin_env.core_context.clone(), session, payload_json).await;
+			}
 
-		// Try core queries
-		if let Some(handler) = crate::infra::wire::registry::CORE_QUERIES.get(method.as_str()) {
-			return handler(plugin_env.core_context.clone(), base_session, payload_json).await;
-		}
+			// Try core queries
+			if let Some(handler) = crate::infra::wire::registry::CORE_QUERIES.get(method.as_str()) {
+				return handler(plugin_env.core_context.clone(), base_session, payload_json).await;
+			}
 
-		// Try library actions
-		if let Some(handler) = crate::infra::wire::registry::LIBRARY_ACTIONS.get(method.as_str()) {
-			let lib_id = library_id.ok_or_else(|| "Library ID required".to_string())?;
-			let session = base_session.with_library(lib_id);
-			return handler(plugin_env.core_context.clone(), session, payload_json).await;
-		}
+			// Try library actions
+			if let Some(handler) =
+				crate::infra::wire::registry::LIBRARY_ACTIONS.get(method.as_str())
+			{
+				let lib_id = library_id.ok_or_else(|| "Library ID required".to_string())?;
+				let session = base_session.with_library(lib_id);
+				return handler(plugin_env.core_context.clone(), session, payload_json).await;
+			}
 
-		// Try core actions
-		if let Some(handler) = crate::infra::wire::registry::CORE_ACTIONS.get(method.as_str()) {
-			return handler(plugin_env.core_context.clone(), payload_json).await;
-		}
+			// Try core actions
+			if let Some(handler) = crate::infra::wire::registry::CORE_ACTIONS.get(method.as_str()) {
+				return handler(plugin_env.core_context.clone(), payload_json).await;
+			}
 
-		Err(format!("Unknown method: {}", method))
+			Err(format!("Unknown method: {}", method))
+		})
 	});
 
 	// 6. Write result to WASM memory

--- a/core/src/location/manager.rs
+++ b/core/src/location/manager.rs
@@ -110,33 +110,47 @@ impl LocationManager {
 					.to_string();
 				let path_str = path.to_string_lossy().to_string();
 
-				// Get inode for the directory
-				let inode = if path.exists() {
-					match std::fs::metadata(path) {
-						Ok(metadata) => {
-							#[cfg(unix)]
-							{
-								use std::os::unix::fs::MetadataExt;
-								Some(metadata.ino())
+				// Get inode for the directory.
+				// Run the (potentially slow) metadata call off the async runtime for stability.
+				let inode = {
+					let path = path.clone();
+					match tokio::task::spawn_blocking(move || {
+						if path.exists() {
+							match std::fs::metadata(&path) {
+								Ok(metadata) => {
+									#[cfg(unix)]
+									{
+										use std::os::unix::fs::MetadataExt;
+										Some(metadata.ino())
+									}
+									#[cfg(windows)]
+									{
+										// Windows has file IDs but they're more complex to extract
+										// For now, leave as None for Windows
+										None::<u64>
+									}
+								}
+								Err(e) => {
+									warn!(
+										"Failed to get metadata for location root {}: {}",
+										path.display(),
+										e
+									);
+									None
+								}
 							}
-							#[cfg(windows)]
-							{
-								// Windows has file IDs but they're more complex to extract
-								// For now, leave as None for Windows
-								None::<u64>
-							}
+						} else {
+							None
 						}
+					})
+					.await
+					{
+						Ok(v) => v,
 						Err(e) => {
-							warn!(
-								"Failed to get metadata for location root {}: {}",
-								path.display(),
-								e
-							);
+							warn!("spawn_blocking for inode metadata failed: {}", e);
 							None
 						}
 					}
-				} else {
-					None
 				};
 
 				(name, path_str, inode)
@@ -521,8 +535,8 @@ impl LocationManager {
 
 	/// Validate a physical filesystem path before creating a location
 	async fn validate_physical_path(&self, path: &PathBuf) -> LocationResult<()> {
-		// Check if path exists
-		if !path.exists() {
+		// Check if path exists (async to avoid blocking runtime on slow FS)
+		if !tokio::fs::try_exists(path).await.unwrap_or(false) {
 			return Err(LocationError::PathNotFound { path: path.clone() });
 		}
 

--- a/core/src/location/mod.rs
+++ b/core/src/location/mod.rs
@@ -146,8 +146,8 @@ pub async fn create_location(
 		.to_str()
 		.ok_or_else(|| LocationError::InvalidPath("Non-UTF8 path".to_string()))?;
 
-	// Validate path exists
-	if !args.path.exists() {
+	// Validate path exists (use async FS to avoid blocking the runtime)
+	if !tokio::fs::try_exists(&args.path).await.unwrap_or(false) {
 		return Err(LocationError::PathNotFound { path: args.path });
 	}
 

--- a/core/src/ops/files/query/directory_listing.rs
+++ b/core/src/ops/files/query/directory_listing.rs
@@ -4,6 +4,7 @@
 //! It returns direct children of a directory without recursive search.
 
 use crate::infra::query::{QueryError, QueryResult};
+use crate::ops::search::SortDirection;
 use crate::{
 	context::CoreContext,
 	domain::{addressing::SdPath, content_identity::ContentIdentity, file::File, tag::Tag},
@@ -32,8 +33,10 @@ pub struct DirectoryListingInput {
 	pub limit: Option<u32>,
 	/// Whether to include hidden files (default: false)
 	pub include_hidden: Option<bool>,
-	/// Sort order for results
+	/// Sort field for results
 	pub sort_by: DirectorySortBy,
+	/// Sort direction. When omitted, uses field-specific defaults (name/type: asc, modified/size: desc).
+	pub sort_direction: Option<SortDirection>,
 	/// Whether to show folders before files (default: false)
 	pub folders_first: Option<bool>,
 }
@@ -77,6 +80,7 @@ impl DirectoryListingQuery {
 				limit: Some(1000),
 				include_hidden: Some(false),
 				sort_by: DirectorySortBy::Type,
+				sort_direction: None,
 				folders_first: Some(false),
 			},
 		}
@@ -94,6 +98,7 @@ impl DirectoryListingQuery {
 				limit,
 				include_hidden,
 				sort_by,
+				sort_direction: None,
 				folders_first: Some(false),
 			},
 		}
@@ -223,16 +228,26 @@ impl DirectoryListingQuery {
 			sql_query.push_str("e.kind DESC, ");
 		}
 
+		let direction = self
+			.input
+			.sort_direction
+			.clone()
+			.unwrap_or_else(|| Self::default_sort_direction(&self.input.sort_by));
+		let dir_sql = match direction {
+			SortDirection::Asc => "ASC",
+			SortDirection::Desc => "DESC",
+		};
+
 		match self.input.sort_by {
-			DirectorySortBy::Name => sql_query.push_str("e.name ASC"),
-			DirectorySortBy::Modified => sql_query.push_str("e.modified_at DESC"),
-			DirectorySortBy::Size => sql_query.push_str("e.size DESC"),
+			DirectorySortBy::Name => sql_query.push_str(&format!("e.name {dir_sql}")),
+			DirectorySortBy::Modified => sql_query.push_str(&format!("e.modified_at {dir_sql}")),
+			DirectorySortBy::Size => sql_query.push_str(&format!("e.size {dir_sql}")),
 			DirectorySortBy::Type => {
 				if !folders_first {
 					// Only add kind sorting if folders_first isn't already set
 					sql_query.push_str("e.kind DESC, ");
 				}
-				sql_query.push_str("e.name ASC");
+				sql_query.push_str(&format!("e.name {dir_sql}"));
 			}
 		}
 
@@ -802,11 +817,24 @@ impl DirectoryListingQuery {
 		})
 	}
 
+	fn default_sort_direction(sort_by: &DirectorySortBy) -> SortDirection {
+		match sort_by {
+			DirectorySortBy::Name | DirectorySortBy::Type => SortDirection::Asc,
+			DirectorySortBy::Modified | DirectorySortBy::Size => SortDirection::Desc,
+		}
+	}
+
 	/// Sort files according to the input options
 	fn sort_files(&self, files: &mut Vec<File>) {
 		use crate::domain::file::EntryKind;
+		use std::cmp::Ordering;
 
 		let folders_first = self.input.folders_first.unwrap_or(false);
+		let direction = self
+			.input
+			.sort_direction
+			.clone()
+			.unwrap_or_else(|| Self::default_sort_direction(&self.input.sort_by));
 
 		files.sort_by(|a, b| {
 			// Folders first if enabled
@@ -818,11 +846,11 @@ impl DirectoryListingQuery {
 				}
 			}
 
-			// Then apply sort order
-			match self.input.sort_by {
+			// Then apply sort field
+			let ordering = match self.input.sort_by {
 				DirectorySortBy::Name => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
-				DirectorySortBy::Modified => b.modified_at.cmp(&a.modified_at),
-				DirectorySortBy::Size => b.size.cmp(&a.size),
+				DirectorySortBy::Modified => a.modified_at.cmp(&b.modified_at),
+				DirectorySortBy::Size => a.size.cmp(&b.size),
 				DirectorySortBy::Type => {
 					// Sort by kind (directories first), then name
 					if !folders_first {
@@ -834,6 +862,11 @@ impl DirectoryListingQuery {
 					}
 					a.name.to_lowercase().cmp(&b.name.to_lowercase())
 				}
+			};
+
+			match direction {
+				SortDirection::Asc => ordering,
+				SortDirection::Desc => ordering.reverse(),
 			}
 		});
 	}

--- a/core/src/ops/files/query/directory_listing.rs
+++ b/core/src/ops/files/query/directory_listing.rs
@@ -238,8 +238,12 @@ impl DirectoryListingQuery {
 			SortDirection::Desc => "DESC",
 		};
 
+		// COLLATE NOCASE so name sorts match user expectation (A–Z, case-insensitive).
+		// SQLite's default binary collation puts uppercase before lowercase.
 		match self.input.sort_by {
-			DirectorySortBy::Name => sql_query.push_str(&format!("e.name {dir_sql}")),
+			DirectorySortBy::Name => {
+				sql_query.push_str(&format!("e.name COLLATE NOCASE {dir_sql}"))
+			}
 			DirectorySortBy::Modified => sql_query.push_str(&format!("e.modified_at {dir_sql}")),
 			DirectorySortBy::Size => sql_query.push_str(&format!("e.size {dir_sql}")),
 			DirectorySortBy::Type => {
@@ -247,7 +251,7 @@ impl DirectoryListingQuery {
 					// Only add kind sorting if folders_first isn't already set
 					sql_query.push_str("e.kind DESC, ");
 				}
-				sql_query.push_str(&format!("e.name {dir_sql}"));
+				sql_query.push_str(&format!("e.name COLLATE NOCASE {dir_sql}"));
 			}
 		}
 

--- a/core/src/service/network/protocol/file_delete.rs
+++ b/core/src/service/network/protocol/file_delete.rs
@@ -118,7 +118,7 @@ impl FileDeleteProtocolHandler {
 				.ok_or_else(|| anyhow::anyhow!("Path is not local"))?;
 
 			// Validate path is within allowed locations
-			if !self.is_path_allowed(local_path) {
+			if !self.is_path_allowed(local_path).await {
 				tracing::warn!(
 					path = %local_path.display(),
 					"Delete request rejected: path outside allowed locations"
@@ -164,15 +164,24 @@ impl FileDeleteProtocolHandler {
 
 	/// Check if a path is within allowed locations (registered Locations from all libraries).
 	/// Uses canonicalization to prevent traversal attacks.
-	fn is_path_allowed(&self, path: &std::path::Path) -> bool {
-		// Canonicalize the target path to resolve symlinks and `..`
-		let canonical_path = match path.canonicalize() {
-			Ok(p) => p,
-			Err(_) => return false, // Path doesn't exist - can't delete anyway
+	///
+	/// Async to avoid blocking the tokio runtime (stability fix).
+	async fn is_path_allowed(&self, path: &std::path::Path) -> bool {
+		// Canonicalize off the async worker to avoid blocking on slow FS or weird mounts.
+		let canonical_path = match tokio::task::spawn_blocking({
+			let p = path.to_path_buf();
+			move || p.canonicalize()
+		})
+		.await
+		.ok()
+		.and_then(|r| r.ok())
+		{
+			Some(p) => p,
+			None => return false, // Path doesn't exist or failed - can't safely delete
 		};
 
 		// Get allowed paths from all libraries via CoreContext
-		let allowed_paths = self.get_all_allowed_paths();
+		let allowed_paths = self.get_all_allowed_paths().await;
 
 		if allowed_paths.is_empty() {
 			tracing::warn!("No allowed paths configured for file delete - denying access");
@@ -181,7 +190,14 @@ impl FileDeleteProtocolHandler {
 
 		// Check if canonicalized path starts with any allowed path
 		for allowed in allowed_paths {
-			if let Ok(canonical_allowed) = allowed.canonicalize() {
+			if let Some(canonical_allowed) = tokio::task::spawn_blocking({
+				let a = allowed.clone();
+				move || a.canonicalize()
+			})
+			.await
+			.ok()
+			.and_then(|r| r.ok())
+			{
 				if canonical_path.starts_with(&canonical_allowed) {
 					return true;
 				}
@@ -192,27 +208,27 @@ impl FileDeleteProtocolHandler {
 	}
 
 	/// Get all allowed paths by combining static allowed_paths with dynamic locations.
-	fn get_all_allowed_paths(&self) -> Vec<std::path::PathBuf> {
+	///
+	/// Async version matching FileTransferProtocolHandler (stability: no block_on).
+	async fn get_all_allowed_paths(&self) -> Vec<std::path::PathBuf> {
 		let mut paths = Vec::new();
 
-		// Add statically configured allowed paths
-		{
+		// Add statically configured allowed paths (clone without holding lock across await)
+		let static_paths = {
 			let allowed = self.allowed_paths.read().unwrap();
-			paths.extend(allowed.clone());
-		}
+			allowed.clone()
+		};
+		paths.extend(static_paths);
 
 		// Add dynamic location paths from all libraries via CoreContext
 		if let Some(ctx) = &self.context {
-			let library_manager_guard = ctx.library_manager.blocking_read();
+			let library_manager_guard = ctx.library_manager.read().await;
 			if let Some(library_manager) = library_manager_guard.as_ref() {
-				let library_list: Vec<std::sync::Arc<crate::library::Library>> =
-					tokio::runtime::Handle::current().block_on(library_manager.list());
+				let library_list = library_manager.list().await;
 				for library in library_list {
 					let location_manager =
 						crate::location::LocationManager::new((*ctx.events).clone());
-					if let Ok(locations) = tokio::runtime::Handle::current()
-						.block_on(location_manager.list_locations(&library))
-					{
+					if let Ok(locations) = location_manager.list_locations(&library).await {
 						for loc in locations {
 							paths.push(loc.path.clone());
 						}
@@ -339,14 +355,14 @@ mod tests {
 	use super::*;
 	use std::path::PathBuf;
 
-	#[test]
-	fn test_is_path_allowed_rejects_paths_outside_allowed_locations() {
+	#[tokio::test]
+	async fn test_is_path_allowed_rejects_paths_outside_allowed_locations() {
 		let handler = FileDeleteProtocolHandler::new();
 
 		// Without context, no paths are allowed (fail-safe)
 		let outside_path = std::path::Path::new("/etc/passwd");
 		assert!(
-			!handler.is_path_allowed(outside_path),
+			!handler.is_path_allowed(outside_path).await,
 			"Paths outside allowed locations must be rejected"
 		);
 
@@ -354,36 +370,36 @@ mod tests {
 		{
 			let system_path = std::path::Path::new("C:\\Windows\\System32\\config\\SAM");
 			assert!(
-				!handler.is_path_allowed(system_path),
+				!handler.is_path_allowed(system_path).await,
 				"System paths must be rejected"
 			);
 		}
 	}
 
-	#[test]
-	fn test_is_path_allowed_denies_all_when_no_context() {
+	#[tokio::test]
+	async fn test_is_path_allowed_denies_all_when_no_context() {
 		let handler = FileDeleteProtocolHandler::new();
 
 		// Without context, all paths should be denied (fail-safe)
 		let any_path = std::env::temp_dir().join("some_file.txt");
 		assert!(
-			!handler.is_path_allowed(&any_path),
+			!handler.is_path_allowed(&any_path).await,
 			"When no context is configured, all access should be denied"
 		);
 	}
 
-	#[test]
-	fn test_get_all_allowed_paths_returns_empty_without_context() {
+	#[tokio::test]
+	async fn test_get_all_allowed_paths_returns_empty_without_context() {
 		let handler = FileDeleteProtocolHandler::new();
-		let paths = handler.get_all_allowed_paths();
+		let paths = handler.get_all_allowed_paths().await;
 		assert!(
 			paths.is_empty(),
 			"Without context, allowed paths should be empty"
 		);
 	}
 
-	#[test]
-	fn test_is_path_allowed_accepts_paths_inside_allowed_locations() {
+	#[tokio::test]
+	async fn test_is_path_allowed_accepts_paths_inside_allowed_locations() {
 		let handler = FileDeleteProtocolHandler::new();
 
 		// Create a temp directory as the allowed location
@@ -396,7 +412,7 @@ mod tests {
 
 		// Test: Path inside allowed location should be ACCEPTED
 		assert!(
-			handler.is_path_allowed(&inner_path),
+			handler.is_path_allowed(&inner_path).await,
 			"Paths inside allowed locations should be accepted"
 		);
 

--- a/core/src/service/network/protocol/file_transfer.rs
+++ b/core/src/service/network/protocol/file_transfer.rs
@@ -402,18 +402,31 @@ impl FileTransferProtocolHandler {
 	/// Check if a path is within one of the allowed paths.
 	/// Uses canonicalization to prevent traversal attacks.
 	async fn is_path_allowed(&self, path: &std::path::Path) -> bool {
-		// Canonicalize the target path to resolve symlinks and `..`
-		let canonical_path = match path.canonicalize() {
-			Ok(p) => p,
-			Err(_) => {
+		// Canonicalize off-runtime (stability). Fall back to parent on failure for writes.
+		let canonical_path = match tokio::task::spawn_blocking({
+			let p = path.to_path_buf();
+			move || p.canonicalize()
+		})
+		.await
+		.ok()
+		.and_then(|r| r.ok())
+		{
+			Some(p) => p,
+			None => {
 				// If the path doesn't exist yet (for writes), check the parent
 				if let Some(parent) = path.parent() {
-					match parent.canonicalize() {
-						Ok(p) => p,
-						Err(e) => {
+					match tokio::task::spawn_blocking({
+						let pp = parent.to_path_buf();
+						move || pp.canonicalize()
+					})
+					.await
+					.ok()
+					.and_then(|r| r.ok())
+					{
+						Some(p) => p,
+						None => {
 							tracing::warn!(
 								path = ?path,
-								error = %e,
 								"File transfer path validation failed: parent directory doesn't exist"
 							);
 							return false; // Parent doesn't exist
@@ -439,10 +452,17 @@ impl FileTransferProtocolHandler {
 		}
 
 		for allowed_root in allowed_paths.iter() {
-			// Canonicalize the allowed root for comparison
-			let canonical_root = match allowed_root.canonicalize() {
-				Ok(p) => p,
-				Err(_) => continue, // Skip non-existent allowed paths
+			// Canonicalize the allowed root for comparison (off runtime)
+			let canonical_root = match tokio::task::spawn_blocking({
+				let r = allowed_root.clone();
+				move || r.canonicalize()
+			})
+			.await
+			.ok()
+			.and_then(|r| r.ok())
+			{
+				Some(p) => p,
+				None => continue, // Skip non-existent allowed paths
 			};
 
 			// Check if the target path starts with the allowed root

--- a/core/src/volume/backend/local.rs
+++ b/core/src/volume/backend/local.rs
@@ -246,7 +246,8 @@ impl VolumeBackend for LocalBackend {
 
 	async fn exists(&self, path: &Path) -> Result<bool, VolumeError> {
 		let full_path = self.resolve_path(path);
-		Ok(full_path.exists())
+		// Async to prevent blocking runtime (stability)
+		Ok(tokio::fs::try_exists(&full_path).await.unwrap_or(false))
 	}
 
 	async fn delete(&self, path: &Path) -> Result<(), VolumeError> {

--- a/core/src/volume/manager.rs
+++ b/core/src/volume/manager.rs
@@ -948,8 +948,9 @@ impl VolumeManager {
 	/// Get volume information for a specific path
 	#[instrument(skip(self))]
 	pub async fn volume_for_path(&self, path: &Path) -> Option<Volume> {
-		// Canonicalize the path to handle relative paths properly
-		let canonical_path = match path.canonicalize() {
+		// Canonicalize the path to handle relative paths properly.
+		// Use async version to avoid blocking the runtime on slow filesystems.
+		let canonical_path = match tokio::fs::canonicalize(path).await {
 			Ok(p) => {
 				// On Windows, canonicalize() returns UNC extended paths (\\?\D:\)
 				// which breaks starts_with() matching against normal mount points (D:\).

--- a/core/tests/normalized_cache_fixtures_test.rs
+++ b/core/tests/normalized_cache_fixtures_test.rs
@@ -331,6 +331,7 @@ async fn capture_event_fixtures_for_typescript(
 		limit: None,
 		include_hidden: Some(false),
 		sort_by: DirectorySortBy::Name,
+		sort_direction: None,
 	};
 
 	let query = DirectoryListingQuery::from_input(query_input)?;

--- a/packages/interface/src/Settings/pages/AdvancedSettings.tsx
+++ b/packages/interface/src/Settings/pages/AdvancedSettings.tsx
@@ -33,8 +33,8 @@ export function AdvancedSettings() {
         </p>
       </div>
 
-      <div className="p-3 bg-amber-500/10 border border-amber-500/20 rounded-lg">
-        <p className="text-sm text-amber-400">
+      <div className="p-3 bg-status-warning/10 border border-status-warning/20 rounded-lg">
+        <p className="text-sm text-status-warning">
           These settings are for expert users. Incorrect configuration may affect performance.
         </p>
       </div>

--- a/packages/interface/src/Settings/pages/ServicesSettings.tsx
+++ b/packages/interface/src/Settings/pages/ServicesSettings.tsx
@@ -39,8 +39,8 @@ export function ServicesSettings() {
         </p>
       </div>
 
-      <div className="p-3 bg-amber-500/10 border border-amber-500/20 rounded-lg">
-        <p className="text-sm text-amber-400">
+      <div className="p-3 bg-status-warning/10 border border-status-warning/20 rounded-lg">
+        <p className="text-sm text-status-warning">
           Changes to service settings may require a daemon restart to take effect.
         </p>
       </div>

--- a/packages/interface/src/components/SpacesSidebar/AddGroupModal.tsx
+++ b/packages/interface/src/components/SpacesSidebar/AddGroupModal.tsx
@@ -1,5 +1,11 @@
 import { useState } from 'react';
-import { Input, Label, dialogManager, useDialog, Dialog } from '@spacedrive/primitives';
+import {
+	Input,
+	Label,
+	Dialog,
+	dialogManager,
+	useDialog,
+} from '@spacedrive/primitives';
 import { useLibraryMutation } from '@sd/ts-client';
 import { useForm } from 'react-hook-form';
 import type { GroupType } from '@sd/ts-client';
@@ -30,11 +36,18 @@ function AddGroupDialog(props: { id: number; spaceId: string }) {
 		});
 		form.reset();
 		setGroupType('Custom');
-		dialog.state.open = false;
+		dialogManager.setState(dialog.id, { open: false });
 	});
 
 	return (
-		<Dialog form={form} dialog={dialog} title="Add Group" onSubmit={onSubmit} ctaLabel="Create">
+		<Dialog
+			form={form}
+			dialog={dialog}
+			title="Add Group"
+			onSubmit={onSubmit}
+			ctaLabel="Create"
+			onCancelled={true}
+		>
 			<div className="space-y-4">
 				<div>
 					<Label>Group Type</Label>

--- a/packages/interface/src/components/SpacesSidebar/SpaceSettingsModal.tsx
+++ b/packages/interface/src/components/SpacesSidebar/SpaceSettingsModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import clsx from 'clsx';
+import type { Space } from '@sd/ts-client';
 import { Input, Label, dialogManager, useDialog, Dialog } from '@spacedrive/primitives';
 import { useLibraryMutation } from '@sd/ts-client';
 import { useForm } from 'react-hook-form';
@@ -9,32 +10,32 @@ interface FormData {
 	name: string;
 }
 
-export function useCreateSpaceDialog() {
-	return dialogManager.create((props) => <CreateSpaceDialog {...props} />);
+export function useSpaceSettingsDialog(space: Space) {
+	return dialogManager.create((props) => (
+		<SpaceSettingsDialog {...props} space={space} />
+	));
 }
 
-function CreateSpaceDialog(props: { id: number }) {
+function SpaceSettingsDialog(props: { id: number; space: Space }) {
 	const dialog = useDialog(props);
-	const [selectedColor, setSelectedColor] = useState(PRESET_COLORS[0]);
-	const [selectedIcon, setSelectedIcon] = useState(PRESET_ICONS[0]);
+	const [selectedColor, setSelectedColor] = useState(props.space.color);
+	const [selectedIcon, setSelectedIcon] = useState(props.space.icon);
 
 	const form = useForm<FormData>({
-		defaultValues: { name: '' },
+		defaultValues: { name: props.space.name },
 	});
 
-	const createSpace = useLibraryMutation('spaces.create');
+	const updateSpace = useLibraryMutation('spaces.update');
 
 	const onSubmit = form.handleSubmit(async (data) => {
 		if (!data.name?.trim()) return;
 
-		await createSpace.mutateAsync({
-			name: data.name,
+		await updateSpace.mutateAsync({
+			space_id: props.space.id,
+			name: data.name.trim(),
 			icon: selectedIcon,
 			color: selectedColor,
 		});
-		form.reset();
-		setSelectedColor(PRESET_COLORS[0]);
-		setSelectedIcon(PRESET_ICONS[0]);
 		dialog.state.open = false;
 	});
 
@@ -42,16 +43,16 @@ function CreateSpaceDialog(props: { id: number }) {
 		<Dialog
 			form={form}
 			dialog={dialog}
-			title="Create Space"
+			title="Space Settings"
 			onSubmit={onSubmit}
-			ctaLabel="Create"
+			ctaLabel="Save"
 		>
 			<div className="space-y-4">
 				<div>
 					<Label>Space Name</Label>
 					<Input
 						{...form.register('name', { required: true })}
-						placeholder="e.g., Work Files, Personal Photos"
+						placeholder="e.g., All Devices, Work Files"
 						autoFocus
 					/>
 				</div>
@@ -68,7 +69,7 @@ function CreateSpaceDialog(props: { id: number }) {
 									'h-8 w-8 rounded-full border-2 transition-all',
 									selectedColor === color
 										? 'scale-110 border-white'
-										: 'border-transparent'
+										: 'border-transparent',
 								)}
 								style={{ backgroundColor: color }}
 							/>
@@ -88,7 +89,7 @@ function CreateSpaceDialog(props: { id: number }) {
 									'rounded-lg px-3 py-2 text-sm font-medium transition-colors',
 									selectedIcon === icon
 										? 'bg-sidebar-selected text-sidebar-ink'
-										: 'bg-app-input text-sidebar-ink-dull hover:bg-app-hover'
+										: 'bg-app-input text-sidebar-ink-dull hover:bg-app-hover',
 								)}
 							>
 								{icon}

--- a/packages/interface/src/components/SpacesSidebar/SpaceSwitcher.tsx
+++ b/packages/interface/src/components/SpacesSidebar/SpaceSwitcher.tsx
@@ -2,7 +2,9 @@ import {GearSix, Plus} from '@phosphor-icons/react';
 import type {Space} from '@sd/ts-client';
 import {DropdownMenu, SelectPill} from '@spacedrive/primitives';
 import clsx from 'clsx';
+import {useState} from 'react';
 import {useCreateSpaceDialog} from './CreateSpaceModal';
+import {useSpaceSettingsDialog} from './SpaceSettingsModal';
 
 interface SpaceSwitcherProps {
 	spaces: Space[] | undefined;
@@ -15,10 +17,18 @@ export function SpaceSwitcher({
 	currentSpace,
 	onSwitch
 }: SpaceSwitcherProps) {
-	const createSpaceDialog = useCreateSpaceDialog;
+	const [menuOpen, setMenuOpen] = useState(false);
+
+	const openDialogAfterMenuCloses = (openDialog: () => void) => {
+		setMenuOpen(false);
+		// Let the dropdown fully unmount before opening a modal overlay.
+		requestAnimationFrame(() => {
+			openDialog();
+		});
+	};
 
 	return (
-		<DropdownMenu.Root>
+		<DropdownMenu.Root open={menuOpen} onOpenChange={setMenuOpen}>
 			<DropdownMenu.Trigger asChild>
 				<SelectPill variant="sidebar" size="lg" className="shrink-0">
 					<div
@@ -30,12 +40,18 @@ export function SpaceSwitcher({
 					</span>
 				</SelectPill>
 			</DropdownMenu.Trigger>
-			<DropdownMenu.Content className="min-w-[var(--radix-dropdown-menu-trigger-width)] p-1">
+			<DropdownMenu.Content
+				sideOffset={4}
+				className="border-sidebar-line !bg-sidebar-box !backdrop-blur-none z-[70] min-w-[var(--radix-dropdown-menu-trigger-width)] p-1 shadow-xl"
+			>
 				{spaces && spaces.length > 1
 					? spaces.map((space) => (
 							<DropdownMenu.Item
 								key={space.id}
-								onClick={() => onSwitch(space.id)}
+								onSelect={(event) => {
+									event.preventDefault();
+									onSwitch(space.id);
+								}}
 								className={clsx(
 									'rounded-md px-2 py-1 text-sm',
 									space.id === currentSpace?.id
@@ -57,13 +73,26 @@ export function SpaceSwitcher({
 					<DropdownMenu.Separator className="border-sidebar-line my-1" />
 				)}
 				<DropdownMenu.Item
-					onClick={() => createSpaceDialog()}
+					onSelect={(event) => {
+						event.preventDefault();
+						openDialogAfterMenuCloses(useCreateSpaceDialog);
+					}}
 					className="hover:bg-sidebar-selected text-sidebar-ink rounded-md px-2 py-1 text-sm font-medium"
 				>
 					<Plus className="mr-2 size-4" weight="bold" />
 					New Space
 				</DropdownMenu.Item>
-				<DropdownMenu.Item className="hover:bg-sidebar-selected text-sidebar-ink rounded-md px-2 py-1 text-sm font-medium">
+				<DropdownMenu.Item
+					disabled={!currentSpace}
+					onSelect={(event) => {
+						event.preventDefault();
+						if (!currentSpace) return;
+						openDialogAfterMenuCloses(() =>
+							useSpaceSettingsDialog(currentSpace),
+						);
+					}}
+					className="hover:bg-sidebar-selected text-sidebar-ink rounded-md px-2 py-1 text-sm font-medium"
+				>
 					<GearSix className="mr-2 size-4" weight="bold" />
 					Space Settings
 				</DropdownMenu.Item>

--- a/packages/interface/src/components/SpacesSidebar/spacePresets.ts
+++ b/packages/interface/src/components/SpacesSidebar/spacePresets.ts
@@ -1,0 +1,21 @@
+export const PRESET_COLORS = [
+	'#3B82F6',
+	'#8B5CF6',
+	'#EC4899',
+	'#10B981',
+	'#F59E0B',
+	'#EF4444',
+	'#06B6D4',
+	'#6366F1',
+];
+
+export const PRESET_ICONS = [
+	'Planet',
+	'Folder',
+	'Briefcase',
+	'House',
+	'Camera',
+	'MusicNotes',
+	'GameController',
+	'Code',
+];

--- a/packages/interface/src/components/TabManager/TabManagerContext.tsx
+++ b/packages/interface/src/components/TabManager/TabManagerContext.tsx
@@ -84,10 +84,13 @@ export interface Tab {
  * All explorer-related state for a single tab.
  * This is the single source of truth - no sync effects needed.
  */
+export type SortOrder = "asc" | "desc";
+
 export interface TabExplorerState {
 	// View settings
 	viewMode: ViewMode;
 	sortBy: SortBy;
+	sortOrder: SortOrder;
 	gridSize: number;
 	gapSize: number;
 	foldersFirst: boolean;
@@ -107,6 +110,7 @@ export interface TabExplorerState {
 const DEFAULT_EXPLORER_STATE: TabExplorerState = {
 	viewMode: "grid",
 	sortBy: "name",
+	sortOrder: "asc",
 	gridSize: 120,
 	gapSize: 16,
 	foldersFirst: true,

--- a/packages/interface/src/components/TabManager/TabManagerContext.tsx
+++ b/packages/interface/src/components/TabManager/TabManagerContext.tsx
@@ -163,6 +163,40 @@ function savePersistedState(state: PersistedState): void {
 	}
 }
 
+/**
+ * Collapse duplicate tabs from older builds that opened the adapters picker
+ * as a separate tab instead of navigating within Sources.
+ */
+function normalizeTabs(tabs: Tab[]): Tab[] {
+	const bestByPath = new Map<string, Tab>();
+	for (const tab of tabs) {
+		const existing = bestByPath.get(tab.savedPath);
+		if (!existing || tab.lastActive > existing.lastActive) {
+			bestByPath.set(tab.savedPath, tab);
+		}
+	}
+
+	let kept = tabs.filter(
+		(tab) => bestByPath.get(tab.savedPath)?.id === tab.id,
+	);
+
+	const sourcesTab = kept.find((tab) => tab.savedPath === "/sources");
+	const adaptersTab = kept.find((tab) => tab.savedPath === "/sources/adapters");
+	if (sourcesTab && adaptersTab) {
+		const dropId =
+			sourcesTab.lastActive >= adaptersTab.lastActive
+				? adaptersTab.id
+				: sourcesTab.id;
+		kept = kept.filter((tab) => tab.id !== dropId);
+	}
+
+	return kept.map((tab) =>
+		tab.savedPath === "/sources/adapters"
+			? { ...tab, title: "Sources" }
+			: tab,
+	);
+}
+
 // ============================================================================
 // Context
 // ============================================================================
@@ -216,7 +250,10 @@ export function TabManagerProvider({
 	const [tabs, setTabs] = useState<Tab[]>(() => {
 		const persisted = loadPersistedState();
 		if (persisted && persisted.tabs.length > 0) {
-			return persisted.tabs;
+			const normalized = normalizeTabs(persisted.tabs);
+			if (normalized.length > 0) {
+				return normalized;
+			}
 		}
 
 		const initialTabId = crypto.randomUUID();
@@ -235,11 +272,12 @@ export function TabManagerProvider({
 	const [activeTabId, setActiveTabId] = useState<string>(() => {
 		const persisted = loadPersistedState();
 		if (persisted && persisted.activeTabId) {
-			// Verify the activeTabId exists in tabs
-			const tabExists = persisted.tabs.some(
+			const normalized = normalizeTabs(persisted.tabs);
+			const tabExists = normalized.some(
 				(t) => t.id === persisted.activeTabId,
 			);
 			if (tabExists) return persisted.activeTabId;
+			if (normalized[0]) return normalized[0].id;
 		}
 		return tabs[0].id;
 	});
@@ -307,30 +345,41 @@ export function TabManagerProvider({
 	const createTab = useCallback(
 		(title?: string, path?: string) => {
 			const tabPath = path ?? defaultNewTabPath;
-			const [pathname, search = ""] = tabPath.split("?");
-			const derivedTitle =
-				title ||
-				deriveTitleFromPath(pathname, search ? `?${search}` : "");
 
-			const newTab: Tab = {
-				id: crypto.randomUUID(),
-				title: derivedTitle,
-				icon: null,
-				isPinned: false,
-				lastActive: Date.now(),
-				savedPath: tabPath,
-			};
+			setTabs((prev) => {
+				const existing = prev.find((tab) => tab.savedPath === tabPath);
+				if (existing) {
+					setActiveTabId(existing.id);
+					return prev;
+				}
 
-			// Initialize explorer state for the new tab
-			setExplorerStates((prev) =>
-				new Map(prev).set(newTab.id, { ...DEFAULT_EXPLORER_STATE }),
-			);
+				const [pathname, search = ""] = tabPath.split("?");
+				const derivedTitle =
+					title ||
+					deriveTitleFromPath(pathname, search ? `?${search}` : "");
 
-			// Initialize empty selection state for the new tab
-			setSelectionStates((prev) => new Map(prev).set(newTab.id, []));
+				const newTab: Tab = {
+					id: crypto.randomUUID(),
+					title: derivedTitle,
+					icon: null,
+					isPinned: false,
+					lastActive: Date.now(),
+					savedPath: tabPath,
+				};
 
-			setTabs((prev) => [...prev, newTab]);
-			setActiveTabId(newTab.id);
+				setExplorerStates((explorerPrev) =>
+					new Map(explorerPrev).set(newTab.id, {
+						...DEFAULT_EXPLORER_STATE,
+					}),
+				);
+
+				setSelectionStates((selectionPrev) =>
+					new Map(selectionPrev).set(newTab.id, []),
+				);
+
+				setActiveTabId(newTab.id);
+				return [...prev, newTab];
+			});
 		},
 		[defaultNewTabPath],
 	);

--- a/packages/interface/src/components/TabManager/TabManagerContext.tsx
+++ b/packages/interface/src/components/TabManager/TabManagerContext.tsx
@@ -184,6 +184,7 @@ interface TabManagerContextValue {
 	setDefaultNewTabPath: (path: string) => void;
 
 	// Explorer state (per-tab)
+	explorerStateVersion: number;
 	getExplorerState: (tabId: string) => TabExplorerState;
 	updateExplorerState: (
 		tabId: string,
@@ -248,13 +249,20 @@ export function TabManagerProvider({
 	>(() => {
 		const persisted = loadPersistedState();
 		if (persisted && persisted.explorerStates) {
-			return new Map(Object.entries(persisted.explorerStates));
+			return new Map(
+				Object.entries(persisted.explorerStates).map(([tabId, state]) => [
+					tabId,
+					{ ...DEFAULT_EXPLORER_STATE, ...state },
+				]),
+			);
 		}
 
 		const initialMap = new Map<string, TabExplorerState>();
 		initialMap.set(tabs[0].id, { ...DEFAULT_EXPLORER_STATE });
 		return initialMap;
 	});
+
+	const [explorerStateVersion, setExplorerStateVersion] = useState(0);
 
 	// Per-tab selection state (ephemeral, not persisted to localStorage)
 	const [selectionStates, setSelectionStates] = useState<
@@ -455,6 +463,7 @@ export function TabManagerProvider({
 				};
 				return new Map(prev).set(tabId, { ...current, ...updates });
 			});
+			setExplorerStateVersion((version) => version + 1);
 		},
 		[],
 	);
@@ -493,6 +502,7 @@ export function TabManagerProvider({
 			previousTab,
 			selectTabAtIndex,
 			setDefaultNewTabPath,
+			explorerStateVersion,
 			getExplorerState,
 			updateExplorerState,
 			getSelectionIds,
@@ -512,6 +522,7 @@ export function TabManagerProvider({
 			previousTab,
 			selectTabAtIndex,
 			setDefaultNewTabPath,
+			explorerStateVersion,
 			getExplorerState,
 			updateExplorerState,
 			getSelectionIds,

--- a/packages/interface/src/components/TabManager/TabNavigationSync.tsx
+++ b/packages/interface/src/components/TabManager/TabNavigationSync.tsx
@@ -13,11 +13,15 @@ function deriveTitleFromPath(pathname: string, search: string): string | null {
 		"/recents": "Recents",
 		"/file-kinds": "File Kinds",
 		"/sources": "Sources",
-		"/sources/adapters": "Adapters",
 		"/search": "Search",
 		"/jobs": "Jobs",
 		"/daemon": "Daemon",
 	};
+
+	// Adapters picker is a sub-page of Sources, not a separate tab.
+	if (pathname === "/sources/adapters") {
+		return "Sources";
+	}
 
 	// Check static routes first
 	if (routeTitles[pathname]) {

--- a/packages/interface/src/routes/explorer/ExplorerView.tsx
+++ b/packages/interface/src/routes/explorer/ExplorerView.tsx
@@ -39,7 +39,7 @@ export function ExplorerView() {
 		viewMode,
 		setViewMode,
 		sortBy,
-		setSortBy,
+		handleSortChange,
 		viewSettings,
 		setViewSettings,
 		goBack,
@@ -141,11 +141,11 @@ export function ExplorerView() {
 		() => (
 			<SortMenuPanel
 				sortBy={sortBy}
-				onSortChange={setSortBy}
+				onSortChange={handleSortChange}
 				viewMode={viewMode as any}
 			/>
 		),
-		[sortBy, setSortBy, viewMode]
+		[sortBy, handleSortChange, viewMode]
 	);
 
 	// Allow rendering if we have a currentPath, a virtual view, or a special mode
@@ -282,7 +282,7 @@ export function ExplorerView() {
 							>
 								<SortMenu
 									sortBy={sortBy}
-									onSortChange={setSortBy}
+									onSortChange={handleSortChange}
 									viewMode={viewMode as any}
 								/>
 							</TopBarItem>

--- a/packages/interface/src/routes/explorer/ExplorerView.tsx
+++ b/packages/interface/src/routes/explorer/ExplorerView.tsx
@@ -2,6 +2,7 @@ import {
 	ArrowLeft,
 	ArrowRight,
 	Info,
+	Plus,
 	SidebarSimple,
 	Tag as TagIcon
 } from '@phosphor-icons/react';
@@ -9,6 +10,7 @@ import {CircleButton, CircleButtonGroup} from '@spacedrive/primitives';
 import clsx from 'clsx';
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import {TopBarItem, TopBarPortal} from '../../TopBar';
+import {useAddStorageDialog} from './components/AddStorageModal';
 import {ExpandableSearchButton} from './components/ExpandableSearchButton';
 import {PathBar} from './components/PathBar';
 import {VirtualPathBar} from './components/VirtualPathBar';
@@ -92,6 +94,12 @@ export function ExplorerView() {
 		setSearchValue('');
 		exitSearchMode();
 	}, [exitSearchMode]);
+
+	const handleAddStorage = useCallback(() => {
+		useAddStorageDialog((sdPath) => {
+			navigateToPath(sdPath);
+		});
+	}, [navigateToPath]);
 
 	useEffect(() => {
 		if (mode.type !== 'search') {
@@ -287,6 +295,19 @@ export function ExplorerView() {
 									sortOrder={sortOrder}
 									onSortChange={handleSortChange}
 									viewMode={viewMode as any}
+								/>
+							</TopBarItem>
+							<TopBarItem
+								id="add-storage"
+								label="Add Storage"
+								priority="high"
+								onClick={handleAddStorage}
+							>
+								<CircleButton
+									icon={Plus}
+									className="!bg-accent hover:!bg-accent-deep !text-white"
+									onClick={handleAddStorage}
+									title="Add Storage"
 								/>
 							</TopBarItem>
 							<TopBarItem

--- a/packages/interface/src/routes/explorer/ExplorerView.tsx
+++ b/packages/interface/src/routes/explorer/ExplorerView.tsx
@@ -39,6 +39,7 @@ export function ExplorerView() {
 		viewMode,
 		setViewMode,
 		sortBy,
+		sortOrder,
 		handleSortChange,
 		viewSettings,
 		setViewSettings,
@@ -141,11 +142,12 @@ export function ExplorerView() {
 		() => (
 			<SortMenuPanel
 				sortBy={sortBy}
+				sortOrder={sortOrder}
 				onSortChange={handleSortChange}
 				viewMode={viewMode as any}
 			/>
 		),
-		[sortBy, handleSortChange, viewMode]
+		[sortBy, sortOrder, handleSortChange, viewMode]
 	);
 
 	// Allow rendering if we have a currentPath, a virtual view, or a special mode
@@ -282,6 +284,7 @@ export function ExplorerView() {
 							>
 								<SortMenu
 									sortBy={sortBy}
+									sortOrder={sortOrder}
 									onSortChange={handleSortChange}
 									viewMode={viewMode as any}
 								/>

--- a/packages/interface/src/routes/explorer/SortMenu.tsx
+++ b/packages/interface/src/routes/explorer/SortMenu.tsx
@@ -13,14 +13,16 @@ import { motion, AnimatePresence } from "framer-motion";
 import clsx from "clsx";
 import { CircleButton } from "@spacedrive/primitives";
 import type { DirectorySortBy, MediaSortBy } from "@sd/ts-client";
+import { sortDirectionLabel, type SortOrder } from "./sortUtils";
 
 interface SortMenuPanelProps {
   sortBy: DirectorySortBy | MediaSortBy;
+  sortOrder: SortOrder;
   onSortChange: (sort: DirectorySortBy | MediaSortBy) => void;
   viewMode: "grid" | "list" | "media" | "column";
 }
 
-export function SortMenuPanel({ sortBy, onSortChange, viewMode }: SortMenuPanelProps) {
+export function SortMenuPanel({ sortBy, sortOrder, onSortChange, viewMode }: SortMenuPanelProps) {
   const sortOptions = viewMode === "media"
     ? [
         { value: "datetaken", label: "Date Taken", icon: Camera },
@@ -60,6 +62,11 @@ export function SortMenuPanel({ sortBy, onSortChange, viewMode }: SortMenuPanelP
             >
               <Icon className="size-4" weight="bold" />
               <span className="flex-1 text-left">{option.label}</span>
+              {isActive && (
+                <span className="text-xs text-ink-dull">
+                  {sortDirectionLabel(option.value as DirectorySortBy | MediaSortBy, sortOrder)}
+                </span>
+              )}
               {isActive && <Check className="size-4" weight="bold" />}
             </button>
           );
@@ -71,12 +78,13 @@ export function SortMenuPanel({ sortBy, onSortChange, viewMode }: SortMenuPanelP
 
 interface SortMenuProps {
   sortBy: DirectorySortBy | MediaSortBy;
+  sortOrder: SortOrder;
   onSortChange: (sort: DirectorySortBy | MediaSortBy) => void;
   viewMode: "grid" | "list" | "media" | "column";
   className?: string;
 }
 
-export function SortMenu({ sortBy, onSortChange, viewMode, className }: SortMenuProps) {
+export function SortMenu({ sortBy, sortOrder, onSortChange, viewMode, className }: SortMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -142,6 +150,7 @@ export function SortMenu({ sortBy, onSortChange, viewMode, className }: SortMenu
             >
               <SortMenuPanel
                 sortBy={sortBy}
+                sortOrder={sortOrder}
                 onSortChange={onSortChange}
                 viewMode={viewMode}
               />

--- a/packages/interface/src/routes/explorer/context.tsx
+++ b/packages/interface/src/routes/explorer/context.tsx
@@ -5,6 +5,7 @@ import {
 	useMemo,
 	useEffect,
 	useCallback,
+	useRef,
 	type ReactNode,
 } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
@@ -738,11 +739,26 @@ export function ExplorerProvider({
 	);
 
 	// "datetaken" only applies to media view; fall back to "modified" elsewhere.
+	// Guard with ref to avoid repeated setSortBy calls during identity churn or rapid view switches,
+	// which could trigger extra queries and re-renders (stability).
+	const didAdjustMediaSortRef = useRef(false);
 	useEffect(() => {
-		if (viewMode === "media" && sortByValue === "type") {
-			setSortBy("datetaken");
-		} else if (viewMode !== "media" && sortByValue === "datetaken") {
-			setSortBy("modified");
+		const shouldBeDatetaken = viewMode === "media" && sortByValue === "type";
+		const shouldBeModified = viewMode !== "media" && sortByValue === "datetaken";
+
+		if (shouldBeDatetaken) {
+			if (!didAdjustMediaSortRef.current) {
+				didAdjustMediaSortRef.current = true;
+				setSortBy("datetaken");
+			}
+		} else if (shouldBeModified) {
+			if (!didAdjustMediaSortRef.current) {
+				didAdjustMediaSortRef.current = true;
+				setSortBy("modified");
+			}
+		} else {
+			// Reset guard when neither correction is needed (e.g. user chose a sort)
+			didAdjustMediaSortRef.current = false;
 		}
 	}, [viewMode, sortByValue, setSortBy]);
 

--- a/packages/interface/src/routes/explorer/context.tsx
+++ b/packages/interface/src/routes/explorer/context.tsx
@@ -486,14 +486,12 @@ export function ExplorerProvider({
 	const sortPrefs = useSortPreferencesStore();
 
 	// Get per-tab state from TabManager
-	const { activeTabId, getExplorerState, updateExplorerState } =
+	const { activeTabId, getExplorerState, updateExplorerState, explorerStateVersion } =
 		useTabManager();
 
-	// Memoize tabState to ensure it updates when activeTabId or explorerStates change
-	const tabState = useMemo(
-		() => getExplorerState(activeTabId),
-		[activeTabId, getExplorerState],
-	);
+	// Read fresh tab state each render; explorerStateVersion forces updates after writes.
+	void explorerStateVersion;
+	const tabState = getExplorerState(activeTabId);
 
 	const [navState, navDispatch] = useReducer(
 		navigationReducer,
@@ -604,23 +602,12 @@ export function ExplorerProvider({
 	useEffect(() => {
 		const savedSort = sortPrefs.getPreferences(pathKey);
 		if (savedSort) {
-			uiDispatch({ type: "SET_SORT_BY", sort: savedSort as SortBy });
+			updateExplorerState(activeTabId, {
+				sortBy: savedSort as TabSortBy,
+				sortOrder: defaultSortOrder(savedSort as SortBy),
+			});
 		}
-	}, [pathKey, sortPrefs]);
-
-	// "datetaken" only applies to media view; fall back to "modified" elsewhere.
-	useEffect(() => {
-		if (uiState.viewMode === "media" && uiState.sortBy === "type") {
-			uiDispatch({ type: "SET_SORT_BY", sort: "datetaken" });
-			sortPrefs.setPreferences(pathKey, "datetaken");
-		} else if (
-			uiState.viewMode !== "media" &&
-			uiState.sortBy === "datetaken"
-		) {
-			uiDispatch({ type: "SET_SORT_BY", sort: "modified" });
-			sortPrefs.setPreferences(pathKey, "modified");
-		}
-	}, [uiState.viewMode, uiState.sortBy, pathKey, sortPrefs]);
+	}, [pathKey, sortPrefs, activeTabId, updateExplorerState]);
 
 	const navigateToPath = useCallback(
 		(path: SdPath) => {
@@ -749,6 +736,15 @@ export function ExplorerProvider({
 		},
 		[handleSortChange],
 	);
+
+	// "datetaken" only applies to media view; fall back to "modified" elsewhere.
+	useEffect(() => {
+		if (viewMode === "media" && sortByValue === "type") {
+			setSortBy("datetaken");
+		} else if (viewMode !== "media" && sortByValue === "datetaken") {
+			setSortBy("modified");
+		}
+	}, [viewMode, sortByValue, setSortBy]);
 
 	const setViewSettings = useCallback(
 		(settings: Partial<ViewSettings>) => {

--- a/packages/interface/src/routes/explorer/context.tsx
+++ b/packages/interface/src/routes/explorer/context.tsx
@@ -28,8 +28,10 @@ import {
 	useViewPreferencesStore,
 	useSortPreferencesStore,
 } from "@sd/ts-client";
+import { defaultSortOrder, type SortOrder } from "./sortUtils";
 
 export type SortBy = DirectorySortBy | MediaSortBy;
+export type { SortOrder };
 export type ViewMode =
 	| "grid"
 	| "list"
@@ -412,6 +414,10 @@ interface ExplorerContextValue {
 	setViewMode: (mode: ViewMode) => void;
 	sortBy: SortBy;
 	setSortBy: (sort: SortBy) => void;
+	sortOrder: SortOrder;
+	setSortOrder: (order: SortOrder) => void;
+	handleSortChange: (sort: SortBy) => void;
+	toggleColumnSort: (columnId: string) => void;
 	viewSettings: ViewSettings;
 	setViewSettings: (settings: Partial<ViewSettings>) => void;
 
@@ -669,6 +675,7 @@ export function ExplorerProvider({
 	// View settings from TabManager (per-tab)
 	const viewMode = tabState.viewMode as ViewMode;
 	const sortByValue = tabState.sortBy as SortBy;
+	const sortOrderValue = tabState.sortOrder ?? defaultSortOrder(sortByValue);
 	const viewSettings: ViewSettings = useMemo(
 		() => ({
 			gridSize: tabState.gridSize,
@@ -703,10 +710,44 @@ export function ExplorerProvider({
 		(sort: SortBy) => {
 			updateExplorerState(activeTabId, {
 				sortBy: sort as TabSortBy,
+				sortOrder: defaultSortOrder(sort),
 			});
 			sortPrefs.setPreferences(pathKey, sort);
 		},
 		[activeTabId, updateExplorerState, pathKey, sortPrefs],
+	);
+
+	const setSortOrder = useCallback(
+		(order: SortOrder) => {
+			updateExplorerState(activeTabId, { sortOrder: order });
+		},
+		[activeTabId, updateExplorerState],
+	);
+
+	const handleSortChange = useCallback(
+		(sort: SortBy) => {
+			if (sortByValue === sort) {
+				setSortOrder(sortOrderValue === "asc" ? "desc" : "asc");
+				return;
+			}
+			setSortBy(sort);
+		},
+		[sortByValue, sortOrderValue, setSortBy, setSortOrder],
+	);
+
+	const toggleColumnSort = useCallback(
+		(columnId: string) => {
+			const sortMap: Record<string, SortBy> = {
+				name: "name",
+				size: "size",
+				modified: "modified",
+				type: "type",
+			};
+			const newSort = sortMap[columnId];
+			if (!newSort) return;
+			handleSortChange(newSort);
+		},
+		[handleSortChange],
 	);
 
 	const setViewSettings = useCallback(
@@ -832,6 +873,10 @@ export function ExplorerProvider({
 			setViewMode,
 			sortBy: sortByValue,
 			setSortBy,
+			sortOrder: sortOrderValue,
+			setSortOrder,
+			handleSortChange,
+			toggleColumnSort,
 			viewSettings,
 			setViewSettings,
 			columnStack,
@@ -880,6 +925,10 @@ export function ExplorerProvider({
 			setViewMode,
 			sortByValue,
 			setSortBy,
+			sortOrderValue,
+			setSortOrder,
+			handleSortChange,
+			toggleColumnSort,
 			viewSettings,
 			setViewSettings,
 			columnStack,

--- a/packages/interface/src/routes/explorer/hooks/useExplorerFiles.ts
+++ b/packages/interface/src/routes/explorer/hooks/useExplorerFiles.ts
@@ -263,8 +263,7 @@ export function useExplorerFiles(): ExplorerFilesResult {
 		} else if (isSearchMode) {
 			result = (searchQuery.data as FileSearchOutput | undefined)?.files || [];
 		} else if (isVirtualView) {
-			// Virtual listings (devices/volumes) are not server-sorted in the same way;
-			// apply client-side sort (also used as fallback for older daemons).
+			// Virtual listings (devices/volumes) are not server-sorted in the same way.
 			result = sortFiles(
 				virtualFiles || [],
 				sortBy,
@@ -272,11 +271,17 @@ export function useExplorerFiles(): ExplorerFilesResult {
 				viewSettings.foldersFirst,
 			);
 		} else {
-			// Directory listings come pre-sorted from the backend (SQL ORDER BY + folders_first).
-			// Trust the server result for correctness and performance (avoids double-sort
-			// of potentially large arrays on every update, which can cause UI jank/hangs).
-			result =
-				(directoryQuery.data as { files: File[] } | undefined)?.files ?? [];
+			// Always sort client-side for directory listings. The backend may return
+			// SQL-ordered rows, but ResourceChanged / ephemeral index events append
+			// into the normalized cache in discovery order and destroy that order.
+			// Results are capped (10k), so this is cheap relative to broken A–Z UX.
+			result = sortFiles(
+				(directoryQuery.data as { files: File[] } | undefined)?.files ??
+					[],
+				sortBy,
+				sortOrder,
+				viewSettings.foldersFirst,
+			);
 		}
 		return result;
 	}, [

--- a/packages/interface/src/routes/explorer/hooks/useExplorerFiles.ts
+++ b/packages/interface/src/routes/explorer/hooks/useExplorerFiles.ts
@@ -260,7 +260,12 @@ export function useExplorerFiles(): ExplorerFilesResult {
 		} else if (isSearchMode) {
 			result = (searchQuery.data as FileSearchOutput | undefined)?.files || [];
 		} else if (isVirtualView) {
-			result = virtualFiles || [];
+			result = sortFiles(
+				virtualFiles || [],
+				sortBy,
+				sortOrder,
+				viewSettings.foldersFirst,
+			);
 		} else {
 			result =
 				(directoryQuery.data as { files: File[] } | undefined)?.files ?? [];

--- a/packages/interface/src/routes/explorer/hooks/useExplorerFiles.ts
+++ b/packages/interface/src/routes/explorer/hooks/useExplorerFiles.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import type { DirectorySortBy, File, FileSearchInput, FileSearchOutput } from "@sd/ts-client";
 import { useNormalizedQuery } from "../../../contexts/SpacedriveContext";
 import { useExplorer } from "../context";
+import { sortFiles, toSortDirection } from "../sortUtils";
 import { useVirtualListing } from "./useVirtualListing";
 
 export type FileSource =
@@ -31,7 +32,7 @@ export interface ExplorerFilesResult {
  */
 export function useExplorerFiles(): ExplorerFilesResult {
 	const explorer = useExplorer();
-	const { mode, currentPath, sortBy, viewSettings } = explorer;
+	const { mode, currentPath, sortBy, sortOrder, viewSettings } = explorer;
 
 	// Check for virtual listing first
 	const { files: virtualFiles, isVirtualView } = useVirtualListing();
@@ -218,6 +219,7 @@ export function useExplorerFiles(): ExplorerFilesResult {
 					limit: null,
 					include_hidden: false,
 					sort_by: sortBy as DirectorySortBy,
+					sort_direction: toSortDirection(sortOrder),
 					folders_first: viewSettings.foldersFirst,
 				}
 			: null!,
@@ -246,24 +248,30 @@ export function useExplorerFiles(): ExplorerFilesResult {
 						: "directory";
 
 	const files = useMemo(() => {
+		let result: File[] = [];
 		if (isFilteredMode) {
-			return (
-				(filteredQuery.data as FileSearchOutput | undefined)?.files || []
+			result =
+				(filteredQuery.data as FileSearchOutput | undefined)?.files || [];
+		} else if (isTagMode) {
+			result = (tagQuery.data as { files: File[] } | undefined)?.files ?? [];
+		} else if (isRecentsMode) {
+			result =
+				(recentsQuery.data as FileSearchOutput | undefined)?.files || [];
+		} else if (isSearchMode) {
+			result = (searchQuery.data as FileSearchOutput | undefined)?.files || [];
+		} else if (isVirtualView) {
+			result = virtualFiles || [];
+		} else {
+			result =
+				(directoryQuery.data as { files: File[] } | undefined)?.files ?? [];
+			result = sortFiles(
+				result,
+				sortBy,
+				sortOrder,
+				viewSettings.foldersFirst,
 			);
 		}
-		if (isTagMode) {
-			return (tagQuery.data as { files: File[] } | undefined)?.files ?? [];
-		}
-		if (isRecentsMode) {
-			return (recentsQuery.data as FileSearchOutput | undefined)?.files || [];
-		}
-		if (isSearchMode) {
-			return (searchQuery.data as FileSearchOutput | undefined)?.files || [];
-		}
-		if (isVirtualView) {
-			return virtualFiles || [];
-		}
-		return (directoryQuery.data as { files: File[] } | undefined)?.files ?? [];
+		return result;
 	}, [
 		isFilteredMode,
 		isTagMode,
@@ -276,6 +284,9 @@ export function useExplorerFiles(): ExplorerFilesResult {
 		searchQuery.data,
 		virtualFiles,
 		directoryQuery.data,
+		sortBy,
+		sortOrder,
+		viewSettings.foldersFirst,
 	]);
 
 	const isLoading = isFilteredMode

--- a/packages/interface/src/routes/explorer/hooks/useExplorerFiles.ts
+++ b/packages/interface/src/routes/explorer/hooks/useExplorerFiles.ts
@@ -211,12 +211,15 @@ export function useExplorerFiles(): ExplorerFilesResult {
 	});
 
 	// Directory query
+	// Use a high but bounded limit for stability: prevents hangs/high memory when
+	// browsing directories with tens or hundreds of thousands of files.
+	// The UI uses virtualized rendering so users can still scroll large (but capped) results.
 	const directoryQuery = useNormalizedQuery({
 		query: "files.directory_listing",
 		input: currentPath
 			? {
 					path: currentPath,
-					limit: null,
+					limit: 10000,
 					include_hidden: false,
 					sort_by: sortBy as DirectorySortBy,
 					sort_direction: toSortDirection(sortOrder),
@@ -260,6 +263,8 @@ export function useExplorerFiles(): ExplorerFilesResult {
 		} else if (isSearchMode) {
 			result = (searchQuery.data as FileSearchOutput | undefined)?.files || [];
 		} else if (isVirtualView) {
+			// Virtual listings (devices/volumes) are not server-sorted in the same way;
+			// apply client-side sort (also used as fallback for older daemons).
 			result = sortFiles(
 				virtualFiles || [],
 				sortBy,
@@ -267,14 +272,11 @@ export function useExplorerFiles(): ExplorerFilesResult {
 				viewSettings.foldersFirst,
 			);
 		} else {
+			// Directory listings come pre-sorted from the backend (SQL ORDER BY + folders_first).
+			// Trust the server result for correctness and performance (avoids double-sort
+			// of potentially large arrays on every update, which can cause UI jank/hangs).
 			result =
 				(directoryQuery.data as { files: File[] } | undefined)?.files ?? [];
-			result = sortFiles(
-				result,
-				sortBy,
-				sortOrder,
-				viewSettings.foldersFirst,
-			);
 		}
 		return result;
 	}, [

--- a/packages/interface/src/routes/explorer/hooks/useExplorerKeyboard.ts
+++ b/packages/interface/src/routes/explorer/hooks/useExplorerKeyboard.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { useExplorer } from "../context";
+import { toSortDirection } from "../sortUtils";
 import { useSelection } from "../SelectionContext";
 import { useNormalizedQuery } from "../../../contexts/SpacedriveContext";
 import type { DirectorySortBy } from "@sd/ts-client";
@@ -15,6 +16,7 @@ export function useExplorerKeyboard() {
 	const {
 		currentPath,
 		sortBy,
+		sortOrder,
 		navigateToPath,
 		viewMode,
 		viewSettings,
@@ -50,6 +52,7 @@ export function useExplorerKeyboard() {
 					limit: null,
 					include_hidden: false,
 					sort_by: sortBy as DirectorySortBy,
+					sort_direction: toSortDirection(sortOrder),
 				}
 			: null!,
 		resourceType: "file",

--- a/packages/interface/src/routes/explorer/sortUtils.ts
+++ b/packages/interface/src/routes/explorer/sortUtils.ts
@@ -14,6 +14,22 @@ export function toSortDirection(order: SortOrder): SortDirection {
 	return order === "asc" ? "Asc" : "Desc";
 }
 
+export function sortDirectionLabel(sortBy: SortBy, sortOrder: SortOrder): string {
+	switch (sortBy) {
+		case "name":
+		case "type":
+			return sortOrder === "asc" ? "A–Z" : "Z–A";
+		case "modified":
+		case "created":
+		case "datetaken":
+			return sortOrder === "asc" ? "Oldest first" : "Newest first";
+		case "size":
+			return sortOrder === "asc" ? "Smallest first" : "Largest first";
+		default:
+			return sortOrder === "asc" ? "Ascending" : "Descending";
+	}
+}
+
 /** Client-side fallback when daemon hasn't been rebuilt yet. */
 export function sortFiles(
 	files: File[],

--- a/packages/interface/src/routes/explorer/sortUtils.ts
+++ b/packages/interface/src/routes/explorer/sortUtils.ts
@@ -1,0 +1,64 @@
+import type { DirectorySortBy, File, MediaSortBy, SortDirection } from "@sd/ts-client";
+
+export type SortBy = DirectorySortBy | MediaSortBy;
+export type SortOrder = "asc" | "desc";
+
+export function defaultSortOrder(sortBy: SortBy): SortOrder {
+	if (sortBy === "modified" || sortBy === "size") {
+		return "desc";
+	}
+	return "asc";
+}
+
+export function toSortDirection(order: SortOrder): SortDirection {
+	return order === "asc" ? "Asc" : "Desc";
+}
+
+/** Client-side fallback when daemon hasn't been rebuilt yet. */
+export function sortFiles(
+	files: File[],
+	sortBy: SortBy,
+	sortOrder: SortOrder,
+	foldersFirst: boolean,
+): File[] {
+	const direction = sortOrder === "asc" ? 1 : -1;
+	const sorted = [...files];
+
+	sorted.sort((a, b) => {
+		if (foldersFirst && a.kind !== b.kind) {
+			const aIsDir = a.kind === "Directory";
+			const bIsDir = b.kind === "Directory";
+			if (aIsDir !== bIsDir) {
+				return aIsDir ? -1 : 1;
+			}
+		}
+
+		let cmp = 0;
+		switch (sortBy) {
+			case "name":
+				cmp = a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+				break;
+			case "modified":
+				cmp = a.modified_at.localeCompare(b.modified_at);
+				break;
+			case "size":
+				cmp = a.size - b.size;
+				break;
+			case "type": {
+				const aIsDir = a.kind === "Directory";
+				const bIsDir = b.kind === "Directory";
+				if (!foldersFirst && aIsDir !== bIsDir) {
+					return aIsDir ? -1 : 1;
+				}
+				cmp = a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+				break;
+			}
+			default:
+				cmp = 0;
+		}
+
+		return cmp * direction;
+	});
+
+	return sorted;
+}

--- a/packages/interface/src/routes/explorer/sortUtils.ts
+++ b/packages/interface/src/routes/explorer/sortUtils.ts
@@ -30,7 +30,7 @@ export function sortDirectionLabel(sortBy: SortBy, sortOrder: SortOrder): string
 	}
 }
 
-/** Client-side fallback when daemon hasn't been rebuilt yet. */
+/** Locale-aware sort. Used for virtual lists and to re-apply order after cache updates. */
 export function sortFiles(
 	files: File[],
 	sortBy: SortBy,
@@ -39,6 +39,10 @@ export function sortFiles(
 ): File[] {
 	const direction = sortOrder === "asc" ? 1 : -1;
 	const sorted = [...files];
+
+	// natural + case-insensitive: "App" and "app" group together; file2 before file10
+	const byName = (a: string, b: string) =>
+		a.localeCompare(b, undefined, { sensitivity: "base", numeric: true });
 
 	sorted.sort((a, b) => {
 		if (foldersFirst && a.kind !== b.kind) {
@@ -52,7 +56,7 @@ export function sortFiles(
 		let cmp = 0;
 		switch (sortBy) {
 			case "name":
-				cmp = a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+				cmp = byName(a.name, b.name);
 				break;
 			case "modified":
 				cmp = a.modified_at.localeCompare(b.modified_at);
@@ -66,7 +70,7 @@ export function sortFiles(
 				if (!foldersFirst && aIsDir !== bIsDir) {
 					return aIsDir ? -1 : 1;
 				}
-				cmp = a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+				cmp = byName(a.name, b.name);
 				break;
 			}
 			default:

--- a/packages/interface/src/routes/explorer/views/ColumnView/Column.tsx
+++ b/packages/interface/src/routes/explorer/views/ColumnView/Column.tsx
@@ -5,6 +5,7 @@ import type { File, SdPath } from "@sd/ts-client";
 import { useNormalizedQuery } from "../../../../contexts/SpacedriveContext";
 import { ColumnItem } from "./ColumnItem";
 import { useExplorer } from "../../context";
+import { toSortDirection } from "../../sortUtils";
 import { useFileContextMenu } from "../../hooks/useFileContextMenu";
 import { useSelection } from "../../SelectionContext";
 
@@ -126,7 +127,7 @@ export const Column = memo(function Column({
 	virtualFiles,
 }: ColumnProps) {
 	const parentRef = useRef<HTMLDivElement>(null);
-	const { viewSettings, sortBy } = useExplorer();
+	const { viewSettings, sortBy, sortOrder } = useExplorer();
 	const { selectedFiles } = useSelection();
 
 	const directoryQuery = useNormalizedQuery({
@@ -136,6 +137,7 @@ export const Column = memo(function Column({
 			limit: null,
 			include_hidden: false,
 			sort_by: sortBy as any,
+			sort_direction: toSortDirection(sortOrder),
 			folders_first: viewSettings.foldersFirst,
 		},
 		resourceType: "file",

--- a/packages/interface/src/routes/explorer/views/ColumnView/ColumnView.tsx
+++ b/packages/interface/src/routes/explorer/views/ColumnView/ColumnView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useCallback, useMemo, useRef } from "react";
 import type { SdPath, File } from "@sd/ts-client";
 import { useExplorer } from "../../context";
+import { toSortDirection } from "../../sortUtils";
 import { useSelection } from "../../SelectionContext";
 import { useNormalizedQuery } from "../../../../contexts/SpacedriveContext";
 import type { DirectorySortBy } from "@sd/ts-client";
@@ -22,6 +23,7 @@ export function ColumnView() {
 		currentPath,
 		navigateToPath,
 		sortBy,
+		sortOrder,
 		viewSettings,
 		columnStack,
 		setColumnStack,
@@ -191,6 +193,7 @@ export function ColumnView() {
 					limit: null,
 					include_hidden: false,
 					sort_by: sortBy as DirectorySortBy,
+					sort_direction: toSortDirection(sortOrder),
 					folders_first: viewSettings.foldersFirst,
 				}
 			: null!,
@@ -241,6 +244,7 @@ export function ColumnView() {
 					limit: null,
 					include_hidden: false,
 					sort_by: sortBy as DirectorySortBy,
+					sort_direction: toSortDirection(sortOrder),
 					folders_first: viewSettings.foldersFirst,
 				}
 			: null!,

--- a/packages/interface/src/routes/explorer/views/KnowledgeView.tsx
+++ b/packages/interface/src/routes/explorer/views/KnowledgeView.tsx
@@ -13,6 +13,7 @@ import {
 } from "@phosphor-icons/react";
 import { KnowledgeInspector } from "../../../components/Inspector/variants/KnowledgeInspector";
 import { useExplorer } from "../context";
+import { toSortDirection } from "../sortUtils";
 import { useNormalizedQuery } from "../../../contexts/SpacedriveContext";
 import type { File, ContentKind } from "@sd/ts-client";
 import { getContentKind } from "@sd/ts-client";
@@ -81,7 +82,7 @@ const CONTENT_KIND_LABELS: Record<ContentKind, string> = {
 };
 
 export function KnowledgeView() {
-	const { inspectorVisible, currentPath, sortBy, viewSettings } =
+	const { inspectorVisible, currentPath, sortBy, sortOrder, viewSettings } =
 		useExplorer();
 
 	const directoryQuery = useNormalizedQuery({
@@ -92,6 +93,7 @@ export function KnowledgeView() {
 					limit: null,
 					include_hidden: false,
 					sort_by: sortBy,
+					sort_direction: toSortDirection(sortOrder),
 					folders_first: viewSettings.foldersFirst,
 				}
 			: null,

--- a/packages/interface/src/routes/explorer/views/ListView/ListView.tsx
+++ b/packages/interface/src/routes/explorer/views/ListView/ListView.tsx
@@ -14,13 +14,12 @@ import {
 	TABLE_PADDING_Y,
 	TABLE_HEADER_HEIGHT,
 } from "./useTable";
-import type { DirectorySortBy } from "@sd/ts-client";
 import { useExplorerFiles } from "../../hooks/useExplorerFiles";
 import { DragSelect } from "./DragSelect";
 import { useEmptySpaceContextMenu } from "../../hooks/useEmptySpaceContextMenu";
 
 export const ListView = memo(function ListView() {
-	const { sortBy, setSortBy, setCurrentFiles } = useExplorer();
+	const { sortBy, sortOrder, toggleColumnSort, setCurrentFiles } = useExplorer();
 	const {
 		focusedIndex,
 		setFocusedIndex,
@@ -127,23 +126,6 @@ export const ListView = memo(function ListView() {
 		return () => window.removeEventListener("keydown", handleKeyDown);
 	}, [focusedIndex, selectFile, setFocusedIndex, moveFocus]);
 
-	// Column sorting handler
-	const handleHeaderClick = useCallback(
-		(columnId: string) => {
-			const sortMap: Record<string, DirectorySortBy> = {
-				name: "name",
-				size: "size",
-				modified: "modified",
-				type: "type",
-			};
-			const newSort = sortMap[columnId];
-			if (newSort) {
-				setSortBy(newSort);
-			}
-		},
-		[setSortBy],
-	);
-
 	// Calculate total width for table
 	const headerGroups = table.getHeaderGroups();
 	const totalWidth = table.getTotalSize() + TABLE_PADDING_X * 2;
@@ -182,7 +164,7 @@ export const ListView = memo(function ListView() {
 										)}
 										style={{ width: header.getSize() }}
 										onClick={() =>
-											handleHeaderClick(header.id)
+											toggleColumnSort(header.id)
 										}
 									>
 										<span className="truncate">
@@ -193,7 +175,12 @@ export const ListView = memo(function ListView() {
 										</span>
 
 										{isSorted && (
-											<CaretDown className="size-3 flex-shrink-0 text-ink-faint" />
+											<CaretDown
+												className={clsx(
+													"size-3 flex-shrink-0 text-ink-faint transition-transform",
+													sortOrder === "asc" && "rotate-180",
+												)}
+											/>
 										)}
 
 										{/* Resize handle */}

--- a/packages/interface/src/routes/explorer/views/ListView/useTable.tsx
+++ b/packages/interface/src/routes/explorer/views/ListView/useTable.tsx
@@ -16,9 +16,6 @@ export const TABLE_HEADER_HEIGHT = 32;
 
 // Column definitions for the list view
 export function useTable(files: File[]) {
-  // Memoize files array reference to prevent unnecessary table updates
-  const stableFiles = useMemo(() => files, [JSON.stringify(files.map(f => f.id))]);
-
   const columns = useMemo<ColumnDef<File>[]>(
     () => [
       {
@@ -61,7 +58,7 @@ export function useTable(files: File[]) {
   const coreRowModel = useMemo(() => getCoreRowModel<File>(), []);
 
   const table = useReactTable({
-    data: stableFiles,
+    data: files,
     columns,
     defaultColumn: {
       minSize: 60,

--- a/packages/interface/src/routes/explorer/views/SizeView/SizeView.tsx
+++ b/packages/interface/src/routes/explorer/views/SizeView/SizeView.tsx
@@ -11,6 +11,7 @@ import {useEffect, useMemo, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
 import {useNormalizedQuery} from '../../../../contexts/SpacedriveContext';
 import {useExplorer} from '../../context';
+import {toSortDirection} from '../../sortUtils';
 import {Thumb} from '../../File/Thumb';
 import {useFileContextMenu} from '../../hooks/useFileContextMenu';
 import {useDraggableFile} from '../../hooks/useDraggableFile';
@@ -310,6 +311,7 @@ export function SizeView() {
 	const {
 		currentPath,
 		sortBy,
+		sortOrder,
 		navigateToPath,
 		viewSettings,
 		sidebarVisible,
@@ -351,6 +353,7 @@ export function SizeView() {
 					limit: null,
 					include_hidden: false,
 					sort_by: sortBy as DirectorySortBy,
+					sort_direction: toSortDirection(sortOrder),
 					folders_first: viewSettings.foldersFirst
 				}
 			: null!,

--- a/packages/interface/src/routes/settings/index.tsx
+++ b/packages/interface/src/routes/settings/index.tsx
@@ -46,7 +46,7 @@ function SettingsSidebar({ currentPage, onPageChange }: SettingsSidebarProps) {
                 : "bg-sidebar-selected text-sidebar-ink"
               : isAboutPage
               ? "text-white/60 hover:text-white hover:bg-white/10"
-              : "text-sidebar-inkDull hover:text-sidebar-ink hover:bg-sidebar-box"
+              : "text-sidebar-ink-dull hover:text-sidebar-ink hover:bg-sidebar-box"
           )}
         >
           {section.label}

--- a/packages/interface/src/routes/sources/Adapters.tsx
+++ b/packages/interface/src/routes/sources/Adapters.tsx
@@ -49,7 +49,7 @@ export function AdaptersScreen() {
 						>
 							<CircleButton
 								icon={ArrowLeft}
-								onClick={() => navigate(-1)}
+								onClick={() => navigate("/sources")}
 							/>
 						</TopBarItem>
 						<TopBarItem

--- a/packages/interface/src/routes/sources/index.tsx
+++ b/packages/interface/src/routes/sources/index.tsx
@@ -1,15 +1,15 @@
 import { Plus, ArrowLeft } from "@phosphor-icons/react";
 import { useNavigate } from "react-router-dom";
 import { useLibraryQuery } from "../../contexts/SpacedriveContext";
-import { useTabManager } from "../../components/TabManager/useTabManager";
 import { SourceCard } from "../../components/Sources/SourceCard";
+import { useOpenAdaptersPicker } from "./useOpenAdaptersPicker";
 import { TopBarPortal, TopBarItem } from "../../TopBar";
 import { CircleButton } from "@spacedrive/primitives";
 import { SearchBar } from "@spacedrive/primitives";
 
 export function SourcesHome() {
 	const navigate = useNavigate();
-	const { createTab } = useTabManager();
+	const openAdaptersPicker = useOpenAdaptersPicker();
 	const { data: sourcesRaw, isLoading, error } = useLibraryQuery({
 		type: "sources.list",
 		input: { data_type: null },
@@ -48,7 +48,7 @@ export function SourcesHome() {
 						<TopBarItem id="add-source" label="Add Source" priority="high">
 							<CircleButton
 								icon={Plus}
-								onClick={() => createTab("Adapters", "/sources/adapters")}
+								onClick={openAdaptersPicker}
 								title="Add Source"
 							/>
 						</TopBarItem>
@@ -78,7 +78,7 @@ export function SourcesHome() {
 						Add a data source to get started
 					</p>
 					<button
-						onClick={() => createTab("Adapters", "/sources/adapters")}
+						onClick={openAdaptersPicker}
 						className="bg-accent hover:bg-accent-deep mt-4 rounded-lg px-3.5 py-1.5 text-sm font-medium text-white transition-colors"
 					>
 						Add Source

--- a/packages/interface/src/routes/sources/useOpenAdaptersPicker.ts
+++ b/packages/interface/src/routes/sources/useOpenAdaptersPicker.ts
@@ -1,0 +1,23 @@
+import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { useTabManager } from "../../components/TabManager/useTabManager";
+
+const ADAPTERS_PATH = "/sources/adapters";
+
+/**
+ * Opens the adapters picker within the current Sources tab.
+ * Closes stale adapters-only tabs left from older builds.
+ */
+export function useOpenAdaptersPicker() {
+	const navigate = useNavigate();
+	const { tabs, activeTabId, closeTab } = useTabManager();
+
+	return useCallback(() => {
+		for (const tab of tabs) {
+			if (tab.id !== activeTabId && tab.savedPath === ADAPTERS_PATH) {
+				closeTab(tab.id);
+			}
+		}
+		navigate(ADAPTERS_PATH);
+	}, [tabs, activeTabId, closeTab, navigate]);
+}

--- a/packages/ts-client/src/generated/types.ts
+++ b/packages/ts-client/src/generated/types.ts
@@ -163,15 +163,15 @@ message: string };
 /**
  * Targets for immediately applying a newly created tag
  */
-export type ApplyToTargets =
+export type ApplyToTargets = 
 /**
  * Apply to content identities (all instances)
  */
-{ type: "Content"; ids: string[] } |
+{ type: "Content"; ids: string[] } | 
 /**
  * Apply to specific entries by database ID (internal use)
  */
-{ type: "Entry"; ids: number[] } |
+{ type: "Entry"; ids: number[] } | 
 /**
  * Apply to specific entries by UUID (from frontend File.id)
  */
@@ -574,14 +574,6 @@ namespace: string | null;
  */
 message: string };
 
-export type DeleteTagInput = { tag_id: string };
-
-export type DeleteTagOutput = { deleted: boolean };
-
-export type UnapplyTagsInput = { entry_ids: string[]; tag_ids: string[] };
-
-export type UnapplyTagsOutput = { entries_affected: number; tags_removed: number; warnings: string[] };
-
 /**
  * Data volume metrics snapshot
  */
@@ -608,6 +600,10 @@ export type DeleteItemOutput = { success: boolean };
 export type DeleteSourceInput = { source_id: string };
 
 export type DeleteSourceOutput = { deleted: boolean };
+
+export type DeleteTagInput = { tag_id: string };
+
+export type DeleteTagOutput = { deleted: boolean };
 
 export type DeleteWhisperModelInput = { model: string };
 
@@ -806,9 +802,13 @@ limit: number | null;
  */
 include_hidden: boolean | null; 
 /**
- * Sort order for results
+ * Sort field for results
  */
 sort_by: DirectorySortBy; 
+/**
+ * Sort direction. When omitted, uses field-specific defaults (name/type: asc, modified/size: desc).
+ */
+sort_direction: SortDirection | null; 
 /**
  * Whether to show folders before files (default: false)
  */
@@ -1593,6 +1593,10 @@ export type GetAdapterConfigInput = { adapter_id: string };
  */
 export type GetAppConfigQueryInput = null;
 
+export type GetFilesByTagInput = { tag_id: string; include_children: boolean; min_confidence: number };
+
+export type GetFilesByTagOutput = { files: File[] };
+
 /**
  * Input for getting library configuration
  */
@@ -1693,6 +1697,18 @@ metrics: SyncMetricsSnapshot };
 export type GetSyncPartnersInput = Record<string, never>;
 
 export type GetSyncPartnersOutput = { partners: SyncPartnerInfo[]; debug_info: SyncPartnersDebugInfo };
+
+export type GetTagAncestorsInput = { tag_id: string };
+
+export type GetTagAncestorsOutput = { ancestors: Tag[] };
+
+export type GetTagByIdInput = { tag_id: string };
+
+export type GetTagByIdOutput = { tag: Tag | null };
+
+export type GetTagChildrenInput = { tag_id: string };
+
+export type GetTagChildrenOutput = { children: Tag[] };
 
 /**
  * Types of groups that can appear in a space
@@ -3358,7 +3374,7 @@ regenerate: boolean };
 /**
  * Input for the redundancy summary query
  */
-export type RedundancySummaryInput = {
+export type RedundancySummaryInput = { 
 /**
  * Optional: restrict summary to specific volumes. None = all volumes.
  */
@@ -3367,39 +3383,31 @@ volume_uuids?: string[] | null };
 /**
  * Complete redundancy summary for the library
  */
-export type RedundancySummaryOutput = {
+export type RedundancySummaryOutput = { 
 /**
  * Per-volume redundancy breakdown
  */
-volumes: VolumeRedundancySummary[];
+volumes: VolumeRedundancySummary[]; 
 /**
  * Library-wide totals
  */
 library_totals: LibraryRedundancyTotals };
 
-export type RegenerateThumbnailInput = {
+export type RegenerateThumbnailInput = { 
 /**
  * UUID of the entry to regenerate thumbnails for
  */
-entry_uuid: string;
+entry_uuid: string; 
 /**
  * Optional variant names (defaults to grid@1x, grid@2x, detail@1x)
  */
-variants: string[] | null;
+variants: string[] | null; 
 /**
  * Force regeneration even if thumbnails exist
  */
 force: boolean };
 
-export type RegenerateThumbnailOutput = { 
-/**
- * Number of thumbnails generated
- */
-generated_count: number; 
-/**
- * Variant names that were generated
- */
-variants: string[] };
+export type RegenerateThumbnailOutput = { generated_count: number; variants: string[] };
 
 /**
  * State of a job running on a remote device
@@ -4222,13 +4230,13 @@ export type TagTargets =
  * Tag by content identity (applies to ALL instances of this content across devices)
  * This is the preferred/default approach
  */
-{ type: "Content"; ids: string[] } |
+{ type: "Content"; ids: string[] } | 
 /**
- * Tag by entry database ID (internal use)
+ * Tag by entry database ID (internal use only)
  */
-{ type: "Entry"; ids: number[] } |
+{ type: "Entry"; ids: number[] } | 
 /**
- * Tag by entry UUID (from frontend File.id)
+ * Tag by entry UUID (use from frontend — File.id is a UUID)
  */
 { type: "EntryUuid"; ids: string[] };
 
@@ -4301,6 +4309,21 @@ export type TranscribeAudioOutput = {
  * Job ID for tracking transcription progress
  */
 job_id: string };
+
+/**
+ * What to untag — uses entry UUIDs (matching the File.id exposed to frontend)
+ */
+export type UnapplyTagsInput = { 
+/**
+ * Entry UUIDs (File.id) to remove tags from
+ */
+entry_ids: string[]; 
+/**
+ * Tag UUIDs to remove
+ */
+tag_ids: string[] };
+
+export type UnapplyTagsOutput = { entries_affected: number; tags_removed: number; warnings: string[] };
 
 /**
  * Statistics for the unified ephemeral index
@@ -5105,6 +5128,7 @@ export type LibraryQuery =
   |  { type: 'files.alternate_instances'; input: AlternateInstancesInput; output: AlternateInstancesOutput }
   |  { type: 'files.by_id'; input: FileByIdQuery; output: File }
   |  { type: 'files.by_path'; input: FileByPathQuery; output: File }
+  |  { type: 'files.by_tag'; input: GetFilesByTagInput; output: GetFilesByTagOutput }
   |  { type: 'files.content_kind_stats'; input: ContentKindStatsInput; output: ContentKindStatsOutput }
   |  { type: 'files.directory_listing'; input: DirectoryListingInput; output: DirectoryListingOutput }
   |  { type: 'files.media_listing'; input: MediaListingInput; output: MediaListingOutput }
@@ -5129,6 +5153,9 @@ export type LibraryQuery =
   |  { type: 'sync.eventLog'; input: GetSyncEventLogInput; output: GetSyncEventLogOutput }
   |  { type: 'sync.metrics'; input: GetSyncMetricsInput; output: GetSyncMetricsOutput }
   |  { type: 'sync.partners'; input: GetSyncPartnersInput; output: GetSyncPartnersOutput }
+  |  { type: 'tags.ancestors'; input: GetTagAncestorsInput; output: GetTagAncestorsOutput }
+  |  { type: 'tags.by_id'; input: GetTagByIdInput; output: GetTagByIdOutput }
+  |  { type: 'tags.children'; input: GetTagChildrenInput; output: GetTagChildrenOutput }
   |  { type: 'tags.search'; input: SearchTagsInput; output: SearchTagsOutput }
   |  { type: 'test.ping'; input: PingInput; output: PingOutput }
   |  { type: 'volumes.list'; input: VolumeListQueryInput; output: VolumeListOutput }
@@ -5239,6 +5266,7 @@ export const WIRE_METHODS = {
     'files.alternate_instances': 'query:files.alternate_instances',
     'files.by_id': 'query:files.by_id',
     'files.by_path': 'query:files.by_path',
+    'files.by_tag': 'query:files.by_tag',
     'files.content_kind_stats': 'query:files.content_kind_stats',
     'files.directory_listing': 'query:files.directory_listing',
     'files.media_listing': 'query:files.media_listing',
@@ -5263,6 +5291,9 @@ export const WIRE_METHODS = {
     'sync.eventLog': 'query:sync.eventLog',
     'sync.metrics': 'query:sync.metrics',
     'sync.partners': 'query:sync.partners',
+    'tags.ancestors': 'query:tags.ancestors',
+    'tags.by_id': 'query:tags.by_id',
+    'tags.children': 'query:tags.children',
     'tags.search': 'query:tags.search',
     'test.ping': 'query:test.ping',
     'volumes.list': 'query:volumes.list',


### PR DESCRIPTION
fix: stability fixes to prevent application hangs (explorer + core)

- Explorer: bound directory_listing to 10k results + removed unconditional
  client-side sortFiles for directory views (backend already sorts; avoids
  main-thread work + memory blowup on huge dirs)
- Core: replaced sync Path::exists / metadata / canonicalize in async paths
  (add_location, validate, volume_for_path, local backend, etc.) with
  tokio equivalents or spawn_blocking
- Eliminated risky block_on calls:
  - file_delete protocol now fully async (like file_transfer)
  - extension host uses block_in_place for WASM host fns
- Guarded viewMode/sort auto-adjust effect in explorer context to prevent
  re-render/query churn from setSortBy identity changes
- Bonus: non-blocking canonicalize in file transfer/delete paths

These are the quick wins + high-risk items (#2 block_on, #3 large dirs,
#4 churn) plus related blocking FS fixes identified while investigating
hangs.

Builds on the A-Z/Z-A sort direction reliability work.