### PR TITLE
fix(interface): handle missing device connection methods

### DIFF
--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -15,6 +15,7 @@
 	},
 	"scripts": {
 		"lint": "eslint src --cache",
+		"test": "bun test ./tests",
 		"typecheck": "tsc -b"
 	},
 	"dependencies": {

--- a/packages/interface/src/routes/overview/ConnectionBadge.tsx
+++ b/packages/interface/src/routes/overview/ConnectionBadge.tsx
@@ -1,0 +1,90 @@
+import {WifiHigh, WifiSlash} from '@phosphor-icons/react';
+import {Tooltip} from '@spacedrive/primitives';
+import clsx from 'clsx';
+import type React from 'react';
+import type {
+	ConnectionBadgeState,
+	ConnectionMethod
+} from './connectionBadgeState';
+import {getConnectionBadgeState} from './connectionBadgeState';
+
+interface ConnectionBadgeConfig {
+	label: string;
+	description: string;
+	icon?: React.ComponentType<{className?: string}>;
+	color?: string;
+}
+
+interface ConnectionBadgeProps {
+	method?: ConnectionMethod | null;
+	online: boolean;
+	current: boolean;
+	icon?: React.ComponentType<{className?: string}>;
+	color?: string;
+}
+
+const configs: Record<ConnectionBadgeState, ConnectionBadgeConfig> = {
+	LocalNetwork: {
+		label: 'Local',
+		description: 'Connected via local network',
+		icon: WifiHigh,
+		color: 'bg-green-500'
+	},
+	DirectInternet: {
+		label: 'Direct',
+		description: 'Connected directly via internet',
+		color: 'bg-blue-500'
+	},
+	RelayProxy: {
+		label: 'Relay',
+		description: 'Connected via relay proxy',
+		color: 'bg-yellow-500'
+	},
+	Offline: {
+		label: 'Offline',
+		description: 'Device is currently offline',
+		icon: WifiSlash,
+		color: 'bg-ink-dull'
+	},
+	Current: {
+		label: 'This device',
+		description: 'This is your current device'
+	},
+	Connecting: {
+		label: 'Connecting',
+		description: 'Determining how this device is connected',
+		color: 'bg-ink-dull'
+	}
+};
+
+export function ConnectionBadge({
+	method,
+	online,
+	current,
+	icon: customIcon,
+	color: customColor
+}: ConnectionBadgeProps) {
+	const state = getConnectionBadgeState({method, online, current});
+	const config = configs[state];
+	const Icon = customIcon || config.icon || null;
+	const dotColor = customColor || config.color || 'bg-ink-dull';
+
+	return (
+		<Tooltip label={config.description}>
+			<div className="flex items-center gap-1.5">
+				{Icon ? (
+					<Icon className="size-3" />
+				) : (
+					!current && (
+						<div
+							className={clsx('size-2 rounded-full', dotColor)}
+						/>
+					)
+				)}
+				<span className="text-ink-dull text-xs font-medium">
+					{config.label}
+				</span>
+			</div>
+		</Tooltip>
+	);
+}

--- a/packages/interface/src/routes/overview/ConnectionBadge.tsx
+++ b/packages/interface/src/routes/overview/ConnectionBadge.tsx
@@ -28,17 +28,17 @@ const configs: Record<ConnectionBadgeState, ConnectionBadgeConfig> = {
 		label: 'Local',
 		description: 'Connected via local network',
 		icon: WifiHigh,
-		color: 'bg-green-500'
+		color: 'bg-status-success'
 	},
 	DirectInternet: {
 		label: 'Direct',
 		description: 'Connected directly via internet',
-		color: 'bg-blue-500'
+		color: 'bg-status-info'
 	},
 	RelayProxy: {
 		label: 'Relay',
 		description: 'Connected via relay proxy',
-		color: 'bg-yellow-500'
+		color: 'bg-status-warning'
 	},
 	Offline: {
 		label: 'Offline',

--- a/packages/interface/src/routes/overview/DevicePanel.tsx
+++ b/packages/interface/src/routes/overview/DevicePanel.tsx
@@ -3,9 +3,7 @@ import {
 	CaretRight,
 	Cpu,
 	HardDrive,
-	Memory,
-	WifiHigh,
-	WifiSlash
+	Memory
 } from '@phosphor-icons/react';
 import DatabaseIcon from '@sd/assets/icons/Database.png';
 import DriveAmazonS3Icon from '@sd/assets/icons/Drive-AmazonS3.png';
@@ -26,7 +24,7 @@ import type {
 	VolumeListOutput,
 	VolumeListQueryInput
 } from '@sd/ts-client';
-import {Tooltip, CircleButton} from '@spacedrive/primitives';
+import {CircleButton} from '@spacedrive/primitives';
 import clsx from 'clsx';
 import {useEffect, useRef, useState} from 'react';
 import Masonry from 'react-masonry-css';
@@ -37,11 +35,13 @@ import {
 	useCoreQuery,
 	useNormalizedQuery
 } from '../../contexts/SpacedriveContext';
+import {ConnectionBadge} from './ConnectionBadge';
+import type {ConnectionMethod} from './connectionBadgeState';
 import {VolumeBar} from './VolumeBar';
 
 // Temporary type extension until types are regenerated
 type DeviceWithConnection = Device & {
-	connection_method?: 'LocalNetwork' | 'DirectInternet' | 'RelayProxy' | null;
+	connection_method?: ConnectionMethod | null;
 };
 
 export function formatBytes(bytes: number): string {
@@ -260,72 +260,6 @@ export function DevicePanel({onLocationSelect}: DevicePanelProps = {}) {
 	);
 }
 
-interface ConnectionBadgeConfig {
-	label: string;
-	description: string;
-	icon?: React.ComponentType<{className?: string}>;
-	color?: string;
-}
-
-interface ConnectionBadgeProps {
-	method: 'LocalNetwork' | 'DirectInternet' | 'RelayProxy';
-	online: boolean;
-	current: boolean;
-	icon?: React.ComponentType<{className?: string}>;
-	color?: string;
-}
-
-function ConnectionBadge({method, online, current, icon: customIcon, color: customColor}: ConnectionBadgeProps) {
-	const configs: Record<string, ConnectionBadgeConfig> = {
-		LocalNetwork: {
-			label: 'Local',
-			description: 'Connected via local network',
-			icon: WifiHigh,
-			color: 'bg-green-500'
-		},
-		DirectInternet: {
-			label: 'Direct',
-			description: 'Connected directly via internet',
-			color: 'bg-blue-500'
-		},
-		RelayProxy: {
-			label: 'Relay',
-			description: 'Connected via relay proxy',
-			color: 'bg-yellow-500'
-		},
-		Offline: {
-			label: 'Offline',
-			description: 'Device is currently offline',
-			icon: WifiSlash,
-			color: 'bg-ink-dull'
-		},
-		Current: {
-			label: 'This device',
-			description: 'This is your current device',
-		}
-	};
-
-	const state = current ? 'Current' : online ? method : 'Offline';
-	const config = configs[state];
-	const Icon = customIcon || config?.icon || null;
-	const dotColor = customColor || config?.color || 'bg-ink-dull';
-
-	return (
-		<Tooltip label={config.description}>
-			<div className="flex items-center gap-1.5">
-				{Icon ? (
-					<Icon className="size-3" />
-				) : !current && (
-					<div className={clsx('size-2 rounded-full', dotColor)} />
-				)}
-				<span className="text-ink-dull text-xs font-medium">
-					{config.label}
-				</span>
-			</div>
-		</Tooltip>
-	);
-}
-
 interface DeviceCardProps {
 	device?: DeviceWithConnection;
 	volumes: Volume[];
@@ -399,10 +333,10 @@ function DeviceCard({
 									{deviceName}
 								</h3>
 								<ConnectionBadge
-										method={device?.connection_method ?? "LocalNetwork"}
-										online={device?.is_online ?? false}
-										current={device?.is_current ?? false}
-									/>
+									method={device?.connection_method}
+									online={device?.is_online ?? false}
+									current={device?.is_current ?? false}
+								/>
 							</div>
 							<p className="text-ink-dull text-sm">
 								{volumesLoading

--- a/packages/interface/src/routes/overview/connectionBadgeState.ts
+++ b/packages/interface/src/routes/overview/connectionBadgeState.ts
@@ -1,0 +1,23 @@
+export type ConnectionMethod = 'LocalNetwork' | 'DirectInternet' | 'RelayProxy';
+
+export type ConnectionBadgeState =
+	| ConnectionMethod
+	| 'Offline'
+	| 'Current'
+	| 'Connecting';
+
+interface ConnectionStateInput {
+	method?: ConnectionMethod | null;
+	online: boolean;
+	current: boolean;
+}
+
+export function getConnectionBadgeState({
+	method,
+	online,
+	current
+}: ConnectionStateInput): ConnectionBadgeState {
+	if (current) return 'Current';
+	if (!online) return 'Offline';
+	return method ?? 'Connecting';
+}

--- a/packages/interface/tests/connectionBadgeState.test.tsx
+++ b/packages/interface/tests/connectionBadgeState.test.tsx
@@ -1,0 +1,56 @@
+import {TooltipProvider} from '@spacedrive/primitives';
+import {describe, expect, test} from 'bun:test';
+import {renderToStaticMarkup} from 'react-dom/server';
+import {ConnectionBadge} from '../src/routes/overview/ConnectionBadge';
+import {getConnectionBadgeState} from '../src/routes/overview/connectionBadgeState';
+
+describe('getConnectionBadgeState', () => {
+	test('identifies the current device before checking its connection', () => {
+		expect(
+			getConnectionBadgeState({
+				method: null,
+				online: false,
+				current: true
+			})
+		).toBe('Current');
+	});
+
+	test('identifies an offline device without a connection method', () => {
+		expect(
+			getConnectionBadgeState({
+				method: null,
+				online: false,
+				current: false
+			})
+		).toBe('Offline');
+	});
+
+	test.each(['LocalNetwork', 'DirectInternet', 'RelayProxy'] as const)(
+		'uses the known %s connection method',
+		(method) => {
+			expect(
+				getConnectionBadgeState({method, online: true, current: false})
+			).toBe(method);
+		}
+	);
+
+	test('shows an online device as connecting until its method is known', () => {
+		expect(
+			getConnectionBadgeState({
+				method: undefined,
+				online: true,
+				current: false
+			})
+		).toBe('Connecting');
+	});
+
+	test('renders the connecting state when a paired device has no method yet', () => {
+		const markup = renderToStaticMarkup(
+			<TooltipProvider>
+				<ConnectionBadge method={null} online current={false} />
+			</TooltipProvider>
+		);
+
+		expect(markup).toContain('Connecting');
+	});
+});

--- a/packages/interface/tests/connectionBadgeState.test.tsx
+++ b/packages/interface/tests/connectionBadgeState.test.tsx
@@ -25,6 +25,16 @@ describe('getConnectionBadgeState', () => {
 		).toBe('Offline');
 	});
 
+	test('identifies an offline device before checking its connection method', () => {
+		expect(
+			getConnectionBadgeState({
+				method: 'LocalNetwork',
+				online: false,
+				current: false
+			})
+		).toBe('Offline');
+	});
+
 	test.each(['LocalNetwork', 'DirectInternet', 'RelayProxy'] as const)(
 		'uses the known %s connection method',
 		(method) => {


### PR DESCRIPTION
## Summary

- prevent the overview from crashing when a paired device is online before its connection method is known
- show a `Connecting` badge with a plain-language tooltip instead of reporting the device as local
- use the app's semantic status colors for connection indicators
- add focused coverage for current, offline precedence, known-method, and missing-method states

Fixes #3039

## Testing

- `bun run --filter @sd/interface test` (8 tests passed)
- `bun run --filter @sd/tauri build`
- rendered the real badge component with production styles at 1280 px and 390 px widths; verified labels, status colors, tooltip, and no horizontal overflow