### PR TITLE
fix(job): resume paused in-memory tasks

### DIFF
--- a/core/src/infra/job/executor.rs
+++ b/core/src/infra/job/executor.rs
@@ -218,15 +218,15 @@ impl<J: JobHandler> JobExecutor<J> {
 		// In-memory resume publishes Running from JobManager after it validates that the
 		// same tracked task accepted the resume request.
 		if *self.state.status_tx.borrow() != JobStatus::Paused {
-			warn!(
-				"DEBUG: JobExecutor setting status to Running for job {}",
-				self.state.job_id
+			debug!(
+				job_id = %self.state.job_id,
+				"Publishing Running status from executor"
 			);
 			let _ = self.state.status_tx.send(super::types::JobStatus::Running);
 
-			warn!(
-				"DEBUG: JobExecutor updating database status to Running for job {}",
-				self.state.job_id
+			debug!(
+				job_id = %self.state.job_id,
+				"Persisting Running status from executor"
 			);
 			if let Err(e) = self
 				.update_job_status_in_db(super::types::JobStatus::Running)
@@ -234,9 +234,9 @@ impl<J: JobHandler> JobExecutor<J> {
 			{
 				error!("Failed to update job status in database: {}", e);
 			} else {
-				warn!(
-					"DEBUG: JobExecutor successfully updated database status to Running for job {}",
-					self.state.job_id
+				debug!(
+					job_id = %self.state.job_id,
+					"Persisted Running status from executor"
 				);
 			}
 		}

--- a/core/src/infra/job/executor.rs
+++ b/core/src/infra/job/executor.rs
@@ -41,7 +41,7 @@ pub struct JobExecutorState {
 	pub job_logging_config: Option<JobLoggingConfig>,
 	pub job_logs_dir: Option<PathBuf>,
 	pub file_logger: Option<Arc<super::logger::FileJobLogger>>,
-	pub persistence_complete_tx: Option<tokio::sync::oneshot::Sender<()>>,
+	pub persistence_complete_tx: Option<watch::Sender<u64>>,
 	pub should_persist: bool,
 }
 
@@ -61,7 +61,7 @@ impl<J: JobHandler> JobExecutor<J> {
 		volume_manager: Option<Arc<crate::volume::VolumeManager>>,
 		job_logging_config: Option<JobLoggingConfig>,
 		job_logs_dir: Option<PathBuf>,
-		persistence_complete_tx: Option<tokio::sync::oneshot::Sender<()>>,
+		persistence_complete_tx: Option<watch::Sender<u64>>,
 		should_persist: bool,
 	) -> Self {
 		// Create file logger if job logging is enabled
@@ -149,6 +149,12 @@ impl<J: JobHandler> JobExecutor<J> {
 		job.update(self.state.job_db.conn()).await?;
 		Ok(())
 	}
+
+	fn signal_persistence_complete(&self) {
+		if let Some(tx) = &self.state.persistence_complete_tx {
+			tx.send_modify(|generation| *generation = generation.wrapping_add(1));
+		}
+	}
 }
 
 #[async_trait]
@@ -209,28 +215,30 @@ impl<J: JobHandler> JobExecutor<J> {
 			self.state.job_id, self.state.job_name
 		);
 
-		// Update status to running
-		warn!(
-			"DEBUG: JobExecutor setting status to Running for job {}",
-			self.state.job_id
-		);
-		let _ = self.state.status_tx.send(super::types::JobStatus::Running);
-
-		// Also persist status to database
-		warn!(
-			"DEBUG: JobExecutor updating database status to Running for job {}",
-			self.state.job_id
-		);
-		if let Err(e) = self
-			.update_job_status_in_db(super::types::JobStatus::Running)
-			.await
-		{
-			error!("Failed to update job status in database: {}", e);
-		} else {
+		// In-memory resume publishes Running from JobManager after it validates that the
+		// same tracked task accepted the resume request.
+		if *self.state.status_tx.borrow() != JobStatus::Paused {
 			warn!(
-				"DEBUG: JobExecutor successfully updated database status to Running for job {}",
+				"DEBUG: JobExecutor setting status to Running for job {}",
 				self.state.job_id
 			);
+			let _ = self.state.status_tx.send(super::types::JobStatus::Running);
+
+			warn!(
+				"DEBUG: JobExecutor updating database status to Running for job {}",
+				self.state.job_id
+			);
+			if let Err(e) = self
+				.update_job_status_in_db(super::types::JobStatus::Running)
+				.await
+			{
+				error!("Failed to update job status in database: {}", e);
+			} else {
+				warn!(
+					"DEBUG: JobExecutor successfully updated database status to Running for job {}",
+					self.state.job_id
+				);
+			}
 		}
 
 		// Create job context
@@ -276,7 +284,7 @@ impl<J: JobHandler> JobExecutor<J> {
 		// Store the final result in the handle for the manager to retrieve
 		*self.state.output.lock().await = Some(result.clone());
 
-		match result {
+		let exec_result = match result {
 			Ok(ref output) => {
 				// Update metrics
 				self.state.metrics = metrics_ref.lock().await.clone();
@@ -325,7 +333,7 @@ impl<J: JobHandler> JobExecutor<J> {
 				);
 				Ok(ExecStatus::Done(sd_task_system::TaskOutput::Empty))
 			}
-			Err(ref e) => {
+			Err(e) => {
 				if e.is_interrupted() {
 					debug!("Job {} interrupted", self.state.job_id);
 
@@ -369,8 +377,8 @@ impl<J: JobHandler> JobExecutor<J> {
 						}
 
 						// Signal that persistence is complete
-						if let Some(tx) = self.state.persistence_complete_tx.take() {
-							let _ = tx.send(());
+						if self.state.persistence_complete_tx.is_some() {
+							self.signal_persistence_complete();
 							info!(
 								"PAUSE_STATE_SAVE: Job {} signaled persistence completion",
 								self.state.job_id
@@ -435,30 +443,23 @@ impl<J: JobHandler> JobExecutor<J> {
 		};
 
 		// Clean up checkpoint if job completed
-		match &result {
-			Ok(_) => {
+		match &exec_result {
+			Ok(ExecStatus::Done(_)) => {
 				let _ = self
 					.state
 					.checkpoint_handler
 					.delete_checkpoint(self.state.job_id)
 					.await;
 
-				// Consume persistence channel if it wasn't used (job completed normally)
-				if let Some(tx) = self.state.persistence_complete_tx.take() {
-					let _ = tx.send(());
-				}
-
-				Ok(ExecStatus::Done(().into()))
+				self.signal_persistence_complete();
 			}
-			Err(e) => {
-				// Consume persistence channel if it wasn't used (job failed)
-				if let Some(tx) = self.state.persistence_complete_tx.take() {
-					let _ = tx.send(());
-				}
-
-				Err(e.clone())
+			Ok(ExecStatus::Paused) => {}
+			Ok(ExecStatus::Canceled) | Err(_) => {
+				self.signal_persistence_complete();
 			}
 		}
+
+		exec_result
 	}
 }
 
@@ -487,7 +488,7 @@ impl<J: JobHandler + std::fmt::Debug> ErasedJob for JobExecutor<J> {
 		volume_manager: Option<std::sync::Arc<crate::volume::VolumeManager>>,
 		job_logging_config: Option<crate::config::JobLoggingConfig>,
 		job_logs_dir: Option<std::path::PathBuf>,
-		persistence_complete_tx: Option<tokio::sync::oneshot::Sender<()>>,
+		persistence_complete_tx: Option<watch::Sender<u64>>,
 		should_persist: bool,
 	) -> Box<dyn sd_task_system::Task<JobError>> {
 		// Update the executor's state with the new parameters

--- a/core/src/infra/job/manager.rs
+++ b/core/src/infra/job/manager.rs
@@ -1986,7 +1986,13 @@ impl JobManager {
 				paused_at: Set(None),
 				..Default::default()
 			};
-			job_model.update(self.db.conn()).await?;
+			if let Err(e) = job_model.update(self.db.conn()).await {
+				warn!(
+					job_id = %job_id,
+					error = %e,
+					"Failed to persist Running status after in-memory resume"
+				);
+			}
 
 			// Create channels
 			let (status_tx, status_rx) = watch::channel(JobStatus::Running);
@@ -2414,6 +2420,8 @@ impl JobManager {
 
 		// Wait for all persistence operations to complete
 		for (job_id, mut rx) in persistence_receivers {
+			// Paused status is published before the executor finishes persistence, so a receiver
+			// with no pending generation can still be waiting for an in-flight save.
 			tokio::select! {
 				result = rx.changed() => {
 					match result {
@@ -2428,7 +2436,7 @@ impl JobManager {
 				_ = tokio::time::sleep(persistence_timeout) => {
 					warn!("Timeout waiting for job {} state persistence after {}s",
 						job_id, persistence_timeout.as_secs());
-					break;
+					continue;
 				}
 			}
 		}

--- a/core/src/infra/job/manager.rs
+++ b/core/src/infra/job/manager.rs
@@ -21,7 +21,9 @@ use crate::{
 };
 use async_trait::async_trait;
 use chrono::Utc;
-use sd_task_system::{TaskDispatcher, TaskHandle, TaskSystem, TaskSystemError};
+use sd_task_system::{
+	TaskDispatcher, TaskHandle, TaskRemoteController, TaskSystem, TaskSystemError,
+};
 use sea_orm::{ActiveModelTrait, ActiveValue::Set, DatabaseConnection, EntityTrait};
 use std::{collections::HashMap, path::PathBuf, sync::Arc};
 use tokio::sync::{broadcast, mpsc, watch, Mutex, RwLock};
@@ -42,36 +44,53 @@ struct RunningJob {
 	task_handle: TaskHandle<JobError>,
 	status_tx: watch::Sender<JobStatus>,
 	latest_progress: Arc<Mutex<Option<Progress>>>,
-	persistence_complete_rx: Option<tokio::sync::oneshot::Receiver<()>>,
+	persistence_complete_rx: Option<watch::Receiver<u64>>,
+	is_resuming: bool,
 	job_name: String,
 	action_context: Option<crate::infra::action::context::ActionContext>,
 	should_emit_events: bool,
 }
 
+const RESUME_PERSISTENCE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Resumes an in-memory task after its latest paused state has been persisted.
+///
+/// The receiver advances once per pause, preventing resumed execution from racing serialized
+/// state. `TaskNotFound` is retried because worker registration can lag the persistence signal.
 async fn resume_in_memory_task(
 	job_id: JobId,
-	task_handle: &TaskHandle<JobError>,
-	persistence_complete_rx: &mut Option<tokio::sync::oneshot::Receiver<()>>,
+	task_controller: &TaskRemoteController,
+	persistence_complete_rx: &mut watch::Receiver<u64>,
 ) -> JobResult<()> {
-	// pause() returns after the task acknowledges the interruption, while the executor can still
-	// be serializing its state. Do not race that work with the next run of the same executor.
-	if let Some(persistence_complete_rx) = persistence_complete_rx.take() {
-		persistence_complete_rx.await.map_err(|_| {
-			JobError::Other(
-				format!(
-					"Job {} stopped before its paused state was persisted",
-					job_id
-				)
-				.into(),
+	tokio::time::timeout(
+		RESUME_PERSISTENCE_TIMEOUT,
+		persistence_complete_rx.changed(),
+	)
+	.await
+	.map_err(|_| {
+		JobError::Other(
+			format!(
+				"Timed out waiting for job {}'s paused state to be persisted",
+				job_id
 			)
-		})?;
-	}
+			.into(),
+		)
+	})?
+	.map_err(|_| {
+		JobError::Other(
+			format!(
+				"Job {} stopped before its paused state was persisted",
+				job_id
+			)
+			.into(),
+		)
+	})?;
 
 	const RESUME_RETRY_LIMIT: usize = 200;
 	const RESUME_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(5);
 
 	for attempt in 0..=RESUME_RETRY_LIMIT {
-		match task_handle.resume().await {
+		match task_controller.resume().await {
 			Ok(()) => return Ok(()),
 			Err(TaskSystemError::TaskNotFound(_)) if attempt < RESUME_RETRY_LIMIT => {
 				tokio::time::sleep(RESUME_RETRY_DELAY).await;
@@ -349,7 +368,7 @@ impl JobManager {
 		};
 
 		// Create persistence completion channel
-		let (persistence_complete_tx, persistence_complete_rx) = tokio::sync::oneshot::channel();
+		let (persistence_complete_tx, persistence_complete_rx) = watch::channel(0);
 
 		// Only enable job file logging for persistent jobs (or if explicitly configured)
 		let job_logging_config = if should_persist
@@ -407,6 +426,7 @@ impl JobManager {
 						status_tx: status_tx.clone(),
 						latest_progress,
 						persistence_complete_rx: Some(persistence_complete_rx),
+						is_resuming: false,
 						job_name: job_name.to_string(),
 						action_context: action_context.clone(),
 						should_emit_events,
@@ -787,7 +807,7 @@ impl JobManager {
 		};
 
 		// Create persistence completion channel
-		let (persistence_complete_tx, persistence_complete_rx) = tokio::sync::oneshot::channel();
+		let (persistence_complete_tx, persistence_complete_rx) = watch::channel(0);
 
 		// Only enable job file logging for persistent jobs (or if explicitly configured)
 		let job_logging_config = if should_persist
@@ -842,6 +862,7 @@ impl JobManager {
 						status_tx: status_tx.clone(),
 						latest_progress: latest_progress.clone(),
 						persistence_complete_rx: Some(persistence_complete_rx),
+						is_resuming: false,
 						job_name: J::NAME.to_string(),
 						action_context: action_context.clone(),
 						should_emit_events,
@@ -1532,8 +1553,7 @@ impl JobManager {
 						};
 
 						// Create persistence completion channel
-						let (persistence_complete_tx, persistence_complete_rx) =
-							tokio::sync::oneshot::channel();
+						let (persistence_complete_tx, persistence_complete_rx) = watch::channel(0);
 
 						// Create executor using the erased job
 						// Resumed jobs are always persistent (loaded from database)
@@ -1588,6 +1608,7 @@ impl JobManager {
 										status_tx: status_tx.clone(),
 										latest_progress,
 										persistence_complete_rx: Some(persistence_complete_rx),
+										is_resuming: false,
 										job_name: job_record.name.clone(),
 										action_context,
 										should_emit_events: true, // Resumed jobs were persisted, so they should emit events
@@ -2039,8 +2060,7 @@ impl JobManager {
 			};
 
 			// Create persistence completion channel
-			let (persistence_complete_tx, persistence_complete_rx) =
-				tokio::sync::oneshot::channel();
+			let (persistence_complete_tx, persistence_complete_rx) = watch::channel(0);
 
 			// Create executor
 			// Resumed jobs are always persistent (loaded from database)
@@ -2081,6 +2101,7 @@ impl JobManager {
 					status_tx: status_tx.clone(),
 					latest_progress,
 					persistence_complete_rx: Some(persistence_complete_rx),
+					is_resuming: false,
 					job_name: job_name.clone(),
 					action_context,
 					should_emit_events: true, // Manually resumed jobs were persisted, so they should emit events
@@ -2201,41 +2222,86 @@ impl JobManager {
 				.device_manager
 				.device_id()
 				.unwrap_or_else(|_| uuid::Uuid::nil());
-			let mut running_jobs = self.running_jobs.write().await;
-			if let Some(running_job) = running_jobs.get_mut(&job_id) {
-				resume_in_memory_task(
-					job_id,
-					&running_job.task_handle,
-					&mut running_job.persistence_complete_rx,
-				)
-				.await?;
+			let (task_controller, task_id, persistence_complete_rx) = {
+				let mut running_jobs = self.running_jobs.write().await;
+				let running_job = running_jobs
+					.get_mut(&job_id)
+					.ok_or_else(|| JobError::NotFound(format!("Job {} not found", job_id)))?;
 
-				// Update status to Running
+				if running_job.handle.status() != JobStatus::Paused || running_job.is_resuming {
+					return Err(JobError::invalid_state(&format!(
+						"Cannot resume job in {:?} state",
+						running_job.handle.status()
+					)));
+				}
+
+				let persistence_complete_rx = running_job
+					.persistence_complete_rx
+					.take()
+					.ok_or_else(|| JobError::invalid_state("Job is already resuming"))?;
+				running_job.is_resuming = true;
+
+				(
+					running_job.task_handle.remote_controller(),
+					running_job.task_handle.task_id(),
+					persistence_complete_rx,
+				)
+			};
+
+			let mut resumed_persistence_rx = persistence_complete_rx.clone();
+			let resume_result =
+				resume_in_memory_task(job_id, &task_controller, &mut resumed_persistence_rx).await;
+
+			{
+				let mut running_jobs = self.running_jobs.write().await;
+				let running_job = running_jobs
+					.get_mut(&job_id)
+					.ok_or_else(|| JobError::NotFound(format!("Job {} not found", job_id)))?;
+
+				if running_job.task_handle.task_id() != task_id || !running_job.is_resuming {
+					return Err(JobError::invalid_state(
+						"Tracked job changed while its task was resuming",
+					));
+				}
+
+				running_job.persistence_complete_rx = Some(if resume_result.is_ok() {
+					resumed_persistence_rx
+				} else {
+					persistence_complete_rx
+				});
+				running_job.is_resuming = false;
+
+				resume_result?;
+				if running_job.handle.status() != JobStatus::Paused {
+					return Err(JobError::invalid_state(&format!(
+						"Job changed to {:?} while resuming",
+						running_job.handle.status()
+					)));
+				}
+
 				running_job
 					.status_tx
 					.send(JobStatus::Running)
 					.map_err(|e| {
 						JobError::Other(format!("Failed to update status: {}", e).into())
 					})?;
-
-				// Update database
-				use sea_orm::{ActiveModelTrait, ActiveValue::Set};
-				let mut job_model = database::jobs::ActiveModel {
-					id: Set(job_id.to_string()),
-					status: Set(JobStatus::Running.to_string()),
-					paused_at: Set(None),
-					..Default::default()
-				};
-				job_model.update(self.db.conn()).await?;
-
-				// Emit resume event
-				self.context.events.emit(Event::JobResumed {
-					job_id: job_id.to_string(),
-					device_id,
-				});
-
-				info!("Job {} resumed", job_id);
 			}
+
+			use sea_orm::{ActiveModelTrait, ActiveValue::Set};
+			let mut job_model = database::jobs::ActiveModel {
+				id: Set(job_id.to_string()),
+				status: Set(JobStatus::Running.to_string()),
+				paused_at: Set(None),
+				..Default::default()
+			};
+			job_model.update(self.db.conn()).await?;
+
+			self.context.events.emit(Event::JobResumed {
+				job_id: job_id.to_string(),
+				device_id,
+			});
+
+			info!("Job {} resumed", job_id);
 		}
 
 		Ok(())
@@ -2347,9 +2413,9 @@ impl JobManager {
 		);
 
 		// Wait for all persistence operations to complete
-		for (job_id, rx) in persistence_receivers {
+		for (job_id, mut rx) in persistence_receivers {
 			tokio::select! {
-				result = rx => {
+				result = rx.changed() => {
 					match result {
 						Ok(()) => {
 							info!("Job {} completed state persistence", job_id);
@@ -2456,44 +2522,57 @@ mod tests {
 	use sd_task_system::{
 		ExecStatus, Interrupter, InterruptionKind, Task, TaskId, TaskOutput, TaskStatus, TaskSystem,
 	};
-	use std::time::Duration;
-	use tokio::{sync::oneshot, time::timeout};
+	use std::{collections::VecDeque, time::Duration};
+	use tokio::{
+		sync::{mpsc, oneshot, watch},
+		time::timeout,
+	};
 
 	#[derive(Debug)]
 	struct PausableTask {
 		id: TaskId,
-		began_tx: Option<oneshot::Sender<()>>,
-		persistence_complete_tx: Option<oneshot::Sender<()>>,
-		release_persistence_rx: Option<oneshot::Receiver<()>>,
-		release_pause_completion_rx: Option<oneshot::Receiver<()>>,
-		has_paused: bool,
+		began_tx: mpsc::UnboundedSender<usize>,
+		persistence_complete_tx: watch::Sender<u64>,
+		pause_gates: VecDeque<(oneshot::Receiver<()>, oneshot::Receiver<()>)>,
+		run_count: usize,
 	}
 
 	impl PausableTask {
-		fn new() -> (
+		fn new(
+			pause_cycles: usize,
+		) -> (
 			Self,
-			oneshot::Receiver<()>,
-			oneshot::Receiver<()>,
-			oneshot::Sender<()>,
-			oneshot::Sender<()>,
+			mpsc::UnboundedReceiver<usize>,
+			watch::Receiver<u64>,
+			Vec<oneshot::Sender<()>>,
+			Vec<oneshot::Sender<()>>,
 		) {
-			let (began_tx, began_rx) = oneshot::channel();
-			let (persistence_complete_tx, persistence_complete_rx) = oneshot::channel();
-			let (release_persistence_tx, release_persistence_rx) = oneshot::channel();
-			let (release_pause_completion_tx, release_pause_completion_rx) = oneshot::channel();
+			let (began_tx, began_rx) = mpsc::unbounded_channel();
+			let (persistence_complete_tx, persistence_complete_rx) = watch::channel(0);
+			let mut pause_gates = VecDeque::new();
+			let mut release_persistence_txs = Vec::new();
+			let mut release_pause_completion_txs = Vec::new();
+
+			for _ in 0..pause_cycles {
+				let (release_persistence_tx, release_persistence_rx) = oneshot::channel();
+				let (release_pause_completion_tx, release_pause_completion_rx) = oneshot::channel();
+				pause_gates.push_back((release_persistence_rx, release_pause_completion_rx));
+				release_persistence_txs.push(release_persistence_tx);
+				release_pause_completion_txs.push(release_pause_completion_tx);
+			}
+
 			(
 				Self {
 					id: TaskId::new_v4(),
-					began_tx: Some(began_tx),
-					persistence_complete_tx: Some(persistence_complete_tx),
-					release_persistence_rx: Some(release_persistence_rx),
-					release_pause_completion_rx: Some(release_pause_completion_rx),
-					has_paused: false,
+					began_tx,
+					persistence_complete_tx,
+					pause_gates,
+					run_count: 0,
 				},
 				began_rx,
 				persistence_complete_rx,
-				release_persistence_tx,
-				release_pause_completion_tx,
+				release_persistence_txs,
+				release_pause_completion_txs,
 			)
 		}
 	}
@@ -2505,30 +2584,22 @@ mod tests {
 		}
 
 		async fn run(&mut self, interrupter: &Interrupter) -> Result<ExecStatus, JobError> {
-			if let Some(began_tx) = self.began_tx.take() {
-				let _ = began_tx.send(());
-			}
+			let run_count = self.run_count;
+			self.run_count += 1;
+			let _ = self.began_tx.send(run_count);
 
-			if self.has_paused {
+			let Some((release_persistence_rx, release_pause_completion_rx)) =
+				self.pause_gates.pop_front()
+			else {
 				return Ok(ExecStatus::Done(TaskOutput::Empty));
-			}
+			};
 
-			self.has_paused = true;
 			match interrupter.await {
 				InterruptionKind::Pause => {
-					self.release_persistence_rx
-						.take()
-						.expect("persistence release receiver")
-						.await
-						.expect("release persistence");
+					release_persistence_rx.await.expect("release persistence");
 					self.persistence_complete_tx
-						.take()
-						.expect("persistence completion sender")
-						.send(())
-						.expect("signal persistence completion");
-					self.release_pause_completion_rx
-						.take()
-						.expect("pause completion release receiver")
+						.send_modify(|generation| *generation += 1);
+					release_pause_completion_rx
 						.await
 						.expect("release pause completion");
 					Ok(ExecStatus::Paused)
@@ -2543,47 +2614,107 @@ mod tests {
 		let task_system = TaskSystem::<JobError>::new();
 		let (
 			task,
-			began_rx,
-			persistence_complete_rx,
-			release_persistence_tx,
-			release_pause_completion_tx,
-		) = PausableTask::new();
+			mut began_rx,
+			mut persistence_complete_rx,
+			mut release_persistence_txs,
+			mut release_pause_completion_txs,
+		) = PausableTask::new(2);
 		let task_id = task.id();
 		let task_handle = task_system.dispatch(task).await.expect("dispatch task");
-		began_rx.await.expect("task did not start");
-		task_handle.pause().await.expect("pause task");
+		let task_controller = task_handle.remote_controller();
 
-		let mut persistence_complete_rx = Some(persistence_complete_rx);
-		{
-			let resume =
-				resume_in_memory_task(JobId(task_id), &task_handle, &mut persistence_complete_rx);
-			tokio::pin!(resume);
+		for cycle in 0..2 {
+			assert_eq!(began_rx.recv().await, Some(cycle));
+			task_controller.pause().await.expect("pause task");
 
-			assert!(
-				timeout(Duration::from_millis(25), &mut resume)
-					.await
-					.is_err(),
-				"resume must wait for paused state persistence"
-			);
-			release_persistence_tx
-				.send(())
-				.expect("release persistence");
-			assert!(
-				timeout(Duration::from_millis(25), &mut resume)
-					.await
-					.is_err(),
-				"resume must retry until the task is registered as paused"
-			);
-			release_pause_completion_tx
-				.send(())
-				.expect("release pause completion");
-			resume.await.expect("resume task");
+			{
+				let resume = resume_in_memory_task(
+					JobId(task_id),
+					&task_controller,
+					&mut persistence_complete_rx,
+				);
+				tokio::pin!(resume);
+
+				assert!(
+					timeout(Duration::from_millis(25), &mut resume)
+						.await
+						.is_err(),
+					"resume must wait for paused state persistence on cycle {cycle}"
+				);
+				release_persistence_txs
+					.remove(0)
+					.send(())
+					.expect("release persistence");
+				assert!(
+					timeout(Duration::from_millis(25), &mut resume)
+						.await
+						.is_err(),
+					"resume must retry until pause registration on cycle {cycle}"
+				);
+				release_pause_completion_txs
+					.remove(0)
+					.send(())
+					.expect("release pause completion");
+				resume.await.expect("resume task");
+			}
 		}
+
+		assert_eq!(began_rx.recv().await, Some(2));
 
 		assert!(matches!(
 			task_handle.await,
 			Ok(TaskStatus::Done((_task_id, TaskOutput::Empty)))
 		));
+		task_system.shutdown().await;
+	}
+
+	#[tokio::test]
+	async fn in_memory_resume_reports_closed_persistence_channel() {
+		let task_system = TaskSystem::<JobError>::new();
+		let (task, mut began_rx, _, _, _) = PausableTask::new(1);
+		let task_id = task.id();
+		let task_handle = task_system.dispatch(task).await.expect("dispatch task");
+		assert_eq!(began_rx.recv().await, Some(0));
+
+		let (persistence_complete_tx, mut persistence_complete_rx) = watch::channel(0);
+		drop(persistence_complete_tx);
+		let error = resume_in_memory_task(
+			JobId(task_id),
+			&task_handle.remote_controller(),
+			&mut persistence_complete_rx,
+		)
+		.await
+		.expect_err("closed persistence channel must fail");
+		assert!(error
+			.to_string()
+			.contains("before its paused state was persisted"));
+
+		task_handle.cancel().await.expect("cancel task");
+		assert!(matches!(task_handle.await, Ok(TaskStatus::Canceled)));
+		task_system.shutdown().await;
+	}
+
+	#[tokio::test]
+	async fn in_memory_resume_propagates_task_system_error() {
+		let task_system = TaskSystem::<JobError>::new();
+		let (task, mut began_rx, _, _, _) = PausableTask::new(1);
+		let task_id = task.id();
+		let task_handle = task_system.dispatch(task).await.expect("dispatch task");
+		assert_eq!(began_rx.recv().await, Some(0));
+
+		let (persistence_complete_tx, mut persistence_complete_rx) = watch::channel(0);
+		persistence_complete_tx.send_modify(|generation| *generation += 1);
+		let error = resume_in_memory_task(
+			JobId(task_id),
+			&task_handle.remote_controller(),
+			&mut persistence_complete_rx,
+		)
+		.await
+		.expect_err("resuming a running task must fail");
+		assert!(matches!(error, JobError::TaskSystem(_)));
+
+		task_handle.cancel().await.expect("cancel task");
+		assert!(matches!(task_handle.await, Ok(TaskStatus::Canceled)));
 		task_system.shutdown().await;
 	}
 }

--- a/core/src/infra/job/manager.rs
+++ b/core/src/infra/job/manager.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use chrono::Utc;
-use sd_task_system::{TaskDispatcher, TaskHandle, TaskSystem};
+use sd_task_system::{TaskDispatcher, TaskHandle, TaskSystem, TaskSystemError};
 use sea_orm::{ActiveModelTrait, ActiveValue::Set, DatabaseConnection, EntityTrait};
 use std::{collections::HashMap, path::PathBuf, sync::Arc};
 use tokio::sync::{broadcast, mpsc, watch, Mutex, RwLock};
@@ -67,10 +67,25 @@ async fn resume_in_memory_task(
 		})?;
 	}
 
-	task_handle
-		.resume()
-		.await
-		.map_err(|e| JobError::task_system(format!("Failed to resume job {}: {}", job_id, e)))
+	const RESUME_RETRY_LIMIT: usize = 200;
+	const RESUME_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(5);
+
+	for attempt in 0..=RESUME_RETRY_LIMIT {
+		match task_handle.resume().await {
+			Ok(()) => return Ok(()),
+			Err(TaskSystemError::TaskNotFound(_)) if attempt < RESUME_RETRY_LIMIT => {
+				tokio::time::sleep(RESUME_RETRY_DELAY).await;
+			}
+			Err(e) => {
+				return Err(JobError::task_system(format!(
+					"Failed to resume job {}: {}",
+					job_id, e
+				)));
+			}
+		}
+	}
+
+	unreachable!("resume retry loop always returns")
 }
 
 impl JobManager {
@@ -2450,6 +2465,7 @@ mod tests {
 		began_tx: Option<oneshot::Sender<()>>,
 		persistence_complete_tx: Option<oneshot::Sender<()>>,
 		release_persistence_rx: Option<oneshot::Receiver<()>>,
+		release_pause_completion_rx: Option<oneshot::Receiver<()>>,
 		has_paused: bool,
 	}
 
@@ -2459,21 +2475,25 @@ mod tests {
 			oneshot::Receiver<()>,
 			oneshot::Receiver<()>,
 			oneshot::Sender<()>,
+			oneshot::Sender<()>,
 		) {
 			let (began_tx, began_rx) = oneshot::channel();
 			let (persistence_complete_tx, persistence_complete_rx) = oneshot::channel();
 			let (release_persistence_tx, release_persistence_rx) = oneshot::channel();
+			let (release_pause_completion_tx, release_pause_completion_rx) = oneshot::channel();
 			(
 				Self {
 					id: TaskId::new_v4(),
 					began_tx: Some(began_tx),
 					persistence_complete_tx: Some(persistence_complete_tx),
 					release_persistence_rx: Some(release_persistence_rx),
+					release_pause_completion_rx: Some(release_pause_completion_rx),
 					has_paused: false,
 				},
 				began_rx,
 				persistence_complete_rx,
 				release_persistence_tx,
+				release_pause_completion_tx,
 			)
 		}
 	}
@@ -2506,6 +2526,11 @@ mod tests {
 						.expect("persistence completion sender")
 						.send(())
 						.expect("signal persistence completion");
+					self.release_pause_completion_rx
+						.take()
+						.expect("pause completion release receiver")
+						.await
+						.expect("release pause completion");
 					Ok(ExecStatus::Paused)
 				}
 				InterruptionKind::Cancel => Ok(ExecStatus::Canceled),
@@ -2516,7 +2541,13 @@ mod tests {
 	#[tokio::test]
 	async fn in_memory_resume_waits_for_persistence_and_resumes_task() {
 		let task_system = TaskSystem::<JobError>::new();
-		let (task, began_rx, persistence_complete_rx, release_persistence_tx) = PausableTask::new();
+		let (
+			task,
+			began_rx,
+			persistence_complete_rx,
+			release_persistence_tx,
+			release_pause_completion_tx,
+		) = PausableTask::new();
 		let task_id = task.id();
 		let task_handle = task_system.dispatch(task).await.expect("dispatch task");
 		began_rx.await.expect("task did not start");
@@ -2537,6 +2568,15 @@ mod tests {
 			release_persistence_tx
 				.send(())
 				.expect("release persistence");
+			assert!(
+				timeout(Duration::from_millis(25), &mut resume)
+					.await
+					.is_err(),
+				"resume must retry until the task is registered as paused"
+			);
+			release_pause_completion_tx
+				.send(())
+				.expect("release pause completion");
 			resume.await.expect("resume task");
 		}
 

--- a/core/src/infra/job/manager.rs
+++ b/core/src/infra/job/manager.rs
@@ -48,6 +48,31 @@ struct RunningJob {
 	should_emit_events: bool,
 }
 
+async fn resume_in_memory_task(
+	job_id: JobId,
+	task_handle: &TaskHandle<JobError>,
+	persistence_complete_rx: &mut Option<tokio::sync::oneshot::Receiver<()>>,
+) -> JobResult<()> {
+	// pause() returns after the task acknowledges the interruption, while the executor can still
+	// be serializing its state. Do not race that work with the next run of the same executor.
+	if let Some(persistence_complete_rx) = persistence_complete_rx.take() {
+		persistence_complete_rx.await.map_err(|_| {
+			JobError::Other(
+				format!(
+					"Job {} stopped before its paused state was persisted",
+					job_id
+				)
+				.into(),
+			)
+		})?;
+	}
+
+	task_handle
+		.resume()
+		.await
+		.map_err(|e| JobError::task_system(format!("Failed to resume job {}: {}", job_id, e)))
+}
+
 impl JobManager {
 	/// Create a new job manager
 	pub async fn new(
@@ -2155,7 +2180,7 @@ impl JobManager {
 
 			info!("Job {} resumed from database", job_id);
 		} else {
-			// Job is already in memory, just update status
+			// Job is already in memory, resume its task before exposing it as running.
 			let device_id = self
 				.context
 				.device_manager
@@ -2163,6 +2188,13 @@ impl JobManager {
 				.unwrap_or_else(|_| uuid::Uuid::nil());
 			let mut running_jobs = self.running_jobs.write().await;
 			if let Some(running_job) = running_jobs.get_mut(&job_id) {
+				resume_in_memory_task(
+					job_id,
+					&running_job.task_handle,
+					&mut running_job.persistence_complete_rx,
+				)
+				.await?;
+
 				// Update status to Running
 				running_job
 					.status_tx
@@ -2402,3 +2434,116 @@ impl CheckpointHandler for DbCheckpointHandler {
 }
 
 use uuid::Uuid;
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use sd_task_system::{
+		ExecStatus, Interrupter, InterruptionKind, Task, TaskId, TaskOutput, TaskStatus, TaskSystem,
+	};
+	use std::time::Duration;
+	use tokio::{sync::oneshot, time::timeout};
+
+	#[derive(Debug)]
+	struct PausableTask {
+		id: TaskId,
+		began_tx: Option<oneshot::Sender<()>>,
+		persistence_complete_tx: Option<oneshot::Sender<()>>,
+		release_persistence_rx: Option<oneshot::Receiver<()>>,
+		has_paused: bool,
+	}
+
+	impl PausableTask {
+		fn new() -> (
+			Self,
+			oneshot::Receiver<()>,
+			oneshot::Receiver<()>,
+			oneshot::Sender<()>,
+		) {
+			let (began_tx, began_rx) = oneshot::channel();
+			let (persistence_complete_tx, persistence_complete_rx) = oneshot::channel();
+			let (release_persistence_tx, release_persistence_rx) = oneshot::channel();
+			(
+				Self {
+					id: TaskId::new_v4(),
+					began_tx: Some(began_tx),
+					persistence_complete_tx: Some(persistence_complete_tx),
+					release_persistence_rx: Some(release_persistence_rx),
+					has_paused: false,
+				},
+				began_rx,
+				persistence_complete_rx,
+				release_persistence_tx,
+			)
+		}
+	}
+
+	#[async_trait::async_trait]
+	impl Task<JobError> for PausableTask {
+		fn id(&self) -> TaskId {
+			self.id
+		}
+
+		async fn run(&mut self, interrupter: &Interrupter) -> Result<ExecStatus, JobError> {
+			if let Some(began_tx) = self.began_tx.take() {
+				let _ = began_tx.send(());
+			}
+
+			if self.has_paused {
+				return Ok(ExecStatus::Done(TaskOutput::Empty));
+			}
+
+			self.has_paused = true;
+			match interrupter.await {
+				InterruptionKind::Pause => {
+					self.release_persistence_rx
+						.take()
+						.expect("persistence release receiver")
+						.await
+						.expect("release persistence");
+					self.persistence_complete_tx
+						.take()
+						.expect("persistence completion sender")
+						.send(())
+						.expect("signal persistence completion");
+					Ok(ExecStatus::Paused)
+				}
+				InterruptionKind::Cancel => Ok(ExecStatus::Canceled),
+			}
+		}
+	}
+
+	#[tokio::test]
+	async fn in_memory_resume_waits_for_persistence_and_resumes_task() {
+		let task_system = TaskSystem::<JobError>::new();
+		let (task, began_rx, persistence_complete_rx, release_persistence_tx) = PausableTask::new();
+		let task_id = task.id();
+		let task_handle = task_system.dispatch(task).await.expect("dispatch task");
+		began_rx.await.expect("task did not start");
+		task_handle.pause().await.expect("pause task");
+
+		let mut persistence_complete_rx = Some(persistence_complete_rx);
+		{
+			let resume =
+				resume_in_memory_task(JobId(task_id), &task_handle, &mut persistence_complete_rx);
+			tokio::pin!(resume);
+
+			assert!(
+				timeout(Duration::from_millis(25), &mut resume)
+					.await
+					.is_err(),
+				"resume must wait for paused state persistence"
+			);
+			release_persistence_tx
+				.send(())
+				.expect("release persistence");
+			resume.await.expect("resume task");
+		}
+
+		assert!(matches!(
+			task_handle.await,
+			Ok(TaskStatus::Done((_task_id, TaskOutput::Empty)))
+		));
+		task_system.shutdown().await;
+	}
+}

--- a/core/src/infra/job/types.rs
+++ b/core/src/infra/job/types.rs
@@ -147,7 +147,7 @@ pub trait ErasedJob: Send + Sync + std::fmt::Debug + 'static {
 		volume_manager: Option<std::sync::Arc<crate::volume::VolumeManager>>,
 		job_logging_config: Option<crate::config::JobLoggingConfig>,
 		job_logs_dir: Option<std::path::PathBuf>,
-		persistence_complete_tx: Option<tokio::sync::oneshot::Sender<()>>,
+		persistence_complete_tx: Option<tokio::sync::watch::Sender<u64>>,
 		should_persist: bool,
 	) -> Box<dyn sd_task_system::Task<crate::infra::job::error::JobError>>;
 

--- a/core/src/infra/job/types.rs
+++ b/core/src/infra/job/types.rs
@@ -123,6 +123,17 @@ pub struct JobRegistration {
 
 /// Type-erased job for dynamic dispatch
 pub trait ErasedJob: Send + Sync + std::fmt::Debug + 'static {
+	/// Creates a task-system executor for this erased job.
+	///
+	/// When present, `persistence_complete_tx` is a monotonically increasing generation counter.
+	/// The executor must increment it exactly once after persistence settles for each execution
+	/// outcome, and must not increment it twice for a single pause or terminal outcome.
+	///
+	/// ```ignore
+	/// persistence_complete_tx.send_modify(|generation| {
+	///     *generation = generation.wrapping_add(1);
+	/// });
+	/// ```
 	fn create_executor(
 		self: Box<Self>,
 		job_id: JobId,

--- a/crates/job-derive/src/lib.rs
+++ b/crates/job-derive/src/lib.rs
@@ -75,7 +75,7 @@ pub fn derive_job(input: TokenStream) -> TokenStream {
 				volume_manager: Option<std::sync::Arc<crate::volume::VolumeManager>>,
 				job_logging_config: Option<crate::config::JobLoggingConfig>,
 				job_logs_dir: Option<std::path::PathBuf>,
-				persistence_complete_tx: Option<tokio::sync::oneshot::Sender<()>>,
+				persistence_complete_tx: Option<tokio::sync::watch::Sender<u64>>,
 				should_persist: bool,
 			) -> Box<dyn sd_task_system::Task<crate::infra::job::error::JobError>> {
 				Box::new(crate::infra::job::executor::JobExecutor::new(


### PR DESCRIPTION
## Summary
- resume the task-system handle for paused jobs that remain in memory
- wait for paused state persistence before re-queueing the same executor
- expose the job as running only after the task system accepts the resume request

## Testing
- `RUSTFLAGS="--cap-lints warn" cargo test -p sd-core --lib infra::job::manager::tests::in_memory_resume_waits_for_persistence_and_resumes_task --no-default-features -- --exact --nocapture`
- repeated the focused race test 20 times (20/20 passed)
- `RUSTFLAGS="--cap-lints warn" cargo test -p sd-task-system --test integration_test pause_test -- --exact --nocapture`
- `RUSTFLAGS="--cap-lints warn" cargo check -p sd-core --no-default-features`

The lint cap is test-command-only because current main forbids a `deprecated_in_future` warning for `AtomicUsize::fetch_update` in `sd-task-system` on the installed Rust toolchain.

Fixes #2968