### PR TITLE
fix(interface): preserve middle-click scrolling on Windows

### DIFF
--- a/apps/tauri/src/platform.ts
+++ b/apps/tauri/src/platform.ts
@@ -25,7 +25,17 @@ export const platform: Platform = {
 	platform: 'tauri',
 
 	getMiddleClickNavigationGuardEnvironment() {
-		return {userAgent: navigator.userAgent, eventTarget: document};
+		return {
+			userAgent: navigator.userAgent,
+			eventTarget: {
+				addEventListener(type, listener, options) {
+					document.addEventListener(type, listener, options);
+				},
+				removeEventListener(type, listener) {
+					document.removeEventListener(type, listener);
+				}
+			}
+		};
 	},
 
 	async openDirectoryPickerDialog(opts) {

--- a/apps/tauri/src/platform.ts
+++ b/apps/tauri/src/platform.ts
@@ -24,6 +24,10 @@ let _isDragging = false;
 export const platform: Platform = {
 	platform: 'tauri',
 
+	getMiddleClickNavigationGuardEnvironment() {
+		return {userAgent: navigator.userAgent, eventTarget: document};
+	},
+
 	async openDirectoryPickerDialog(opts) {
 		const result = await open({
 			directory: true,

--- a/packages/interface/src/Shell.tsx
+++ b/packages/interface/src/Shell.tsx
@@ -17,10 +17,7 @@ import {
 } from "./components/TabManager";
 import { usePlatform } from "./contexts/PlatformContext";
 import { useTheme } from "./hooks/useTheme";
-import {
-	installMiddleClickNavigationGuard,
-	shouldInstallMiddleClickNavigationGuard,
-} from "./util/middleClickNavigation";
+import { installMiddleClickNavigationGuardForPlatform } from "./util/middleClickNavigation";
 
 interface ShellProps {
 	client: SpacedriveClient;
@@ -85,18 +82,14 @@ export function Shell({ client }: ShellProps) {
 	const platform = usePlatform();
 	const isTauri = platform.platform === "tauri";
 
-	useEffect(() => {
-		if (
-			!shouldInstallMiddleClickNavigationGuard(
+	useEffect(
+		() =>
+			installMiddleClickNavigationGuardForPlatform(
 				platform.platform,
-				navigator.userAgent,
-			)
-		) {
-			return;
-		}
-
-		return installMiddleClickNavigationGuard(document);
-	}, [platform.platform]);
+				platform.getMiddleClickNavigationGuardEnvironment?.(),
+			),
+		[platform],
+	);
 
 	return (
 		<SpacedriveProvider client={client}>

--- a/packages/interface/src/Shell.tsx
+++ b/packages/interface/src/Shell.tsx
@@ -1,6 +1,7 @@
 import { SpacedriveProvider, type SpacedriveClient } from "./contexts/SpacedriveContext";
 import { ServerProvider } from "./contexts/ServerContext";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { useEffect } from "react";
 import { RouterProvider } from "react-router-dom";
 import { Dialogs, Toaster, TooltipProvider } from "@spacedrive/primitives";
 
@@ -16,6 +17,10 @@ import {
 } from "./components/TabManager";
 import { usePlatform } from "./contexts/PlatformContext";
 import { useTheme } from "./hooks/useTheme";
+import {
+	installMiddleClickNavigationGuard,
+	shouldInstallMiddleClickNavigationGuard,
+} from "./util/middleClickNavigation";
 
 interface ShellProps {
 	client: SpacedriveClient;
@@ -79,6 +84,19 @@ function ShellWithDaemonCheck() {
 export function Shell({ client }: ShellProps) {
 	const platform = usePlatform();
 	const isTauri = platform.platform === "tauri";
+
+	useEffect(() => {
+		if (
+			!shouldInstallMiddleClickNavigationGuard(
+				platform.platform,
+				navigator.userAgent,
+			)
+		) {
+			return;
+		}
+
+		return installMiddleClickNavigationGuard(document);
+	}, [platform.platform]);
 
 	return (
 		<SpacedriveProvider client={client}>

--- a/packages/interface/src/contexts/PlatformContext.tsx
+++ b/packages/interface/src/contexts/PlatformContext.tsx
@@ -1,5 +1,7 @@
 import { createContext, useContext, PropsWithChildren } from "react";
 
+import type { MiddleClickNavigationGuardTarget } from "../util/middleClickNavigation";
+
 /**
  * Platform abstraction layer
  *
@@ -13,7 +15,7 @@ export type Platform = {
 	/** Provide browser event access for the Windows Tauri middle-click guard. */
 	getMiddleClickNavigationGuardEnvironment?(): {
 		userAgent: string;
-		eventTarget: EventTarget;
+		eventTarget: MiddleClickNavigationGuardTarget;
 	};
 
 	/** Open native directory picker dialog (Tauri only) */

--- a/packages/interface/src/contexts/PlatformContext.tsx
+++ b/packages/interface/src/contexts/PlatformContext.tsx
@@ -10,6 +10,12 @@ export type Platform = {
 	/** Platform discriminator */
 	platform: "web" | "tauri";
 
+	/** Provide browser event access for the Windows Tauri middle-click guard. */
+	getMiddleClickNavigationGuardEnvironment?(): {
+		userAgent: string;
+		eventTarget: EventTarget;
+	};
+
 	/** Open native directory picker dialog (Tauri only) */
 	openDirectoryPickerDialog?(opts?: {
 		title?: string;

--- a/packages/interface/src/util/middleClickNavigation.ts
+++ b/packages/interface/src/util/middleClickNavigation.ts
@@ -1,3 +1,20 @@
+export type MiddleClickNavigationEvent = {
+	button: number;
+	preventDefault(): void;
+};
+
+export type MiddleClickNavigationGuardTarget = {
+	addEventListener(
+		type: 'auxclick',
+		listener: (event: MiddleClickNavigationEvent) => void,
+		options: {passive: false}
+	): void;
+	removeEventListener(
+		type: 'auxclick',
+		listener: (event: MiddleClickNavigationEvent) => void
+	): void;
+};
+
 export function shouldInstallMiddleClickNavigationGuard(
 	platform: 'web' | 'tauri',
 	userAgent: string
@@ -6,12 +23,10 @@ export function shouldInstallMiddleClickNavigationGuard(
 }
 
 export function installMiddleClickNavigationGuard(
-	target: EventTarget
+	target: MiddleClickNavigationGuardTarget
 ): () => void {
-	const preventMiddleClickNavigation = (event: Event) => {
-		const mouseEvent = event as MouseEvent;
-
-		if (mouseEvent.button === 1) mouseEvent.preventDefault();
+	const preventMiddleClickNavigation = (event: MiddleClickNavigationEvent) => {
+		if (event.button === 1) event.preventDefault();
 	};
 
 	target.addEventListener('auxclick', preventMiddleClickNavigation, {
@@ -24,7 +39,10 @@ export function installMiddleClickNavigationGuard(
 
 export function installMiddleClickNavigationGuardForPlatform(
 	platform: 'web' | 'tauri',
-	environment?: {userAgent: string; eventTarget: EventTarget}
+	environment?: {
+		userAgent: string;
+		eventTarget: MiddleClickNavigationGuardTarget;
+	}
 ): (() => void) | undefined {
 	if (
 		!environment ||

--- a/packages/interface/src/util/middleClickNavigation.ts
+++ b/packages/interface/src/util/middleClickNavigation.ts
@@ -21,3 +21,20 @@ export function installMiddleClickNavigationGuard(
 	return () =>
 		target.removeEventListener('auxclick', preventMiddleClickNavigation);
 }
+
+export function installMiddleClickNavigationGuardForPlatform(
+	platform: 'web' | 'tauri',
+	environment?: {userAgent: string; eventTarget: EventTarget}
+): (() => void) | undefined {
+	if (
+		!environment ||
+		!shouldInstallMiddleClickNavigationGuard(
+			platform,
+			environment.userAgent
+		)
+	) {
+		return;
+	}
+
+	return installMiddleClickNavigationGuard(environment.eventTarget);
+}

--- a/packages/interface/src/util/middleClickNavigation.ts
+++ b/packages/interface/src/util/middleClickNavigation.ts
@@ -1,0 +1,23 @@
+export function shouldInstallMiddleClickNavigationGuard(
+	platform: 'web' | 'tauri',
+	userAgent: string
+): boolean {
+	return platform === 'tauri' && userAgent.includes('Windows');
+}
+
+export function installMiddleClickNavigationGuard(
+	target: EventTarget
+): () => void {
+	const preventMiddleClickNavigation = (event: Event) => {
+		const mouseEvent = event as MouseEvent;
+
+		if (mouseEvent.button === 1) mouseEvent.preventDefault();
+	};
+
+	target.addEventListener('auxclick', preventMiddleClickNavigation, {
+		passive: false
+	});
+
+	return () =>
+		target.removeEventListener('auxclick', preventMiddleClickNavigation);
+}

--- a/packages/interface/tests/middleClickNavigation.test.ts
+++ b/packages/interface/tests/middleClickNavigation.test.ts
@@ -1,6 +1,7 @@
 import {describe, expect, it} from 'bun:test';
 import {
 	installMiddleClickNavigationGuard,
+	installMiddleClickNavigationGuardForPlatform,
 	shouldInstallMiddleClickNavigationGuard
 } from '../src/util/middleClickNavigation';
 
@@ -62,5 +63,27 @@ describe('middle-click navigation guard', () => {
 		target.dispatchEvent(event);
 
 		expect(event.defaultPrevented).toBe(false);
+	});
+
+	it('does not require browser globals when the platform provides no environment', () => {
+		expect(installMiddleClickNavigationGuardForPlatform('web')).toBeUndefined();
+		expect(installMiddleClickNavigationGuardForPlatform('tauri')).toBeUndefined();
+	});
+
+	it('installs and cleans up through the Tauri-provided environment', () => {
+		const eventTarget = new EventTarget();
+		const cleanup = installMiddleClickNavigationGuardForPlatform('tauri', {
+			userAgent: 'Windows NT 10.0',
+			eventTarget
+		});
+		const guardedEvent = mouseEvent('auxclick', 1);
+
+		eventTarget.dispatchEvent(guardedEvent);
+		expect(guardedEvent.defaultPrevented).toBe(true);
+
+		cleanup?.();
+		const eventAfterCleanup = mouseEvent('auxclick', 1);
+		eventTarget.dispatchEvent(eventAfterCleanup);
+		expect(eventAfterCleanup.defaultPrevented).toBe(false);
 	});
 });

--- a/packages/interface/tests/middleClickNavigation.test.ts
+++ b/packages/interface/tests/middleClickNavigation.test.ts
@@ -1,0 +1,66 @@
+import {describe, expect, it} from 'bun:test';
+import {
+	installMiddleClickNavigationGuard,
+	shouldInstallMiddleClickNavigationGuard
+} from '../src/util/middleClickNavigation';
+
+function mouseEvent(type: string, button: number) {
+	const event = new Event(type, {cancelable: true});
+	Object.defineProperty(event, 'button', {value: button});
+	return event;
+}
+
+describe('middle-click navigation guard', () => {
+	it('is enabled only for the Windows desktop app', () => {
+		expect(
+			shouldInstallMiddleClickNavigationGuard('tauri', 'Windows NT 10.0')
+		).toBe(true);
+		expect(
+			shouldInstallMiddleClickNavigationGuard('web', 'Windows NT 10.0')
+		).toBe(false);
+		expect(
+			shouldInstallMiddleClickNavigationGuard('tauri', 'Linux x86_64')
+		).toBe(false);
+	});
+
+	it('prevents middle-button auxiliary clicks', () => {
+		const target = new EventTarget();
+		installMiddleClickNavigationGuard(target);
+		const event = mouseEvent('auxclick', 1);
+
+		target.dispatchEvent(event);
+
+		expect(event.defaultPrevented).toBe(true);
+	});
+
+	it.each([0, 2])('does not prevent mouse button %i', (button) => {
+		const target = new EventTarget();
+		installMiddleClickNavigationGuard(target);
+		const event = mouseEvent('auxclick', button);
+
+		target.dispatchEvent(event);
+
+		expect(event.defaultPrevented).toBe(false);
+	});
+
+	it('does not prevent the middle-button press that starts autoscroll', () => {
+		const target = new EventTarget();
+		installMiddleClickNavigationGuard(target);
+		const event = mouseEvent('mousedown', 1);
+
+		target.dispatchEvent(event);
+
+		expect(event.defaultPrevented).toBe(false);
+	});
+
+	it('removes the guard during cleanup', () => {
+		const target = new EventTarget();
+		const cleanup = installMiddleClickNavigationGuard(target);
+		cleanup();
+		const event = mouseEvent('auxclick', 1);
+
+		target.dispatchEvent(event);
+
+		expect(event.defaultPrevented).toBe(false);
+	});
+});

--- a/packages/interface/tests/middleClickNavigation.test.ts
+++ b/packages/interface/tests/middleClickNavigation.test.ts
@@ -2,6 +2,7 @@ import {describe, expect, it} from 'bun:test';
 import {
 	installMiddleClickNavigationGuard,
 	installMiddleClickNavigationGuardForPlatform,
+	type MiddleClickNavigationGuardTarget,
 	shouldInstallMiddleClickNavigationGuard
 } from '../src/util/middleClickNavigation';
 
@@ -9,6 +10,17 @@ function mouseEvent(type: string, button: number) {
 	const event = new Event(type, {cancelable: true});
 	Object.defineProperty(event, 'button', {value: button});
 	return event;
+}
+
+function guardTarget(target: EventTarget): MiddleClickNavigationGuardTarget {
+	return {
+		addEventListener(type, listener, options) {
+			target.addEventListener(type, listener as EventListener, options);
+		},
+		removeEventListener(type, listener) {
+			target.removeEventListener(type, listener as EventListener);
+		}
+	};
 }
 
 describe('middle-click navigation guard', () => {
@@ -26,7 +38,7 @@ describe('middle-click navigation guard', () => {
 
 	it('prevents middle-button auxiliary clicks', () => {
 		const target = new EventTarget();
-		installMiddleClickNavigationGuard(target);
+		installMiddleClickNavigationGuard(guardTarget(target));
 		const event = mouseEvent('auxclick', 1);
 
 		target.dispatchEvent(event);
@@ -36,7 +48,7 @@ describe('middle-click navigation guard', () => {
 
 	it.each([0, 2])('does not prevent mouse button %i', (button) => {
 		const target = new EventTarget();
-		installMiddleClickNavigationGuard(target);
+		installMiddleClickNavigationGuard(guardTarget(target));
 		const event = mouseEvent('auxclick', button);
 
 		target.dispatchEvent(event);
@@ -46,7 +58,7 @@ describe('middle-click navigation guard', () => {
 
 	it('does not prevent the middle-button press that starts autoscroll', () => {
 		const target = new EventTarget();
-		installMiddleClickNavigationGuard(target);
+		installMiddleClickNavigationGuard(guardTarget(target));
 		const event = mouseEvent('mousedown', 1);
 
 		target.dispatchEvent(event);
@@ -56,7 +68,7 @@ describe('middle-click navigation guard', () => {
 
 	it('removes the guard during cleanup', () => {
 		const target = new EventTarget();
-		const cleanup = installMiddleClickNavigationGuard(target);
+		const cleanup = installMiddleClickNavigationGuard(guardTarget(target));
 		cleanup();
 		const event = mouseEvent('auxclick', 1);
 
@@ -74,7 +86,7 @@ describe('middle-click navigation guard', () => {
 		const eventTarget = new EventTarget();
 		const cleanup = installMiddleClickNavigationGuardForPlatform('tauri', {
 			userAgent: 'Windows NT 10.0',
-			eventTarget
+			eventTarget: guardTarget(eventTarget)
 		});
 		const guardedEvent = mouseEvent('auxclick', 1);
 


### PR DESCRIPTION
## Summary

- preserve Windows WebView2 middle-button autoscroll while preventing the following auxiliary click from triggering browser-history navigation
- install the guard only in the Windows Tauri app, leaving the web app and other desktop platforms unchanged
- remove the listener when the shell unmounts and cover platform scope, button handling, autoscroll preservation, and cleanup with focused tests

This is deliberately narrower than #3068. That PR prevents the middle-button `mousedown`, which also disables the scrolling workflow reported in #3008, and includes unrelated archive cleanup. This implementation follows the v1 `auxclick` behavior from 55d2ec7a while adding Windows/Tauri scoping and tests.

## Test plan

- `bun test packages/interface/tests/middleClickNavigation.test.ts` (6 passed)
- `bun run --filter @sd/tauri build` (passed)
- `bun run --filter @sd/interface typecheck` still reports current mainline asset, Spacebot, and generated-client errors; no error references any changed file

Closes #3008