### PR TITLE
fix(ts-client): prune out-of-scope batch resources

### DIFF
--- a/packages/ts-client/src/hooks/useNormalizedQuery.ts
+++ b/packages/ts-client/src/hooks/useNormalizedQuery.ts
@@ -549,6 +549,17 @@ export function updateBatchResources<O>(
 
 	// Apply client-side filtering (safety fallback)
 	const filteredResources = filterBatchResources(resources, options);
+	const filteredResourceIds = new Set(
+		filteredResources.map((resource) => resource.id).filter(Boolean),
+	);
+	const outOfScopeResourceIds = new Set<string>(
+		resources
+			.filter(
+				(resource) =>
+					resource.id && !filteredResourceIds.has(resource.id),
+			)
+			.map((resource) => resource.id),
+	);
 
 	const wireMethod = toWireMethod(options.query);
 	if (options.debug) {
@@ -558,49 +569,77 @@ export function updateBatchResources<O>(
 		}
 	}
 
-	// If all resources were filtered out, they may have moved OUT of scope
-	// Remove them from cache if they exist (handles file moves out of current view)
-	if (filteredResources.length === 0) {
-		for (const resource of resources) {
-			if (resource.id) {
-				deleteResource(resource.id, queryKey, queryClient);
-			}
-		}
-		return;
-	}
-
 	queryClient.setQueryData<O>(queryKey, (oldData: any) => {
 		if (options.debug) {
 			console.log(`[useNormalizedQuery] ${wireMethod} setQueryData: oldData has`, Array.isArray(oldData) ? oldData.length : Object.keys(oldData || {}).join(','), `adding ${filteredResources.length} resources`);
 		}
+
+		// Atomic server batches are forwarded when any resource matches the scope.
+		// Prune resources that moved out before merging those that still match.
+		const scopedOldData = removeResourcesFromCacheData(
+			oldData,
+			outOfScopeResourceIds,
+		);
+
 		// If the query hasn't returned yet, seed the cache with the event data.
 		// This handles the race where the subscription's buffer replay delivers
 		// events before the initial query response arrives. Without this, the
 		// events would be silently dropped and the UI stays empty.
-		if (!oldData) {
+		if (!scopedOldData) {
+			if (filteredResources.length === 0) {
+				return scopedOldData;
+			}
 			return { files: filteredResources, total_count: filteredResources.length, has_more: false } as O;
 		}
 
 		// Handle array responses
-		if (Array.isArray(oldData)) {
+		if (Array.isArray(scopedOldData)) {
 			return updateArrayCache(
-				oldData,
+				scopedOldData,
 				filteredResources,
 				noMergeFields,
 			) as O;
 		}
 
 		// Handle wrapped responses { files: [...] }
-		if (oldData && typeof oldData === "object") {
+		if (typeof scopedOldData === "object") {
 			return updateWrappedCache(
-				oldData,
+				scopedOldData,
 				filteredResources,
 				noMergeFields,
 			) as O;
 		}
 
-		return oldData;
+		return scopedOldData;
 	});
+}
+
+function removeResourcesFromCacheData(
+	oldData: any,
+	resourceIds: ReadonlySet<string>,
+): any {
+	if (!oldData || resourceIds.size === 0) return oldData;
+
+	if (Array.isArray(oldData)) {
+		return oldData.filter((item: any) => !resourceIds.has(item.id));
+	}
+
+	if (typeof oldData === "object") {
+		const arrayField = Object.keys(oldData).find((key) =>
+			Array.isArray(oldData[key]),
+		);
+
+		if (arrayField) {
+			return {
+				...oldData,
+				[arrayField]: oldData[arrayField].filter(
+					(item: any) => !resourceIds.has(item.id),
+				),
+			};
+		}
+	}
+
+	return oldData;
 }
 
 /**

--- a/packages/ts-client/tests/useNormalizedQuery.mixed-batch.test.ts
+++ b/packages/ts-client/tests/useNormalizedQuery.mixed-batch.test.ts
@@ -1,0 +1,162 @@
+import {describe, expect, test} from 'bun:test';
+import {QueryClient} from '@tanstack/react-query';
+import {
+	filterBatchResources,
+	updateBatchResources,
+	type UseNormalizedQueryOptions
+} from '../src/hooks/useNormalizedQuery';
+
+const queryKey = ['query:files.directory_listing', 'library-id', {}];
+
+function file(id: string, path: string, name = id) {
+	return {
+		id,
+		name,
+		sd_path: {
+			Physical: {
+				device_slug: 'device',
+				path
+			}
+		}
+	};
+}
+
+function options(path: string): UseNormalizedQueryOptions<any> {
+	return {
+		query: 'files.directory_listing',
+		resourceType: 'file',
+		pathScope: {
+			Physical: {
+				device_slug: 'device',
+				path
+			}
+		},
+		includeDescendants: false
+	};
+}
+
+function updateCache(
+	initialFiles: ReturnType<typeof file>[],
+	resources: ReturnType<typeof file>[],
+	pathScope: string
+) {
+	const queryClient = new QueryClient();
+	queryClient.setQueryData(queryKey, {
+		files: initialFiles,
+		total_count: initialFiles.length,
+		has_more: false
+	});
+
+	updateBatchResources(
+		resources,
+		null,
+		options(pathScope),
+		queryKey,
+		queryClient
+	);
+
+	return queryClient.getQueryData(queryKey) as {
+		files: ReturnType<typeof file>[];
+		total_count: number;
+		has_more: boolean;
+	};
+}
+
+describe('updateBatchResources scoped batches', () => {
+	test('removes out-of-scope IDs and merges in-scope resources in one mixed batch', () => {
+		const result = updateCache(
+			[
+				file('moved-out', 'C:\\Users\\Test\\Current\\moved.txt'),
+				file(
+					'staying',
+					'C:\\Users\\Test\\Current\\staying.txt',
+					'old-name'
+				),
+				file('untouched', 'C:\\Users\\Test\\Current\\untouched.txt')
+			],
+			[
+				file('moved-out', 'C:/Users/Test/Other/moved.txt'),
+				file(
+					'staying',
+					'c:/users/test/current/staying.txt',
+					'new-name'
+				),
+				file('moved-in', 'C:/USERS/TEST/CURRENT/moved-in.txt')
+			],
+			'C:\\Users\\Test\\Current\\'
+		);
+
+		expect(result.files.map(({id}) => id)).toEqual([
+			'staying',
+			'untouched',
+			'moved-in'
+		]);
+		expect(result.files.find(({id}) => id === 'staying')?.name).toBe(
+			'new-name'
+		);
+	});
+
+	test('applies the same mixed-batch update to direct array caches', () => {
+		const queryClient = new QueryClient();
+		queryClient.setQueryData(queryKey, [
+			file('moved-out', '/current/moved.txt'),
+			file('staying', '/current/staying.txt', 'old-name')
+		]);
+
+		updateBatchResources(
+			[
+				file('moved-out', '/other/moved.txt'),
+				file('staying', '/current/staying.txt', 'new-name')
+			],
+			null,
+			options('/current'),
+			queryKey,
+			queryClient
+		);
+
+		expect(queryClient.getQueryData(queryKey)).toEqual([
+			file('staying', '/current/staying.txt', 'new-name')
+		]);
+	});
+
+	test('removes every cached resource when the entire batch moves out of scope', () => {
+		const result = updateCache(
+			[
+				file('first', '/current/first.txt'),
+				file('second', '/current/second.txt')
+			],
+			[
+				file('first', '/other/first.txt'),
+				file('second', '/other/second.txt')
+			],
+			'/current'
+		);
+
+		expect(result.files).toEqual([]);
+	});
+
+	test('merges every resource when the entire batch remains in scope', () => {
+		const result = updateCache(
+			[file('existing', '/current/existing.txt', 'old-name')],
+			[
+				file('existing', '/current/existing.txt', 'new-name'),
+				file('new', '/current/new.txt')
+			],
+			'/current/'
+		);
+
+		expect(result.files.map(({id}) => id)).toEqual(['existing', 'new']);
+		expect(result.files[0]?.name).toBe('new-name');
+	});
+
+	test('keeps POSIX path matching case-sensitive', () => {
+		const resources = [
+			file('matching', '/Users/Test/Current/file.txt'),
+			file('different-case', '/users/test/current/file.txt')
+		];
+
+		expect(
+			filterBatchResources(resources, options('/Users/Test/Current'))
+		).toEqual([resources[0]]);
+	});
+});


### PR DESCRIPTION
## Summary

A scoped `useNormalizedQuery` subscription receives an entire atomic `ResourceChangedBatch` when any resource in the batch matches its path scope. Previously, when a batch mixed resources that remained in the current directory with resources that moved out, the hook merged only the in-scope resources but did not remove the moved-out IDs. This could leave ghost entries in the old directory after a bulk move.

This change updates the cache in one transaction: it removes IDs for resources filtered out of the current scope, then merges the resources that still match. Existing all-in-scope and all-out-of-scope behavior is preserved.

## Validation

- `bun test packages/ts-client/tests/useNormalizedQuery.mixed-batch.test.ts`: 5 passed, 0 failed
- `bun run --filter @sd/tauri build`: passed
- `bun run --filter @sd/interface typecheck`: existing mainline baseline failure (846 TypeScript error lines); changed-file diagnostics: 0
- `bun run --filter @sd/ts-client build`: existing mainline failure in `useSearchFiles.ts:100` because `SearchFilters` fields are missing; no diagnostic in the changed production file

The focused tests cover mixed batches for wrapped and direct-array caches, all resources moving out, all resources remaining in scope, Windows separator/case normalization, and POSIX case-sensitive matching.

Manual Explorer smoke testing was not run.

> [!NOTE]
> **Summary:** Fixes a cache pruning bug in `useNormalizedQuery` where atomic batches with mixed resources (some in scope, some moved out) would fail to remove out-of-scope IDs, leaving ghost entries after bulk operations. The fix atomically removes out-of-scope resource IDs before merging in-scope updates.
>
> **Changes:** Added `removeResourcesFromCacheData()` helper that filters out IDs for resources outside the query scope before cache updates. Both array and wrapped cache responses are handled.
>
> **Testing:** New test suite covers mixed-batch scenarios including case-insensitive path matching on Windows, POSIX case-sensitive matching, and both wrapped (`{ files: [...] }`) and direct array responses.
> <sub>Written by [Tembo](https://app.tembo.io) for commit [a7498a3c3](https://github.com/spacedriveapp/spacedrive/commit/a7498a3c37170cc2c0b35d5af66f685a750ebdc0). This will update automatically on new commits.</sub>
