### PR TITLE
fix(volume): handle european decimal commas in parse_size_string and pin df locale to C

### DIFF
--- a/core/src/volume/platform/linux.rs
+++ b/core/src/volume/platform/linux.rs
@@ -34,7 +34,7 @@ pub async fn detect_volumes(
 		// Use df to get mounted filesystems
 		let output = Command::new("df")
 			.env("LC_ALL", "C")
-			.args(["-h", "-T"]) // -T shows filesystem type
+			.args(["-B1", "-T"]) // Use byte counts; -T shows filesystem type
 			.output()
 			.map_err(|e| VolumeError::platform(format!("Failed to run df: {}", e)))?;
 

--- a/core/src/volume/platform/linux.rs
+++ b/core/src/volume/platform/linux.rs
@@ -31,10 +31,11 @@ pub async fn detect_volumes(
 	task::spawn_blocking(move || {
 		let mut volumes = Vec::new();
 
-		// Use df to get mounted filesystems
+		// Use df to get mounted filesystems. LC_ALL=C and -B1 provide
+		// locale-independent byte counts; -T keeps the filesystem type.
 		let output = Command::new("df")
 			.env("LC_ALL", "C")
-			.args(["-B1", "-T"]) // Use byte counts; -T shows filesystem type
+			.args(["-B1", "-T"])
 			.output()
 			.map_err(|e| VolumeError::platform(format!("Failed to run df: {}", e)))?;
 

--- a/core/src/volume/platform/linux.rs
+++ b/core/src/volume/platform/linux.rs
@@ -33,6 +33,7 @@ pub async fn detect_volumes(
 
 		// Use df to get mounted filesystems
 		let output = Command::new("df")
+			.env("LC_ALL", "C")
 			.args(["-h", "-T"]) // -T shows filesystem type
 			.output()
 			.map_err(|e| VolumeError::platform(format!("Failed to run df: {}", e)))?;

--- a/core/src/volume/utils.rs
+++ b/core/src/volume/utils.rs
@@ -22,6 +22,7 @@ pub fn parse_size_string(size_str: &str) -> VolumeResult<u64> {
 		return Ok(0);
 	}
 
+	// Normalize decimal and grouping commas for human-readable producers on other platforms.
 	let size_str = if size_str.matches(',').count() == 1 && !size_str.contains('.') {
 		let parts: Vec<&str> = size_str.split(',').collect();
 		let after_comma = parts[1].trim_end_matches(char::is_alphabetic);
@@ -38,6 +39,14 @@ pub fn parse_size_string(size_str: &str) -> VolumeResult<u64> {
 	} else {
 		(size_str.as_str(), "")
 	};
+
+	// Linux `df -B1` emits integer byte counts. Parse those directly so values above
+	// f64's exact-integer range retain all bits of precision.
+	if unit.is_empty() && !number_part.contains('.') {
+		return number_part
+			.parse::<u64>()
+			.map_err(|_| VolumeError::InvalidData(format!("Invalid size: {}", size_str)));
+	}
 
 	let number: f64 = number_part
 		.parse()
@@ -347,6 +356,15 @@ mod tests {
 			(1.5 * 1024.0 * 1024.0 * 1024.0) as u64
 		);
 		assert_eq!(parse_size_string("1610612736").unwrap(), 1_610_612_736);
+		assert_eq!(
+			parse_size_string("9007199254740993").unwrap(),
+			9_007_199_254_740_993
+		);
+		assert_eq!(
+			parse_size_string("1,5G").unwrap(),
+			(1.5 * 1024.0 * 1024.0 * 1024.0) as u64
+		);
+		assert_eq!(parse_size_string("1,024K").unwrap(), 1024 * 1024);
 		assert_eq!(parse_size_string("-").unwrap(), 0);
 	}
 

--- a/core/src/volume/utils.rs
+++ b/core/src/volume/utils.rs
@@ -22,11 +22,7 @@ pub fn parse_size_string(size_str: &str) -> VolumeResult<u64> {
 		return Ok(0);
 	}
 
-	let size_str = if size_str.contains(',') && !size_str.contains('.') {
-		size_str.replace(',', ".")
-	} else {
-		size_str.replace(',', "")
-	};
+	let size_str = size_str.replace(',', ""); // Remove grouping separators
 	let (number_part, unit) = if let Some(pos) = size_str.find(char::is_alphabetic) {
 		(&size_str[..pos], &size_str[pos..])
 	} else {
@@ -340,10 +336,7 @@ mod tests {
 			parse_size_string("1.5G").unwrap(),
 			(1.5 * 1024.0 * 1024.0 * 1024.0) as u64
 		);
-		assert_eq!(
-			parse_size_string("1,5G").unwrap(),
-			(1.5 * 1024.0 * 1024.0 * 1024.0) as u64
-		);
+		assert_eq!(parse_size_string("1610612736").unwrap(), 1_610_612_736);
 		assert_eq!(parse_size_string("-").unwrap(), 0);
 	}
 

--- a/core/src/volume/utils.rs
+++ b/core/src/volume/utils.rs
@@ -22,7 +22,17 @@ pub fn parse_size_string(size_str: &str) -> VolumeResult<u64> {
 		return Ok(0);
 	}
 
-	let size_str = size_str.replace(',', ""); // Remove grouping separators
+	let size_str = if size_str.matches(',').count() == 1 && !size_str.contains('.') {
+		let parts: Vec<&str> = size_str.split(',').collect();
+		let after_comma = parts[1].trim_end_matches(char::is_alphabetic);
+		if after_comma.len() <= 2 {
+			size_str.replace(',', ".")
+		} else {
+			size_str.replace(',', "")
+		}
+	} else {
+		size_str.replace(',', "")
+	};
 	let (number_part, unit) = if let Some(pos) = size_str.find(char::is_alphabetic) {
 		(&size_str[..pos], &size_str[pos..])
 	} else {

--- a/core/src/volume/utils.rs
+++ b/core/src/volume/utils.rs
@@ -22,7 +22,11 @@ pub fn parse_size_string(size_str: &str) -> VolumeResult<u64> {
 		return Ok(0);
 	}
 
-	let size_str = size_str.replace(",", ""); // Remove commas
+	let size_str = if size_str.contains(',') && !size_str.contains('.') {
+		size_str.replace(',', ".")
+	} else {
+		size_str.replace(',', "")
+	};
 	let (number_part, unit) = if let Some(pos) = size_str.find(char::is_alphabetic) {
 		(&size_str[..pos], &size_str[pos..])
 	} else {
@@ -334,6 +338,10 @@ mod tests {
 		assert_eq!(parse_size_string("1G").unwrap(), 1024 * 1024 * 1024);
 		assert_eq!(
 			parse_size_string("1.5G").unwrap(),
+			(1.5 * 1024.0 * 1024.0 * 1024.0) as u64
+		);
+		assert_eq!(
+			parse_size_string("1,5G").unwrap(),
 			(1.5 * 1024.0 * 1024.0 * 1024.0) as u64
 		);
 		assert_eq!(parse_size_string("-").unwrap(), 0);

--- a/core/src/volume/utils.rs
+++ b/core/src/volume/utils.rs
@@ -42,7 +42,7 @@ pub fn parse_size_string(size_str: &str) -> VolumeResult<u64> {
 
 	// Linux `df -B1` emits integer byte counts. Parse those directly so values above
 	// f64's exact-integer range retain all bits of precision.
-	if unit.is_empty() && !number_part.contains('.') {
+	if (unit.is_empty() || unit.eq_ignore_ascii_case("B")) && !number_part.contains('.') {
 		return number_part
 			.parse::<u64>()
 			.map_err(|_| VolumeError::InvalidData(format!("Invalid size: {}", size_str)));
@@ -358,6 +358,10 @@ mod tests {
 		assert_eq!(parse_size_string("1610612736").unwrap(), 1_610_612_736);
 		assert_eq!(
 			parse_size_string("9007199254740993").unwrap(),
+			9_007_199_254_740_993
+		);
+		assert_eq!(
+			parse_size_string("9007199254740993B").unwrap(),
 			9_007_199_254_740_993
 		);
 		assert_eq!(


### PR DESCRIPTION
### Problem

Linux volume detection parsed locale-sensitive, human-readable `df` output. A decimal comma such as `1,5G` could be interpreted as `15G`, and converting raw byte counts through `f64` could lose precision above `2^53`.

### Root cause

- Linux `df` was not pinned to a stable locale or raw-byte output.
- `parse_size_string` stripped commas unconditionally.
- Exact integer byte counts still passed through floating-point conversion.

### Change

1. Run Linux `df` with `LC_ALL=C` and `-B1 -T` for stable raw-byte output.
2. Distinguish decimal commas from grouped values for other human-readable producers.
3. Parse unitless and case-insensitive `B`-suffixed integers directly as `u64` so values above `2^53` remain exact.
4. Add regression coverage for decimal comma, grouped input, and large exact byte counts.

### Verification

```text
cargo +stable-x86_64-pc-windows-gnu test -p sd-core test_parse_size_string --lib

running 1 test
test volume::utils::tests::test_parse_size_string ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 321 filtered out
```

Covered examples include:

- `1,5G`
- `1,024K`
- `9007199254740993`
- `9007199254740993B`

CodeRabbit's current-head review is successful, and its precision finding is marked addressed in `868f6e6`.

### Reference

Fixes #3086
