### PR TITLE
chore(crypto): bump cmov to 0.5.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,9 +1356,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.3.1"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1dc960ba75d543267db9254da8ec1cb318a037beb3f8d2497520e410096fab"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cobs"

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -36,7 +36,7 @@ zeroize      = { workspace = true, features = ["derive"] }
 # External dependencies
 aead             = { version = "0.6.0-rc.2", default-features = false }
 chacha20poly1305 = "0.11.0-rc.1"
-cmov             = "0.3.1"
+cmov             = "0.5.4"
 generic-array    = { version = "=0.14.7", features = ["serde", "zeroize"] } # Update blocked by aead
 hex              = "0.4.3"
 rand_chacha      = "0.9.0-alpha.2"


### PR DESCRIPTION
sd-crypto's `ct::ConstantTimeEq` (used to compare keys, hashes and MACs) is built directly on cmov's `Cmov`/`CmovEq` traits. We're pinned to 0.3.1, which is missing two fixes:

- [RUSTSEC-2026-0003](https://rustsec.org/advisories/RUSTSEC-2026-0003.html): the portable fallback used on 32-bit ARM could still have the optimizer emit a branch, leaking timing information about where two secrets first differ.
- [GHSA-3rjw-m598-pq24](https://github.com/RustCrypto/utils/security/advisories/GHSA-3rjw-m598-pq24) (fixed in 0.5.4): `Cmov`/`CmovEq` on aarch64 could produce a wrong result if the high bits of a register were set, which is a correctness bug on top of the timing one.

Bumping straight to 0.5.4 picks up both. No source changes needed, cmov's `cmovz`/`cmovnz`/`cmovne` API is unchanged across this range.

## Tested

- `cargo test -p sd-crypto`: 94 passed, including all `ct::` cases
- `cargo clippy -p sd-crypto --all-targets`: clean

Only touched `crates/crypto`, didn't try to build the rest of the workspace.